### PR TITLE
feat(shop): add support for item enchantments and enchantment glint

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -247,8 +247,37 @@ public class ShopManager {
             int defaultQuantity,
             Boolean hideQuantityButtons,
             AmethystToolType amethystToolType,
-            long amethystDurationSeconds
+            long amethystDurationSeconds,
+            List<String> enchantments,
+            boolean glint
     ) {
+        public ShopItem(
+                String key,
+                String menuSection,
+                Material material,
+                String displayName,
+                List<String> lore,
+                int slot,
+                double pricePerUnit,
+                Currency currency,
+                String command,
+                boolean giveItem,
+                String permission,
+                int minQuantity,
+                int maxQuantity,
+                int defaultQuantity,
+                Boolean hideQuantityButtons,
+                AmethystToolType amethystToolType,
+                long amethystDurationSeconds
+        ) {
+            this(
+                    key, menuSection, material, displayName, lore, slot, pricePerUnit,
+                    currency, command, giveItem, permission, minQuantity, maxQuantity,
+                    defaultQuantity, hideQuantityButtons, amethystToolType, amethystDurationSeconds,
+                    List.of(), false
+            );
+        }
+
         public boolean isAmethystToolReward() {
             return amethystToolType != null;
         }
@@ -502,6 +531,22 @@ public class ShopManager {
             }
 
             Material material = ItemUtils.parseMaterial(itemSec.getString("MATERIAL", "STONE"));
+
+            List<String> enchantments = new ArrayList<>();
+            if (itemSec.isConfigurationSection("ENCHANTMENTS")) {
+                ConfigurationSection enchSec = itemSec.getConfigurationSection("ENCHANTMENTS");
+                if (enchSec != null) {
+                    for (String enchKey : enchSec.getKeys(false)) {
+                        int level = enchSec.getInt(enchKey, 1);
+                        enchantments.add(enchKey + ":" + level);
+                    }
+                }
+            } else if (itemSec.isList("ENCHANTMENTS")) {
+                enchantments.addAll(itemSec.getStringList("ENCHANTMENTS"));
+            }
+
+            boolean glint = itemSec.getBoolean("GLINT", false);
+
             items.add(new ShopItem(
                     key,
                     menuSection,
@@ -519,7 +564,9 @@ public class ShopManager {
                     itemSec.contains("DEFAULT-QUANTITY") ? itemSec.getInt("DEFAULT-QUANTITY") : -1,
                     itemSec.contains("HIDE-QUANTITY-BUTTONS") ? itemSec.getBoolean("HIDE-QUANTITY-BUTTONS") : null,
                     null,
-                    -1L
+                    -1L,
+                    enchantments,
+                    glint
             ));
         }
 
@@ -920,7 +967,14 @@ public class ShopManager {
     }
 
     private ItemStack createPurchasedItem(ShopItem item, int amount) {
-        return new ItemStack(item.material(), Math.max(1, amount));
+        ItemStack stack = new ItemStack(item.material(), Math.max(1, amount));
+        if (item.enchantments() != null && !item.enchantments().isEmpty()) {
+            ItemUtils.addEnchantments(stack, item.enchantments());
+        }
+        if (item.glint()) {
+            ItemUtils.setGlint(stack, true);
+        }
+        return stack;
     }
 
     private boolean canFitPurchasedItem(Player player, ShopItem item, int amount) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
@@ -284,11 +284,18 @@ public class ShopMenu extends BaseMenu {
             lore.add(replaceShopGuiPlaceholders(line, item, quote, favorite));
         }
 
-        return ItemUtils.createItem(
+        ItemStack displayStack = ItemUtils.createItem(
                 item.material(),
                 plugin.getCurrencyManager().applyStaticPlaceholders(item.displayName()),
                 plugin.getCurrencyManager().applyStaticPlaceholders(lore)
         );
+        if (item.enchantments() != null && !item.enchantments().isEmpty()) {
+            ItemUtils.addEnchantments(displayStack, item.enchantments());
+        }
+        if (item.glint()) {
+            ItemUtils.setGlint(displayStack, true);
+        }
+        return displayStack;
     }
 
     private String replaceShopGuiPlaceholders(

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
@@ -10,6 +10,7 @@ import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.profile.PlayerProfile;
@@ -370,8 +371,31 @@ public class ItemUtils {
     }
 
     public static ItemStack addEnchantments(ItemStack item, List<String> enchantmentStrings) {
-        if (enchantmentStrings == null) return item;
+        if (item == null || enchantmentStrings == null || enchantmentStrings.isEmpty()) return item;
+        ItemMeta meta = item.getItemMeta();
+        if (meta instanceof EnchantmentStorageMeta storageMeta) {
+            for (String entry : enchantmentStrings) {
+                if (entry == null) continue;
+                String[] parts = entry.split(":");
+                if (parts.length < 2) continue;
+                String name = parts[0].trim().toLowerCase();
+                int level;
+                try {
+                    level = Integer.parseInt(parts[1].trim());
+                } catch (NumberFormatException e) {
+                    continue;
+                }
+                Enchantment ench = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(name));
+                if (ench != null) {
+                    storageMeta.addStoredEnchant(ench, level, true);
+                }
+            }
+            item.setItemMeta(storageMeta);
+            return item;
+        }
+
         for (String entry : enchantmentStrings) {
+            if (entry == null) continue;
             String[] parts = entry.split(":");
             if (parts.length < 2) continue;
             String name = parts[0].trim().toLowerCase();
@@ -385,6 +409,26 @@ public class ItemUtils {
             if (ench != null) {
                 item.addUnsafeEnchantment(ench, level);
             }
+        }
+        return item;
+    }
+
+    public static ItemStack setGlint(ItemStack item, boolean glint) {
+        if (item == null || item.getType().isAir()) return item;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return item;
+
+        try {
+            meta.setEnchantmentGlintOverride(glint);
+            item.setItemMeta(meta);
+            return item;
+        } catch (NoSuchMethodError | Exception ignored) {
+        }
+
+        if (glint) {
+            meta.addEnchant(Enchantment.UNBREAKING, 1, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            item.setItemMeta(meta);
         }
         return item;
     }

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -300,6 +300,15 @@ NETHER-MENU:
 GEAR-MENU:
   TITLE: '&8gear - shop'
   SIZE: 27
+  # Custom item enchantments and glow effects can be configured per item:
+  # ENCHANTMENTS:
+  #   MENDING: 1
+  #   UNBREAKING: 3
+  # Or list format:
+  # ENCHANTMENTS:
+  #   - "mending:1"
+  #   - "unbreaking:3"
+  # GLINT: true
   # Configuration section for Obsidian Item.
   OBSIDIAN-ITEM:
     # The text or value for Currency. Available options: Any valid string text


### PR DESCRIPTION
where shop items lacked support for custom enchantments and glowing glint effects, preventing server admins from configuring enchanted gear or visual glints in shop.yml for GUI displays and item purchases.