### PR TITLE
fix(sell): open sell progress menu for sellmulti/sellprogress commands (#75)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -623,8 +623,11 @@ public final class UltimateDonutSmp extends JavaPlugin {
         SellCommand sellCmd = new SellCommand(this);
         setExecutor("sell", sellCmd, FeatureManager.Feature.SELL);
         setExecutor("sellmulti", sellCmd, FeatureManager.Feature.SELL);
+        setTabCompleter("sellmulti", sellCmd);
         setExecutor("sellmultiplier", sellCmd, FeatureManager.Feature.SELL);
+        setTabCompleter("sellmultiplier", sellCmd);
         setExecutor("sellprogress", sellCmd, FeatureManager.Feature.SELL);
+        setTabCompleter("sellprogress", sellCmd);
         setExecutor("sellhand", sellCmd, FeatureManager.Feature.SELL);
         setExecutor("sellall", sellCmd, FeatureManager.Feature.SELL);
         setExecutor("sellhistory", sellCmd, FeatureManager.Feature.SELL);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/SellCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/SellCommand.java
@@ -4,14 +4,21 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.SellAllConfirmMenu;
 import com.bx.ultimateDonutSmp.menus.SellHistoryMenu;
 import com.bx.ultimateDonutSmp.menus.SellMenu;
+import com.bx.ultimateDonutSmp.menus.SellProgressMenu;
 import com.bx.ultimateDonutSmp.menus.SellStatsAdminMenu;
+import com.bx.ultimateDonutSmp.models.SellCategory;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
-public class SellCommand implements CommandExecutor {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SellCommand implements CommandExecutor, TabCompleter {
 
     private final UltimateDonutSmp plugin;
 
@@ -32,7 +39,14 @@ public class SellCommand implements CommandExecutor {
         }
 
         switch (label.toLowerCase()) {
-            case "sell", "sellmulti", "sellmultiplier", "sellprogress" -> new SellMenu(plugin).open(player);
+            case "sell" -> new SellMenu(plugin).open(player);
+            case "sellmulti", "sellmultiplier", "sellprogress" -> {
+                SellCategory category = SellCategory.CROPS;
+                if (args.length > 0) {
+                    category = SellCategory.fromConfigKey(args[0]).orElse(SellCategory.CROPS);
+                }
+                new SellProgressMenu(plugin, category).open(player);
+            }
             case "sellhand"    -> {
                 double total = plugin.getShopManager().sellInventory(player, true);
                 if (total <= 0) player.sendMessage(ColorUtils.toComponent(
@@ -49,4 +63,20 @@ public class SellCommand implements CommandExecutor {
         }
         return true;
     }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1 && (alias.equalsIgnoreCase("sellmulti") || alias.equalsIgnoreCase("sellmultiplier") || alias.equalsIgnoreCase("sellprogress"))) {
+            List<String> completions = new ArrayList<>();
+            String input = args[0].toLowerCase();
+            for (SellCategory category : SellCategory.values()) {
+                if (category.name().toLowerCase().startsWith(input) || category.getConfigKey().toLowerCase().startsWith(input)) {
+                    completions.add(category.getConfigKey().toLowerCase());
+                }
+            }
+            return completions;
+        }
+        return Collections.emptyList();
+    }
 }
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -181,26 +181,22 @@ commands:
   sell:
     description: Open sell menu
     usage: /sell
-    aliases:
-    - sellmulti
-    - sellmultiplier
-    - sellprogress
     permission: ultimatedonutsmp.command.sell
     permission-message: "&cYou do not have permission to use /sell."
   sellmulti:
     description: Open sell multiplier menu
-    usage: /sellmulti
-    permission: ultimatedonutsmp.command.sell
+    usage: /sellmulti [category]
+    permission: ultimatedonutsmp.command.sellmulti
     permission-message: "&cYou do not have permission to use /sellmulti."
   sellmultiplier:
     description: Open sell multiplier menu
-    usage: /sellmultiplier
-    permission: ultimatedonutsmp.command.sell
+    usage: /sellmultiplier [category]
+    permission: ultimatedonutsmp.command.sellmulti
     permission-message: "&cYou do not have permission to use /sellmultiplier."
   sellprogress:
     description: Open sell multiplier progress menu
-    usage: /sellprogress
-    permission: ultimatedonutsmp.command.sell
+    usage: /sellprogress [category]
+    permission: ultimatedonutsmp.command.sellprogress
     permission-message: "&cYou do not have permission to use /sellprogress."
   sellhand:
     description: Sell item in hand
@@ -1176,6 +1172,8 @@ permissions:
       ultimatedonutsmp.command.auctionhouse: true
       ultimatedonutsmp.command.enderchest: true
       ultimatedonutsmp.command.sell: true
+      ultimatedonutsmp.command.sellmulti: true
+      ultimatedonutsmp.command.sellprogress: true
       ultimatedonutsmp.command.sellhand: true
       ultimatedonutsmp.command.sellall: true
       ultimatedonutsmp.command.sellhistory: true
@@ -1354,6 +1352,12 @@ permissions:
     default: true
   ultimatedonutsmp.command.sell:
     description: Access to /sell command
+    default: true
+  ultimatedonutsmp.command.sellmulti:
+    description: Access to /sellmulti command
+    default: true
+  ultimatedonutsmp.command.sellprogress:
+    description: Access to /sellprogress command
     default: true
   ultimatedonutsmp.command.sellhand:
     description: Access to /sellhand command


### PR DESCRIPTION
Using /sellmulti or /sellprogress led players to the general /sell GUI instead of opening the sell multiplier progress menu, while missing permission nodes prevented LuckPerms from managing access.