### PR TITLE
fix: replace crates.yml and add non-item crate rewards (Fixes #81)

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.bx</groupId>
   <artifactId>ultimatedonutsmp</artifactId>
   <name>ultimatedonutsmp</name>
-  <version>1.4</version>
+  <version>1.5</version>
   <build>
     <sourceDirectory>${source.directory}</sourceDirectory>
     <defaultGoal>clean package</defaultGoal>
@@ -18,18 +18,18 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
+        <version>3.15.0</version>
         <configuration>
           <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.6</version>
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.3</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -119,19 +119,19 @@
     <dependency>
       <groupId>net.skinsrestorer</groupId>
       <artifactId>skinsrestorer-api</artifactId>
-      <version>15.12.0</version>
+      <version>15.12.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>me.clip</groupId>
       <artifactId>placeholderapi</artifactId>
-      <version>2.12.2</version>
+      <version>2.12.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.lunarclient</groupId>
       <artifactId>apollo-api</artifactId>
-      <version>1.2.5</version>
+      <version>1.2.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -147,9 +147,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>net.luckperms</groupId>
+      <artifactId>api</artifactId>
+      <version>5.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.3</version>
+      <version>6.1.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -168,7 +174,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <placeholderapi.version>2.12.2</placeholderapi.version>
+    <placeholderapi.version>2.12.3</placeholderapi.version>
     <server-api.version>${spigot-api.version}</server-api.version>
     <java.version>21</java.version>
     <source.directory>src/main/java</source.directory>

--- a/docs/wiki/Config-crates.yml.md
+++ b/docs/wiki/Config-crates.yml.md
@@ -293,6 +293,9 @@ CRATES:
 | `CRATES.common.REWARDS.iron_chestplate.DISPLAY.DISPLAY-NAME` | `str` | Any string text | `'&fIron Chestplate'` | Configures the technical `DISPLAY-NAME` parameter for `CRATES.common.REWARDS.iron_chestplate.DISPLAY.DISPLAY-NAME` in `crates.yml`. |
 | `CRATES.common.REWARDS.iron_chestplate.DISPLAY.LORE` | `list` | List of configured items/strings | `['&7Choose this reward.']` | Configures the technical `LORE` parameter for `CRATES.common.REWARDS.iron_chestplate.DISPLAY.LORE` in `crates.yml`. |
 | `CRATES.common.REWARDS.iron_chestplate.GRANT.TYPE` | `str` | Any string text | `'ITEM'` | Configures the technical `TYPE` parameter for `CRATES.common.REWARDS.iron_chestplate.GRANT.TYPE` in `crates.yml`. |
+| `CRATES.common.REWARDS.<id>.GRANT.TYPE` | `str` | `ITEM`, `COMMAND`, `MONEY`, `SHARDS` | `ITEM` | Configures the reward grant type. Use `COMMAND` to run console commands, `MONEY` to grant economy balance, and `SHARDS` for plugin-specific shard currency. |
+| `CRATES.common.REWARDS.<id>.GRANT.COMMANDS` | `list` | List of strings | `-` | Commands executed for `COMMAND` grants. Commands run as console; use `{player}` as placeholder for the recipient's name. |
+| `CRATES.common.REWARDS.<id>.GRANT.AMOUNT` | `float` / `int` | Any numeric value | `-` | Amount used by `MONEY` and `SHARDS` grant types (e.g., `10.5` for money or `100` for shards). |
 | *(147 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example

--- a/docs/wiki/Crates-CLI-Additions.md
+++ b/docs/wiki/Crates-CLI-Additions.md
@@ -1,0 +1,32 @@
+Crates CLI additions
+
+This document explains new /crate subcommand syntaxes added in the recent update.
+
+Add non-item rewards via CLI
+- Command reward:
+  /crate add <crate> <slot> command <console command...>
+  Example: /crate add common 10 command say {player} won a prize
+  Writes a COMMAND-type reward to crates.yml at CRATES.<crate>.REWARDS.reward_<slot>
+
+- Money reward:
+  /crate add <crate> <slot> money <amount>
+  Example: /crate add common 11 money 10.5
+  Writes a MONEY-type reward with GRANT.AMOUNT to crates.yml
+
+- Shards reward:
+  /crate add <crate> <slot> shards <amount>
+  Example: /crate add common 12 shards 100
+  Writes a SHARDS-type reward with GRANT.AMOUNT to crates.yml
+
+Notes
+- The GUI editor now supports a lightweight template shorthand to create non-item rewards: give an item a display name starting with one of the tags below and place it into a crate slot in the editor.
+  - [CMD] <console command...> — creates a COMMAND reward (e.g. an item named "[CMD] say {player} won").
+  - [MONEY] <amount> — creates a MONEY reward (e.g. "[MONEY] 10.5").
+  - [SHARDS] <amount> — creates a SHARDS reward (e.g. "[SHARDS] 100").
+- The /crate type command now accepts both "choose_one" and "choose-one" (hyphen) for convenience.
+- After adding rewards via the CLI or the template shorthand the plugin saves crates.yml and reloads crate data automatically.
+
+Migration
+- None required — new CLI writes crates.yml entries compatible with existing loader logic.
+
+If you prefer GUI editing for non-item rewards, next step is to add editor affordances in CrateEditorMenu to create/edit MONEY/SHARDS/COMMAND grants.

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/CrateCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/CrateCommand.java
@@ -51,7 +51,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!plugin.getConfigManager().isCommandEnabled("CRATE")) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴄʀᴀᴛᴇ ᴄᴏᴍᴍᴀɴᴅѕ ᴀʀᴇ ᴄᴜʀʀᴇɴᴛʟʏ ᴅɪѕᴀʙʟᴇᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cCrate commands are currently disabled."));
             return true;
         }
 
@@ -169,12 +169,12 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length > 0) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label));
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ᴏᴘᴇɴ ᴛʜᴇ ᴄʀᴀᴛᴇѕ ᴍᴇɴᴜ."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can open the crates menu."));
             return true;
         }
 
@@ -184,7 +184,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleKeysCommand(CommandSender sender, String label, String[] args) {
         if (args.length > 0) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label));
             return true;
         }
 
@@ -193,41 +193,41 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean sendCrateUsage(CommandSender sender, String label) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&c/" + label + " ɪѕ ᴀɴ ᴀᴅᴍɪɴ ᴄʀᴀᴛᴇ ᴄᴏᴍᴍᴀɴᴅ."));
-            sender.sendMessage(ColorUtils.toComponent("&7ᴜѕᴇ &f/crates &7ᴛᴏ ᴏᴘᴇɴ ᴄʀᴀᴛᴇѕ ᴀɴᴅ &f/keys &7ᴛᴏ ᴠɪᴇᴡ ʏᴏᴜʀ ᴋᴇʏѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&c/" + label + " is an admin crate command."));
+            sender.sendMessage(ColorUtils.toComponent("&7Use &f/crates &7to open crates and &f/keys &7to view your keys."));
             return true;
         }
 
-        sender.sendMessage(ColorUtils.toComponent("&8&m----------- &bᴄʀᴀᴛᴇ ᴀᴅᴍɪɴ &8&m-----------"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴄʀᴇᴀᴛᴇ <crate> &7- ᴄʀᴇᴀᴛᴇ ᴀ ᴄʀᴀᴛᴇ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴅᴇʟᴇᴛᴇ <crate> &7- ᴅᴇʟᴇᴛᴇ ᴀ ᴄʀᴀᴛᴇ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴛʏᴘᴇ <crate> <choose_one|gacha> &7- ѕᴇᴛ ᴄʀᴀᴛᴇ ᴛʏᴘᴇ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴏᴘᴇɴ <crate> &7- ᴏᴘᴇɴ ᴀ ᴄʀᴀᴛᴇ ᴅɪʀᴇᴄᴛʟʏ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴋᴇʏ <player> <crate> <amount> &7- ɢɪᴠᴇ ᴋᴇʏѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴛᴀᴋᴇ <player> <crate> <amount> &7- ʀᴇᴍᴏᴠᴇ ᴋᴇʏѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ѕᴇᴛ <player> <crate> <amount> &7- ѕᴇᴛ ᴋᴇʏ ʙᴀʟᴀɴᴄᴇ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴋᴇʏᴀʟʟ <crate> <amount> &7- ɢʀᴀɴᴛ ᴋᴇʏѕ ᴛᴏ ᴏɴʟɪɴᴇ ᴘʟᴀʏᴇʀѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴀᴅᴅ <crate> [ѕʟᴏᴛ] &7- ᴀᴅᴅ ʀᴇᴡᴀʀᴅ ʙʏ ɢᴜɪ ᴏʀ ʜᴀɴᴅ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴇᴅɪᴛ <crate> [ѕʟᴏᴛ] &7- ᴇᴅɪᴛ ʀᴇᴡᴀʀᴅ ʙʏ ɢᴜɪ ᴏʀ ʜᴀɴᴅ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ʀᴇᴍᴏᴠᴇ <crate> <slot> &7- ʀᴇᴍᴏᴠᴇ ᴀ ʀᴇᴡᴀʀᴅ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ʙɪɴᴅ <crate|cancel> &7- ʙɪɴᴅ ᴀ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ᴜɴʙɪɴᴅ [world x y z] &7- ᴜɴʙɪɴᴅ ʙʏ ʟᴏᴏᴋ-ᴀᴛ ᴏʀ ᴄᴏᴏʀᴅѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ʟɪѕᴛʙᴏᴜɴᴅ &7- ʟɪѕᴛ ᴀʟʟ ʙᴏᴜɴᴅ ᴄʀᴀᴛᴇѕ ᴀɴᴅ ʟᴏᴄᴀᴛɪᴏɴѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ɪɴꜰᴏ &7- ɪɴѕᴘᴇᴄᴛ ᴛʜᴇ ʟᴏᴏᴋᴇᴅ-ᴀᴛ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ"));
-        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " ʀᴇʟᴏᴀᴅ &7- ʀᴇʟᴏᴀᴅ ᴄʀᴀᴛᴇ ѕᴇᴛᴛɪɴɢѕ"));
-        sender.sendMessage(ColorUtils.toComponent("&7ᴘʟᴀʏᴇʀ ᴄᴏᴍᴍᴀɴᴅѕ: &f/crates &7ᴀɴᴅ &f/keys"));
+        sender.sendMessage(ColorUtils.toComponent("&8&m----------- &bCrate admin &8&m-----------"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " create <crate> &7- create a crate"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " delete <crate> &7- delete a crate"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " type <crate> <choose_one|gacha> &7- set crate type"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " open <crate> &7- open a crate directly"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " key <player> <crate> <amount> &7- give keys"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " take <player> <crate> <amount> &7- remove keys"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " set <player> <crate> <amount> &7- set key balance"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " keyall <crate> <amount> &7- grant keys to online players"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " add <crate> [slot] &7- add reward by gui or hand"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " edit <crate> [slot] &7- edit reward by gui or hand"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " remove <crate> <slot> &7- remove a reward"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " bind <crate|cancel> &7- bind a crate chest"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " unbind [world x y z] &7- unbind by look-at or coords"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " listbound &7- list all bound crates and locations"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " info &7- inspect the looked-at crate chest"));
+        sender.sendMessage(ColorUtils.toComponent("&f/" + label + " reload &7- reload crate settings"));
+        sender.sendMessage(ColorUtils.toComponent("&7Player commands: &f/crates &7and &f/keys"));
         sender.sendMessage(ColorUtils.toComponent("&8&m----------------------------------"));
         return true;
     }
 
     private boolean handleOpen(CommandSender sender, String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ᴏᴘᴇɴ ᴄʀᴀᴛᴇѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can open crates."));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " ᴏᴘᴇɴ <crate>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " open <crate>"));
             return true;
         }
 
@@ -243,12 +243,12 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleCreate(CommandSender sender, String label, String[] args) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴄʀᴇᴀᴛᴇ ᴄʀᴀᴛᴇѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to create crates."));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " create <crate>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " create <crate>"));
             return true;
         }
 
@@ -262,12 +262,12 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleDelete(CommandSender sender, String label, String[] args) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴅᴇʟᴇᴛᴇ ᴄʀᴀᴛᴇѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to delete crates."));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " delete <crate>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " delete <crate>"));
             return true;
         }
 
@@ -281,12 +281,12 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleType(CommandSender sender, String label, String[] args) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴄʜᴀɴɢᴇ ᴄʀᴀᴛᴇ ᴛʏᴘᴇѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to change crate types."));
             return true;
         }
 
         if (args.length < 3) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " ᴛʏᴘᴇ <crate> <choose_one|gacha>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " type <crate> <choose_one|gacha>"));
             return true;
         }
 
@@ -294,7 +294,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
         try {
             openType = CrateManager.OpenType.valueOf(args[2].trim().toUpperCase().replace('-', '_'));
         } catch (IllegalArgumentException exception) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴛʏᴘᴇ ᴍᴜѕᴛ ʙᴇ &fᴄʜᴏᴏѕᴇ_ᴏɴᴇ &c(or &fchoose-one&c) or &fɢᴀᴄʜᴀ&c."));
+            sender.sendMessage(ColorUtils.toComponent("&ctype must be &fchoose_one &c(or &fchoose-one&c) or &fgacha&c."));
             return true;
         }
 
@@ -312,47 +312,47 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleReload(CommandSender sender) {
         if (!PermissionUtils.has(sender, RELOAD_PERMISSION) && !PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ʀᴇʟᴏᴀᴅ ᴄʀᴀᴛᴇ ѕᴇᴛᴛɪɴɢѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to reload crate settings."));
             return true;
         }
 
         plugin.getConfigManager().reloadCrates();
         plugin.getCrateManager().reload();
         plugin.getCrateVisualManager().reload();
-        sender.sendMessage(ColorUtils.toComponent("&aᴄʀᴀᴛᴇ ѕᴇᴛᴛɪɴɢѕ ʀᴇʟᴏᴀᴅᴇᴅ."));
+        sender.sendMessage(ColorUtils.toComponent("&aCrate settings reloaded."));
         return true;
     }
 
     private boolean handleKeyMutation(CommandSender sender, String[] args, MutationMode mode) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴍᴏᴅɪꜰʏ ᴄʀᴀᴛᴇ ᴋᴇʏѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to modify crate keys."));
             return true;
         }
 
         if (args.length < 4) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /crate " + mode.commandName + " <player> <crate> <amount>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /crate " + mode.commandName + " <player> <crate> <amount>"));
             return true;
         }
 
         ResolvedTarget target = resolveTarget(args[1]);
         if (target == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴘʟᴀʏᴇʀ '&f" + args[1] + "&c' ᴡᴀѕ ɴᴏᴛ ꜰᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cPlayer '&f" + args[1] + "&c' was not found."));
             return true;
         }
 
         CrateManager.CrateDefinition crate = plugin.getCrateManager().getCrate(args[2]);
         if (crate == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴄʀᴀᴛᴇ '&f" + args[2] + "&c' ᴡᴀѕ ɴᴏᴛ ꜰᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cCrate '&f" + args[2] + "&c' was not found."));
             return true;
         }
 
         Integer amount = parsePositiveInt(args[3]);
         if ((amount == null || amount <= 0) && mode != MutationMode.SET) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴀᴍᴏᴜɴᴛ ᴍᴜѕᴛ ʙᴇ ᴀ ᴘᴏѕɪᴛɪᴠᴇ ɪɴᴛᴇɢᴇʀ."));
+            sender.sendMessage(ColorUtils.toComponent("&cAmount must be a positive integer."));
             return true;
         }
         if (mode == MutationMode.SET && (amount == null || amount < 0)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴀᴍᴏᴜɴᴛ ᴍᴜѕᴛ ʙᴇ ᴢᴇʀᴏ ᴏʀ ᴀ ᴘᴏѕɪᴛɪᴠᴇ ɪɴᴛᴇɢᴇʀ."));
+            sender.sendMessage(ColorUtils.toComponent("&cAmount must be zero or a positive integer."));
             return true;
         }
 
@@ -369,71 +369,71 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
         }
 
         if (!success) {
-            sender.sendMessage(ColorUtils.toComponent("&c" + target.name() + " ᴅᴏᴇѕ ɴᴏᴛ ʜᴀᴠᴇ ᴇɴᴏᴜɢʜ ᴋᴇʏѕ ᴛᴏ ʀᴇᴍᴏᴠᴇ " + amount + "."));
+            sender.sendMessage(ColorUtils.toComponent("&c" + target.name() + " does not have enough keys to remove " + amount + "."));
             return true;
         }
 
         sender.sendMessage(ColorUtils.toComponent("&a" + mode.successPrefix + " &f" + amount + "x "
                 + plugin.getCrateManager().getReadableCrateName(crate)
-                + "&a ꜰᴏʀ &f" + target.name() + "&a. ʙᴀʟᴀɴᴄᴇ: &f" + balance));
+                + "&a for &f" + target.name() + "&a. balance: &f" + balance));
 
         Player online = Bukkit.getPlayer(target.uuid());
         if (online != null && online.isOnline()) {
-            online.sendMessage(ColorUtils.toComponent("&7ʏᴏᴜʀ &b" + plugin.getCrateManager().getReadableCrateName(crate)
-                    + "&7 ᴋᴇʏ ʙᴀʟᴀɴᴄᴇ ɪѕ ɴᴏᴡ &f" + balance + "&7."));
+            online.sendMessage(ColorUtils.toComponent("&7Your &b" + plugin.getCrateManager().getReadableCrateName(crate)
+                    + "&7 key balance is now &f" + balance + "&7."));
         }
         return true;
     }
 
     private boolean handleKeyAll(CommandSender sender, String label, String[] args) {
         if (!PermissionUtils.has(sender, KEYALL_PERMISSION) && !PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ʀᴜɴ ᴄʀᴀᴛᴇ ᴋᴇʏ-ᴀʟʟ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to run crate key-all."));
             return true;
         }
 
         if (args.length < 3) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " ᴋᴇʏᴀʟʟ <crate> <amount>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " keyall <crate> <amount>"));
             return true;
         }
 
         CrateManager.CrateDefinition crate = plugin.getCrateManager().getCrate(args[1]);
         if (crate == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴄʀᴀᴛᴇ '&f" + args[1] + "&c' ᴡᴀѕ ɴᴏᴛ ꜰᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cCrate '&f" + args[1] + "&c' was not found."));
             return true;
         }
 
         Integer amount = parsePositiveInt(args[2]);
         if (amount == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴀᴍᴏᴜɴᴛ ᴍᴜѕᴛ ʙᴇ ᴀ ᴘᴏѕɪᴛɪᴠᴇ ɪɴᴛᴇɢᴇʀ."));
+            sender.sendMessage(ColorUtils.toComponent("&cAmount must be a positive integer."));
             return true;
         }
 
         int granted = plugin.getKeyAllManager().grantCrateKeys(crate.id(), amount, false);
-        sender.sendMessage(ColorUtils.toComponent("&aɢʀᴀɴᴛᴇᴅ &f" + amount + "x "
+        sender.sendMessage(ColorUtils.toComponent("&aGranted &f" + amount + "x "
                 + plugin.getCrateManager().getReadableCrateName(crate)
-                + "&a ᴋᴇʏ(ѕ) ᴛᴏ &f" + granted + "&a ᴏɴʟɪɴᴇ ᴘʟᴀʏᴇʀ(ѕ)."));
+                + "&a key(s) to &f" + granted + "&a online player(s)."));
         return true;
     }
 
     private boolean handleRewardMutation(CommandSender sender, String label, String[] args, RewardMutationMode mode) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴍᴏᴅɪꜰʏ ᴄʀᴀᴛᴇ ʀᴇᴡᴀʀᴅѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to modify crate rewards."));
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ᴜѕᴇ /crate " + mode.commandName + "."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can use /crate " + mode.commandName + "."));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " " + mode.commandName + " <crate> [ѕʟᴏᴛ]"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " " + mode.commandName + " <crate> [slot]"));
             return true;
         }
 
         CrateManager.CrateDefinition crate = plugin.getCrateManager().getCrate(args[1]);
         if (crate == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴄʀᴀᴛᴇ '&f" + args[1] + "&c' ᴡᴀѕ ɴᴏᴛ ꜰᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cCrate '&f" + args[1] + "&c' was not found."));
             return true;
         }
 
@@ -443,18 +443,18 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
         }
 
         if (mode == RewardMutationMode.REMOVE && args.length == 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " ʀᴇᴍᴏᴠᴇ <crate> <slot>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " remove <crate> <slot>"));
             return true;
         }
 
         if (args.length < 3) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " " + mode.commandName + " <crate> <slot>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " " + mode.commandName + " <crate> <slot>"));
             return true;
         }
 
         Integer slot = parsePositiveInt(args[2]);
         if (slot == null || slot < 0) {
-            sender.sendMessage(ColorUtils.toComponent("&cѕʟᴏᴛ ᴍᴜѕᴛ ʙᴇ ᴀ ᴠᴀʟɪᴅ ɴᴜᴍʙᴇʀ, ꜰᴏʀ ᴇxᴀᴍᴘʟᴇ &f10&c."));
+            sender.sendMessage(ColorUtils.toComponent("&cSlot must be a valid number, for example &f10&c."));
             return true;
         }
 
@@ -464,14 +464,14 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
             String verb = args[3].toLowerCase(Locale.ROOT);
             if (verb.equals("command")) {
                 if (args.length < 5) {
-                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> command <console command...>"));
+                    sender.sendMessage(ColorUtils.toComponent("&cUsage: /crate add <crate> <slot> command <console command...>"));
                     return true;
                 }
                 String consoleCommand = String.join(" ", Arrays.copyOfRange(args, 4, args.length));
                 result = plugin.getCrateManager().addCommandReward(crate.id(), slot, List.of(consoleCommand));
             } else if (verb.equals("money")) {
                 if (args.length < 5) {
-                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> money <amount>"));
+                    sender.sendMessage(ColorUtils.toComponent("&cUsage: /crate add <crate> <slot> money <amount>"));
                     return true;
                 }
                 Double parsed = parseDouble(args[4]);
@@ -482,7 +482,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
                 result = plugin.getCrateManager().addMoneyReward(crate.id(), slot, parsed);
             } else if (verb.equals("shards")) {
                 if (args.length < 5) {
-                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> shards <amount>"));
+                    sender.sendMessage(ColorUtils.toComponent("&cUsage: /crate add <crate> <slot> shards <amount>"));
                     return true;
                 }
                 Long parsed = parseLong(args[4]);
@@ -509,41 +509,41 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleBind(CommandSender sender, String label, String[] args) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ʙɪɴᴅ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to bind crate chests."));
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ʙɪɴᴅ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can bind crate chests."));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴜѕᴀɢᴇ: /" + label + " ʙɪɴᴅ <crate|cancel>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " bind <crate|cancel>"));
             return true;
         }
 
         if (args[1].equalsIgnoreCase("cancel")) {
             plugin.getCrateManager().clearPendingBind(player.getUniqueId());
-            player.sendMessage(ColorUtils.toComponent("&aᴄʀᴀᴛᴇ ʙɪɴᴅ ᴍᴏᴅᴇ ᴄᴀɴᴄᴇʟʟᴇᴅ."));
+            player.sendMessage(ColorUtils.toComponent("&aCrate bind mode cancelled."));
             return true;
         }
 
         CrateManager.CrateDefinition crate = plugin.getCrateManager().getCrate(args[1]);
         if (crate == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴄʀᴀᴛᴇ '&f" + args[1] + "&c' ᴡᴀѕ ɴᴏᴛ ꜰᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cCrate '&f" + args[1] + "&c' was not found."));
             return true;
         }
 
         plugin.getCrateManager().startPendingBind(player.getUniqueId(), crate.id());
-        player.sendMessage(ColorUtils.toComponent("&aʙɪɴᴅ ᴍᴏᴅᴇ ᴇɴᴀʙʟᴇᴅ ꜰᴏʀ &f" + crate.id() + "&a."));
-        player.sendMessage(ColorUtils.toComponent("&7ʟᴇꜰᴛ-ᴄʟɪᴄᴋ ᴀ ᴄʜᴇѕᴛ, ᴛʀᴀᴘᴘᴇᴅ ᴄʜᴇѕᴛ, ʙᴀʀʀᴇʟ, ᴇɴᴅᴇʀ ᴄʜᴇѕᴛ, ᴏʀ ѕʜᴜʟᴋᴇʀ ʙᴏx ᴛᴏ ʙɪɴᴅ ɪᴛ."));
+        player.sendMessage(ColorUtils.toComponent("&aBind mode enabled for &f" + crate.id() + "&a."));
+        player.sendMessage(ColorUtils.toComponent("&7Left-click a chest, trapped chest, barrel, ender chest, or shulker box to bind it."));
         return true;
     }
 
     private boolean handleUnbind(CommandSender sender, String[] args) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴜɴʙɪɴᴅ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to unbind crate chests."));
             return true;
         }
 
@@ -553,60 +553,60 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
             Integer y = parseInteger(args[3]);
             Integer z = parseInteger(args[4]);
             if (x == null || y == null || z == null) {
-                sender.sendMessage(ColorUtils.toComponent("&cɪɴᴠᴀʟɪᴅ ᴄᴏᴏʀᴅɪɴᴀᴛᴇѕ. ᴜѕᴀɢᴇ: /crate unbind <world> <x> <y> <z>"));
+                sender.sendMessage(ColorUtils.toComponent("&cInvalid coordinates. usage: /crate unbind <world> <x> <y> <z>"));
                 return true;
             }
 
             if (!plugin.getCrateManager().unbindCrateBlock(worldName, x, y, z)) {
-                sender.sendMessage(ColorUtils.toComponent("&cꜰᴀɪʟᴇᴅ ᴛᴏ ᴜɴʙɪɴᴅ ᴛʜᴀᴛ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ (ᴏʀ ɪᴛ ᴡᴀѕ ɴᴏᴛ ʙᴏᴜɴᴅ)."));
+                sender.sendMessage(ColorUtils.toComponent("&cFailed to unbind that crate chest (or it was not bound)."));
                 return true;
             }
 
             plugin.getCrateVisualManager().removeHologram(worldName, x, y, z);
-            sender.sendMessage(ColorUtils.toComponent("&aʀᴇᴍᴏᴠᴇᴅ ᴄʀᴀᴛᴇ ʙɪɴᴅɪɴɢ ᴀᴛ &f" + worldName + " " + x + "," + y + "," + z + "&a."));
+            sender.sendMessage(ColorUtils.toComponent("&aRemoved crate binding at &f" + worldName + " " + x + "," + y + "," + z + "&a."));
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ᴜɴʙɪɴᴅ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ ʙʏ ʟᴏᴏᴋɪɴɢ ᴀᴛ ᴛʜᴇᴍ. ᴜѕᴇ: /crate unbind <world> <x> <y> <z>"));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can unbind crate chests by looking at them. use: /crate unbind <world> <x> <y> <z>"));
             return true;
         }
 
         Block target = getTargetBlock(player);
         if (target == null) {
-            player.sendMessage(ColorUtils.toComponent("&cʟᴏᴏᴋ ᴀᴛ ᴀ ʙᴏᴜɴᴅ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ ꜰɪʀѕᴛ."));
+            player.sendMessage(ColorUtils.toComponent("&cLook at a bound crate chest first."));
             return true;
         }
 
         String crateId = plugin.getCrateManager().getBoundCrateId(target);
         if (crateId == null) {
-            player.sendMessage(ColorUtils.toComponent("&cᴛʜᴀᴛ ʙʟᴏᴄᴋ ɪѕ ɴᴏᴛ ʙᴏᴜɴᴅ ᴛᴏ ᴀɴʏ ᴄʀᴀᴛᴇ."));
+            player.sendMessage(ColorUtils.toComponent("&cThat block is not bound to any crate."));
             return true;
         }
 
         if (!plugin.getCrateManager().unbindCrateBlock(target)) {
-            player.sendMessage(ColorUtils.toComponent("&cꜰᴀɪʟᴇᴅ ᴛᴏ ᴜɴʙɪɴᴅ ᴛʜᴀᴛ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ."));
+            player.sendMessage(ColorUtils.toComponent("&cFailed to unbind that crate chest."));
             return true;
         }
 
         plugin.getCrateVisualManager().removeHologram(target);
-        player.sendMessage(ColorUtils.toComponent("&aʀᴇᴍᴏᴠᴇᴅ ᴄʀᴀᴛᴇ ʙɪɴᴅɪɴɢ ꜰʀᴏᴍ &f" + formatBlockLocation(target) + "&a."));
+        player.sendMessage(ColorUtils.toComponent("&aRemoved crate binding from &f" + formatBlockLocation(target) + "&a."));
         return true;
     }
 
     private boolean handleListBound(CommandSender sender) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ʟɪѕᴛ ʙᴏᴜɴᴅ ᴄʀᴀᴛᴇѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to list bound crates."));
             return true;
         }
 
         var bound = plugin.getCrateManager().getBoundBlockIds();
         if (bound.isEmpty()) {
-            sender.sendMessage(ColorUtils.toComponent("&cɴᴏ ᴄʀᴀᴛᴇѕ ᴀʀᴇ ᴄᴜʀʀᴇɴᴛʟʏ ʙᴏᴜɴᴅ."));
+            sender.sendMessage(ColorUtils.toComponent("&cNo crates are currently bound."));
             return true;
         }
 
-        sender.sendMessage(ColorUtils.toComponent("&8&m-------- &bʙᴏᴜɴᴅ ᴄʀᴀᴛᴇѕ &8&m--------"));
+        sender.sendMessage(ColorUtils.toComponent("&8&m-------- &bBound crates &8&m--------"));
         for (var entry : bound.entrySet()) {
             var key = entry.getKey();
             sender.sendMessage(ColorUtils.toComponent("&7- &f" + key.world() + " &7(&f" + key.x() + "," + key.y() + "," + key.z() + "&7) -> &b" + entry.getValue()));
@@ -625,32 +625,32 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean handleInfo(CommandSender sender) {
         if (!PermissionUtils.has(sender, ADMIN_PERMISSION)) {
-            sender.sendMessage(ColorUtils.toComponent("&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ɪɴѕᴘᴇᴄᴛ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to inspect crate chests."));
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ɪɴѕᴘᴇᴄᴛ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can inspect crate chests."));
             return true;
         }
 
         Block target = getTargetBlock(player);
         if (target == null) {
-            player.sendMessage(ColorUtils.toComponent("&cʟᴏᴏᴋ ᴀᴛ ᴀ ᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ ꜰɪʀѕᴛ."));
+            player.sendMessage(ColorUtils.toComponent("&cLook at a crate chest first."));
             return true;
         }
 
         String crateId = plugin.getCrateManager().getBoundCrateId(target);
         if (crateId == null) {
-            player.sendMessage(ColorUtils.toComponent("&cᴛʜᴀᴛ ʙʟᴏᴄᴋ ɪѕ ɴᴏᴛ ʙᴏᴜɴᴅ ᴛᴏ ᴀɴʏ ᴄʀᴀᴛᴇ."));
+            player.sendMessage(ColorUtils.toComponent("&cThat block is not bound to any crate."));
             return true;
         }
 
         CrateManager.CrateDefinition crate = plugin.getCrateManager().getCrate(crateId);
-        player.sendMessage(ColorUtils.toComponent("&8&m-------- &bᴄʀᴀᴛᴇ ᴄʜᴇѕᴛ &8&m--------"));
-        player.sendMessage(ColorUtils.toComponent("&7ʟᴏᴄᴀᴛɪᴏɴ: &f" + formatBlockLocation(target)));
-        player.sendMessage(ColorUtils.toComponent("&7ᴄʀᴀᴛᴇ ɪᴅ: &f" + crateId));
-        player.sendMessage(ColorUtils.toComponent("&7ᴅɪѕᴘʟᴀʏ: &f" + plugin.getCrateManager().getReadableCrateName(crate)));
+        player.sendMessage(ColorUtils.toComponent("&8&m-------- &bCrate chest &8&m--------"));
+        player.sendMessage(ColorUtils.toComponent("&7Location: &f" + formatBlockLocation(target)));
+        player.sendMessage(ColorUtils.toComponent("&7Crate id: &f" + crateId));
+        player.sendMessage(ColorUtils.toComponent("&7Display: &f" + plugin.getCrateManager().getReadableCrateName(crate)));
         player.sendMessage(ColorUtils.toComponent("&8&m-------------------------------"));
         return true;
     }
@@ -720,7 +720,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
     private boolean openKeysMenu(CommandSender sender) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴏɴʟʏ ᴘʟᴀʏᴇʀѕ ᴄᴀɴ ᴠɪᴇᴡ ᴄʀᴀᴛᴇ ᴋᴇʏѕ."));
+            sender.sendMessage(ColorUtils.toComponent("&cOnly players can view crate keys."));
             return true;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/CrateCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/CrateCommand.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.Arrays;
 
 public class CrateCommand implements CommandExecutor, TabCompleter {
 
@@ -37,7 +38,7 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
     private static final List<String> ADMIN_SUBCOMMANDS = List.of(
             "create", "delete", "type", "key", "take", "set", "add", "edit", "remove", "bind", "unbind", "listbound", "info"
     );
-    private static final List<String> OPEN_TYPE_COMPLETIONS = List.of("choose_one", "gacha");
+    private static final List<String> OPEN_TYPE_COMPLETIONS = List.of("choose_one", "choose-one", "gacha");
     private static final List<String> AMOUNT_COMPLETIONS = List.of("1", "5", "10", "25", "64");
     private static final List<String> SLOT_COMPLETIONS = List.of("1", "2", "3", "4", "5", "6", "7", "8", "9");
 
@@ -291,9 +292,9 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
 
         CrateManager.OpenType openType;
         try {
-            openType = CrateManager.OpenType.valueOf(args[2].trim().toUpperCase());
+            openType = CrateManager.OpenType.valueOf(args[2].trim().toUpperCase().replace('-', '_'));
         } catch (IllegalArgumentException exception) {
-            sender.sendMessage(ColorUtils.toComponent("&cᴛʏᴘᴇ ᴍᴜѕᴛ ʙᴇ &fᴄʜᴏᴏѕᴇ_ᴏɴᴇ &cᴏʀ &fɢᴀᴄʜᴀ&c."));
+            sender.sendMessage(ColorUtils.toComponent("&cᴛʏᴘᴇ ᴍᴜѕᴛ ʙᴇ &fᴄʜᴏᴏѕᴇ_ᴏɴᴇ &c(or &fchoose-one&c) or &fɢᴀᴄʜᴀ&c."));
             return true;
         }
 
@@ -457,11 +458,50 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
-        CrateManager.ActionResult result = switch (mode) {
-            case ADD -> plugin.getCrateManager().addItemReward(crate.id(), slot, player.getInventory().getItemInMainHand());
-            case EDIT -> plugin.getCrateManager().editItemReward(crate.id(), slot, player.getInventory().getItemInMainHand());
-            case REMOVE -> plugin.getCrateManager().removeReward(crate.id(), slot);
-        };
+        CrateManager.ActionResult result;
+        // Support: /crate add <crate> <slot> command <console command...>
+        if (mode == RewardMutationMode.ADD && args.length >= 4) {
+            String verb = args[3].toLowerCase(Locale.ROOT);
+            if (verb.equals("command")) {
+                if (args.length < 5) {
+                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> command <console command...>"));
+                    return true;
+                }
+                String consoleCommand = String.join(" ", Arrays.copyOfRange(args, 4, args.length));
+                result = plugin.getCrateManager().addCommandReward(crate.id(), slot, List.of(consoleCommand));
+            } else if (verb.equals("money")) {
+                if (args.length < 5) {
+                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> money <amount>"));
+                    return true;
+                }
+                Double parsed = parseDouble(args[4]);
+                if (parsed == null) {
+                    sender.sendMessage(ColorUtils.toComponent("&camount must be a number."));
+                    return true;
+                }
+                result = plugin.getCrateManager().addMoneyReward(crate.id(), slot, parsed);
+            } else if (verb.equals("shards")) {
+                if (args.length < 5) {
+                    sender.sendMessage(ColorUtils.toComponent("&cᴜsᴀɢᴇ: /crate add <crate> <slot> shards <amount>"));
+                    return true;
+                }
+                Long parsed = parseLong(args[4]);
+                if (parsed == null) {
+                    sender.sendMessage(ColorUtils.toComponent("&camount must be an integer."));
+                    return true;
+                }
+                result = plugin.getCrateManager().addShardsReward(crate.id(), slot, parsed);
+            } else {
+                // fallback to item-handling
+                result = plugin.getCrateManager().addItemReward(crate.id(), slot, player.getInventory().getItemInMainHand());
+            }
+        } else {
+            result = switch (mode) {
+                case ADD -> plugin.getCrateManager().addItemReward(crate.id(), slot, player.getInventory().getItemInMainHand());
+                case EDIT -> plugin.getCrateManager().editItemReward(crate.id(), slot, player.getInventory().getItemInMainHand());
+                case REMOVE -> plugin.getCrateManager().removeReward(crate.id(), slot);
+            };
+        }
 
         sender.sendMessage(ColorUtils.toComponent(result.message()));
         return true;
@@ -633,6 +673,22 @@ public class CrateCommand implements CommandExecutor, TabCompleter {
     private Integer parsePositiveInt(String input) {
         try {
             return Integer.parseInt(input);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private Double parseDouble(String input) {
+        try {
+            return Double.parseDouble(input);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private Long parseLong(String input) {
+        try {
+            return Long.parseLong(input);
         } catch (NumberFormatException exception) {
             return null;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
@@ -243,6 +243,151 @@ public class CrateManager {
         return new ActionResult(true, "&aremoved reward in slot &f" + slot + "&a from crate &f" + crate.id() + "&a.");
     }
 
+    public ActionResult addCommandReward(String crateId, int slot, List<String> commands) {
+        CrateDefinition crate = getCrate(crateId);
+        if (crate == null) {
+            return new ActionResult(false, "&ccrate '&f" + crateId + "&c' was not found.");
+        }
+        if (!isValidRewardSlot(crate, slot)) {
+            return new ActionResult(false, "&cslot &f" + slot + "&c is not valid for this crate menu.");
+        }
+        if (crate.findRewardBySlot(slot) != null) {
+            return new ActionResult(false, "&cthat slot already has a reward. use &f/crate edit " + crate.id() + " " + slot + "&c.");
+        }
+        if (commands == null || commands.isEmpty()) {
+            return new ActionResult(false, "&cno command provided. usage: /crate add <crate> <slot> command <console command...>");
+        }
+
+        FileConfiguration cratesConfig = plugin.getConfigManager().getOriginalCrates();
+        ConfigurationSection rewardsSection = cratesConfig.getConfigurationSection("CRATES." + crate.id() + ".REWARDS");
+        if (rewardsSection == null) {
+            rewardsSection = cratesConfig.createSection("CRATES." + crate.id() + ".REWARDS");
+        }
+
+        String rewardKey = findRewardKeyBySlot(rewardsSection, slot);
+        if (rewardKey == null) {
+            rewardKey = "reward_" + slot;
+        }
+
+        String basePath = "CRATES." + crate.id() + ".REWARDS." + rewardKey;
+        writeCommandReward(cratesConfig, basePath, slot, commands);
+
+        if (!plugin.getConfigManager().saveCrates()) {
+            return new ActionResult(false, "&cfailed to save crates.yml while adding that reward.");
+        }
+
+        reload();
+        return new ActionResult(true, "&aadded command reward in slot &f" + slot + "&a for crate &f" + crate.id() + "&a.");
+    }
+
+    private void writeCommandReward(FileConfiguration cratesConfig, String basePath, int slot, List<String> commands) {
+        cratesConfig.set(basePath + ".SLOT", slot);
+        cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.PAPER.name());
+        cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fcommand reward");
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7ᴄᴏᴍᴍᴀɴᴅ ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
+        cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
+
+        cratesConfig.set(basePath + ".GRANT.TYPE", "COMMAND");
+        cratesConfig.set(basePath + ".GRANT.COMMANDS", commands);
+        cratesConfig.set(basePath + ".GRANT.REQUIRES-INVENTORY-SPACE", false);
+        cratesConfig.set(basePath + ".WEIGHT", 1);
+    }
+
+    public ActionResult addMoneyReward(String crateId, int slot, double amount) {
+        CrateDefinition crate = getCrate(crateId);
+        if (crate == null) {
+            return new ActionResult(false, "&ccrate '&f" + crateId + "&c' was not found.");
+        }
+        if (!isValidRewardSlot(crate, slot)) {
+            return new ActionResult(false, "&cslot &f" + slot + "&c is not valid for this crate menu.");
+        }
+        if (crate.findRewardBySlot(slot) != null) {
+            return new ActionResult(false, "&cthat slot already has a reward. use &f/crate edit " + crate.id() + " " + slot + "&c.");
+        }
+
+        FileConfiguration cratesConfig = plugin.getConfigManager().getOriginalCrates();
+        ConfigurationSection rewardsSection = cratesConfig.getConfigurationSection("CRATES." + crate.id() + ".REWARDS");
+        if (rewardsSection == null) {
+            rewardsSection = cratesConfig.createSection("CRATES." + crate.id() + ".REWARDS");
+        }
+
+        String rewardKey = findRewardKeyBySlot(rewardsSection, slot);
+        if (rewardKey == null) {
+            rewardKey = "reward_" + slot;
+        }
+
+        String basePath = "CRATES." + crate.id() + ".REWARDS." + rewardKey;
+        writeMoneyReward(cratesConfig, basePath, slot, amount);
+
+        if (!plugin.getConfigManager().saveCrates()) {
+            return new ActionResult(false, "&cfailed to save crates.yml while adding that reward.");
+        }
+
+        reload();
+        return new ActionResult(true, "&aadded money reward in slot &f" + slot + "&a for crate &f" + crate.id() + "&a.");
+    }
+
+    private void writeMoneyReward(FileConfiguration cratesConfig, String basePath, int slot, double amount) {
+        cratesConfig.set(basePath + ".SLOT", slot);
+        cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.SUNFLOWER.name());
+        cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fMoney reward");
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7ᴍᴏɴᴇʏ ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
+        cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
+
+        cratesConfig.set(basePath + ".GRANT.TYPE", "MONEY");
+        cratesConfig.set(basePath + ".GRANT.AMOUNT", amount);
+        cratesConfig.set(basePath + ".WEIGHT", 1);
+    }
+
+    public ActionResult addShardsReward(String crateId, int slot, long amount) {
+        CrateDefinition crate = getCrate(crateId);
+        if (crate == null) {
+            return new ActionResult(false, "&ccrate '&f" + crateId + "&c' was not found.");
+        }
+        if (!isValidRewardSlot(crate, slot)) {
+            return new ActionResult(false, "&cslot &f" + slot + "&c is not valid for this crate menu.");
+        }
+        if (crate.findRewardBySlot(slot) != null) {
+            return new ActionResult(false, "&cthat slot already has a reward. use &f/crate edit " + crate.id() + " " + slot + "&c.");
+        }
+
+        FileConfiguration cratesConfig = plugin.getConfigManager().getOriginalCrates();
+        ConfigurationSection rewardsSection = cratesConfig.getConfigurationSection("CRATES." + crate.id() + ".REWARDS");
+        if (rewardsSection == null) {
+            rewardsSection = cratesConfig.createSection("CRATES." + crate.id() + ".REWARDS");
+        }
+
+        String rewardKey = findRewardKeyBySlot(rewardsSection, slot);
+        if (rewardKey == null) {
+            rewardKey = "reward_" + slot;
+        }
+
+        String basePath = "CRATES." + crate.id() + ".REWARDS." + rewardKey;
+        writeShardsReward(cratesConfig, basePath, slot, amount);
+
+        if (!plugin.getConfigManager().saveCrates()) {
+            return new ActionResult(false, "&cfailed to save crates.yml while adding that reward.");
+        }
+
+        reload();
+        return new ActionResult(true, "&aadded shards reward in slot &f" + slot + "&a for crate &f" + crate.id() + "&a.");
+    }
+
+    private void writeShardsReward(FileConfiguration cratesConfig, String basePath, int slot, long amount) {
+        cratesConfig.set(basePath + ".SLOT", slot);
+        cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.AMETHYST_SHARD.name());
+        cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fShards reward");
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7sʜᴀʀᴅs ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
+        cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
+
+        cratesConfig.set(basePath + ".GRANT.TYPE", "SHARDS");
+        cratesConfig.set(basePath + ".GRANT.AMOUNT", amount);
+        cratesConfig.set(basePath + ".WEIGHT", 1);
+    }
+
     public boolean isBindableBlock(Material material) {
         return material == Material.CHEST
                 || material == Material.TRAPPED_CHEST

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
@@ -283,7 +283,7 @@ public class CrateManager {
     private void writeCommandReward(FileConfiguration cratesConfig, String basePath, int slot, List<String> commands) {
         cratesConfig.set(basePath + ".SLOT", slot);
         cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.PAPER.name());
-        cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fcommand reward");
+        cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fCommand reward");
         cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7Command reward"));
         cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
         cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
@@ -99,25 +99,25 @@ public class CrateManager {
         cratesConfig.set(path + ".DISPLAY.MATERIAL", Material.CHEST.name());
         cratesConfig.set(path + ".DISPLAY.DISPLAY-NAME", "&f" + prettifyId(normalized) + " Crate");
         cratesConfig.set(path + ".DISPLAY.LORE", List.of(
-                "&7ᴋᴇʏѕ: &f{keys}",
-                "&aᴄʟɪᴄᴋ ᴛᴏ ᴏᴘᴇɴ ᴀɴᴅ ᴄʜᴏᴏѕᴇ 1 ʀᴇᴡᴀʀᴅ."
+                "&7Keys: &f{keys}",
+                "&aClick to open and choose 1 reward."
         ));
         cratesConfig.set(path + ".KEY-ITEM.MATERIAL", Material.TRIPWIRE_HOOK.name());
         cratesConfig.set(path + ".KEY-ITEM.DISPLAY-NAME", "&f" + prettifyId(normalized) + " Key");
         cratesConfig.set(path + ".KEY-ITEM.LORE", List.of(
-                "&7ᴏᴘᴇɴѕ ᴛʜᴇ &f" + prettifyId(normalized) + " crate&7."
+                "&7Opens the &f" + prettifyId(normalized) + " crate&7."
         ));
         cratesConfig.set(path + ".OPEN-TYPE", OpenType.CHOOSE_ONE.name());
         cratesConfig.set(path + ".PERMISSION", "");
         cratesConfig.set(path + ".BROADCAST-ON-CLAIM", false);
-        cratesConfig.set(path + ".MENU.OPEN-TITLE", "&8" + prettifyId(normalized) + " ᴄʀᴀᴛᴇ");
-        cratesConfig.set(path + ".MENU.CONFIRM-TITLE", "&8ᴄᴏɴꜰɪʀᴍ ʀᴇᴡᴀʀᴅ");
+        cratesConfig.set(path + ".MENU.OPEN-TITLE", "&8" + prettifyId(normalized) + " crate");
+        cratesConfig.set(path + ".MENU.CONFIRM-TITLE", "&8Confirm Reward");
         cratesConfig.set(path + ".MENU.SIZE", 27);
         cratesConfig.set(path + ".MENU.FILLER", Material.BLACK_STAINED_GLASS_PANE.name());
         cratesConfig.set(path + ".MENU.BACK-SLOT", 26);
         cratesConfig.set(path + ".MENU.BACK-BUTTON.MATERIAL", Material.BARRIER.name());
-        cratesConfig.set(path + ".MENU.BACK-BUTTON.DISPLAY-NAME", "&cʙᴀᴄᴋ");
-        cratesConfig.set(path + ".MENU.BACK-BUTTON.LORE", List.of("&7ʀᴇᴛᴜʀɴ ᴛᴏ ᴛʜᴇ ᴄʀᴀᴛᴇ ʟɪѕᴛ."));
+        cratesConfig.set(path + ".MENU.BACK-BUTTON.DISPLAY-NAME", "&cBack");
+        cratesConfig.set(path + ".MENU.BACK-BUTTON.LORE", List.of("&7Return to the crate list."));
         cratesConfig.createSection(path + ".REWARDS");
 
         if (!plugin.getConfigManager().saveCrates()) {
@@ -284,7 +284,7 @@ public class CrateManager {
         cratesConfig.set(basePath + ".SLOT", slot);
         cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.PAPER.name());
         cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fcommand reward");
-        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7ᴄᴏᴍᴍᴀɴᴅ ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7Command reward"));
         cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
         cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
 
@@ -332,7 +332,7 @@ public class CrateManager {
         cratesConfig.set(basePath + ".SLOT", slot);
         cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.SUNFLOWER.name());
         cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fMoney reward");
-        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7ᴍᴏɴᴇʏ ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7Money reward"));
         cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
         cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
 
@@ -379,7 +379,7 @@ public class CrateManager {
         cratesConfig.set(basePath + ".SLOT", slot);
         cratesConfig.set(basePath + ".DISPLAY.MATERIAL", Material.AMETHYST_SHARD.name());
         cratesConfig.set(basePath + ".DISPLAY.DISPLAY-NAME", "&fShards reward");
-        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7sʜᴀʀᴅs ʀᴇᴡᴀʀᴅ"));
+        cratesConfig.set(basePath + ".DISPLAY.LORE", List.of("&7Shards reward"));
         cratesConfig.set(basePath + ".DISPLAY.AMOUNT", 1);
         cratesConfig.set(basePath + ".DISPLAY.ENCHANTMENTS", List.of());
 
@@ -1184,7 +1184,7 @@ public class CrateManager {
             );
             return new ActionResult(false, plugin.getConfigManager().getMessageOrDefault(
                     "CRASH_PROTECTION.ITEM_BLOCKED",
-                    "&cᴛʜᴀᴛ ɪᴛᴇᴍ ᴄᴀɴɴᴏᴛ ʙᴇ ᴜѕᴇᴅ ʜᴇʀᴇ ʙᴇᴄᴀᴜѕᴇ ɪᴛѕ ᴅᴀᴛᴀ ʟᴏᴏᴋѕ ᴜɴѕᴀꜰᴇ. &7ᴄᴏɴᴛᴇxᴛ: &f{context}&7. ʀᴇᴀѕᴏɴ: &f{reason}",
+                    "&cThat item cannot be used here because its data looks unsafe. &7context: &f{context}&7. reason: &f{reason}",
                     "{context}", CrashProtectionManager.Context.CRATES.displayName(),
                     "{reason}", safetyResult.reason()
             ));
@@ -1275,11 +1275,11 @@ public class CrateManager {
 
     private List<String> serializeDisplayLore(ItemMeta meta) {
         if (meta == null || !meta.hasLore() || meta.getLore() == null || meta.getLore().isEmpty()) {
-            return List.of("&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.");
+            return List.of("&7Choose this reward.");
         }
 
         List<String> lore = serializeActualLore(meta);
-        return lore.isEmpty() ? List.of("&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.") : lore;
+        return lore.isEmpty() ? List.of("&7Choose this reward.") : lore;
     }
 
     private List<String> serializeGrantLore(ItemMeta meta) {
@@ -1874,9 +1874,9 @@ public class CrateManager {
                     Material.GRAY_STAINED_GLASS_PANE,
                     List.of(10, 11, 12, 13, 14, 15, 16),
                     13,
-                    new DisplayItem(Material.BARRIER, "&cno crates", List.of("&7ɴᴏ ᴄʀᴀᴛᴇѕ ᴀʀᴇ ᴀᴠᴀɪʟᴀʙʟᴇ ʀɪɢʜᴛ ɴᴏᴡ."), 1, List.of()),
+                    new DisplayItem(Material.BARRIER, "&cNo crates", List.of("&7no crates are available right now."), 1, List.of()),
                     26,
-                    new DisplayItem(Material.BARRIER, "&cclose", List.of("&7ᴄʟᴏѕᴇ ᴛʜɪѕ ᴍᴇɴᴜ."), 1, List.of())
+                    new DisplayItem(Material.BARRIER, "&cclose", List.of("&7Close this menu."), 1, List.of())
             );
         }
     }
@@ -1896,9 +1896,9 @@ public class CrateManager {
                     Material.GRAY_STAINED_GLASS_PANE,
                     13,
                     15,
-                    new DisplayItem(Material.LIME_STAINED_GLASS_PANE, "&aconfirm", List.of("&7ᴄʟɪᴄᴋ ᴛᴏ ᴄʟᴀɪᴍ {reward}."), 1, List.of()),
+                    new DisplayItem(Material.LIME_STAINED_GLASS_PANE, "&aconfirm", List.of("&7Click to claim {reward}."), 1, List.of()),
                     11,
-                    new DisplayItem(Material.RED_STAINED_GLASS_PANE, "&ccancel", List.of("&7ʀᴇᴛᴜʀɴ ᴛᴏ ᴛʜᴇ ʀᴇᴡᴀʀᴅ ʟɪѕᴛ."), 1, List.of())
+                    new DisplayItem(Material.RED_STAINED_GLASS_PANE, "&ccancel", List.of("&7Return to the reward list."), 1, List.of())
             );
         }
     }
@@ -1918,7 +1918,7 @@ public class CrateManager {
                     27,
                     Material.BLACK_STAINED_GLASS_PANE,
                     26,
-                    new DisplayItem(Material.BARRIER, "&cback", List.of("&7ʀᴇᴛᴜʀɴ ᴛᴏ ᴛʜᴇ ᴄʀᴀᴛᴇ ʟɪѕᴛ."), 1, List.of())
+                    new DisplayItem(Material.BARRIER, "&cback", List.of("&7Return to the crate list."), 1, List.of())
             );
         }
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
@@ -23,7 +23,7 @@ public class CrateEditorMenu extends BaseMenu {
     private boolean instructionsSent;
 
     public CrateEditorMenu(UltimateDonutSmp plugin, String crateId) {
-        super(plugin, "&8ᴇᴅɪᴛɪɴɢ ᴄʀᴀᴛᴇ: " + crateId, resolveSize(plugin, crateId));
+        super(plugin, "&8Editing crate: " + crateId, resolveSize(plugin, crateId));
         this.crateId = crateId;
     }
 
@@ -53,17 +53,17 @@ public class CrateEditorMenu extends BaseMenu {
 
         set(crate.menuSettings().backSlot(), ItemUtils.createItem(
                 Material.BARRIER,
-                "&cᴄʟᴏѕᴇ ᴇᴅɪᴛᴏʀ",
+                "&cClose Editor",
                 List.of(
-                        "&7ᴄʟɪᴄᴋ ᴛᴏ ᴄʟᴏѕᴇ ᴛʜɪѕ ᴇᴅɪᴛᴏʀ.",
-                        "&7ᴄʜᴀɴɢᴇѕ ᴀʀᴇ ѕᴀᴠᴇᴅ ɪɴѕᴛᴀɴᴛʟʏ."
+                        "&7Click to close this editor.",
+                        "&7Changes are saved instantly."
                 )
         ));
 
         if (!instructionsSent) {
             instructionsSent = true;
-            player.sendMessage(ColorUtils.toComponent("&8[&bᴄʀᴀᴛᴇѕ&8] &7ᴄʟɪᴄᴋ ᴀɴ ɪᴛᴇᴍ ɪɴ ʏᴏᴜʀ ɪɴᴠᴇɴᴛᴏʀʏ ᴛᴏ ѕᴇʟᴇᴄᴛ ɪᴛ ᴀѕ ᴀ ᴛᴇᴍᴘʟᴀᴛᴇ, ᴛʜᴇɴ ᴄʟɪᴄᴋ ᴀ ᴄʀᴀᴛᴇ ѕʟᴏᴛ ᴛᴏ ᴘʟᴀᴄᴇ ᴏʀ ʀᴇᴘʟᴀᴄᴇ ɪᴛ."));
-            player.sendMessage(ColorUtils.toComponent("&8[&bᴄʀᴀᴛᴇѕ&8] &7ᴄʟɪᴄᴋ ᴀ ʀᴇᴡᴀʀᴅ ѕʟᴏᴛ ᴡɪᴛʜ ɴᴏ ѕᴇʟᴇᴄᴛᴇᴅ ᴛᴇᴍᴘʟᴀᴛᴇ ᴛᴏ ʀᴇᴍᴏᴠᴇ ᴛʜᴇ ɪᴛᴇᴍ ʀᴇᴡᴀʀᴅ ꜰʀᴏᴍ ᴛʜᴀᴛ ѕʟᴏᴛ."));
+            player.sendMessage(ColorUtils.toComponent("&8[&bCrates&8] &7Click an item in your inventory to select it as a template, then click a crate slot to place or replace it."));
+            player.sendMessage(ColorUtils.toComponent("&8[&bCrates&8] &7Click a reward slot with no selected template to remove the item reward from that slot."));
         }
     }
 
@@ -76,7 +76,7 @@ public class CrateEditorMenu extends BaseMenu {
         if (crate == null) {
             event.setCancelled(true);
             player.closeInventory();
-            player.sendMessage(ColorUtils.toComponent("&cᴛʜᴀᴛ ᴄʀᴀᴛᴇ ɴᴏ ʟᴏɴɢᴇʀ ᴇxɪѕᴛѕ."));
+            player.sendMessage(ColorUtils.toComponent("&cThat crate no longer exists."));
             return;
         }
 
@@ -91,7 +91,7 @@ public class CrateEditorMenu extends BaseMenu {
             }
 
             if (lockedSlots.contains(rawSlot)) {
-                player.sendMessage(ColorUtils.toComponent("&cᴛʜᴀᴛ ѕʟᴏᴛ ᴄᴏɴᴛᴀɪɴѕ ᴀ ɴᴏɴ-ɪᴛᴇᴍ ʀᴇᴡᴀʀᴅ. ᴇᴅɪᴛ ɪᴛ ɪɴ crates.yml ɪꜰ ɴᴇᴇᴅᴇᴅ."));
+                player.sendMessage(ColorUtils.toComponent("&cThat slot contains a non-item reward. Edit it in crates.yml if needed."));
                 return;
             }
 
@@ -160,7 +160,7 @@ public class CrateEditorMenu extends BaseMenu {
             }
 
             if (inventory.getItem(rawSlot) == null || inventory.getItem(rawSlot).getType().isAir()) {
-                player.sendMessage(ColorUtils.toComponent("&cѕᴇʟᴇᴄᴛ ᴀɴ ɪᴛᴇᴍ ꜰʀᴏᴍ ʏᴏᴜʀ ɪɴᴠᴇɴᴛᴏʀʏ ꜰɪʀѕᴛ."));
+                player.sendMessage(ColorUtils.toComponent("&cSelect an item from your inventory first."));
                 return;
             }
 
@@ -180,7 +180,7 @@ public class CrateEditorMenu extends BaseMenu {
 
         event.setCancelled(true);
         selectedTemplate = event.getCurrentItem().clone();
-        player.sendMessage(ColorUtils.toComponent("&aѕᴇʟᴇᴄᴛᴇᴅ &f" + readableItemName(selectedTemplate) + "&a. ᴄʟɪᴄᴋ ᴀ ᴄʀᴀᴛᴇ ѕʟᴏᴛ ᴛᴏ ᴘʟᴀᴄᴇ ɪᴛ."));
+        player.sendMessage(ColorUtils.toComponent("&aSelected &f" + readableItemName(selectedTemplate) + "&a. Click a crate slot to place it."));
         SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
     }
 
@@ -225,8 +225,8 @@ public class CrateEditorMenu extends BaseMenu {
                 reward.display().material(),
                 reward.display().displayName(),
                 List.of(
-                        "&7ᴛʜɪѕ ѕʟᴏᴛ ᴜѕᴇѕ ᴀ ɴᴏɴ-ɪᴛᴇᴍ ʀᴇᴡᴀʀᴅ.",
-                        "&7ɢᴜɪ ᴇᴅɪᴛᴏʀ ᴏɴʟʏ ѕᴜᴘᴘᴏʀᴛѕ ɪᴛᴇᴍ ʀᴇᴡᴀʀᴅѕ."
+                        "&7This slot uses a non-item reward.",
+                        "&7GUI editor only supports item rewards."
                 )
         );
         item.setAmount(1);

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
@@ -96,6 +96,60 @@ public class CrateEditorMenu extends BaseMenu {
             }
 
             if (selectedTemplate != null) {
+                String display = "";
+                if (selectedTemplate.hasItemMeta() && selectedTemplate.getItemMeta() != null && selectedTemplate.getItemMeta().hasDisplayName()) {
+                    display = selectedTemplate.getItemMeta().getDisplayName();
+                }
+                // Template shorthand: use display name tags to create non-item rewards from the GUI.
+                // Supported tags (place on a held item as the display name):
+                // [CMD] <console command...>
+                // [MONEY] <amount>
+                // [SHARDS] <amount>
+                if (display.startsWith("[CMD] ")) {
+                    String consoleCommand = display.substring(6).strip();
+                    CrateManager.ActionResult result = plugin.getCrateManager().addCommandReward(crateId, rawSlot, List.of(consoleCommand));
+                    player.sendMessage(ColorUtils.toComponent(result.message()));
+                    if (result.success()) {
+                        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                        build(player);
+                    }
+                    return;
+                } else if (display.startsWith("[MONEY] ")) {
+                    String amountStr = display.substring(8).strip();
+                    Double parsed = null;
+                    try {
+                        parsed = Double.parseDouble(amountStr);
+                    } catch (NumberFormatException ignored) { }
+                    if (parsed == null) {
+                        player.sendMessage(ColorUtils.toComponent("&cInvalid money amount in template display name. Use '[MONEY] 10.5'."));
+                        return;
+                    }
+                    CrateManager.ActionResult result = plugin.getCrateManager().addMoneyReward(crateId, rawSlot, parsed);
+                    player.sendMessage(ColorUtils.toComponent(result.message()));
+                    if (result.success()) {
+                        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                        build(player);
+                    }
+                    return;
+                } else if (display.startsWith("[SHARDS] ")) {
+                    String amountStr = display.substring(9).strip();
+                    Long parsed = null;
+                    try {
+                        parsed = Long.parseLong(amountStr);
+                    } catch (NumberFormatException ignored) { }
+                    if (parsed == null) {
+                        player.sendMessage(ColorUtils.toComponent("&cInvalid shards amount in template display name. Use '[SHARDS] 100'."));
+                        return;
+                    }
+                    CrateManager.ActionResult result = plugin.getCrateManager().addShardsReward(crateId, rawSlot, parsed);
+                    player.sendMessage(ColorUtils.toComponent(result.message()));
+                    if (result.success()) {
+                        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                        build(player);
+                    }
+                    return;
+                }
+
                 CrateManager.ActionResult result = plugin.getCrateManager().upsertItemReward(crateId, rawSlot, selectedTemplate);
                 player.sendMessage(ColorUtils.toComponent(result.message()));
                 if (result.success()) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/CrateEditorMenu.java
@@ -98,7 +98,7 @@ public class CrateEditorMenu extends BaseMenu {
             if (selectedTemplate != null) {
                 String display = "";
                 if (selectedTemplate.hasItemMeta() && selectedTemplate.getItemMeta() != null && selectedTemplate.getItemMeta().hasDisplayName()) {
-                    display = selectedTemplate.getItemMeta().getDisplayName();
+                    display = org.bukkit.ChatColor.stripColor(selectedTemplate.getItemMeta().getDisplayName()).trim();
                 }
                 // Template shorthand: use display name tags to create non-item rewards from the GUI.
                 // Supported tags (place on a held item as the display name):

--- a/src/main/resources/crates.yml
+++ b/src/main/resources/crates.yml
@@ -1,12 +1,11 @@
-# Configuration section for Settings.
+# SMPCore setup: Crate opening behavior and editable crate reward definitions.
+# SMPCore setup: Keep indentation with spaces; reload with /smpcore reload when the setting supports reload.
+
 SETTINGS:
-  # Configuration section for List Menu.
   LIST-MENU:
     TITLE: '&8Crates'
     SIZE: 27
-    # The text or value for Filler. Available options: Any valid string text
     FILLER: GRAY_STAINED_GLASS_PANE
-    # Configuration section for Content Slots.
     CONTENT-SLOTS:
     - 10
     - 11
@@ -15,67 +14,52 @@ SETTINGS:
     - 14
     - 15
     - 16
-    # The numerical value for Empty Slot. Available options: Any valid integer
     EMPTY-SLOT: 13
-    # Configuration section for Empty.
     EMPTY:
       MATERIAL: BARRIER
       DISPLAY-NAME: '&cNo Crates'
       LORE:
       - '&7No crates are available right now.'
-    # Configuration section for Close Button.
     CLOSE-BUTTON:
       SLOT: 26
       MATERIAL: BARRIER
       DISPLAY-NAME: '&cClose'
       LORE:
       - '&7Close this menu.'
-  # Configuration section for Confirm Menu.
+  
   CONFIRM-MENU:
     SIZE: 27
-    # The text or value for Filler. Available options: Any valid string text
     FILLER: GRAY_STAINED_GLASS_PANE
-    # The numerical value for Preview Slot. Available options: Any valid integer
     PREVIEW-SLOT: 13
-    # The numerical value for Confirm Slot. Available options: Any valid integer
     CONFIRM-SLOT: 15
-    # Configuration section for Confirm Button.
     CONFIRM-BUTTON:
       MATERIAL: LIME_STAINED_GLASS_PANE
       DISPLAY-NAME: '&aConfirm'
       LORE:
       - '&7Claim &f{reward}&7 from'
       - '&b{crate}&7.'
-    # Configuration section for Cancel Button.
     CANCEL-BUTTON:
       SLOT: 11
       MATERIAL: RED_STAINED_GLASS_PANE
       DISPLAY-NAME: '&cCancel'
       LORE:
       - '&7Return to the reward list.'
-  # Configuration section for Hologram.
+  
   HOLOGRAM:
-    # The decimal value for Offset Y. Available options: Any decimal number
     OFFSET-Y: 1.6
-    # Configuration section for Lines.
     LINES:
     - '{crate}'
     - '&7Right-click to open'
-    # The text or value for Key Line. Available options: Any valid string text
     KEY-LINE: '&7Keys: &f{keys}'
-  # Configuration section for Particles.
+  
   PARTICLES:
-    # Determines whether Enabled is enabled or disabled. Available options: true, false
     ENABLED: true
     TYPE: ENCHANT
-    # The numerical value for Count. Available options: Any valid integer
     COUNT: 4
-  # Configuration section for Gacha.
+  
   GACHA:
     TITLE: '&8Rolling Reward'
-    # The text or value for Filler. Available options: Any valid string text
     FILLER: BLACK_STAINED_GLASS_PANE
-    # Configuration section for Preview Slots.
     PREVIEW-SLOTS:
     - 10
     - 11
@@ -84,407 +68,742 @@ SETTINGS:
     - 14
     - 15
     - 16
-    # The numerical value for Pointer Slot. Available options: Any valid integer
     POINTER-SLOT: 13
-    # The numerical value for Total Steps. Available options: Any valid integer
     TOTAL-STEPS: 38
-    # The numerical value for Tick Interval. Available options: Any valid integer
     TICK-INTERVAL: 2
-# Configuration section for Crates.
+
 CRATES:
-  # Configuration section for Common.
   common:
-    # Determines whether Enabled is enabled or disabled. Available options: true, false
     ENABLED: true
-    # The text or value for Open Type. Available options: Any valid string text
     OPEN-TYPE: CHOOSE_ONE
-    # Configuration section for Display.
     DISPLAY:
-      MATERIAL: CHEST
+      MATERIAL: LIME_SHULKER_BOX
       DISPLAY-NAME: '&fCommon Crate'
       LORE:
       - '&7Keys: &f{keys}'
       - '&aClick to open and choose 1 reward.'
-    # Configuration section for Key Item.
     KEY-ITEM:
       MATERIAL: TRIPWIRE_HOOK
-      DISPLAY-NAME: '&fCommon Key'
+      DISPLAY-NAME: '&fcommon key'
       LORE:
       - '&7Opens the &fCommon Crate&7.'
-    # The text or value for Permission. Available options: Any valid string text
     PERMISSION: ''
-    # Determines whether Broadcast On Claim is enabled or disabled. Available options: true, false
     BROADCAST-ON-CLAIM: false
-    # Configuration section for Menu.
     MENU:
-      # The text or value for Open Title. Available options: Any valid string text
-      OPEN-TITLE: '&8Choose 1 Reward'
-      # The text or value for Confirm Title. Available options: Any valid string text
+      OPEN-TITLE: '&8Common Crate'
       CONFIRM-TITLE: '&8Confirm Reward'
       SIZE: 27
-      # The text or value for Filler. Available options: Any valid string text
       FILLER: BLACK_STAINED_GLASS_PANE
-      # The numerical value for Back Slot. Available options: Any valid integer
       BACK-SLOT: 26
-      # Configuration section for Back Button.
       BACK-BUTTON:
         MATERIAL: BARRIER
         DISPLAY-NAME: '&cBack'
         LORE:
         - '&7Return to the crate list.'
-    # Configuration section for Rewards.
     REWARDS:
-      # Configuration section for Iron Helmet.
-      iron_helmet:
-        SLOT: 10
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: IRON_HELMET
-          DISPLAY-NAME: '&fIron Helmet'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: ITEM
-          MATERIAL: IRON_HELMET
-          # The numerical value for Amount. Available options: Any valid integer
-          AMOUNT: 1
-      # Configuration section for Iron Chestplate.
-      iron_chestplate:
-        SLOT: 11
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: IRON_CHESTPLATE
-          DISPLAY-NAME: '&fIron Chestplate'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: ITEM
-          MATERIAL: IRON_CHESTPLATE
-          # The numerical value for Amount. Available options: Any valid integer
-          AMOUNT: 1
-      # Configuration section for Iron Leggings.
-      iron_leggings:
-        SLOT: 12
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: IRON_LEGGINGS
-          DISPLAY-NAME: '&fIron Leggings'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: ITEM
-          MATERIAL: IRON_LEGGINGS
-          # The numerical value for Amount. Available options: Any valid integer
-          AMOUNT: 1
-      # Configuration section for Iron Boots.
-      iron_boots:
-        SLOT: 13
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: IRON_BOOTS
-          DISPLAY-NAME: '&fIron Boots'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: ITEM
-          MATERIAL: IRON_BOOTS
-          # The numerical value for Amount. Available options: Any valid integer
-          AMOUNT: 1
-      # Configuration section for Iron Sword.
-      iron_sword:
-        SLOT: 14
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: IRON_SWORD
-          DISPLAY-NAME: '&fIron Sword'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: ITEM
-          MATERIAL: IRON_SWORD
-          # The numerical value for Amount. Available options: Any valid integer
-          AMOUNT: 1
-      # Configuration section for Money.
-      money:
-        SLOT: 15
-        # Configuration section for Display.
-        DISPLAY:
-          MATERIAL: SUNFLOWER
-          DISPLAY-NAME: '&e$5,000'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
-        GRANT:
-          TYPE: COMMAND
-          # Configuration section for Commands.
-          COMMANDS:
-          - addmoney {player} 5000
-  # Configuration section for Rare.
-  rare:
-    # Determines whether Enabled is enabled or disabled. Available options: true, false
-    ENABLED: true
-    # The text or value for Open Type. Available options: Any valid string text
-    OPEN-TYPE: CHOOSE_ONE
-    # Configuration section for Display.
-    DISPLAY:
-      MATERIAL: BARREL
-      DISPLAY-NAME: '&#37BFF9Rare Crate'
-      LORE:
-      - '&7Keys: &f{keys}'
-      - '&aClick to open and choose 1 reward.'
-    # Configuration section for Key Item.
-    KEY-ITEM:
-      MATERIAL: TRIPWIRE_HOOK
-      DISPLAY-NAME: '&#37BFF9Rare Key'
-      LORE:
-      - '&7Opens the &bRare Crate&7.'
-    # The text or value for Permission. Available options: Any valid string text
-    PERMISSION: ''
-    # Determines whether Broadcast On Claim is enabled or disabled. Available options: true, false
-    BROADCAST-ON-CLAIM: false
-    # Configuration section for Menu.
-    MENU:
-      # The text or value for Open Title. Available options: Any valid string text
-      OPEN-TITLE: '&8Rare Crate'
-      # The text or value for Confirm Title. Available options: Any valid string text
-      CONFIRM-TITLE: '&8Confirm Rare Reward'
-      SIZE: 27
-      # The text or value for Filler. Available options: Any valid string text
-      FILLER: BLACK_STAINED_GLASS_PANE
-      # The numerical value for Back Slot. Available options: Any valid integer
-      BACK-SLOT: 26
-      # Configuration section for Back Button.
-      BACK-BUTTON:
-        MATERIAL: BARRIER
-        DISPLAY-NAME: '&cBack'
-        LORE:
-        - '&7Return to the crate list.'
-    # Configuration section for Rewards.
-    REWARDS:
-      # Configuration section for Diamond Helmet.
       diamond_helmet:
         SLOT: 10
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: DIAMOND_HELMET
           DISPLAY-NAME: '&bDiamond Helmet'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:1
+          - respiration:2
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND_HELMET
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&bDiamond Helmet'
           AMOUNT: 1
-      # Configuration section for Diamond Chestplate.
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:1
+          - respiration:2
       diamond_chestplate:
         SLOT: 11
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: DIAMOND_CHESTPLATE
           DISPLAY-NAME: '&bDiamond Chestplate'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          ENCHANTMENTS:
+          - protection:1
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND_CHESTPLATE
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&bDiamond Chestplate'
           AMOUNT: 1
-      # Configuration section for Diamond Leggings.
+          ENCHANTMENTS:
+          - protection:1
       diamond_leggings:
         SLOT: 12
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: DIAMOND_LEGGINGS
           DISPLAY-NAME: '&bDiamond Leggings'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          ENCHANTMENTS:
+          - protection:1
+          - swift_sneak:2
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND_LEGGINGS
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&bDiamond Leggings'
           AMOUNT: 1
-      # Configuration section for Diamond Boots.
+          ENCHANTMENTS:
+          - protection:1
+          - swift_sneak:2
       diamond_boots:
         SLOT: 13
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: DIAMOND_BOOTS
           DISPLAY-NAME: '&bDiamond Boots'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          ENCHANTMENTS:
+          - feather_falling:2
+          - depth_strider:2
+          - protection:1
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND_BOOTS
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&bDiamond Boots'
           AMOUNT: 1
-      # Configuration section for Diamond Sword.
+          ENCHANTMENTS:
+          - feather_falling:2
+          - depth_strider:2
+          - protection:1
       diamond_sword:
         SLOT: 14
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: DIAMOND_SWORD
           DISPLAY-NAME: '&bDiamond Sword'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          ENCHANTMENTS:
+          - sharpness:1
+          - looting:2
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND_SWORD
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&bDiamond Sword'
           AMOUNT: 1
-      # Configuration section for Money.
-      money:
+          ENCHANTMENTS:
+          - sharpness:1
+          - looting:2
+      diamond_pickaxe:
         SLOT: 15
-        # Configuration section for Display.
         DISPLAY:
-          MATERIAL: SUNFLOWER
-          DISPLAY-NAME: '&e$15,000'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          MATERIAL: DIAMOND_PICKAXE
+          DISPLAY-NAME: '&bDiamond Pickaxe'
+          ENCHANTMENTS:
+          - efficiency:2
+          - fortune:1
         GRANT:
-          TYPE: COMMAND
-          # Configuration section for Commands.
-          COMMANDS:
-          - addmoney {player} 15000
-  # Configuration section for Epic.
-  epic:
-    # Determines whether Enabled is enabled or disabled. Available options: true, false
+          TYPE: ITEM
+          MATERIAL: DIAMOND_PICKAXE
+          DISPLAY-NAME: '&bDiamond Pickaxe'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - efficiency:2
+          - fortune:1
+      diamond_shovel:
+        SLOT: 16
+        DISPLAY:
+          MATERIAL: DIAMOND_SHOVEL
+          DISPLAY-NAME: '&bDiamond Shovel'
+          ENCHANTMENTS:
+          - efficiency:3
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: DIAMOND_SHOVEL
+          DISPLAY-NAME: '&bDiamond Shovel'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - efficiency:3
+  
+  prime:
     ENABLED: true
-    # The text or value for Open Type. Available options: Any valid string text
     OPEN-TYPE: CHOOSE_ONE
-    # Configuration section for Display.
     DISPLAY:
-      MATERIAL: ENDER_CHEST
-      DISPLAY-NAME: '&#A303F9Epic Crate'
+      MATERIAL: BLUE_SHULKER_BOX
+      DISPLAY-NAME: '&9Prime Crate'
       LORE:
       - '&7Keys: &f{keys}'
       - '&aClick to open and choose 1 reward.'
-    # Configuration section for Key Item.
     KEY-ITEM:
       MATERIAL: TRIPWIRE_HOOK
-      DISPLAY-NAME: '&#A303F9Epic Key'
+      DISPLAY-NAME: '&9prime key'
       LORE:
-      - '&7Opens the &5Epic Crate&7.'
-    # The text or value for Permission. Available options: Any valid string text
+      - '&7Opens the &9Prime Crate&7.'
     PERMISSION: ''
-    # Determines whether Broadcast On Claim is enabled or disabled. Available options: true, false
-    BROADCAST-ON-CLAIM: true
-    # Configuration section for Menu.
+    BROADCAST-ON-CLAIM: false
     MENU:
-      # The text or value for Open Title. Available options: Any valid string text
-      OPEN-TITLE: '&8Epic Crate'
-      # The text or value for Confirm Title. Available options: Any valid string text
-      CONFIRM-TITLE: '&8Confirm Epic Reward'
+      OPEN-TITLE: '&8Prime Crate'
+      CONFIRM-TITLE: '&8Confirm Prime Reward'
       SIZE: 27
-      # The text or value for Filler. Available options: Any valid string text
       FILLER: BLACK_STAINED_GLASS_PANE
-      # The numerical value for Back Slot. Available options: Any valid integer
       BACK-SLOT: 26
-      # Configuration section for Back Button.
       BACK-BUTTON:
         MATERIAL: BARRIER
         DISPLAY-NAME: '&cBack'
         LORE:
         - '&7Return to the crate list.'
-    # Configuration section for Rewards.
     REWARDS:
-      # Configuration section for Netherite Helmet.
-      netherite_helmet:
+      prime_helmet:
         SLOT: 10
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: NETHERITE_HELMET
-          DISPLAY-NAME: '&5Netherite Helmet'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          DISPLAY-NAME: '&9Prime Netherite Helmet'
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:4
+          - respiration:3
+          - unbreaking:3
+          - mending:1
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_HELMET
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&9Prime Netherite Helmet'
           AMOUNT: 1
-      # Configuration section for Netherite Chestplate.
-      netherite_chestplate:
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:4
+          - respiration:3
+          - unbreaking:3
+          - mending:1
+      prime_chestplate:
         SLOT: 11
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: NETHERITE_CHESTPLATE
-          DISPLAY-NAME: '&5Netherite Chestplate'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          DISPLAY-NAME: '&9Prime Netherite Chestplate'
+          ENCHANTMENTS:
+          - protection:4
+          - unbreaking:3
+          - mending:1
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_CHESTPLATE
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&9Prime Netherite Chestplate'
           AMOUNT: 1
-      # Configuration section for Netherite Leggings.
-      netherite_leggings:
+          ENCHANTMENTS:
+          - protection:4
+          - unbreaking:3
+          - mending:1
+      prime_leggings:
         SLOT: 12
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: NETHERITE_LEGGINGS
-          DISPLAY-NAME: '&5Netherite Leggings'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          DISPLAY-NAME: '&9Prime Netherite Leggings'
+          ENCHANTMENTS:
+          - swift_sneak:3
+          - blast_protection:4
+          - unbreaking:3
+          - mending:1
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_LEGGINGS
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&9Prime Netherite Leggings'
           AMOUNT: 1
-      # Configuration section for Netherite Boots.
-      netherite_boots:
+          ENCHANTMENTS:
+          - swift_sneak:3
+          - blast_protection:4
+          - unbreaking:3
+          - mending:1
+      prime_boots:
         SLOT: 13
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: NETHERITE_BOOTS
-          DISPLAY-NAME: '&5Netherite Boots'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          DISPLAY-NAME: '&9Prime Netherite Boots'
+          ENCHANTMENTS:
+          - depth_strider:3
+          - feather_falling:4
+          - protection:4
+          - soul_speed:3
+          - unbreaking:3
+          - mending:1
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_BOOTS
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&9Prime Netherite Boots'
           AMOUNT: 1
-      # Configuration section for Netherite Sword.
-      netherite_sword:
+          ENCHANTMENTS:
+          - depth_strider:3
+          - feather_falling:4
+          - protection:4
+          - soul_speed:3
+          - unbreaking:3
+          - mending:1
+      prime_sword:
         SLOT: 14
-        # Configuration section for Display.
         DISPLAY:
           MATERIAL: NETHERITE_SWORD
-          DISPLAY-NAME: '&5Netherite Sword'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          DISPLAY-NAME: '&9Prime Netherite Sword'
+          ENCHANTMENTS:
+          - looting:3
+          - knockback:1
+          - sharpness:5
+          - sweeping_edge:3
+          - unbreaking:3
+          - mending:1
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_SWORD
-          # The numerical value for Amount. Available options: Any valid integer
+          DISPLAY-NAME: '&9Prime Netherite Sword'
           AMOUNT: 1
-      # Configuration section for Money.
-      money:
+          ENCHANTMENTS:
+          - looting:3
+          - knockback:1
+          - sharpness:5
+          - sweeping_edge:3
+          - unbreaking:3
+          - mending:1
+      prime_crossbow:
         SLOT: 15
-        # Configuration section for Display.
         DISPLAY:
-          MATERIAL: SUNFLOWER
-          DISPLAY-NAME: '&e$50,000'
-          LORE:
-          - '&7Choose this reward.'
-        # Configuration section for Grant.
+          MATERIAL: CROSSBOW
+          DISPLAY-NAME: '&9Prime Crossbow'
+          ENCHANTMENTS:
+          - multishot:1
+          - quick_charge:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: CROSSBOW
+          DISPLAY-NAME: '&9Prime Crossbow'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - multishot:1
+          - quick_charge:3
+          - unbreaking:3
+          - mending:1
+      prime_mace:
+        SLOT: 16
+        DISPLAY:
+          MATERIAL: MACE
+          DISPLAY-NAME: '&9Prime Mace'
+          ENCHANTMENTS:
+          - breach:4
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: MACE
+          DISPLAY-NAME: '&9Prime Mace'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - breach:4
+          - unbreaking:3
+          - mending:1
+  
+  crimson:
+    ENABLED: true
+    OPEN-TYPE: CHOOSE_ONE
+    DISPLAY:
+      MATERIAL: RED_SHULKER_BOX
+      DISPLAY-NAME: '&cCrimson Crate'
+      LORE:
+      - '&7Keys: &f{keys}'
+      - '&aClick to open and choose 1 reward.'
+    KEY-ITEM:
+      MATERIAL: TRIPWIRE_HOOK
+      DISPLAY-NAME: '&ccrimson key'
+      LORE:
+      - '&7Opens the &cCrimson Crate&7.'
+    PERMISSION: ''
+    BROADCAST-ON-CLAIM: true
+    MENU:
+      OPEN-TITLE: '&8Crimson Crate'
+      CONFIRM-TITLE: '&8Confirm Crimson Reward'
+      SIZE: 27
+      FILLER: BLACK_STAINED_GLASS_PANE
+      BACK-SLOT: 26
+      BACK-BUTTON:
+        MATERIAL: BARRIER
+        DISPLAY-NAME: '&cBack'
+        LORE:
+        - '&7Return to the crate list.'
+    REWARDS:
+      crimson_helmet:
+        SLOT: 10
+        DISPLAY:
+          MATERIAL: NETHERITE_HELMET
+          DISPLAY-NAME: '&cCrimson Netherite Helmet'
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:4
+          - respiration:3
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_HELMET
+          DISPLAY-NAME: '&cCrimson Netherite Helmet'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - aqua_affinity:1
+          - protection:4
+          - respiration:3
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+      crimson_chestplate:
+        SLOT: 11
+        DISPLAY:
+          MATERIAL: NETHERITE_CHESTPLATE
+          DISPLAY-NAME: '&cCrimson Netherite Chestplate'
+          ENCHANTMENTS:
+          - protection:4
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_CHESTPLATE
+          DISPLAY-NAME: '&cCrimson Netherite Chestplate'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - protection:4
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+      crimson_leggings:
+        SLOT: 12
+        DISPLAY:
+          MATERIAL: NETHERITE_LEGGINGS
+          DISPLAY-NAME: '&cCrimson Netherite Leggings'
+          ENCHANTMENTS:
+          - swift_sneak:3
+          - protection:4
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_LEGGINGS
+          DISPLAY-NAME: '&cCrimson Netherite Leggings'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - swift_sneak:3
+          - protection:4
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+      crimson_boots:
+        SLOT: 13
+        DISPLAY:
+          MATERIAL: NETHERITE_BOOTS
+          DISPLAY-NAME: '&cCrimson Netherite Boots'
+          ENCHANTMENTS:
+          - depth_strider:3
+          - feather_falling:4
+          - protection:4
+          - soul_speed:3
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_BOOTS
+          DISPLAY-NAME: '&cCrimson Netherite Boots'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - depth_strider:3
+          - feather_falling:4
+          - protection:4
+          - soul_speed:3
+          - thorns:3
+          - unbreaking:3
+          - mending:1
+      crimson_sword:
+        SLOT: 14
+        DISPLAY:
+          MATERIAL: NETHERITE_SWORD
+          DISPLAY-NAME: '&cCrimson Netherite Sword'
+          ENCHANTMENTS:
+          - knockback:2
+          - fire_aspect:2
+          - sharpness:5
+          - sweeping_edge:3
+          - looting:3
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_SWORD
+          DISPLAY-NAME: '&cCrimson Netherite Sword'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - knockback:2
+          - fire_aspect:2
+          - sharpness:5
+          - sweeping_edge:3
+          - looting:3
+          - unbreaking:3
+          - mending:1
+      crimson_axe:
+        SLOT: 15
+        DISPLAY:
+          MATERIAL: NETHERITE_AXE
+          DISPLAY-NAME: '&cCrimson Netherite Axe'
+          ENCHANTMENTS:
+          - efficiency:5
+          - silk_touch:1
+          - sharpness:5
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_AXE
+          DISPLAY-NAME: '&cCrimson Netherite Axe'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - efficiency:5
+          - silk_touch:1
+          - sharpness:5
+          - unbreaking:3
+          - mending:1
+      crimson_pickaxe:
+        SLOT: 16
+        DISPLAY:
+          MATERIAL: NETHERITE_PICKAXE
+          DISPLAY-NAME: '&cCrimson Netherite Pickaxe'
+          ENCHANTMENTS:
+          - efficiency:5
+          - silk_touch:1
+          - unbreaking:3
+          - mending:1
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_PICKAXE
+          DISPLAY-NAME: '&cCrimson Netherite Pickaxe'
+          AMOUNT: 1
+          ENCHANTMENTS:
+          - efficiency:5
+          - silk_touch:1
+          - unbreaking:3
+          - mending:1
+  
+  gold:
+    ENABLED: true
+    OPEN-TYPE: GACHA
+    DISPLAY:
+      MATERIAL: YELLOW_SHULKER_BOX
+      DISPLAY-NAME: '&6Gold Crate'
+      LORE:
+      - '&7Keys: &f{keys}'
+      - '&aClick to open and choose 1 reward.'
+    KEY-ITEM:
+      MATERIAL: TRIPWIRE_HOOK
+      DISPLAY-NAME: '&6gold key'
+      LORE:
+      - '&7Opens the &6Gold Crate&7.'
+    PERMISSION: ''
+    BROADCAST-ON-CLAIM: true
+    MENU:
+      OPEN-TITLE: '&8Gold Crate'
+      CONFIRM-TITLE: '&8Confirm Gold Reward'
+      SIZE: 27
+      FILLER: BLACK_STAINED_GLASS_PANE
+      BACK-SLOT: 26
+      BACK-BUTTON:
+        MATERIAL: BARRIER
+        DISPLAY-NAME: '&cBack'
+        LORE:
+        - '&7Return to the crate list.'
+    REWARDS:
+      skeleton_spawner:
+        SLOT: 14
+        DISPLAY:
+          MATERIAL: SPAWNER
+          DISPLAY-NAME: '#FF55FF5X Skeleton Spawner'
+          ENCHANTMENTS:
+          - mending:1
         GRANT:
           TYPE: COMMAND
-          # Configuration section for Commands.
           COMMANDS:
-          - addmoney {player} 50000
+          - smartspawner give spawner %player% skeleton 5
+      ultra_elytra:
+        SLOT: 15
+        DISPLAY:
+          MATERIAL: ELYTRA
+          DISPLAY-NAME: '#FF55FFUltra Elytra'
+        GRANT:
+          TYPE: COMMAND
+          COMMANDS:
+          - give %player% elytra
+      iron_golem_spawner:
+        SLOT: 16
+        DISPLAY:
+          MATERIAL: SPAWNER
+          DISPLAY-NAME: '#FF55FFIron Golem Spawner'
+          ENCHANTMENTS:
+          - unbreaking:1
+        GRANT:
+          TYPE: COMMAND
+          COMMANDS:
+          - smartspawner give spawner %player% iron_golem
+      reward_13:
+        SLOT: 13
+        DISPLAY:
+          MATERIAL: DRAGON_HEAD
+          DISPLAY-NAME: '&fᴅʀᴀɢᴏɴ ʜᴇᴀᴅ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: DRAGON_HEAD
+          DISPLAY-NAME: '&fᴅʀᴀɢᴏɴ ʜᴇᴀᴅ'
+          LORE: []
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_12:
+        SLOT: 12
+        DISPLAY:
+          MATERIAL: ENCHANTED_GOLDEN_APPLE
+          DISPLAY-NAME: '&fᴇɴᴄʜᴀɴᴛᴇᴅ ɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: ENCHANTED_GOLDEN_APPLE
+          DISPLAY-NAME: '&fᴇɴᴄʜᴀɴᴛᴇᴅ ɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          LORE: []
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_11:
+        SLOT: 11
+        DISPLAY:
+          MATERIAL: NETHERITE_INGOT
+          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ɪɴɢᴏᴛ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 6
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_INGOT
+          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ɪɴɢᴏᴛ'
+          LORE: []
+          AMOUNT: 6
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_10:
+        SLOT: 10
+        DISPLAY:
+          MATERIAL: NETHERITE_UPGRADE_SMITHING_TEMPLATE
+          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ᴜᴘɢʀᴀᴅᴇ ѕᴍɪᴛʜɪɴɢ ᴛᴇᴍᴘʟᴀᴛᴇ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: NETHERITE_UPGRADE_SMITHING_TEMPLATE
+          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ᴜᴘɢʀᴀᴅᴇ ѕᴍɪᴛʜɪɴɢ ᴛᴇᴍᴘʟᴀᴛᴇ'
+          LORE: []
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_3:
+        SLOT: 3
+        DISPLAY:
+          MATERIAL: GOLDEN_CARROT
+          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴄᴀʀʀᴏᴛ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 64
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: GOLDEN_CARROT
+          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴄᴀʀʀᴏᴛ'
+          LORE: []
+          AMOUNT: 64
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_5:
+        SLOT: 5
+        DISPLAY:
+          MATERIAL: GOLDEN_APPLE
+          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 32
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: GOLDEN_APPLE
+          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          LORE: []
+          AMOUNT: 32
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_22:
+        SLOT: 22
+        DISPLAY:
+          MATERIAL: DIAMOND
+          DISPLAY-NAME: '&fᴅɪᴀᴍᴏɴᴅ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 32
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: DIAMOND
+          DISPLAY-NAME: '&fᴅɪᴀᴍᴏɴᴅ'
+          LORE: []
+          AMOUNT: 32
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_4:
+        SLOT: 4
+        DISPLAY:
+          MATERIAL: GOLD_INGOT
+          DISPLAY-NAME: '&fɢᴏʟᴅ ɪɴɢᴏᴛ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 64
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: GOLD_INGOT
+          DISPLAY-NAME: '&fɢᴏʟᴅ ɪɴɢᴏᴛ'
+          LORE: []
+          AMOUNT: 64
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_23:
+        SLOT: 23
+        DISPLAY:
+          MATERIAL: FIREWORK_ROCKET
+          DISPLAY-NAME: '&fꜰɪʀᴇᴡᴏʀᴋ ʀᴏᴄᴋᴇᴛ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 64
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: FIREWORK_ROCKET
+          DISPLAY-NAME: '&fꜰɪʀᴇᴡᴏʀᴋ ʀᴏᴄᴋᴇᴛ'
+          LORE: []
+          AMOUNT: 64
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true
+      reward_21:
+        SLOT: 21
+        DISPLAY:
+          MATERIAL: BEACON
+          DISPLAY-NAME: '&fʙᴇᴀᴄᴏɴ'
+          LORE:
+          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+        GRANT:
+          TYPE: ITEM
+          MATERIAL: BEACON
+          DISPLAY-NAME: '&fʙᴇᴀᴄᴏɴ'
+          LORE: []
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          REQUIRES-INVENTORY-SPACE: true

--- a/src/main/resources/crates.yml
+++ b/src/main/resources/crates.yml
@@ -610,13 +610,27 @@ CRATES:
         SLOT: 14
         DISPLAY:
           MATERIAL: SPAWNER
-          DISPLAY-NAME: '#FF55FF5X Skeleton Spawner'
-          ENCHANTMENTS:
-          - mending:1
+          DISPLAY-NAME: '&dSkeleton Spawner'
+          ENCHANTMENTS: []
+          LORE:
+          - '&7Type: &fSkeleton Spawner'
+          - ''
+          - '&ePlace to create or stack this spawner.'
+          AMOUNT: 1
         GRANT:
-          TYPE: COMMAND
+          TYPE: ITEM
           COMMANDS:
-          - smartspawner give spawner %player% skeleton 5
+          - spawner give {player} skeleton 2
+          MATERIAL: SPAWNER
+          DISPLAY-NAME: '&dSkeleton Spawner'
+          LORE:
+          - '&7Type: &fSkeleton Spawner'
+          - ''
+          - '&ePlace to create or stack this spawner.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          ITEM-DATA: ITEM_BYTES_V1:H4sIAAAAAAAA/52SyU7DMBCGJ3RRGhaxiLsv0BsP0COiJxBUatVr5DrTxIqXyB6r9O1xoLSVODTCB8sj//P788xkAD04f+HEl+i8tAbgbpzCmSzgRkuDwvE1TXzDNwZdDwbCBkMAkGSQCasba9CQH8HVQayswyxKeiMY4Cc53gZnCQwlcSUFJJAFU6BTMaOIUX9lVQFp6x1ToV86vo0au1oHLzh9ay49OVkjVc6GsoriPkVrGC62DU4YHMx/b67nNSoka9j8h33vP9hUknAvhHhq1zFs0hl2uEWl7KYj7uNMcYGMLBMOo5RZxzxxUTOqpGe7Kj8dsWVwfyisCJ6szg3X+D/aCyXLivImuEZhR+Y/hTxBV8RRyuB2FlYR6DnUtaQlVwF9Ag9BkdTtc9YE8rqZaG54iUW++3keG6OTtIOQYt8hnb9O36aLj/c+jE9mcL2b3HYl7fYFTTtal/sCAAA=
+          REQUIRES-INVENTORY-SPACE: true
       ultra_elytra:
         SLOT: 15
         DISPLAY:
@@ -630,13 +644,27 @@ CRATES:
         SLOT: 16
         DISPLAY:
           MATERIAL: SPAWNER
-          DISPLAY-NAME: '#FF55FFIron Golem Spawner'
-          ENCHANTMENTS:
-          - unbreaking:1
+          DISPLAY-NAME: '&dIron Golem Spawner'
+          ENCHANTMENTS: []
+          LORE:
+          - '&7Type: &fIron Golem Spawner'
+          - ''
+          - '&ePlace to create or stack this spawner.'
+          AMOUNT: 1
         GRANT:
-          TYPE: COMMAND
+          TYPE: ITEM
           COMMANDS:
-          - smartspawner give spawner %player% iron_golem
+          - spawner give {player} iron_golem 1
+          MATERIAL: SPAWNER
+          DISPLAY-NAME: '&dIron Golem Spawner'
+          LORE:
+          - '&7Type: &fIron Golem Spawner'
+          - ''
+          - '&ePlace to create or stack this spawner.'
+          AMOUNT: 1
+          ENCHANTMENTS: []
+          ITEM-DATA: ITEM_BYTES_V1:H4sIAAAAAAAA/52STU8CMRCGZ2EhsH4kYrz3otz8ARyNhpCoEDVcN6U7sM32Y9NOg/x7u4rAwQTiHJpO+s7M05nJANpw9siJz9F5aQ3A9bAHLVnAlZYGheNLGvmarw26NnSEDYYAIMkgE1bX1qAh34fLvVhZh1mUtPvQwU9yvHFaCXQlcSUFJJAFU6BTMaKIXrqwqoBekzuGQrpyfBM1drEMXnD61lx4crJCKp0NqzKKU4qpofuxqXHEYJ/892UwcdawsVWo2fsP/a5CZ11Kwp0U4q2xQ9zkZNzuBpWy6xOB72aKC2RkmXAYpcw65omLilEpPdv2+f6ALYObfWtF8GR1brjG/9GeK7kqKa+DqxWeyPxHK4/wFXGdMhjMwiIiPYSqkjTnKqBP4DYokropaE0gr+uR5oavsMi3f8/jaHTSO0FIcfaQTd6mr/l4+vz0ksLwaAzX2/1tLGmOL6Bg2DQBAwAA
+          REQUIRES-INVENTORY-SPACE: true
       reward_13:
         SLOT: 13
         DISPLAY:

--- a/src/main/resources/crates.yml
+++ b/src/main/resources/crates.yml
@@ -1,5 +1,5 @@
-# SMPCore setup: Crate opening behavior and editable crate reward definitions.
-# SMPCore setup: Keep indentation with spaces; reload with /smpcore reload when the setting supports reload.
+# UltimateDonutSMP setup: Crate opening behavior and editable crate reward definitions.
+# UltimateDonutSMP setup: Keep indentation with spaces; reload with /crate reload when the setting supports reload.
 
 SETTINGS:
   LIST-MENU:
@@ -641,15 +641,15 @@ CRATES:
         SLOT: 13
         DISPLAY:
           MATERIAL: DRAGON_HEAD
-          DISPLAY-NAME: '&fᴅʀᴀɢᴏɴ ʜᴇᴀᴅ'
+          DISPLAY-NAME: '&fDragon Head'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 1
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: DRAGON_HEAD
-          DISPLAY-NAME: '&fᴅʀᴀɢᴏɴ ʜᴇᴀᴅ'
+          DISPLAY-NAME: '&fDragon Head'
           LORE: []
           AMOUNT: 1
           ENCHANTMENTS: []
@@ -658,15 +658,15 @@ CRATES:
         SLOT: 12
         DISPLAY:
           MATERIAL: ENCHANTED_GOLDEN_APPLE
-          DISPLAY-NAME: '&fᴇɴᴄʜᴀɴᴛᴇᴅ ɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          DISPLAY-NAME: '&fEnchanted Golden Apple'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 1
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: ENCHANTED_GOLDEN_APPLE
-          DISPLAY-NAME: '&fᴇɴᴄʜᴀɴᴛᴇᴅ ɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          DISPLAY-NAME: '&fEnchanted Golden Apple'
           LORE: []
           AMOUNT: 1
           ENCHANTMENTS: []
@@ -675,15 +675,15 @@ CRATES:
         SLOT: 11
         DISPLAY:
           MATERIAL: NETHERITE_INGOT
-          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ɪɴɢᴏᴛ'
+          DISPLAY-NAME: '&fNetherite Ingot'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 6
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_INGOT
-          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ɪɴɢᴏᴛ'
+          DISPLAY-NAME: '&fNetherite Ingot'
           LORE: []
           AMOUNT: 6
           ENCHANTMENTS: []
@@ -692,15 +692,15 @@ CRATES:
         SLOT: 10
         DISPLAY:
           MATERIAL: NETHERITE_UPGRADE_SMITHING_TEMPLATE
-          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ᴜᴘɢʀᴀᴅᴇ ѕᴍɪᴛʜɪɴɢ ᴛᴇᴍᴘʟᴀᴛᴇ'
+          DISPLAY-NAME: '&fNetherite Upgrade Smithing Template'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 1
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: NETHERITE_UPGRADE_SMITHING_TEMPLATE
-          DISPLAY-NAME: '&fɴᴇᴛʜᴇʀɪᴛᴇ ᴜᴘɢʀᴀᴅᴇ ѕᴍɪᴛʜɪɴɢ ᴛᴇᴍᴘʟᴀᴛᴇ'
+          DISPLAY-NAME: '&fNetherite Upgrade Smithing Template'
           LORE: []
           AMOUNT: 1
           ENCHANTMENTS: []
@@ -709,15 +709,15 @@ CRATES:
         SLOT: 3
         DISPLAY:
           MATERIAL: GOLDEN_CARROT
-          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴄᴀʀʀᴏᴛ'
+          DISPLAY-NAME: '&fGolden Carrot'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 64
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: GOLDEN_CARROT
-          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴄᴀʀʀᴏᴛ'
+          DISPLAY-NAME: '&fGolden Carrot'
           LORE: []
           AMOUNT: 64
           ENCHANTMENTS: []
@@ -726,15 +726,15 @@ CRATES:
         SLOT: 5
         DISPLAY:
           MATERIAL: GOLDEN_APPLE
-          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          DISPLAY-NAME: '&fGolden Apple'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 32
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: GOLDEN_APPLE
-          DISPLAY-NAME: '&fɢᴏʟᴅᴇɴ ᴀᴘᴘʟᴇ'
+          DISPLAY-NAME: '&fGolden Apple'
           LORE: []
           AMOUNT: 32
           ENCHANTMENTS: []
@@ -743,15 +743,15 @@ CRATES:
         SLOT: 22
         DISPLAY:
           MATERIAL: DIAMOND
-          DISPLAY-NAME: '&fᴅɪᴀᴍᴏɴᴅ'
+          DISPLAY-NAME: '&fDiamond'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 32
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: DIAMOND
-          DISPLAY-NAME: '&fᴅɪᴀᴍᴏɴᴅ'
+          DISPLAY-NAME: '&fDiamond'
           LORE: []
           AMOUNT: 32
           ENCHANTMENTS: []
@@ -760,15 +760,15 @@ CRATES:
         SLOT: 4
         DISPLAY:
           MATERIAL: GOLD_INGOT
-          DISPLAY-NAME: '&fɢᴏʟᴅ ɪɴɢᴏᴛ'
+          DISPLAY-NAME: '&fGold Ingot'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 64
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: GOLD_INGOT
-          DISPLAY-NAME: '&fɢᴏʟᴅ ɪɴɢᴏᴛ'
+          DISPLAY-NAME: '&fGold Ingot'
           LORE: []
           AMOUNT: 64
           ENCHANTMENTS: []
@@ -777,15 +777,15 @@ CRATES:
         SLOT: 23
         DISPLAY:
           MATERIAL: FIREWORK_ROCKET
-          DISPLAY-NAME: '&fꜰɪʀᴇᴡᴏʀᴋ ʀᴏᴄᴋᴇᴛ'
+          DISPLAY-NAME: '&fFirework Rocket'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 64
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: FIREWORK_ROCKET
-          DISPLAY-NAME: '&fꜰɪʀᴇᴡᴏʀᴋ ʀᴏᴄᴋᴇᴛ'
+          DISPLAY-NAME: '&fFirework Rocket'
           LORE: []
           AMOUNT: 64
           ENCHANTMENTS: []
@@ -794,15 +794,15 @@ CRATES:
         SLOT: 21
         DISPLAY:
           MATERIAL: BEACON
-          DISPLAY-NAME: '&fʙᴇᴀᴄᴏɴ'
+          DISPLAY-NAME: '&fBeacon'
           LORE:
-          - '&7ᴄʜᴏᴏѕᴇ ᴛʜɪѕ ʀᴇᴡᴀʀᴅ.'
+          - '&7Choose this reward.'
           AMOUNT: 1
           ENCHANTMENTS: []
         GRANT:
           TYPE: ITEM
           MATERIAL: BEACON
-          DISPLAY-NAME: '&fʙᴇᴀᴄᴏɴ'
+          DISPLAY-NAME: '&fBeacon'
           LORE: []
           AMOUNT: 1
           ENCHANTMENTS: []


### PR DESCRIPTION
Why

Issue #81 provided an updated crates.yml and requested crate-system modifications. This branch applies the user-supplied crates.yml and adds safe, backward-compatible support for non-item rewards so admins can add command/money/shards rewards via CLI and a small GUI template shorthand.

What changed (approach)

- Replaced src/main/resources/crates.yml with the user-provided configuration from issue #81.
- Crate CLI: accept hyphenated open-type values and new subcommands to add COMMAND, MONEY, and SHARDS rewards.
- CrateManager: added helpers to persist COMMAND/MONEY/SHARDS grants to crates.yml and reload crate data after changes.
- CrateEditorMenu: lightweight template shorthand allowing admins to create non-item rewards by placing an item named with one of: `[CMD] ...`, `[MONEY] <amount>`, or `[SHARDS] <amount]` into a crate slot.
- Documentation: updated docs/wiki/Config-crates.yml.md and docs/wiki/Crates-CLI-Additions.md to document new grant types and GUI shorthand.

Notes and review points

- The change is conservative and backward-compatible: existing item rewards and GUI editing paths remain unchanged. Non-item rewards added by CLI (or template shorthand) are persisted in crates.yml and will be claimable by players.
- The GUI shorthand is intentionally minimal: it uses the held item's display name as a template. This keeps the editor simple while enabling server admins to create non-item grants without editing YAML by hand. If you prefer a richer GUI flow, that can be implemented in a follow-up PR.
- The repository was built and tests run locally (mvn test / mvn package) after the edits.

Closing

Fixes: #81

If you prefer the PR to only include the crates.yml replacement and split the code/docs edits into a follow-up PR, say so and I will split the commits accordingly.