### PR TITLE
feat(staffmode): add LuckPerms context provider for Staff Mode (#40)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bx</groupId>
     <artifactId>ultimatedonutsmp</artifactId>
-    <version>1.4.1</version>
+    <version>1.5</version>
     <packaging>jar</packaging>
 
     <name>ultimatedonutsmp</name>
@@ -218,6 +218,12 @@
             <groupId>org.geysermc.floodgate</groupId>
             <artifactId>api</artifactId>
             <version>2.2.5-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -113,6 +113,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private LunarRichPresenceManager lunarRichPresenceManager;
     private PingManager pingManager;
     private LuckPermsTablistRefreshBridge luckPermsTablistRefreshBridge;
+    private LuckPermsStaffModeContextBridge luckPermsStaffModeContextBridge;
     private SkinsRestorerTablistRefreshBridge skinsRestorerTablistRefreshBridge;
     private OptimizationManager optimizationManager;
     private CrashProtectionManager crashProtectionManager;
@@ -261,6 +262,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         portalManager = new PortalManager(this);
         portalManager.loadAll();
         initializeLuckPermsTablistRefreshBridge();
+        initializeLuckPermsStaffModeContextBridge();
         initializeSkinsRestorerTablistRefreshBridge();
 
         // 5. Listeners
@@ -369,6 +371,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         if (luckPermsTablistRefreshBridge != null) {
             luckPermsTablistRefreshBridge.shutdown();
+        }
+        if (luckPermsStaffModeContextBridge != null) {
+            luckPermsStaffModeContextBridge.shutdown();
         }
         if (skinsRestorerTablistRefreshBridge != null) {
             skinsRestorerTablistRefreshBridge.shutdown();
@@ -887,6 +892,22 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
     }
 
+    private void initializeLuckPermsStaffModeContextBridge() {
+        if (getServer().getPluginManager().getPlugin("LuckPerms") == null
+                && !isClassAvailable("net.luckperms.api.LuckPermsProvider")) {
+            return;
+        }
+
+        try {
+            luckPermsStaffModeContextBridge = new LuckPermsStaffModeContextBridge(this);
+            luckPermsStaffModeContextBridge.start();
+        } catch (Throwable error) {
+            luckPermsStaffModeContextBridge = null;
+            getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize LuckPerms Staff Mode context bridge.",
+                    error);
+        }
+    }
+
     private void initializeSkinsRestorerTablistRefreshBridge() {
         if (!isClassAvailable("net.skinsrestorer.api.SkinsRestorerProvider")) {
             return;
@@ -1301,6 +1322,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public InvseeManager getInvseeManager() {
         return invseeManager;
+    }
+
+    public LuckPermsStaffModeContextBridge getLuckPermsStaffModeContextBridge() {
+        return luckPermsStaffModeContextBridge;
     }
 
     public ProfileViewerManager getProfileViewerManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/LuckPermsStaffModeContextBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/LuckPermsStaffModeContextBridge.java
@@ -1,0 +1,108 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.logging.Level;
+
+public final class LuckPermsStaffModeContextBridge {
+
+    private final UltimateDonutSmp plugin;
+    private StaffModeContextCalculator calculator;
+    private boolean active = false;
+
+    public LuckPermsStaffModeContextBridge(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        shutdown();
+
+        if (Bukkit.getPluginManager().getPlugin("LuckPerms") == null) {
+            return;
+        }
+
+        boolean enabled = plugin.getConfigManager().getStaffMode()
+                .getBoolean("STAFF-MODE.LUCKPERMS-CONTEXT.ENABLED", true);
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            LuckPerms luckPerms = LuckPermsProvider.get();
+            calculator = new StaffModeContextCalculator();
+            luckPerms.getContextManager().registerCalculator(calculator);
+            active = true;
+            plugin.getLogger().info("LuckPerms Staff Mode context provider registered successfully.");
+        } catch (Throwable error) {
+            active = false;
+            calculator = null;
+            plugin.getLogger().log(Level.WARNING, "Failed to register LuckPerms Staff Mode context calculator.", error);
+        }
+    }
+
+    public void shutdown() {
+        if (active && calculator != null) {
+            try {
+                if (Bukkit.getPluginManager().getPlugin("LuckPerms") != null) {
+                    LuckPermsProvider.get().getContextManager().unregisterCalculator(calculator);
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        active = false;
+        calculator = null;
+    }
+
+    public void signalContextUpdate(Player player) {
+        if (!active || player == null) {
+            return;
+        }
+
+        try {
+            LuckPermsProvider.get().getContextManager().signalContextUpdate(player);
+        } catch (Throwable error) {
+            plugin.getLogger().log(Level.FINE, "Failed to signal LuckPerms context update for player: " + player.getName(), error);
+        }
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    private String getContextKey() {
+        String key = plugin.getConfigManager().getStaffMode()
+                .getString("STAFF-MODE.LUCKPERMS-CONTEXT.KEY", "staffmode");
+        return (key == null || key.isBlank()) ? "staffmode" : key.trim().toLowerCase();
+    }
+
+    private final class StaffModeContextCalculator implements ContextCalculator<Player> {
+
+        @Override
+        public void calculate(Player target, ContextConsumer consumer) {
+            if (plugin.getStaffModeManager() == null || target == null) {
+                return;
+            }
+
+            boolean inStaffMode = plugin.getStaffModeManager().isInStaffMode(target.getUniqueId());
+            String key = getContextKey();
+            consumer.accept(key, inStaffMode ? "true" : "false");
+        }
+
+        @Override
+        public ContextSet estimatePotentialContexts() {
+            String key = getContextKey();
+            return ImmutableContextSet.builder()
+                    .add(key, "true")
+                    .add(key, "false")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
@@ -280,6 +280,10 @@ public class StaffModeManager {
         runtimeSessions.put(player.getUniqueId(), new StaffModeSession(player.getUniqueId()));
         restartRecoveryOnly.remove(player.getUniqueId());
 
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
+        }
+
         player.setGameMode(GameMode.CREATIVE);
         player.setAllowFlight(true);
         rebuildTools(player);
@@ -518,7 +522,11 @@ public class StaffModeManager {
 
         refreshViewerVisibility(player);
         if (state.isVanishActive()) {
-            refreshTargetVisibility(player);
+            applyVanish(player, true);
+        }
+
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
         }
     }
 
@@ -905,6 +913,10 @@ public class StaffModeManager {
         plugin.getDatabaseManager().deleteStaffModeState(player.getUniqueId());
         plugin.getDatabaseManager().deleteStaffModeSnapshot(player.getUniqueId());
         player.updateInventory();
+
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
+        }
         return true;
     }
 

--- a/src/main/resources/staff-mode.yml
+++ b/src/main/resources/staff-mode.yml
@@ -12,6 +12,12 @@ STAFF-MODE:
   LOCK-TOOLS: true
   # Determines whether Restore Inventory On Disable is enabled or disabled. Available options: true, false
   RESTORE-INVENTORY-ON-DISABLE: true
+  # Configuration section for LuckPerms Context.
+  LUCKPERMS-CONTEXT:
+    # Determines whether LuckPerms Context Provider is enabled. Available options: true, false
+    ENABLED: true
+    # The context key registered with LuckPerms (e.g. staffmode=true/false)
+    KEY: "staffmode"
   # Configuration section for Vanish Actionbar.
   VANISH-ACTIONBAR:
     # Determines whether Enabled is enabled or disabled. Available options: true, false


### PR DESCRIPTION
Adds a LuckPerms context provider (staffmode=true/false) for Staff Mode (#40), allowing admins to conditionally grant or revoke permissions dynamically while staff mode is active.