### PR TITLE
fix(logs & worth): add tab completion for /logs and prevent worth lore in custom GUIs

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -84,7 +84,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "ecsee" -> completeEcsee(sender, args);
             case "sellhand" -> singleArg(args, AMOUNTS);
             case "worth" -> completeWorth(sender, args);
-            case "balance", "stats", "playtime", "alts", "profileviewer", "punishments" ->
+            case "balance", "stats", "playtime", "alts", "profileviewer", "punishments", "logs" ->
                     completeKnownPlayer(args, sender, true);
             case "ping", "findplayer" -> completeOnlinePlayer(args, sender, true);
             case "pay", "shardpay" -> completePayment(sender, args);


### PR DESCRIPTION
## Summary
- **Logs Command**: Added player tab completion support for /logs <player> in UniversalCommandTabCompleter so player names are suggested when typing the command in-game.
- **Worth GUI Display**: Prevented worth preview lore from cluttering custom GUI menu items.

## Changes Made
- Modified UniversalCommandTabCompleter.java to include logs in the tab completion player resolution switch case.
- Prevented worth display lore on custom GUI menu items.

## Verification
- Verified compilation with mvn clean compile (BUILD SUCCESS).

## Before
<img width="803" height="351" alt="image" src="https://github.com/user-attachments/assets/3171c66a-ff1d-451f-b304-edb161d07f20" />

## After
<img width="712" height="358" alt="image" src="https://github.com/user-attachments/assets/bdda3508-34aa-4a90-820a-9ac04bef1361" />