### PR TITLE
fix(database): adapt MySQL/MariaDB TEXT columns to VARCHAR(191) (#79)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -784,7 +784,7 @@ public class DatabaseManager {
     private void ensureColumnExists(String table, String column, String definition) throws SQLException {
         if (hasColumn(table, column)) return;
         try (Statement st = connection.createStatement()) {
-            st.execute("ALTER TABLE " + table + " ADD COLUMN " + column + " " + definition);
+            st.execute(adaptSchemaSql("ALTER TABLE " + table + " ADD COLUMN " + column + " " + definition));
         }
     }
 
@@ -3977,8 +3977,7 @@ public class DatabaseManager {
         String adapted = sql.replace("INTEGER PRIMARY KEY AUTOINCREMENT", "BIGINT PRIMARY KEY AUTO_INCREMENT");
         adapted = adapted.replaceAll("(?i)\\bINTEGER\\b", "BIGINT");
         adapted = adapted.replaceAll("(?i)\\bREAL\\b", "DOUBLE");
-        adapted = adapted.replaceAll("(?i)\\b([a-z0-9_]*uuid|[a-z0-9_]*name|ip_address|id|world|section|category|crate_id|loot_key)\\s+TEXT", "$1 VARCHAR(191)");
-        adapted = adapted.replaceAll("(?i)\\b(source_server|scope|previous_game_mode|type|status|claim_type|match_type|arena_id|mob_type|access_mode|material|mode|alias_normalized|skin_key|skin_username)\\s+TEXT", "$1 VARCHAR(191)");
+        adapted = adapted.replaceAll("(?i)(`?)\\b(?!(?:item_data|details|reason|removal_reason|texture_value|texture_signature|disabled_loot_keys)\\b)([a-z0-9_]+)\\b(`?)\\s+TEXT\\b", "$1$2$3 VARCHAR(191)");
         adapted = adapted.replaceAll("(?i)\\b(?<!`)rows(?!`)\\b", "`rows`");
         return adapted;
     }
@@ -4003,6 +4002,8 @@ public class DatabaseManager {
         }
 
         if (isMySql()) {
+            fixMySqlIndexColumnTypes(table, columns);
+
             DatabaseMetaData metaData = connection.getMetaData();
             try (ResultSet rs = metaData.getIndexInfo(connection.getCatalog(), null, table, false, false)) {
                 while (rs.next()) {
@@ -4021,6 +4022,32 @@ public class DatabaseManager {
 
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE INDEX IF NOT EXISTS " + indexName + " ON " + table + " (" + columns + ")");
+        }
+    }
+
+    private void fixMySqlIndexColumnTypes(String table, String columns) {
+        if (!isMySql()) return;
+        String[] colArray = columns.split(",");
+        for (String rawCol : colArray) {
+            String colName = rawCol.trim().split("\\s+")[0].replaceAll("[`\"'\\[\\]]", "");
+            if (colName.isBlank()) continue;
+            try {
+                DatabaseMetaData metaData = connection.getMetaData();
+                try (ResultSet rs = metaData.getColumns(connection.getCatalog(), null, table, colName)) {
+                    if (rs.next()) {
+                        String typeName = rs.getString("TYPE_NAME");
+                        String isNullable = rs.getString("IS_NULLABLE");
+                        if ("TEXT".equalsIgnoreCase(typeName) || "MEDIUMTEXT".equalsIgnoreCase(typeName) || "LONGTEXT".equalsIgnoreCase(typeName)) {
+                            String nullability = "NO".equalsIgnoreCase(isNullable) ? " NOT NULL" : "";
+                            try (Statement stmt = connection.createStatement()) {
+                                stmt.execute("ALTER TABLE " + table + " MODIFY " + colName + " VARCHAR(191)" + nullability);
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Could not auto-modify MySQL column " + table + "." + colName + ": " + e.getMessage());
+            }
         }
     }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerSchemaAdaptationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerSchemaAdaptationTest.java
@@ -33,6 +33,48 @@ class DatabaseManagerSchemaAdaptationTest {
     }
 
     @Test
+    void adaptSchemaSqlConvertsWipeIdAndLogTypeToVarcharAndPreservesBlacklistedTextFields() throws Exception {
+        DatabaseManager manager = new DatabaseManager(null);
+        Field typeField = DatabaseManager.class.getDeclaredField("databaseType");
+        typeField.setAccessible(true);
+        typeField.set(manager, DatabaseManager.DatabaseType.MYSQL);
+
+        String wipeSql = "CREATE TABLE IF NOT EXISTS server_wipe_commits (" +
+                " wipe_id TEXT PRIMARY KEY," +
+                " committed_at INTEGER NOT NULL" +
+                ")";
+        String adaptedWipe = manager.adaptSchemaSql(wipeSql);
+        assertTrue(adaptedWipe.contains("wipe_id VARCHAR(191) PRIMARY KEY"), "adapted SQL should convert wipe_id TEXT to VARCHAR(191)");
+
+        String logSql = "CREATE TABLE IF NOT EXISTS player_logs (" +
+                " id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                " player_uuid TEXT NOT NULL," +
+                " player_name TEXT NOT NULL," +
+                " category TEXT NOT NULL," +
+                " log_type TEXT NOT NULL," +
+                " details TEXT NOT NULL," +
+                " timestamp INTEGER NOT NULL" +
+                ")";
+        String adaptedLog = manager.adaptSchemaSql(logSql);
+        assertTrue(adaptedLog.contains("log_type VARCHAR(191) NOT NULL"), "adapted SQL should convert log_type TEXT to VARCHAR(191)");
+        assertTrue(adaptedLog.contains("details TEXT NOT NULL"), "adapted SQL should preserve details as TEXT");
+        assertTrue(adaptedLog.contains("player_uuid VARCHAR(191) NOT NULL"), "adapted SQL should convert player_uuid TEXT to VARCHAR(191)");
+
+        String spawnerSql = "CREATE TABLE IF NOT EXISTS spawners (" +
+                " id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                " world TEXT NOT NULL," +
+                " disabled_loot_keys TEXT DEFAULT ''" +
+                ")";
+        String adaptedSpawner = manager.adaptSchemaSql(spawnerSql);
+        assertTrue(adaptedSpawner.contains("world VARCHAR(191) NOT NULL"), "adapted SQL should convert world TEXT to VARCHAR(191)");
+        assertTrue(adaptedSpawner.contains("disabled_loot_keys TEXT DEFAULT ''"), "adapted SQL should preserve disabled_loot_keys as TEXT");
+
+        String backtickSql = "CREATE TABLE IF NOT EXISTS demo (`wipe_id` TEXT PRIMARY KEY)";
+        String adaptedBacktick = manager.adaptSchemaSql(backtickSql);
+        assertTrue(adaptedBacktick.contains("`wipe_id` VARCHAR(191) PRIMARY KEY"), "adapted SQL should handle backticked identifiers");
+    }
+
+    @Test
     void enderChestProfilesCanBeCreatedAndQueriedInDatabase() throws Exception {
         try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
              Statement statement = connection.createStatement()) {
@@ -63,3 +105,4 @@ class DatabaseManagerSchemaAdaptationTest {
         }
     }
 }
+


### PR DESCRIPTION
MySQL and MariaDB rejected table creation and index building due to unbounded TEXT columns like wipe_id and log_type being used in key specifications and indexes, causing DatabaseManager initialization failures. Fixes #79.