### PR TITLE
fix(shop): require MATERIAL key for menu items and support GLINT: false to hide enchantment glint

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -113,6 +113,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private LunarRichPresenceManager lunarRichPresenceManager;
     private PingManager pingManager;
     private LuckPermsTablistRefreshBridge luckPermsTablistRefreshBridge;
+    private LuckPermsStaffModeContextBridge luckPermsStaffModeContextBridge;
     private SkinsRestorerTablistRefreshBridge skinsRestorerTablistRefreshBridge;
     private OptimizationManager optimizationManager;
     private CrashProtectionManager crashProtectionManager;
@@ -261,6 +262,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         portalManager = new PortalManager(this);
         portalManager.loadAll();
         initializeLuckPermsTablistRefreshBridge();
+        initializeLuckPermsStaffModeContextBridge();
         initializeSkinsRestorerTablistRefreshBridge();
 
         // 5. Listeners
@@ -369,6 +371,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         if (luckPermsTablistRefreshBridge != null) {
             luckPermsTablistRefreshBridge.shutdown();
+        }
+        if (luckPermsStaffModeContextBridge != null) {
+            luckPermsStaffModeContextBridge.shutdown();
         }
         if (skinsRestorerTablistRefreshBridge != null) {
             skinsRestorerTablistRefreshBridge.shutdown();
@@ -639,6 +644,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("leaderboard", lbCmd, FeatureManager.Feature.LEADERBOARDS);
         setExecutor("freeze", new FreezeCommand(this));
         setExecutor("fly", new FlyCommand(this));
+        setExecutor("flyspeed", new FlySpeedCommand(this));
         setExecutor("kill", new KillCommand(this));
         setExecutor("heal", new HealCommand(this));
         setExecutor("feed", new FeedCommand(this));
@@ -883,6 +889,22 @@ public final class UltimateDonutSmp extends JavaPlugin {
         } catch (Throwable error) {
             luckPermsTablistRefreshBridge = null;
             getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize LuckPerms tablist refresh bridge.",
+                    error);
+        }
+    }
+
+    private void initializeLuckPermsStaffModeContextBridge() {
+        if (getServer().getPluginManager().getPlugin("LuckPerms") == null
+                && !isClassAvailable("net.luckperms.api.LuckPermsProvider")) {
+            return;
+        }
+
+        try {
+            luckPermsStaffModeContextBridge = new LuckPermsStaffModeContextBridge(this);
+            luckPermsStaffModeContextBridge.start();
+        } catch (Throwable error) {
+            luckPermsStaffModeContextBridge = null;
+            getLogger().log(java.util.logging.Level.WARNING, "Failed to initialize LuckPerms Staff Mode context bridge.",
                     error);
         }
     }
@@ -1301,6 +1323,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public InvseeManager getInvseeManager() {
         return invseeManager;
+    }
+
+    public LuckPermsStaffModeContextBridge getLuckPermsStaffModeContextBridge() {
+        return luckPermsStaffModeContextBridge;
     }
 
     public ProfileViewerManager getProfileViewerManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/FlySpeedCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/FlySpeedCommand.java
@@ -1,0 +1,154 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+
+public class FlySpeedCommand implements CommandExecutor {
+
+    private static final String PERMISSION = "ultimatedonutsmp.command.flyspeed";
+    private static final String STAFF_PERMISSION = "ultimatedonutsmp.staff.flyspeed";
+    private static final String FLY_STAFF_PERMISSION = "ultimatedonutsmp.staff.fly";
+
+    private final UltimateDonutSmp plugin;
+
+    public FlySpeedCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0 || args.length > 2) {
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <1-10> [player]"));
+            return true;
+        }
+
+        // Permission check
+        if (sender instanceof Player player) {
+            String playerFlyPerm = plugin.getConfigManager().getConfig()
+                    .getString("FLY-SYSTEM.PLAYER-FLY-PERMISSION", "ultimatedonutsmp.player.fly");
+            boolean hasPerm = PermissionUtils.has(player, PERMISSION)
+                    || PermissionUtils.has(player, STAFF_PERMISSION)
+                    || PermissionUtils.has(player, FLY_STAFF_PERMISSION)
+                    || PermissionUtils.has(player, playerFlyPerm);
+
+            if (!hasPerm) {
+                player.sendMessage(ColorUtils.toComponent(
+                        plugin.getConfigManager().getMessageOrDefault("STAFF.NO_PERMISSION_OTHERS", "&cYou do not have permission.")
+                ));
+                return true;
+            }
+        }
+
+        int minSpeed = plugin.getConfigManager().getConfig().getInt("FLY-SYSTEM.MIN-SPEED", 1);
+        int maxSpeed = plugin.getConfigManager().getConfig().getInt("FLY-SYSTEM.MAX-SPEED", 10);
+
+        Double parsedSpeed = null;
+        Player target = null;
+
+        if (args.length == 1) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <1-10> <player>"));
+                return true;
+            }
+            target = player;
+            parsedSpeed = parseSpeed(args[0]);
+        } else { // args.length == 2
+            // Try args[0] as speed, args[1] as player
+            parsedSpeed = parseSpeed(args[0]);
+            if (parsedSpeed != null) {
+                target = findOnlinePlayer(args[1]);
+            } else {
+                // Try args[1] as speed, args[0] as player
+                parsedSpeed = parseSpeed(args[1]);
+                if (parsedSpeed != null) {
+                    target = findOnlinePlayer(args[0]);
+                }
+            }
+
+            if (target == null && parsedSpeed == null) {
+                sendInvalidSpeedMessage(sender, minSpeed, maxSpeed);
+                return true;
+            }
+            if (target == null) {
+                sender.sendMessage(ColorUtils.toComponent("&cPlayer not online."));
+                return true;
+            }
+            // Check permissions for setting others' flyspeed
+            if (sender instanceof Player player && !player.getUniqueId().equals(target.getUniqueId())) {
+                boolean isStaff = PermissionUtils.has(player, STAFF_PERMISSION)
+                        || PermissionUtils.has(player, FLY_STAFF_PERMISSION)
+                        || PermissionUtils.has(player, "ultimatedonutsmp.command.flyspeed.others");
+                if (!isStaff) {
+                    player.sendMessage(ColorUtils.toComponent(
+                            plugin.getConfigManager().getMessageOrDefault("STAFF.NO_PERMISSION_OTHERS", "&cYou do not have permission.")
+                    ));
+                    return true;
+                }
+            }
+        }
+
+        if (parsedSpeed == null || parsedSpeed < minSpeed || parsedSpeed > maxSpeed) {
+            sendInvalidSpeedMessage(sender, minSpeed, maxSpeed);
+            return true;
+        }
+
+        // Convert 1-10 scale to Bukkit's fly speed range (-1.0f to 1.0f). Standard default speed in Bukkit is 0.1f.
+        float bukkitSpeed = (float) (parsedSpeed / 10.0);
+        bukkitSpeed = Math.max(-1.0f, Math.min(1.0f, bukkitSpeed));
+        target.setFlySpeed(bukkitSpeed);
+
+        String speedStr = (parsedSpeed == parsedSpeed.intValue())
+                ? String.valueOf(parsedSpeed.intValue())
+                : String.valueOf(parsedSpeed);
+
+        String setMsg = plugin.getConfigManager().getMessageOrDefault("FLYSPEED.SET", "&aFly speed set to &f{speed}&a.", "{speed}", speedStr, "%speed%", speedStr);
+        target.sendMessage(ColorUtils.toComponent(setMsg, target));
+
+        if (!(sender instanceof Player player) || !player.getUniqueId().equals(target.getUniqueId())) {
+            sender.sendMessage(ColorUtils.toComponent(
+                    "&7Fly speed for &e" + target.getName() + " &7set to &a" + speedStr + "&7."
+            ));
+        }
+
+        return true;
+    }
+
+    private Double parseSpeed(String arg) {
+        try {
+            return Double.parseDouble(arg);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void sendInvalidSpeedMessage(CommandSender sender, int minSpeed, int maxSpeed) {
+        String defaultMsg = "&cInvalid speed. Please enter a number from " + minSpeed + " to " + maxSpeed + ".";
+        String invalidMsg = plugin.getConfigManager().getMessageOrDefault("FLYSPEED.INVALID", defaultMsg);
+        sender.sendMessage(ColorUtils.toComponent(invalidMsg));
+    }
+
+    private Player findOnlinePlayer(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+        Player exact = Bukkit.getPlayerExact(input);
+        if (exact != null) {
+            return exact;
+        }
+        String expected = input.toLowerCase(Locale.ROOT);
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getName().toLowerCase(Locale.ROOT).equals(expected)) {
+                return player;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -471,7 +471,7 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
                     "duel", "queue", "leave", "draw", "arena", "ffa", "ffastats", "ffaarena"
             );
             case "staff" -> List.of(
-                    "staffmode", "stafflist", "staffchat", "helpop", "report", "freeze", "fly",
+                    "staffmode", "stafflist", "staffchat", "helpop", "report", "freeze", "fly", "flyspeed",
                     "heal", "feed", "gamemode", "randomteleport", "teleport", "alts", "vanish",
                     "invsee", "profileviewer", "punishments", "ban", "tempban", "mute", "tempmute",
                     "warn", "kick", "blacklist", "unban", "unmute", "unblacklist", "findplayer", "rename"

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -84,7 +84,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "ecsee" -> completeEcsee(sender, args);
             case "sellhand" -> singleArg(args, AMOUNTS);
             case "worth" -> completeWorth(sender, args);
-            case "balance", "stats", "playtime", "alts", "profileviewer", "punishments" ->
+            case "balance", "stats", "playtime", "alts", "profileviewer", "punishments", "logs" ->
                     completeKnownPlayer(args, sender, true);
             case "ping", "findplayer" -> completeOnlinePlayer(args, sender, true);
             case "pay", "shardpay" -> completePayment(sender, args);
@@ -93,6 +93,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "shards" -> completeShards(sender, args);
             case "freeze" -> completePlayerOrReload(sender, args, "ultimatedonutsmp.admin.freeze", false);
             case "fly", "heal", "feed" -> completeOnlinePlayer(args, sender, true);
+            case "flyspeed" -> completeFlySpeed(args, sender);
             case "staffmode" -> completePlayerOrReload(sender, args, "ultimatedonutsmp.admin.staffmode", true);
             case "helpop", "staffchat" -> List.of();
             case "rename" -> singleArg(args, List.of("reset", "clear", "remove"));
@@ -499,6 +500,16 @@ public class UniversalCommandTabCompleter implements TabCompleter {
 
     private List<String> completeOnlinePlayer(String[] args, CommandSender sender, boolean includeSelf) {
         return args.length == 1 ? partial(args[0], onlinePlayerNames(sender, includeSelf)) : List.of();
+    }
+
+    private List<String> completeFlySpeed(String[] args, CommandSender sender) {
+        if (args.length == 1) {
+            return partial(args[0], List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        }
+        if (args.length == 2) {
+            return partial(args[1], onlinePlayerNames(sender, true));
+        }
+        return List.of();
     }
 
     private List<String> completeKnownPlayer(String[] args, CommandSender sender, boolean includeSelf) {

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
@@ -77,6 +77,23 @@ public class WorthPacketDisplay implements Listener {
         }
     }
 
+    private boolean isMenuInventory(Player player, org.bukkit.inventory.Inventory topInv) {
+        if (player != null && inPluginMenu.contains(player.getUniqueId())) {
+            return true;
+        }
+        if (topInv == null) {
+            return false;
+        }
+        org.bukkit.inventory.InventoryHolder holder = topInv.getHolder();
+        if (holder instanceof BaseMenu) {
+            return true;
+        }
+        if (holder != null && !(holder instanceof org.bukkit.block.Container) && !(holder instanceof org.bukkit.entity.Player)) {
+            return true;
+        }
+        return false;
+    }
+
     private void registerPacketListener() {
         final UltimateDonutSmp uds = plugin; // packetadapter has its own plugin field
         protocolManager.addPacketListener(new PacketAdapter(plugin, ListenerPriority.NORMAL,
@@ -97,8 +114,31 @@ public class WorthPacketDisplay implements Listener {
                 }
 
                 PacketContainer packet = event.getPacket();
+                int windowId = readWindowId(packet);
+                int topSize = 0;
+                boolean isMenu = false;
+
+                if (windowId > 0) {
+                    try {
+                        org.bukkit.inventory.InventoryView openView = player.getOpenInventory();
+                        if (openView != null) {
+                            org.bukkit.inventory.Inventory topInv = openView.getTopInventory();
+                            if (topInv != null) {
+                                topSize = topInv.getSize();
+                                isMenu = isMenuInventory(player, topInv);
+                            }
+                        }
+                    } catch (Exception ignored) {}
+                    if (!isMenu && inPluginMenu.contains(player.getUniqueId())) {
+                        isMenu = true;
+                    }
+                }
 
                 if (event.getPacketType() == PacketType.Play.Server.SET_SLOT) {
+                    int slot = readSlotIndex(packet);
+                    if (windowId > 0 && isMenu && (slot < topSize || slot == -1 || topSize == 0)) {
+                        return;
+                    }
                     ItemStack item = packet.getItemModifier().read(0);
                     if (item != null && item.getType() == suppressedMat) {
                         return;
@@ -118,6 +158,10 @@ public class WorthPacketDisplay implements Listener {
                 boolean changed = false;
                 for (int i = 0; i < items.size(); i++) {
                     ItemStack item = items.get(i);
+                    if (windowId > 0 && isMenu && (topSize == 0 || i < topSize)) {
+                        updated.add(item);
+                        continue;
+                    }
                     if (item != null && item.getType() == suppressedMat) {
                         updated.add(item);
                         continue;

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/LuckPermsStaffModeContextBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/LuckPermsStaffModeContextBridge.java
@@ -1,0 +1,108 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.logging.Level;
+
+public final class LuckPermsStaffModeContextBridge {
+
+    private final UltimateDonutSmp plugin;
+    private StaffModeContextCalculator calculator;
+    private boolean active = false;
+
+    public LuckPermsStaffModeContextBridge(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        shutdown();
+
+        if (Bukkit.getPluginManager().getPlugin("LuckPerms") == null) {
+            return;
+        }
+
+        boolean enabled = plugin.getConfigManager().getStaffMode()
+                .getBoolean("STAFF-MODE.LUCKPERMS-CONTEXT.ENABLED", true);
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            LuckPerms luckPerms = LuckPermsProvider.get();
+            calculator = new StaffModeContextCalculator();
+            luckPerms.getContextManager().registerCalculator(calculator);
+            active = true;
+            plugin.getLogger().info("LuckPerms Staff Mode context provider registered successfully.");
+        } catch (Throwable error) {
+            active = false;
+            calculator = null;
+            plugin.getLogger().log(Level.WARNING, "Failed to register LuckPerms Staff Mode context calculator.", error);
+        }
+    }
+
+    public void shutdown() {
+        if (active && calculator != null) {
+            try {
+                if (Bukkit.getPluginManager().getPlugin("LuckPerms") != null) {
+                    LuckPermsProvider.get().getContextManager().unregisterCalculator(calculator);
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        active = false;
+        calculator = null;
+    }
+
+    public void signalContextUpdate(Player player) {
+        if (!active || player == null) {
+            return;
+        }
+
+        try {
+            LuckPermsProvider.get().getContextManager().signalContextUpdate(player);
+        } catch (Throwable error) {
+            plugin.getLogger().log(Level.FINE, "Failed to signal LuckPerms context update for player: " + player.getName(), error);
+        }
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    private String getContextKey() {
+        String key = plugin.getConfigManager().getStaffMode()
+                .getString("STAFF-MODE.LUCKPERMS-CONTEXT.KEY", "staffmode");
+        return (key == null || key.isBlank()) ? "staffmode" : key.trim().toLowerCase();
+    }
+
+    private final class StaffModeContextCalculator implements ContextCalculator<Player> {
+
+        @Override
+        public void calculate(Player target, ContextConsumer consumer) {
+            if (plugin.getStaffModeManager() == null || target == null) {
+                return;
+            }
+
+            boolean inStaffMode = plugin.getStaffModeManager().isInStaffMode(target.getUniqueId());
+            String key = getContextKey();
+            consumer.accept(key, inStaffMode ? "true" : "false");
+        }
+
+        @Override
+        public ContextSet estimatePotentialContexts() {
+            String key = getContextKey();
+            return ImmutableContextSet.builder()
+                    .add(key, "true")
+                    .add(key, "false")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -526,7 +526,7 @@ public class ShopManager {
             }
 
             ConfigurationSection itemSec = sourceSection.getConfigurationSection(key);
-            if (itemSec == null || !itemSec.getBoolean("ENABLED", true)) {
+            if (itemSec == null || !itemSec.getBoolean("ENABLED", true) || !itemSec.contains("MATERIAL")) {
                 continue;
             }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -249,7 +249,7 @@ public class ShopManager {
             AmethystToolType amethystToolType,
             long amethystDurationSeconds,
             List<String> enchantments,
-            boolean glint
+            Boolean glint
     ) {
         public ShopItem(
                 String key,
@@ -274,7 +274,7 @@ public class ShopManager {
                     key, menuSection, material, displayName, lore, slot, pricePerUnit,
                     currency, command, giveItem, permission, minQuantity, maxQuantity,
                     defaultQuantity, hideQuantityButtons, amethystToolType, amethystDurationSeconds,
-                    List.of(), false
+                    List.of(), null
             );
         }
 
@@ -545,7 +545,7 @@ public class ShopManager {
                 enchantments.addAll(itemSec.getStringList("ENCHANTMENTS"));
             }
 
-            boolean glint = itemSec.getBoolean("GLINT", false);
+            Boolean glint = itemSec.contains("GLINT") ? itemSec.getBoolean("GLINT") : null;
 
             items.add(new ShopItem(
                     key,
@@ -971,8 +971,8 @@ public class ShopManager {
         if (item.enchantments() != null && !item.enchantments().isEmpty()) {
             ItemUtils.addEnchantments(stack, item.enchantments());
         }
-        if (item.glint()) {
-            ItemUtils.setGlint(stack, true);
+        if (item.glint() != null) {
+            ItemUtils.setGlint(stack, item.glint());
         }
         return stack;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
@@ -280,6 +280,10 @@ public class StaffModeManager {
         runtimeSessions.put(player.getUniqueId(), new StaffModeSession(player.getUniqueId()));
         restartRecoveryOnly.remove(player.getUniqueId());
 
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
+        }
+
         player.setGameMode(GameMode.CREATIVE);
         player.setAllowFlight(true);
         rebuildTools(player);
@@ -518,7 +522,11 @@ public class StaffModeManager {
 
         refreshViewerVisibility(player);
         if (state.isVanishActive()) {
-            refreshTargetVisibility(player);
+            applyVanish(player, true);
+        }
+
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
         }
     }
 
@@ -905,6 +913,10 @@ public class StaffModeManager {
         plugin.getDatabaseManager().deleteStaffModeState(player.getUniqueId());
         plugin.getDatabaseManager().deleteStaffModeSnapshot(player.getUniqueId());
         player.updateInventory();
+
+        if (plugin.getLuckPermsStaffModeContextBridge() != null) {
+            plugin.getLuckPermsStaffModeContextBridge().signalContextUpdate(player);
+        }
         return true;
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
@@ -136,8 +136,8 @@ public class PurchaseShopMenu extends BaseMenu {
         if (item.enchantments() != null && !item.enchantments().isEmpty()) {
             ItemUtils.addEnchantments(preview, item.enchantments());
         }
-        if (item.glint()) {
-            ItemUtils.setGlint(preview, true);
+        if (item.glint() != null) {
+            ItemUtils.setGlint(preview, item.glint());
         }
         preview.setAmount(Math.min(quantity, preview.getMaxStackSize()));
         set(getPreviewSlot(), preview);

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
@@ -133,6 +133,12 @@ public class PurchaseShopMenu extends BaseMenu {
         lore.add("&7ᴄᴜʀʀᴇɴᴄʏ: &f" + plugin.getCurrencyManager().plural(currencyType()));
 
         ItemStack preview = ItemUtils.createItem(item.material(), item.displayName(), lore);
+        if (item.enchantments() != null && !item.enchantments().isEmpty()) {
+            ItemUtils.addEnchantments(preview, item.enchantments());
+        }
+        if (item.glint()) {
+            ItemUtils.setGlint(preview, true);
+        }
         preview.setAmount(Math.min(quantity, preview.getMaxStackSize()));
         set(getPreviewSlot(), preview);
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
@@ -292,8 +292,8 @@ public class ShopMenu extends BaseMenu {
         if (item.enchantments() != null && !item.enchantments().isEmpty()) {
             ItemUtils.addEnchantments(displayStack, item.enchantments());
         }
-        if (item.glint()) {
-            ItemUtils.setGlint(displayStack, true);
+        if (item.glint() != null) {
+            ItemUtils.setGlint(displayStack, item.glint());
         }
         return displayStack;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
@@ -413,13 +413,16 @@ public class ItemUtils {
         return item;
     }
 
-    public static ItemStack setGlint(ItemStack item, boolean glint) {
-        if (item == null || item.getType().isAir()) return item;
+    public static ItemStack setGlint(ItemStack item, Boolean glint) {
+        if (item == null || item.getType().isAir() || glint == null) return item;
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return item;
 
         try {
             meta.setEnchantmentGlintOverride(glint);
+            if (!glint && meta.hasEnchants()) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
             item.setItemMeta(meta);
             return item;
         } catch (NoSuchMethodError | Exception ignored) {
@@ -427,6 +430,9 @@ public class ItemUtils {
 
         if (glint) {
             meta.addEnchant(Enchantment.UNBREAKING, 1, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            item.setItemMeta(meta);
+        } else if (meta.hasEnchants()) {
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             item.setItemMeta(meta);
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
@@ -420,9 +420,6 @@ public class ItemUtils {
 
         try {
             meta.setEnchantmentGlintOverride(glint);
-            if (!glint && meta.hasEnchants()) {
-                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            }
             item.setItemMeta(meta);
             return item;
         } catch (NoSuchMethodError | Exception ignored) {
@@ -430,9 +427,6 @@ public class ItemUtils {
 
         if (glint) {
             meta.addEnchant(Enchantment.UNBREAKING, 1, true);
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            item.setItemMeta(meta);
-        } else if (meta.hasEnchants()) {
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             item.setItemMeta(meta);
         }


### PR DESCRIPTION
misconfigured items in shop.yml missing a material key caused dummy stone items to render in the shop gui, and items with enchantments always displayed a purple glint even when glint was set to false.