### PR TITLE
fix(staffmode): debounce tool interact events to prevent double click on blocks (#42)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
@@ -19,12 +19,20 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class StaffModeListener implements Listener {
 
+    private static final long INTERACT_COOLDOWN_MS = 200L;
+
     private final UltimateDonutSmp plugin;
+    private final Map<UUID, Long> lastInteractTimes = new ConcurrentHashMap<>();
 
     public StaffModeListener(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -135,13 +143,23 @@ public class StaffModeListener implements Listener {
         event.setUseInteractedBlock(org.bukkit.event.Event.Result.DENY);
 
         Action action = event.getAction();
-        if ((action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
-                && toolType == StaffToolType.FREEZE) {
-            plugin.getStaffModeManager().openFrozenPlayers(player);
+        boolean isLeftClickFreeze = (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
+                && toolType == StaffToolType.FREEZE;
+        boolean isRightClick = (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK);
+
+        if (!isLeftClickFreeze && !isRightClick) {
             return;
         }
 
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+        long now = System.currentTimeMillis();
+        Long last = lastInteractTimes.get(player.getUniqueId());
+        if (last != null && (now - last) < INTERACT_COOLDOWN_MS) {
+            return;
+        }
+        lastInteractTimes.put(player.getUniqueId(), now);
+
+        if (isLeftClickFreeze) {
+            plugin.getStaffModeManager().openFrozenPlayers(player);
             return;
         }
 
@@ -189,6 +207,11 @@ public class StaffModeListener implements Listener {
             default -> {
             }
         }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        lastInteractTimes.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
@@ -1,0 +1,147 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.StaffModeManager;
+import com.bx.ultimateDonutSmp.staff.StaffToolType;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StaffModeListenerTest {
+
+    private UUID playerUuid;
+    private AtomicInteger vanishToggleCount;
+    private StaffModeListener listener;
+
+    public static class TestStaffModeManager extends StaffModeManager {
+        private AtomicInteger toggleCount;
+
+        public TestStaffModeManager() {
+            super(null);
+        }
+
+        @Override
+        public boolean isInStaffMode(UUID uuid) {
+            return true;
+        }
+
+        @Override
+        public StaffToolType resolveTool(ItemStack item) {
+            return StaffToolType.VANISH;
+        }
+
+        @Override
+        public boolean canUseVanish(Player player) {
+            return true;
+        }
+
+        @Override
+        public boolean toggleVanish(Player player) {
+            if (toggleCount != null) {
+                toggleCount.incrementAndGet();
+            }
+            return true;
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        playerUuid = UUID.randomUUID();
+        vanishToggleCount = new AtomicInteger(0);
+
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+
+        Constructor<?> pluginConstructor = reflectionFactory.newConstructorForSerialization(
+                UltimateDonutSmp.class, objectConstructor
+        );
+        UltimateDonutSmp mockPlugin = (UltimateDonutSmp) pluginConstructor.newInstance();
+
+        Constructor<?> smmConstructor = reflectionFactory.newConstructorForSerialization(
+                TestStaffModeManager.class, objectConstructor
+        );
+        TestStaffModeManager mockStaffModeManager = (TestStaffModeManager) smmConstructor.newInstance();
+
+        Field countField = TestStaffModeManager.class.getDeclaredField("toggleCount");
+        countField.setAccessible(true);
+        countField.set(mockStaffModeManager, vanishToggleCount);
+
+        Field smmField = UltimateDonutSmp.class.getDeclaredField("staffModeManager");
+        smmField.setAccessible(true);
+        smmField.set(mockPlugin, mockStaffModeManager);
+
+        listener = new StaffModeListener(mockPlugin);
+    }
+
+    @Test
+    void interactDebouncesRapidClicks() throws Exception {
+        Player mockPlayer = (Player) Proxy.newProxyInstance(
+                StaffModeListenerTest.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return playerUuid;
+                    }
+                    return null;
+                }
+        );
+
+        ItemStack mockItem = new ItemStack(Material.FEATHER);
+
+        PlayerInteractEvent event1 = new PlayerInteractEvent(
+                mockPlayer,
+                Action.RIGHT_CLICK_BLOCK,
+                mockItem,
+                null,
+                null,
+                EquipmentSlot.HAND
+        );
+
+        PlayerInteractEvent event2 = new PlayerInteractEvent(
+                mockPlayer,
+                Action.RIGHT_CLICK_AIR,
+                mockItem,
+                null,
+                null,
+                EquipmentSlot.HAND
+        );
+
+        listener.onInteract(event1);
+        assertTrue(event1.isCancelled(), "First event should be cancelled");
+        assertEquals(1, vanishToggleCount.get(), "First click should trigger vanish toggle");
+
+        listener.onInteract(event2);
+        assertTrue(event2.isCancelled(), "Second event should still be cancelled");
+        assertEquals(1, vanishToggleCount.get(), "Rapid second click within 200ms should be debounced");
+
+        Thread.sleep(210);
+
+        PlayerInteractEvent event3 = new PlayerInteractEvent(
+                mockPlayer,
+                Action.RIGHT_CLICK_AIR,
+                mockItem,
+                null,
+                null,
+                EquipmentSlot.HAND
+        );
+
+        listener.onInteract(event3);
+        assertTrue(event3.isCancelled(), "Third event should be cancelled");
+        assertEquals(2, vanishToggleCount.get(), "Click after cooldown expires should trigger vanish toggle again");
+    }
+}


### PR DESCRIPTION
Fixes #42

### Summary
When right-clicking a block with a staff mode tool (such as Vanish), Bukkit/Paper fires a \RIGHT_CLICK_BLOCK\ event, followed immediately by a fallback \RIGHT_CLICK_AIR\ event (due to block usage denial/cancellation). This caused staff tool actions to trigger twice per physical click (e.g. toggling vanish on then immediately off).

### Changes
- Added a 200ms per-player interact debounce in \StaffModeListener\.
- Dispatched events still cancel block/item interaction, but secondary tool action executions within 200ms are ignored.
- Added player cleanup on \PlayerQuitEvent\.
- Added unit test \StaffModeListenerTest\ verifying click debouncing logic.

### Verification
- \mvn test\ passes cleanly (114 tests passed).