### PR TITLE
ci: update a single rolling pre-release per version instead of creati…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,25 +36,6 @@ jobs:
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Calculate Pre-Release Build Number
-        id: build_counter
-        run: |
-          VERSION="${{ steps.metadata.outputs.version }}"
-          TAGS=$(gh api repos/${{ github.repository }}/tags --jq '.[].name' | grep "^v${VERSION}-pre" || true)
-          if [ -z "$TAGS" ]; then
-            BUILD_NUM=1
-          else
-            LATEST=$(echo "$TAGS" | sed "s/^v${VERSION}-pre//" | grep -E '^[0-9]+$' | sort -n | tail -n 1)
-            if [ -z "$LATEST" ]; then
-              BUILD_NUM=1
-            else
-              BUILD_NUM=$((LATEST + 1))
-            fi
-          fi
-          echo "build_num=$BUILD_NUM" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Shaded Jar
         uses: actions/upload-artifact@v4
         with:
@@ -62,19 +43,26 @@ jobs:
           path: target/UltimateDonutSmp-*.jar
           if-no-files-found: error
 
+      - name: Update Nightly Tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git tag -f "v${{ steps.metadata.outputs.version }}-pre"
+          git push -f origin "v${{ steps.metadata.outputs.version }}-pre"
+
       - name: Release Nightly Build
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: "v${{ steps.metadata.outputs.version }}-pre${{ steps.build_counter.outputs.build_num }}"
-          name: "UltimateDonutSMP v${{ steps.metadata.outputs.version }}-pre${{ steps.build_counter.outputs.build_num }}"
+          tag_name: "v${{ steps.metadata.outputs.version }}-pre"
+          name: "UltimateDonutSMP v${{ steps.metadata.outputs.version }}-pre (nightly)"
           body: |
-            ### UltimateDonutSMP v${{ steps.metadata.outputs.version }}-pre${{ steps.build_counter.outputs.build_num }}
-            This is an automated pre-release build compiled from the latest source code.
-            
+            ### UltimateDonutSMP v${{ steps.metadata.outputs.version }}-pre
+            This is an automated pre-release build, updated in place on every push to `main`.
+
             - **Commit:** ${{ github.sha }}
             - **Branch:** ${{ github.ref_name }}
             - **Build Date:** ${{ github.event.head_commit.timestamp }}
+            - **Build:** #${{ github.run_number }}
           prerelease: true
           files: target/UltimateDonutSmp-${{ steps.metadata.outputs.version }}.jar
           make_latest: false


### PR DESCRIPTION
every push to main currently creates a new tag and release (v1.4-pre1, -pre2, ...). github notifies everyone who starred or watches the repo about each new release, so their home feeds get spammed on every commit. this keeps one rolling pre release per version that is updated in place, saving release notifications for actual releases.