### PR TITLE
feat: unify crate preview/open into one key-aware rewards menu

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/CrateChestListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/CrateChestListener.java
@@ -90,16 +90,12 @@ public class CrateChestListener implements Listener {
             return;
         }
 
-        if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
-            event.setCancelled(true);
-            plugin.getSpigotScheduler().runEntity(player, () -> openPreview(player, crate));
+        if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
 
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
-            return;
-        }
-
+        // both clicks open the same rewards menu; per-reward copy and the claim click
+        // tell the player whether they have a key (no separate preview mode)
         event.setCancelled(true);
         plugin.getSpigotScheduler().runEntity(player, () -> openCrate(player, clickedBlock, crate));
     }
@@ -132,17 +128,29 @@ public class CrateChestListener implements Listener {
             return;
         }
 
-        CrateManager.OpenResult result = plugin.getCrateManager().startOpening(player, crate.id());
+        // a burst of interact events can schedule several opens in one tick; once the
+        // first one opened a crate menu, silently drop the rest
+        var holder = player.getOpenInventory().getTopInventory().getHolder();
+        if (holder instanceof CrateRewardMenu || holder instanceof CrateGachaMenu) {
+            return;
+        }
+
+        // gacha rolls a reward immediately, so it still needs the key up front;
+        // the choose-one menu opens keyless and gates the key at the claim click
+        boolean gacha = crate.openType() == CrateManager.OpenType.GACHA;
+        CrateManager.OpenResult result = plugin.getCrateManager().startOpening(player, crate.id(), gacha);
         if (!result.success()) {
+            player.sendMessage(ColorUtils.toComponent(result.message()));
             if (result.reason() == CrateManager.FailureReason.NO_KEYS) {
                 plugin.getCrateVisualManager().playNoKeyEffects(player);
+                // keyless gacha cannot roll; show the rewards preview instead
+                openPreview(player, crate);
             }
-            player.sendMessage(ColorUtils.toComponent(result.message()));
             return;
         }
 
         plugin.getCrateVisualManager().playOpenEffects(player, block, crate);
-        if (crate.openType() == CrateManager.OpenType.GACHA) {
+        if (gacha) {
             new CrateGachaMenu(plugin, crate).open(player);
             return;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
@@ -426,6 +426,15 @@ public class CrateManager {
     }
 
     public OpenResult startOpening(Player player, String crateId) {
+        return startOpening(player, crateId, true);
+    }
+
+    /**
+     * Starts a crate session. With {@code requireKey} false the menu opens without a key —
+     * the key is still checked and consumed at claim time ({@code claimSelectedReward}), so
+     * keyless browsing cannot grant rewards.
+     */
+    public OpenResult startOpening(Player player, String crateId, boolean requireKey) {
         CrateDefinition crate = getCrate(crateId);
         if (crate == null) {
             return new OpenResult(false, FailureReason.CRATE_NOT_FOUND,
@@ -439,7 +448,14 @@ public class CrateManager {
             return new OpenResult(false, FailureReason.NO_PERMISSION,
                     "&cyou do not have permission to open this crate.", crate);
         }
-        if (activeSessions.containsKey(player.getUniqueId())) {
+        CrateOpenSession existing = activeSessions.get(player.getUniqueId());
+        // reopening the same crate before picking a reward is not an error — block clicks
+        // can double-fire and menu close clears the session a tick late
+        if (existing != null && existing.crate() != null
+                && existing.crate().id().equalsIgnoreCase(crate.id())
+                && existing.selectedReward() == null) {
+            activeSessions.remove(player.getUniqueId());
+        } else if (existing != null) {
             return new OpenResult(false, FailureReason.ALREADY_OPENING,
                     "&cyou are already opening a crate.", crate);
         }
@@ -447,7 +463,7 @@ public class CrateManager {
             return new OpenResult(false, FailureReason.INVALID_CRATE,
                     "&cthis crate has no valid rewards configured.", crate);
         }
-        if (getKeyBalance(player, crate.id()) <= 0) {
+        if (requireKey && getKeyBalance(player, crate.id()) <= 0) {
             return new OpenResult(false, FailureReason.NO_KEYS,
                     "&cyou do not have any " + getReadableCrateName(crate) + " keys.", crate);
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/CrateRewardMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/CrateRewardMenu.java
@@ -50,7 +50,11 @@ public class CrateRewardMenu extends BaseMenu {
                 continue;
             }
 
-            set(targetSlot, plugin.getCrateManager().createRewardDisplayItem(player, crate, reward));
+            ItemStack display = plugin.getCrateManager().createRewardDisplayItem(player, crate, reward);
+            if (openContext.interactive()) {
+                appendKeyHint(display, player);
+            }
+            set(targetSlot, display);
             rewardSlots.put(targetSlot, reward.id());
         }
 
@@ -74,6 +78,12 @@ public class CrateRewardMenu extends BaseMenu {
 
         String rewardId = rewardSlots.get(slot);
         if (rewardId == null) {
+            return;
+        }
+
+        if (plugin.getCrateManager().getKeyBalance(player, crate.id()) <= 0) {
+            plugin.getCrateVisualManager().playNoKeyEffects(player);
+            player.sendMessage(ColorUtils.toComponent(keyHintLine(player, false)));
             return;
         }
 
@@ -109,6 +119,29 @@ public class CrateRewardMenu extends BaseMenu {
 
     public OpenContext openContext() {
         return openContext;
+    }
+
+    // one unified menu instead of preview/open modes: the reward copy says whether the
+    // player can claim (keys are a per-player balance, not an inventory item), and a
+    // keyless claim click explains itself in place
+    private void appendKeyHint(ItemStack display, Player player) {
+        var meta = display.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        List<String> lore = meta.getLore() == null ? new ArrayList<>() : new ArrayList<>(meta.getLore());
+        lore.add("");
+        boolean hasKey = plugin.getCrateManager().getKeyBalance(player, crate.id()) > 0;
+        lore.add(ColorUtils.toComponent(keyHintLine(player, hasKey)));
+        meta.setLore(lore);
+        display.setItemMeta(meta);
+    }
+
+    private String keyHintLine(Player player, boolean hasKey) {
+        String raw = hasKey
+                ? plugin.getConfigManager().getMessageOrDefault("CRATES.REWARD-CLAIM-HINT", "&aClick to claim this reward!")
+                : plugin.getConfigManager().getMessageOrDefault("CRATES.REWARD-NO-KEY", "&cYou don't have a {crate} key!");
+        return plugin.getCrateManager().applyPlaceholders(raw, player, crate, null);
     }
 
     private List<Integer> buildCenteredRewardSlots(int rewardCount, int inventorySize, int excludedSlot) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/CratesMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/CratesMenu.java
@@ -65,7 +65,9 @@ public class CratesMenu extends BaseMenu {
         }
 
         SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
-        CrateManager.OpenResult result = plugin.getCrateManager().startOpening(player, crateId);
+        CrateManager.CrateDefinition definition = plugin.getCrateManager().getCrate(crateId);
+        boolean gacha = definition != null && definition.openType() == CrateManager.OpenType.GACHA;
+        CrateManager.OpenResult result = plugin.getCrateManager().startOpening(player, crateId, gacha);
         if (!result.success()) {
             player.sendMessage(ColorUtils.toComponent(result.message()));
             build(player);

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2810,6 +2810,9 @@ MESSAGES:
     HEADER: '&8[&6ᴀʟᴛѕ&8] &e%player%'
     KNOWN_IPS: '&7ᴋɴᴏᴡɴ ɪᴘѕ: &f%ips%'
     ENTRY: '&8- &e%player% &7[%status%&7] &fѕʜᴀʀᴇᴅ: %ips%'
+  CRATES:
+    REWARD-CLAIM-HINT: '&aClick to claim this reward!'
+    REWARD-NO-KEY: '&cYou don''t have a {crate} key!'
   FRIENDS:
     NO_PERMISSION: '&cyou do not have permission.'
     USAGE: '&cᴜѕᴀɢᴇ: /friends [ʟɪѕᴛ|ꜰᴏʟʟᴏᴡ|ʀᴇᴍᴏᴠᴇ|ѕᴇᴀʀᴄʜ|ꜰᴏʟʟᴏᴡɪɴɢ|ꜰᴏʟʟᴏᴡᴇʀѕ|ꜰʀɪᴇɴᴅѕ]'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -684,6 +684,10 @@ ALTS:
   ENTRY: "&8- &e%player% &7[%status%&7] &fѕʜᴀʀᴇᴅ: %ips%" # Sets the message text for this response.
 
 # UDS setup: Configure FRIENDS options for this file.
+CRATES:
+  REWARD-CLAIM-HINT: "&aClick to claim this reward!" # Reward lore line when the player has a key.
+  REWARD-NO-KEY: "&cYou don't have a {crate} key!" # Reward lore line and click feedback when the player has no key.
+
 FRIENDS:
   NO_PERMISSION: "&cyou do not have permission." # Sets the message text for this response.
   USAGE: "&cᴜѕᴀɢᴇ: /friends [ʟɪѕᴛ|ꜰᴏʟʟᴏᴡ|ʀᴇᴍᴏᴠᴇ|ѕᴇᴀʀᴄʜ|ꜰᴏʟʟᴏᴡɪɴɢ|ꜰᴏʟʟᴏᴡᴇʀѕ|ꜰʀɪᴇɴᴅѕ]" # Sets the message text for this response.


### PR DESCRIPTION
Crate chests split into two menus: left-click previews, right-click claim, and a keyless right click+shift just plays a sound and drops a rejection in chat, so the block visibly does nothing. adventure players can't even reach the preview, since attack-block events don't fire for them.

This merges both into one menu that opens on either click, key or not. Each reward carries a status line from the language system: 'Click to claim this reward!' with a key, 'You don't have a {crate} key!' without, and a keyless claim click explains itself in place instead of in chat. keys are still checked and consumed at claim time, so browsing grants nothing.

I don't really play donutsmp so i'm not sure if this is exactly how they do crates over there, this solution is inspired in hypixel and I think it just makes more sense imo

<img width="1280" height="696" alt="recording" src="https://github.com/user-attachments/assets/bc5ac406-6c2f-41b1-82ad-86d468a7e0ee" />
