### PR TITLE
fix(hide): fix disguise not rendering on other players' POV (#92)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HideProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HideProtocolLibBridge.java
@@ -63,7 +63,7 @@ final class HideProtocolLibBridge implements HidePacketBridge {
     private void registerPlayerInfoListener() {
         playerInfoListener = new PacketAdapter(
                 plugin,
-                ListenerPriority.MONITOR,
+                ListenerPriority.HIGHEST,
                 PacketType.Play.Server.PLAYER_INFO,
                 PacketType.Play.Server.SCOREBOARD_TEAM
         ) {
@@ -174,6 +174,9 @@ final class HideProtocolLibBridge implements HidePacketBridge {
             return null;
         }
         UUID profileId = data.getProfileId();
+        if (profileId == null && data.getProfile() != null) {
+            profileId = data.getProfile().getUUID();
+        }
         if (profileId == null) {
             return data;
         }


### PR DESCRIPTION
a player using /disguise appeared disguised on their own perspective, but other players still saw their original username, skin, and nametag because the protocol packet listener was registered at MONITOR priority instead of a packet-modifying priority like HIGHEST.