### PR TITLE
fix(duels): prevent End City Elytra looting and duel world border exploits (#43)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
@@ -3,8 +3,12 @@ package com.bx.ultimateDonutSmp.listeners;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.DuelManager;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EnderCrystal;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -17,13 +21,19 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityPlaceEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.persistence.PersistentDataType;
@@ -149,6 +159,11 @@ public class DuelListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onTeleport(PlayerTeleportEvent event) {
+        plugin.getDuelManager().handleArenaBorderTeleport(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onCrystalPlace(EntityPlaceEvent event) {
         if (!(event.getEntity() instanceof EnderCrystal crystal)) {
             return;
@@ -250,6 +265,70 @@ public class DuelListener implements Listener {
                     player.updateInventory();
                 }
             });
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        UUID uuid = player.getUniqueId();
+        if (!plugin.getDuelManager().isInDuel(uuid) && !plugin.getDuelManager().isTransitioning(uuid)) {
+            return;
+        }
+        com.bx.ultimateDonutSmp.models.DuelMatch match = plugin.getDuelManager().getActiveMatch(uuid);
+        if (match != null && match.usesGeneratedWorld()) {
+            InventoryType type = event.getInventory().getType();
+            if (type != InventoryType.CRAFTING && type != InventoryType.PLAYER) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        if (!plugin.getDuelManager().isInDuel(uuid) && !plugin.getDuelManager().isTransitioning(uuid)) {
+            return;
+        }
+        com.bx.ultimateDonutSmp.models.DuelMatch match = plugin.getDuelManager().getActiveMatch(uuid);
+        if (match != null && match.usesGeneratedWorld()) {
+            if (event.getClickedBlock() != null && event.getClickedBlock().getState() instanceof Container) {
+                if (!plugin.getDuelManager().canModifyArena(player)) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        if (!plugin.getDuelManager().isInDuel(uuid) && !plugin.getDuelManager().isTransitioning(uuid)) {
+            return;
+        }
+        com.bx.ultimateDonutSmp.models.DuelMatch match = plugin.getDuelManager().getActiveMatch(uuid);
+        if (match != null && match.usesGeneratedWorld()) {
+            if (event.getRightClicked() instanceof ItemFrame || event.getRightClicked() instanceof ArmorStand) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onItemPickup(EntityPickupItemEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        UUID uuid = player.getUniqueId();
+        if (plugin.getDuelManager().isInDuel(uuid) || plugin.getDuelManager().isTransitioning(uuid)) {
+            if (event.getItem().getItemStack().getType() == Material.ELYTRA) {
+                event.setCancelled(true);
+                event.getItem().remove();
+            }
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
@@ -34,6 +34,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.Damageable;
@@ -1157,6 +1158,23 @@ public class DuelManager {
         if (isInsideGeneratedArenaBorder(match, event.getFrom())) {
             event.setTo(event.getFrom());
         } else {
+            pushPlayerBackToArena(player, match);
+        }
+    }
+
+    public void handleArenaBorderTeleport(PlayerTeleportEvent event) {
+        if (event == null || event.getTo() == null) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        DuelMatch match = getActiveMatch(player.getUniqueId());
+        if (match == null || !match.usesGeneratedWorld() || !worldManager.isBorderEnabled()) {
+            return;
+        }
+
+        if (!isInsideGeneratedArenaBorder(match, event.getTo())) {
+            event.setCancelled(true);
             pushPlayerBackToArena(player, match);
         }
     }
@@ -2771,7 +2789,7 @@ public class DuelManager {
         }
     }
 
-    private DuelMatch getActiveMatch(UUID uuid) {
+    public DuelMatch getActiveMatch(UUID uuid) {
         if (uuid == null) {
             return null;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DuelWorldManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DuelWorldManager.java
@@ -60,6 +60,19 @@ public class DuelWorldManager {
     private static final String VANILLA_POOL_PATH = RANDOM_BIOMES_PATH + ".VANILLA_POOL";
     private static final String WORLDBORDER_PATH = "WORLDBORDER";
 
+    private static final Set<String> DEFAULT_EXCLUDED_BIOMES = Set.of(
+            "minecraft:the_end",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands",
+            "minecraft:end_barrens",
+            "minecraft:small_end_islands",
+            "minecraft:nether_wastes",
+            "minecraft:soul_sand_valley",
+            "minecraft:crimson_forest",
+            "minecraft:warped_forest",
+            "minecraft:basalt_deltas"
+    );
+
     private final UltimateDonutSmp plugin;
     private final Set<String> generatedWorldNames = new HashSet<>();
     private final Set<String> reusableFlatWorldNames = new HashSet<>();
@@ -218,6 +231,9 @@ public class DuelWorldManager {
                 continue;
             }
             if (excluded.contains(key)) {
+                continue;
+            }
+            if (allowed.isEmpty() && DEFAULT_EXCLUDED_BIOMES.contains(key)) {
                 continue;
             }
             result.add(biome);
@@ -929,7 +945,7 @@ public class DuelWorldManager {
         int radius = getArenaRadius();
         border.setCenter(0.5D, 0.5D);
         border.setSize(Math.max(2D, config().getDouble(WORLDBORDER_PATH + ".SIZE", radius * 2D)));
-        border.setDamageAmount(0D);
+        border.setDamageAmount(Math.max(0.1D, config().getDouble(WORLDBORDER_PATH + ".DAMAGE_AMOUNT", 1.0D)));
         border.setDamageBuffer(Math.max(0D, config().getDouble(WORLDBORDER_PATH + ".DAMAGE_BUFFER", 0D)));
         border.setWarningDistance(Math.max(0, config().getInt(WORLDBORDER_PATH + ".WARNING_DISTANCE", 4)));
         border.setWarningTime(Math.max(0, config().getInt(WORLDBORDER_PATH + ".WARNING_TIME", 5)));

--- a/src/main/resources/duels.yml
+++ b/src/main/resources/duels.yml
@@ -127,7 +127,17 @@ MAP_SOURCES:
     # Whitelist of biome keys allowed for selection (empty [] = all biomes allowed)
     ALLOWLIST: []
     # Blacklist of biome keys excluded from selection
-    EXCLUDE: []
+    EXCLUDE:
+      - "minecraft:the_end"
+      - "minecraft:end_highlands"
+      - "minecraft:end_midlands"
+      - "minecraft:end_barrens"
+      - "minecraft:small_end_islands"
+      - "minecraft:nether_wastes"
+      - "minecraft:soul_sand_valley"
+      - "minecraft:crimson_forest"
+      - "minecraft:warped_forest"
+      - "minecraft:basalt_deltas"
 
     # Pre-prepared world pool settings for FLAT terrain mode
     FLAT_POOL:


### PR DESCRIPTION
Resolves #43

### Summary of Changes
- **Biome Exclusions**: Excluded End biomes (\	he_end\, \end_highlands\, \end_midlands\, \end_barrens\, \small_end_islands\) and Nether biomes by default in \duels.yml\ and \DuelWorldManager.java\ to prevent random biome selection from generating End biomes with End Cities.
- **World Border Damage & Teleport Prevention**: Enabled non-zero world border damage in \DuelWorldManager.java\ and added \PlayerTeleportEvent\ checks in \DuelManager.java\ and \DuelListener.java\ to stop players from glitching or teleporting (Ender Pearls, Chorus Fruit) past arena boundaries.
- **Container & Item Pickup Protection**: Added event listeners in \DuelListener.java\ to block container opening, container block/item frame interactions, and Elytra item pickups during duels.