### PR TITLE
feat(flyspeed): add /flyspeed command with configurable speed limits

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -639,6 +639,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("leaderboard", lbCmd, FeatureManager.Feature.LEADERBOARDS);
         setExecutor("freeze", new FreezeCommand(this));
         setExecutor("fly", new FlyCommand(this));
+        setExecutor("flyspeed", new FlySpeedCommand(this));
         setExecutor("kill", new KillCommand(this));
         setExecutor("heal", new HealCommand(this));
         setExecutor("feed", new FeedCommand(this));

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/FlySpeedCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/FlySpeedCommand.java
@@ -1,0 +1,154 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+
+public class FlySpeedCommand implements CommandExecutor {
+
+    private static final String PERMISSION = "ultimatedonutsmp.command.flyspeed";
+    private static final String STAFF_PERMISSION = "ultimatedonutsmp.staff.flyspeed";
+    private static final String FLY_STAFF_PERMISSION = "ultimatedonutsmp.staff.fly";
+
+    private final UltimateDonutSmp plugin;
+
+    public FlySpeedCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0 || args.length > 2) {
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <1-10> [player]"));
+            return true;
+        }
+
+        // Permission check
+        if (sender instanceof Player player) {
+            String playerFlyPerm = plugin.getConfigManager().getConfig()
+                    .getString("FLY-SYSTEM.PLAYER-FLY-PERMISSION", "ultimatedonutsmp.player.fly");
+            boolean hasPerm = PermissionUtils.has(player, PERMISSION)
+                    || PermissionUtils.has(player, STAFF_PERMISSION)
+                    || PermissionUtils.has(player, FLY_STAFF_PERMISSION)
+                    || PermissionUtils.has(player, playerFlyPerm);
+
+            if (!hasPerm) {
+                player.sendMessage(ColorUtils.toComponent(
+                        plugin.getConfigManager().getMessageOrDefault("STAFF.NO_PERMISSION_OTHERS", "&cYou do not have permission.")
+                ));
+                return true;
+            }
+        }
+
+        int minSpeed = plugin.getConfigManager().getConfig().getInt("FLY-SYSTEM.MIN-SPEED", 1);
+        int maxSpeed = plugin.getConfigManager().getConfig().getInt("FLY-SYSTEM.MAX-SPEED", 10);
+
+        Double parsedSpeed = null;
+        Player target = null;
+
+        if (args.length == 1) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <1-10> <player>"));
+                return true;
+            }
+            target = player;
+            parsedSpeed = parseSpeed(args[0]);
+        } else { // args.length == 2
+            // Try args[0] as speed, args[1] as player
+            parsedSpeed = parseSpeed(args[0]);
+            if (parsedSpeed != null) {
+                target = findOnlinePlayer(args[1]);
+            } else {
+                // Try args[1] as speed, args[0] as player
+                parsedSpeed = parseSpeed(args[1]);
+                if (parsedSpeed != null) {
+                    target = findOnlinePlayer(args[0]);
+                }
+            }
+
+            if (target == null && parsedSpeed == null) {
+                sendInvalidSpeedMessage(sender, minSpeed, maxSpeed);
+                return true;
+            }
+            if (target == null) {
+                sender.sendMessage(ColorUtils.toComponent("&cPlayer not online."));
+                return true;
+            }
+            // Check permissions for setting others' flyspeed
+            if (sender instanceof Player player && !player.getUniqueId().equals(target.getUniqueId())) {
+                boolean isStaff = PermissionUtils.has(player, STAFF_PERMISSION)
+                        || PermissionUtils.has(player, FLY_STAFF_PERMISSION)
+                        || PermissionUtils.has(player, "ultimatedonutsmp.command.flyspeed.others");
+                if (!isStaff) {
+                    player.sendMessage(ColorUtils.toComponent(
+                            plugin.getConfigManager().getMessageOrDefault("STAFF.NO_PERMISSION_OTHERS", "&cYou do not have permission.")
+                    ));
+                    return true;
+                }
+            }
+        }
+
+        if (parsedSpeed == null || parsedSpeed < minSpeed || parsedSpeed > maxSpeed) {
+            sendInvalidSpeedMessage(sender, minSpeed, maxSpeed);
+            return true;
+        }
+
+        // Convert 1-10 scale to Bukkit's fly speed range (-1.0f to 1.0f). Standard default speed in Bukkit is 0.1f.
+        float bukkitSpeed = (float) (parsedSpeed / 10.0);
+        bukkitSpeed = Math.max(-1.0f, Math.min(1.0f, bukkitSpeed));
+        target.setFlySpeed(bukkitSpeed);
+
+        String speedStr = (parsedSpeed == parsedSpeed.intValue())
+                ? String.valueOf(parsedSpeed.intValue())
+                : String.valueOf(parsedSpeed);
+
+        String setMsg = plugin.getConfigManager().getMessageOrDefault("FLYSPEED.SET", "&aFly speed set to &f{speed}&a.", "{speed}", speedStr, "%speed%", speedStr);
+        target.sendMessage(ColorUtils.toComponent(setMsg, target));
+
+        if (!(sender instanceof Player player) || !player.getUniqueId().equals(target.getUniqueId())) {
+            sender.sendMessage(ColorUtils.toComponent(
+                    "&7Fly speed for &e" + target.getName() + " &7set to &a" + speedStr + "&7."
+            ));
+        }
+
+        return true;
+    }
+
+    private Double parseSpeed(String arg) {
+        try {
+            return Double.parseDouble(arg);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void sendInvalidSpeedMessage(CommandSender sender, int minSpeed, int maxSpeed) {
+        String defaultMsg = "&cInvalid speed. Please enter a number from " + minSpeed + " to " + maxSpeed + ".";
+        String invalidMsg = plugin.getConfigManager().getMessageOrDefault("FLYSPEED.INVALID", defaultMsg);
+        sender.sendMessage(ColorUtils.toComponent(invalidMsg));
+    }
+
+    private Player findOnlinePlayer(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+        Player exact = Bukkit.getPlayerExact(input);
+        if (exact != null) {
+            return exact;
+        }
+        String expected = input.toLowerCase(Locale.ROOT);
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getName().toLowerCase(Locale.ROOT).equals(expected)) {
+                return player;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -471,7 +471,7 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
                     "duel", "queue", "leave", "draw", "arena", "ffa", "ffastats", "ffaarena"
             );
             case "staff" -> List.of(
-                    "staffmode", "stafflist", "staffchat", "helpop", "report", "freeze", "fly",
+                    "staffmode", "stafflist", "staffchat", "helpop", "report", "freeze", "fly", "flyspeed",
                     "heal", "feed", "gamemode", "randomteleport", "teleport", "alts", "vanish",
                     "invsee", "profileviewer", "punishments", "ban", "tempban", "mute", "tempmute",
                     "warn", "kick", "blacklist", "unban", "unmute", "unblacklist", "findplayer", "rename"

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -93,6 +93,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "shards" -> completeShards(sender, args);
             case "freeze" -> completePlayerOrReload(sender, args, "ultimatedonutsmp.admin.freeze", false);
             case "fly", "heal", "feed" -> completeOnlinePlayer(args, sender, true);
+            case "flyspeed" -> completeFlySpeed(args, sender);
             case "staffmode" -> completePlayerOrReload(sender, args, "ultimatedonutsmp.admin.staffmode", true);
             case "helpop", "staffchat" -> List.of();
             case "rename" -> singleArg(args, List.of("reset", "clear", "remove"));
@@ -499,6 +500,16 @@ public class UniversalCommandTabCompleter implements TabCompleter {
 
     private List<String> completeOnlinePlayer(String[] args, CommandSender sender, boolean includeSelf) {
         return args.length == 1 ? partial(args[0], onlinePlayerNames(sender, includeSelf)) : List.of();
+    }
+
+    private List<String> completeFlySpeed(String[] args, CommandSender sender) {
+        if (args.length == 1) {
+            return partial(args[0], List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        }
+        if (args.length == 2) {
+            return partial(args[1], onlinePlayerNames(sender, true));
+        }
+        return List.of();
     }
 
     private List<String> completeKnownPlayer(String[] args, CommandSender sender, boolean includeSelf) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -240,6 +240,10 @@ FLY-SYSTEM:
   PLAYER-FLY-PERMISSION: 'ultimatedonutsmp.player.fly'
   # Disable flight automatically when the player leaves the allowed areas or enters combat.
   AUTO-DISABLE-OUTSIDE: true
+  # Minimum allowed flying speed (integer/decimal between 1 and 10)
+  MIN-SPEED: 1
+  # Maximum allowed flying speed (integer/decimal between 1 and 10)
+  MAX-SPEED: 10
 # Configuration section for Worth Lore.
 WORTH-LORE:
   # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -311,6 +311,12 @@ commands:
     usage: /fly [player]
     permission: ultimatedonutsmp.command.fly
     permission-message: "&cYou do not have permission to use /fly."
+  flyspeed:
+    description: Adjust flying speed for yourself or another player
+    usage: /flyspeed <1-10> [player]
+    aliases: [fs]
+    permission: ultimatedonutsmp.command.flyspeed
+    permission-message: "&cYou do not have permission to use /flyspeed."
   heal:
     description: Restore health for yourself or another player
     usage: /heal [player]
@@ -901,6 +907,9 @@ permissions:
   ultimatedonutsmp.staff.fly:
     description: Toggle flight mode for yourself or another player
     default: op
+  ultimatedonutsmp.staff.flyspeed:
+    description: Adjust flying speed for yourself or another player
+    default: op
   ultimatedonutsmp.staff.heal:
     description: Restore health for yourself or another player
     default: op
@@ -920,6 +929,7 @@ permissions:
       ultimatedonutsmp.staff.freeze: true
       ultimatedonutsmp.staff.freeze.alert: true
       ultimatedonutsmp.staff.fly: true
+      ultimatedonutsmp.staff.flyspeed: true
       ultimatedonutsmp.staff.heal: true
       ultimatedonutsmp.staff.feed: true
       ultimatedonutsmp.staff.gamemode: true
@@ -1404,6 +1414,9 @@ permissions:
     default: op
   ultimatedonutsmp.command.fly:
     description: Access to /fly command
+    default: op
+  ultimatedonutsmp.command.flyspeed:
+    description: Access to /flyspeed command
     default: op
   ultimatedonutsmp.command.heal:
     description: Access to /heal command


### PR DESCRIPTION
Add a /flyspeed <speed> command allowing players with the required permission to adjust flying speed.

where authorized players or staff members can adjust flying speed with configurable minimum and maximum values (FLY-SYSTEM.MIN-SPEED and FLY-SYSTEM.MAX-SPEED)

## Image
<img width="793" height="193" alt="image" src="https://github.com/user-attachments/assets/8e988e75-afe0-42af-a4ea-0d662e024b1e" />

## Video
<a href="https://youtu.be/t1jJ2KNmSyg">
  <img src="https://img.youtube.com/vi/t1jJ2KNmSyg/hqdefault.jpg" alt="Video Preview" width="500" />
</a>