### PR TITLE
Sync the keyall countdown to the playtime clock

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/KeyAllManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/KeyAllManager.java
@@ -73,8 +73,8 @@ public class KeyAllManager {
 
             initializeCountdown(data, cycleSeconds, true);
             long remaining = data.getKeyAllRemainingSeconds();
-            if (remaining > 1L) {
-                data.setKeyAllRemainingSeconds(remaining - 1L);
+            if (remaining > 0L) {
+                // counts down off playtime now, no manual decrement
                 continue;
             }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -57,6 +57,7 @@ public class PlayerData {
     private boolean quietSpawnEnabled;
     private boolean nightVisionEnabled;
     private long keyAllRemainingSeconds;
+    private long keyAllAnchorPlaytimeSeconds;
     private boolean dirty;
 
     public PlayerData(UUID uuid, String username) {
@@ -113,6 +114,7 @@ public class PlayerData {
         this.quietSpawnEnabled = false;
         this.nightVisionEnabled = false;
         this.keyAllRemainingSeconds = -1L;
+        this.keyAllAnchorPlaytimeSeconds = 0L;
         this.dirty = false;
     }
 
@@ -669,11 +671,21 @@ public class PlayerData {
     }
 
     public long getKeyAllRemainingSeconds() {
-        return keyAllRemainingSeconds;
+        if (keyAllRemainingSeconds < 0L) {
+            return keyAllRemainingSeconds;
+        }
+        // count down off the same clock as playtime so the scoreboard lines stay in sync
+        long elapsed = getTotalPlaytimeSeconds() - keyAllAnchorPlaytimeSeconds;
+        if (elapsed < 0L) {
+            elapsed = 0L;
+        }
+        long remaining = keyAllRemainingSeconds - elapsed;
+        return remaining < 0L ? 0L : remaining;
     }
 
     public void setKeyAllRemainingSeconds(long keyAllRemainingSeconds) {
         this.keyAllRemainingSeconds = Math.max(-1L, keyAllRemainingSeconds);
+        this.keyAllAnchorPlaytimeSeconds = getTotalPlaytimeSeconds();
         dirty = true;
     }
 
@@ -701,6 +713,7 @@ public class PlayerData {
         this.moneySpent = 0D;
         this.moneyMade = 0D;
         this.sessionStartMillis = newSessionStartMillis;
+        this.keyAllAnchorPlaytimeSeconds = 0L;
         this.dirty = true;
     }
 }


### PR DESCRIPTION
The keyall countdown and playtime both sit on the scoreboard but run on separate clocks. playtime is wall clock, while the keyall countdown is an integer decremented by a tick task, so it drifts and the two lines tick at different moments.

This derives the countdown from the same playtime value (getTotalPlaytimeSeconds) via a per session anchor, so both lines advance on one clock and flip on the same second. the task no longer decrements by hand, it just grants the reward and re anchors when it hits zero. Persistence and the offline pause are unchanged.

This aims to fix #22 

This bug is only noticeable when the user is first starting, since later on there's no more seconds to display anyways, but yeah.

<img width="237" height="169" alt="Recording 2026-07-08 at 23 23 29" src="https://github.com/user-attachments/assets/4f34ee64-6c31-4950-ba51-13b09200deb1" />
