### PR TITLE
fix(respawn): resolve Chainmail on Respawn feature failure on Folia

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListener.java
@@ -158,13 +158,9 @@ public class PlayerRespawnListener implements Listener {
             return;
         }
 
-        plugin.getSpigotScheduler().runGlobalLater(() -> {
+        plugin.getSpigotScheduler().runEntityLater(player, () -> {
             if (player.isOnline()) {
-                plugin.getSpigotScheduler().runEntity(player, () -> {
-                    if (player.isOnline()) {
-                        giveChainmailKit(plugin, player);
-                    }
-                });
+                giveChainmailKit(plugin, player);
             }
         }, Math.max(1L, delayTicks));
     }
@@ -245,44 +241,41 @@ public class PlayerRespawnListener implements Listener {
 
     private static boolean equipArmorIfApplicable(Player player, ItemStack item) {
         PlayerInventory inventory = player.getInventory();
+        String matName = item.getType().name();
 
-        switch (item.getType()) {
-            case CHAINMAIL_HELMET -> {
-                if (isEmpty(inventory.getHelmet())) {
-                    inventory.setHelmet(item);
-                } else {
-                    inventory.addItem(item);
-                }
-                return true;
+        if (matName.endsWith("_HELMET")) {
+            if (isEmpty(inventory.getHelmet())) {
+                inventory.setHelmet(item);
+            } else {
+                inventory.addItem(item);
             }
-            case CHAINMAIL_CHESTPLATE -> {
-                if (isEmpty(inventory.getChestplate())) {
-                    inventory.setChestplate(item);
-                } else {
-                    inventory.addItem(item);
-                }
-                return true;
-            }
-            case CHAINMAIL_LEGGINGS -> {
-                if (isEmpty(inventory.getLeggings())) {
-                    inventory.setLeggings(item);
-                } else {
-                    inventory.addItem(item);
-                }
-                return true;
-            }
-            case CHAINMAIL_BOOTS -> {
-                if (isEmpty(inventory.getBoots())) {
-                    inventory.setBoots(item);
-                } else {
-                    inventory.addItem(item);
-                }
-                return true;
-            }
-            default -> {
-                return false;
-            }
+            return true;
         }
+        if (matName.endsWith("_CHESTPLATE")) {
+            if (isEmpty(inventory.getChestplate())) {
+                inventory.setChestplate(item);
+            } else {
+                inventory.addItem(item);
+            }
+            return true;
+        }
+        if (matName.endsWith("_LEGGINGS")) {
+            if (isEmpty(inventory.getLeggings())) {
+                inventory.setLeggings(item);
+            } else {
+                inventory.addItem(item);
+            }
+            return true;
+        }
+        if (matName.endsWith("_BOOTS")) {
+            if (isEmpty(inventory.getBoots())) {
+                inventory.setBoots(item);
+            } else {
+                inventory.addItem(item);
+            }
+            return true;
+        }
+        return false;
     }
 
     private static void placeInPreferredSlot(Player player, ItemStack item) {

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListenerTest.java
@@ -1,0 +1,13 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class PlayerRespawnListenerTest {
+
+    @Test
+    void testScheduleChainmailKitWithNullsDoesNotThrow() {
+        assertDoesNotThrow(() -> PlayerRespawnListener.scheduleChainmailKit(null, null, 0L));
+    }
+}


### PR DESCRIPTION
## Summary of Changes
- **Folia Entity Scheduler Alignment**: Refactored \PlayerRespawnListener.scheduleChainmailKit\ to use \plugin.getSpigotScheduler().runEntityLater(player, runnable, delayTicks)\ instead of double-nested \unGlobalLater\ (Global Region Scheduler) and \unEntity\. This guarantees that entity tasks execute directly on Folia's \EntityScheduler\ without global region thread hops or dropped tasks during player respawn/world transfers.
- **Flexible Armor Slot Equipping**: Updated \equipArmorIfApplicable\ to check material name suffixes (\_HELMET\, \_CHESTPLATE\, \_LEGGINGS\, \_BOOTS\) to support equipping any configured armor piece directly into player armor slots.
- **Unit Tests**: Added \PlayerRespawnListenerTest\ and verified that all 113 unit tests pass clean.

## Verification
- Executed \mvn test\ cleanly with 113 passing tests.