### PR TITLE
fix(discord): prevent commented lines from being sent to discord webhooks (#83)

### DIFF
--- a/docs/wiki/Config-discord.yml.md
+++ b/docs/wiki/Config-discord.yml.md
@@ -30,32 +30,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FF0000'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':hammer: **Punishment Type:** Ban
+      DESCRIPTION: |-
+        :hammer: **Punishment Type:** Ban
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -70,26 +63,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FFFF00'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':mute: **Punishment Type:** Mute
+      DESCRIPTION: |-
+        :mute: **Punishment Type:** Mute
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
+        %date%
+
+        **ID:** `%id%`
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -104,28 +96,28 @@ WEBHOOKS:
 | `WEBHOOKS.MESSAGES.BAN.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `WEBHOOKS` system. Set to `true` to enable, `false` to disable. |
 | `WEBHOOKS.MESSAGES.BAN.TITLE` | `str` | Any string text | `'Player Banned - %player%'` | Configures the technical `TITLE` parameter for `WEBHOOKS.MESSAGES.BAN.TITLE` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.BAN.COLOR` | `str` | Any string text | `'#FF0000'` | Configures the technical `COLOR` parameter for `WEBHOOKS.MESSAGES.BAN.COLOR` in `discord.yml`. |
-| `WEBHOOKS.MESSAGES.BAN.DESCRIPTION` | `str` | Any string text | `':hammer: **Punishment Type:** Ban #...'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.BAN.DESCRIPTION` in `discord.yml`. |
+| `WEBHOOKS.MESSAGES.BAN.DESCRIPTION` | `str` | Any string text | `':hammer: **Punishment Type:** Ban'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.BAN.DESCRIPTION` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.BAN.THUMBNAIL` | `str` | Any string text | `'%skin_bust%'` | Configures the technical `THUMBNAIL` parameter for `WEBHOOKS.MESSAGES.BAN.THUMBNAIL` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.BAN.AUTHOR_NAME` | `str` | Any string text | `'Ban System'` | Configures the technical `AUTHOR_NAME` parameter for `WEBHOOKS.MESSAGES.BAN.AUTHOR_NAME` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.BAN.FOOTER` | `str` | Any string text | `'Punishment issued via server'` | Configures the technical `FOOTER` parameter for `WEBHOOKS.MESSAGES.BAN.FOOTER` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.MUTE.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `WEBHOOKS` system. Set to `true` to enable, `false` to disable. |
 | `WEBHOOKS.MESSAGES.MUTE.TITLE` | `str` | Any string text | `'Player Muted - %player%'` | Configures the technical `TITLE` parameter for `WEBHOOKS.MESSAGES.MUTE.TITLE` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.MUTE.COLOR` | `str` | Any string text | `'#FFFF00'` | Configures the technical `COLOR` parameter for `WEBHOOKS.MESSAGES.MUTE.COLOR` in `discord.yml`. |
-| `WEBHOOKS.MESSAGES.MUTE.DESCRIPTION` | `str` | Any string text | `':mute: **Punishment Type:** Mute # ...'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.MUTE.DESCRIPTION` in `discord.yml`. |
+| `WEBHOOKS.MESSAGES.MUTE.DESCRIPTION` | `str` | Any string text | `':mute: **Punishment Type:** Mute'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.MUTE.DESCRIPTION` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.MUTE.THUMBNAIL` | `str` | Any string text | `'%skin_bust%'` | Configures the technical `THUMBNAIL` parameter for `WEBHOOKS.MESSAGES.MUTE.THUMBNAIL` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.MUTE.AUTHOR_NAME` | `str` | Any string text | `'Moderation System'` | Configures the technical `AUTHOR_NAME` parameter for `WEBHOOKS.MESSAGES.MUTE.AUTHOR_NAME` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.MUTE.FOOTER` | `str` | Any string text | `'Chat restriction applied'` | Configures the technical `FOOTER` parameter for `WEBHOOKS.MESSAGES.MUTE.FOOTER` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.WARN.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `WEBHOOKS` system. Set to `true` to enable, `false` to disable. |
 | `WEBHOOKS.MESSAGES.WARN.TITLE` | `str` | Any string text | `'Player Warned - %player%'` | Configures the technical `TITLE` parameter for `WEBHOOKS.MESSAGES.WARN.TITLE` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.WARN.COLOR` | `str` | Any string text | `'#FFA500'` | Configures the technical `COLOR` parameter for `WEBHOOKS.MESSAGES.WARN.COLOR` in `discord.yml`. |
-| `WEBHOOKS.MESSAGES.WARN.DESCRIPTION` | `str` | Any string text | `':warning: **Punishment Type:** Warn...'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.WARN.DESCRIPTION` in `discord.yml`. |
+| `WEBHOOKS.MESSAGES.WARN.DESCRIPTION` | `str` | Any string text | `':warning: **Punishment Type:** Warning'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.WARN.DESCRIPTION` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.WARN.THUMBNAIL` | `str` | Any string text | `'%skin_bust%'` | Configures the technical `THUMBNAIL` parameter for `WEBHOOKS.MESSAGES.WARN.THUMBNAIL` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.WARN.AUTHOR_NAME` | `str` | Any string text | `'Moderation System'` | Configures the technical `AUTHOR_NAME` parameter for `WEBHOOKS.MESSAGES.WARN.AUTHOR_NAME` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.WARN.FOOTER` | `str` | Any string text | `'Warning issued'` | Configures the technical `FOOTER` parameter for `WEBHOOKS.MESSAGES.WARN.FOOTER` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.KICK.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `WEBHOOKS` system. Set to `true` to enable, `false` to disable. |
 | `WEBHOOKS.MESSAGES.KICK.TITLE` | `str` | Any string text | `'Player Kicked - %player%'` | Configures the technical `TITLE` parameter for `WEBHOOKS.MESSAGES.KICK.TITLE` in `discord.yml`. |
 | `WEBHOOKS.MESSAGES.KICK.COLOR` | `str` | Any string text | `'#FF6347'` | Configures the technical `COLOR` parameter for `WEBHOOKS.MESSAGES.KICK.COLOR` in `discord.yml`. |
-| `WEBHOOKS.MESSAGES.KICK.DESCRIPTION` | `str` | Any string text | `':boot: **Punishment Type:** Kick # ...'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.KICK.DESCRIPTION` in `discord.yml`. |
+| `WEBHOOKS.MESSAGES.KICK.DESCRIPTION` | `str` | Any string text | `':boot: **Punishment Type:** Kick'` | Configures the technical `DESCRIPTION` parameter for `WEBHOOKS.MESSAGES.KICK.DESCRIPTION` in `discord.yml`. |
 | *(10 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DiscordWebhookManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DiscordWebhookManager.java
@@ -86,10 +86,13 @@ public class DiscordWebhookManager {
 
         addSkinPlaceholders(root, placeholders, avatarUuid);
 
+        String rawDescription = message.getString("DESCRIPTION", "");
+        String description = sanitizeDescription(rawDescription);
+
         String payload = buildPayload(
                 applyPlaceholders(message.getString("TITLE", key), placeholders),
                 parseColor(message.getString("COLOR", "#00A4FC")),
-                applyPlaceholders(message.getString("DESCRIPTION", ""), placeholders),
+                applyPlaceholders(description, placeholders),
                 applyPlaceholders(message.getString("AUTHOR_NAME", ""), placeholders),
                 applyPlaceholders(message.getString("AUTHOR_ICON", ""), placeholders),
                 applyPlaceholders(message.getString("FOOTER", ""), placeholders),
@@ -239,6 +242,32 @@ public class DiscordWebhookManager {
             output = output.replace(entry.getKey(), entry.getValue() == null ? "" : entry.getValue());
         }
         return output;
+    }
+
+    String sanitizeDescription(String input) {
+        if (input == null || input.isBlank()) {
+            return "";
+        }
+        String[] lines = input.split("\\r?\\n");
+        StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("# The text or")
+                    || trimmed.startsWith("# The Text Or")
+                    || trimmed.startsWith("# The text and")
+                    || trimmed.startsWith("# The text for")
+                    || trimmed.startsWith("# The text mode")
+                    || trimmed.startsWith("# The text option")
+                    || trimmed.contains("Available options:")
+                    || trimmed.contains("Available Options.")) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append('\n');
+            }
+            builder.append(line);
+        }
+        return builder.toString();
     }
 
     private int parseColor(String input) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -371,10 +371,7 @@ SHARDS:
         # The text or value for Reward Message. Available options: Any valid string text
         REWARD-MESSAGE: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
         # The text or value for Boosted Reward Message. Available options: Any valid string text
-        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7)
-          # The text or value for # The Text Or Mode For &7(Total. Available Options. Available options: Any valid string text
-          # The text or mode for &7(Total. Available options: Any string text &7(Total:
-          &#A303F9%total%&7)'
+        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total: &#A303F9%total%&7)'
         # The text or value for Leave Message. Available options: Any valid string text
         LEAVE-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
         # The numerical value for Afk Time. Available options: Any valid integer
@@ -384,8 +381,7 @@ SHARDS:
         # The text or value for Afk Location. Available options: Any valid string text
         AFK-LOCATION: ''
         # The text or value for Afk Message. Available options: Any valid string text
-        AFK-MESSAGE: '&7You have been moved to the AFK area for being inactive in
-          the shard zone.'
+        AFK-MESSAGE: '&7You have been moved to the AFK area for being inactive in the shard zone.'
         # Determines whether Teleport On Afk is enabled or disabled. Available options: true, false
         TELEPORT-ON-AFK: true
         # Configuration section for Excluded Worlds.

--- a/src/main/resources/discord.yml
+++ b/src/main/resources/discord.yml
@@ -19,32 +19,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FF0000'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':hammer: **Punishment Type:** Ban
+      DESCRIPTION: |-
+        :hammer: **Punishment Type:** Ban
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -59,32 +52,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FFFF00'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':mute: **Punishment Type:** Mute
+      DESCRIPTION: |-
+        :mute: **Punishment Type:** Mute
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -99,28 +85,22 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FFA500'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':warning: **Punishment Type:** Warning
+      DESCRIPTION: |-
+        :warning: **Punishment Type:** Warning
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -135,25 +115,20 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FF6347'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':boot: **Punishment Type:** Kick
+      DESCRIPTION: |-
+        :boot: **Punishment Type:** Kick
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
-
-        '
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -168,32 +143,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#000000'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':no_entry: **PERMANENT NETWORK BAN**
+      DESCRIPTION: |-
+        :no_entry: **PERMANENT NETWORK BAN**
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
+        **ID:** `%id%`
 
-        # The text or value for # The Text Or Mode For . Available Options. Available options: Any valid string text
-        # The text or mode for . Available options: Any string text :exclamation:
+        :exclamation:
         This is a permanent network-wide ban
-
-        '
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DiscordWebhookManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DiscordWebhookManagerTest.java
@@ -1,0 +1,37 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiscordWebhookManagerTest {
+
+    @Test
+    void sanitizeDescriptionStripsCorruptedCommentGeneratorLines() {
+        DiscordWebhookManager manager = new DiscordWebhookManager(null);
+
+        String corruptedInput = ":hammer: **Punishment Type:** Ban\n"
+                + "\n"
+                + "# The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text\n"
+                + "# The text or mode for **Player. Available options: Any string text **Player:**\n"
+                + "%player%\n"
+                + "\n"
+                + "# The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text\n"
+                + "# The text or mode for **Staff. Available options: Any string text **Staff:**\n"
+                + "%staff%\n"
+                + "\n"
+                + "**Reason:**\n"
+                + "||%reason%||";
+
+        String cleaned = manager.sanitizeDescription(corruptedInput);
+
+        assertFalse(cleaned.contains("Available options:"));
+        assertFalse(cleaned.contains("# The text or"));
+        assertTrue(cleaned.contains(":hammer: **Punishment Type:** Ban"));
+        assertTrue(cleaned.contains("%player%"));
+        assertTrue(cleaned.contains("%staff%"));
+        assertTrue(cleaned.contains("||%reason%||"));
+    }
+}


### PR DESCRIPTION
commented out lines inside multi-line config descriptions in discord.yml were being parsed as string content and sent directly to discord webhooks.