### PR TITLE
fix(shards): fix passive everywhere shard rewards for active players

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -497,6 +497,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         pm.registerEvents(new ExplosionDamageListener(this), this);
         pm.registerEvents(new PlayerRespawnListener(this), this);
         pm.registerEvents(new PlayerMoveListener(this), this);
+        pm.registerEvents(new PlayerActivityListener(this), this);
         pm.registerEvents(new PortalListener(this), this);
         pm.registerEvents(new CuboidWandListener(this), this);
         pm.registerEvents(new InventoryClickListener(this), this);

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerActivityListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerActivityListener.java
@@ -1,0 +1,62 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class PlayerActivityListener implements Listener {
+
+    private final UltimateDonutSmp plugin;
+
+    public PlayerActivityListener(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        plugin.getAFKManager().recordMovement(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        plugin.getAFKManager().recordMovement(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        plugin.getAFKManager().recordMovement(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player) {
+            plugin.getAFKManager().recordMovement(player.getUniqueId());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) {
+            plugin.getAFKManager().recordMovement(player.getUniqueId());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChat(AsyncPlayerChatEvent event) {
+        plugin.getAFKManager().recordMovement(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        plugin.getAFKManager().recordMovement(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerMoveListener.java
@@ -22,7 +22,15 @@ public class PlayerMoveListener implements Listener {
     public void onMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
 
-        // Only care about block-level movement
+        if (event.getFrom().getX() != event.getTo().getX()
+                || event.getFrom().getY() != event.getTo().getY()
+                || event.getFrom().getZ() != event.getTo().getZ()
+                || event.getFrom().getYaw() != event.getTo().getYaw()
+                || event.getFrom().getPitch() != event.getTo().getPitch()) {
+            plugin.getAFKManager().recordMovement(player.getUniqueId());
+        }
+
+        // Only care about block-level movement for flight checks and cuboids
         if (event.getFrom().getBlockX() == event.getTo().getBlockX()
                 && event.getFrom().getBlockZ() == event.getTo().getBlockZ()
                 && event.getFrom().getBlockY() == event.getTo().getBlockY()) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
@@ -596,7 +596,7 @@ public class ShardManager {
 
     public String getEverywhereRequiredPermission() {
         return emptyToNull(plugin.getConfigManager().getConfig()
-                .getString("SHARDS.EVERYWHERE.REQUIRED-PERMISSION", "ULTIMATEDONUTSMP.SHARDS.EVERYWHERE"));
+                .getString("SHARDS.EVERYWHERE.REQUIRED-PERMISSION", "ultimatedonutsmp.shards.everywhere"));
     }
 
     public boolean hasEverywherePermission(Player player) {
@@ -609,8 +609,13 @@ public class ShardManager {
     }
 
     public int getEverywhereRecentMovementWindowSeconds() {
-        return Math.max(0, plugin.getConfigManager().getConfig()
+        int configured = Math.max(0, plugin.getConfigManager().getConfig()
                 .getInt("SHARDS.EVERYWHERE.RECENT-MOVEMENT-WINDOW", 15));
+        if (configured <= 0) {
+            return 0;
+        }
+        int intervalSeconds = Math.max(1, getEverywhereEveryMinutes()) * 60;
+        return Math.max(configured, intervalSeconds);
     }
 
     public boolean isEverywhereExcludedWorld(String worldName) {
@@ -806,7 +811,7 @@ public class ShardManager {
     }
 
     private String emptyToNull(String value) {
-        if (value == null || value.isBlank()) {
+        if (value == null || value.isBlank() || value.equalsIgnoreCase("none") || value.equalsIgnoreCase("false") || value.equalsIgnoreCase("null")) {
             return null;
         }
         return value;

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/ShardTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/ShardTask.java
@@ -24,13 +24,10 @@ public class ShardTask implements Runnable {
     public void run() {
         ShardManager sm = plugin.getShardManager();
 
-        if (!sm.isEverywhereEnabled()) {
-            return;
-        }
-
         int intervalMinutes = Math.max(1, sm.getEverywhereEveryMinutes());
         minuteTick = (minuteTick + 1) % intervalMinutes;
-        if (minuteTick != 0) {
+
+        if (!sm.isEverywhereEnabled() || minuteTick != 0) {
             return;
         }
 


### PR DESCRIPTION
players with everywhere shards permission and ENABLED: true were not receiving passive shard rewards due to a movement window mismatch between interval ticks and recent movement tracking, unrecorded non-location player actions, and unnormalized permission node strings.