### PR TITLE
fix(staff-mode): prevent creative item dropping into hotbar (#39)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
@@ -47,9 +47,17 @@ public class StaffModeListener implements Listener {
         boolean movingBetweenInventories = event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
                 || event.getClick().isKeyboardClick()
                 || event.getAction() == InventoryAction.COLLECT_TO_CURSOR;
+        boolean isDropAction = event.getAction() == InventoryAction.DROP_ALL_CURSOR
+                || event.getAction() == InventoryAction.DROP_ONE_CURSOR
+                || event.getAction() == InventoryAction.DROP_ALL_SLOT
+                || event.getAction() == InventoryAction.DROP_ONE_SLOT;
+        boolean isOutsideClick = event.getSlotType() == org.bukkit.event.inventory.InventoryType.SlotType.OUTSIDE
+                || event.getClickedInventory() == null;
 
         if (!clickOwnInventory
                 && !movingBetweenInventories
+                && !isDropAction
+                && !isOutsideClick
                 && !plugin.getStaffModeManager().isStaffTool(currentItem)
                 && !plugin.getStaffModeManager().isStaffTool(cursorItem)) {
             return;


### PR DESCRIPTION
Fixes #39 where dragging or dropping items out of Creative mode inventory while in Staff Mode resulted in the created items being placed into the player's hotbar.

## Cause of the Bug
When in Staff Mode with \LOCK-TOOLS: true\, dropping an item from the Creative inventory triggers an \InventoryClickEvent\/\InventoryCreativeEvent\ targeting an outside slot or drop action. \StaffModeListener#onInventoryClick\ ignored non-staff tool items clicked outside the player's inventory, returning early without cancelling the event. While \PlayerDropItemEvent\ cancelled spawning the item entity in the world, Minecraft's creative fallback placed the newly created item into the player's hotbar.

## Changes Made
- Updated \StaffModeListener#onInventoryClick\ to detect inventory drop actions (\DROP_ALL_CURSOR\, \DROP_ONE_CURSOR\, \DROP_ALL_SLOT\, \DROP_ONE_SLOT\) and clicks outside the window (\SlotType.OUTSIDE\ or \getClickedInventory() == null\).
- Directly cancel the event and deny the result when Staff Mode tool locking is enabled, preventing creative item creation from going uncancelled.

## Verification
- Ran \mvn clean test\ successfully with 113/113 tests passing.