### PR TITLE
feat: permission-based priority queue for /rtp

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -111,6 +111,17 @@ public class RTPManager {
     private record LocationAttempt(Location location, boolean countedAttempt) {
     }
 
+    public record RTPQueueEntry(
+            UUID playerId,
+            String worldName,
+            int priority,
+            long queueTimeMillis
+    ) {}
+
+    private static final Comparator<RTPQueueEntry> QUEUE_COMPARATOR = Comparator
+            .comparingInt(RTPQueueEntry::priority).reversed()
+            .thenComparingLong(RTPQueueEntry::queueTimeMillis);
+
     private final UltimateDonutSmp plugin;
     private final Map<UUID, Map<String, Long>> cooldownsByPlayer = new ConcurrentHashMap<>();
     private final Map<UUID, BukkitTask> activeSearchTasks = new ConcurrentHashMap<>();
@@ -119,6 +130,7 @@ public class RTPManager {
     private final Map<UUID, SearchProgress> activeSearches = new ConcurrentHashMap<>();
     private final Map<String, java.util.Queue<Location>> locationPreCache = new ConcurrentHashMap<>();
     private final Set<String> preCacheInFlight = ConcurrentHashMap.newKeySet();
+    private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
     private List<RTPDestination> menuDestinations = List.of();
 
@@ -129,12 +141,148 @@ public class RTPManager {
 
     public void reload() {
         clearAllSearches();
+        clearQueue();
         cooldownsByPlayer.clear();
         locationPreCache.clear();
         preCacheInFlight.clear();
         configuredDestinations = loadConfiguredDestinations();
         menuDestinations = buildMenuDestinations(configuredDestinations);
         refillPreCacheAllWorlds();
+    }
+
+    public boolean isPriorityQueueEnabled() {
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return true;
+        }
+        return plugin.getConfigManager().getRtp().getBoolean("SETTINGS.PRIORITY-QUEUE.ENABLED", true);
+    }
+
+    public int getPlayerPriority(Player player) {
+        if (player == null || !isPriorityQueueEnabled()) {
+            return 0;
+        }
+
+        int maxPriority = plugin.getConfigManager().getRtp()
+                .getInt("SETTINGS.PRIORITY-QUEUE.DEFAULT-PRIORITY", 0);
+
+        ConfigurationSection section = plugin.getConfigManager().getRtp()
+                .getConfigurationSection("SETTINGS.PRIORITY-QUEUE.PERMISSIONS");
+        if (section != null) {
+            Map<String, Object> values = section.getValues(true);
+            for (Map.Entry<String, Object> entry : values.entrySet()) {
+                if (entry.getValue() instanceof Number number) {
+                    String permNode = entry.getKey();
+                    if (player.hasPermission(permNode)) {
+                        int val = number.intValue();
+                        if (val > maxPriority) {
+                            maxPriority = val;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (org.bukkit.permissions.PermissionAttachmentInfo pai : player.getEffectivePermissions()) {
+            String perm = pai.getPermission();
+            if (perm != null && pai.getValue() && perm.toLowerCase(Locale.ROOT).startsWith("ultimatedonutsmp.rtp.priority.")) {
+                String sub = perm.substring("ultimatedonutsmp.rtp.priority.".length());
+                try {
+                    int val = Integer.parseInt(sub);
+                    if (val > maxPriority) {
+                        maxPriority = val;
+                    }
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        return maxPriority;
+    }
+
+    public boolean isInQueue(UUID playerId) {
+        if (playerId == null) {
+            return false;
+        }
+        synchronized (waitingQueue) {
+            for (RTPQueueEntry entry : waitingQueue) {
+                if (entry.playerId().equals(playerId)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public int getQueuePosition(UUID playerId) {
+        if (playerId == null) {
+            return -1;
+        }
+        synchronized (waitingQueue) {
+            List<RTPQueueEntry> sorted = new ArrayList<>(waitingQueue);
+            sorted.sort(QUEUE_COMPARATOR);
+            for (int i = 0; i < sorted.size(); i++) {
+                if (sorted.get(i).playerId().equals(playerId)) {
+                    return i + 1;
+                }
+            }
+        }
+        return -1;
+    }
+
+    public void removeFromQueue(UUID playerId) {
+        if (playerId == null) {
+            return;
+        }
+        synchronized (waitingQueue) {
+            waitingQueue.removeIf(entry -> entry.playerId().equals(playerId));
+        }
+    }
+
+    public void clearQueue() {
+        synchronized (waitingQueue) {
+            waitingQueue.clear();
+        }
+    }
+
+    public int getQueueSize() {
+        return waitingQueue.size();
+    }
+
+    public synchronized void processNextInQueue() {
+        if (!isPriorityQueueEnabled()) {
+            return;
+        }
+        if (isQueueFull(null)) {
+            return;
+        }
+
+        List<RTPQueueEntry> sorted;
+        synchronized (waitingQueue) {
+            if (waitingQueue.isEmpty()) {
+                return;
+            }
+            sorted = new ArrayList<>(waitingQueue);
+            sorted.sort(QUEUE_COMPARATOR);
+        }
+
+        for (RTPQueueEntry entry : sorted) {
+            removeFromQueue(entry.playerId());
+
+            Player player = Bukkit.getPlayer(entry.playerId());
+            if (player == null || !player.isOnline()) {
+                continue;
+            }
+
+            if (hasActiveRtpFlow(entry.playerId()) || plugin.getTeleportManager().hasPendingType(entry.playerId(), "RTP")) {
+                continue;
+            }
+
+            SearchSettings settings = getWorldSearchSettings(entry.worldName());
+            if (settings != null) {
+                startSearch(player, entry.worldName(), settings);
+                break;
+            }
+        }
     }
 
     public boolean isPreCacheEnabled() {
@@ -196,14 +344,16 @@ public class RTPManager {
             directSearch.complete(null);
         }
 
-        if (!clearActionBar) {
-            return;
+        removeFromQueue(playerId);
+
+        if (clearActionBar) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                PlayerSettingUtils.clearActionBar(player);
+            }
         }
 
-        Player player = plugin.getServer().getPlayer(playerId);
-        if (player != null && player.isOnline()) {
-            PlayerSettingUtils.clearActionBar(player);
-        }
+        processNextInQueue();
     }
 
     public List<RTPDestination> getMenuDestinations() {
@@ -678,6 +828,15 @@ public class RTPManager {
             return false;
         }
 
+        if (isInQueue(player.getUniqueId())) {
+            int pos = getQueuePosition(player.getUniqueId());
+            String message = plugin.getConfigManager().getRtp()
+                    .getString("MESSAGES.ALREADY-IN-QUEUE", "&cʏᴏᴜ ᴀʀᴇ ᴀʟʀᴇᴀᴅʏ ɪɴ ᴛʜᴇ ʀᴛᴘ ᴡᴀɪᴛɪɴɢ ǫᴜᴇᴜᴇ ᴀᴛ ᴘᴏѕɪᴛɪᴏɴ #{position}.")
+                    .replace("{position}", String.valueOf(pos));
+            player.sendMessage(ColorUtils.toComponent(message));
+            return false;
+        }
+
         long cooldownRemaining = getCooldownRemainingMillis(player.getUniqueId(), worldName);
         if (cooldownRemaining > 0L) {
             long remainingSeconds = Math.max(1L, (long) Math.ceil(cooldownRemaining / 1000.0D));
@@ -690,11 +849,26 @@ public class RTPManager {
         }
 
         if (isQueueFull(player.getUniqueId())) {
-            player.sendMessage(ColorUtils.toComponent(
-                    plugin.getConfigManager().getRtp()
-                            .getString("MESSAGES.MAX-PLAYERS", "&cᴛᴏᴏ ᴍᴀɴʏ ᴘʟᴀʏᴇʀѕ ᴀʀᴇ ᴜѕɪɴɢ ʀᴛᴘ ʀɪɢʜᴛ ɴᴏᴡ. ᴘʟᴇᴀѕᴇ ᴛʀʏ ᴀɢᴀɪɴ ʟᴀᴛᴇʀ.")
-            ));
-            return false;
+            if (isPriorityQueueEnabled()) {
+                int priority = getPlayerPriority(player);
+                RTPQueueEntry entry = new RTPQueueEntry(player.getUniqueId(), worldName, priority, System.currentTimeMillis());
+                synchronized (waitingQueue) {
+                    waitingQueue.add(entry);
+                }
+                int pos = getQueuePosition(player.getUniqueId());
+                String message = plugin.getConfigManager().getRtp()
+                        .getString("MESSAGES.QUEUE-JOINED", "&eRTP slots are full. You are in queue at position &#4B72FF#{position}&e (Priority: &f{priority}&e).")
+                        .replace("{position}", String.valueOf(pos))
+                        .replace("{priority}", String.valueOf(priority));
+                player.sendMessage(ColorUtils.toComponent(message));
+                return true;
+            } else {
+                player.sendMessage(ColorUtils.toComponent(
+                        plugin.getConfigManager().getRtp()
+                                .getString("MESSAGES.MAX-PLAYERS", "&cᴛᴏᴏ ᴍᴀɴʏ ᴘʟᴀʏᴇʀѕ ᴀʀᴇ ᴜѕɪɴɢ ʀᴛᴘ ʀɪɢʜᴛ ɴᴏᴡ. ᴘʟᴇᴀѕᴇ ᴛʀʏ ᴀɢᴀɪɴ ʟᴀᴛᴇʀ.")
+                ));
+                return false;
+            }
         }
 
         startSearch(player, worldName, settings);
@@ -723,21 +897,23 @@ public class RTPManager {
         SearchProgress progress = new SearchProgress(worldName, settings);
         activeSearches.put(player.getUniqueId(), progress);
 
-        BukkitTask task = plugin.getSpigotScheduler().runEntityTimer(
-                player,
-                () -> tickSearch(player.getUniqueId()),
-                0L,
-                SEARCH_ACTIONBAR_REFRESH_TICKS
-        );
-        if (task != null) {
-            activeSearchTasks.put(player.getUniqueId(), task);
+        if (plugin.getSpigotScheduler() != null) {
+            BukkitTask task = plugin.getSpigotScheduler().runEntityTimer(
+                    player,
+                    () -> tickSearch(player.getUniqueId()),
+                    0L,
+                    SEARCH_ACTIONBAR_REFRESH_TICKS
+            );
+            if (task != null) {
+                activeSearchTasks.put(player.getUniqueId(), task);
+            }
         }
 
         refillPreCache(worldName);
     }
 
     private void tickSearch(UUID playerId) {
-        Player player = plugin.getServer().getPlayer(playerId);
+        Player player = Bukkit.getPlayer(playerId);
         SearchProgress progress = activeSearches.get(playerId);
         if (player == null || !player.isOnline() || progress == null) {
             clearSearch(playerId);
@@ -856,7 +1032,7 @@ public class RTPManager {
         Location found = attempt == null ? null : attempt.location();
         if (found != null) {
             progress.pendingFoundLocation = found;
-            Player player = plugin.getServer().getPlayer(playerId);
+            Player player = Bukkit.getPlayer(playerId);
             if (player != null && player.isOnline() && progress.elapsedTicks >= MIN_SEARCH_DISPLAY_TICKS) {
                 stopSearch(playerId, false);
                 finishSearch(player, progress.worldName, found);
@@ -886,7 +1062,7 @@ public class RTPManager {
                 + "/" + getMaxGenerateFallbackSamples()
                 + ".");
 
-        Player player = plugin.getServer().getPlayer(playerId);
+        Player player = Bukkit.getPlayer(playerId);
         clearSearch(playerId);
         if (player == null || !player.isOnline()) {
             return;
@@ -997,6 +1173,7 @@ public class RTPManager {
         if (player.isOnline()) {
             plugin.getTeleportManager().queue(player, found, "RTP", null);
         }
+        processNextInQueue();
     }
 
     private void sendSearchActionBar(Player player, SearchProgress progress) {
@@ -1843,11 +2020,13 @@ public class RTPManager {
     private boolean isQueueFull(UUID playerId) {
         int maxPlayers = getMaxConcurrentRtp();
         int inProgress = countActiveSearches() + plugin.getTeleportManager().countPendingByType("RTP");
-        if (isSearching(playerId)) {
-            inProgress = Math.max(0, inProgress - 1);
-        }
-        if (plugin.getTeleportManager().hasPendingType(playerId, "RTP")) {
-            inProgress = Math.max(0, inProgress - 1);
+        if (playerId != null) {
+            if (isSearching(playerId)) {
+                inProgress = Math.max(0, inProgress - 1);
+            }
+            if (plugin.getTeleportManager().hasPendingType(playerId, "RTP")) {
+                inProgress = Math.max(0, inProgress - 1);
+            }
         }
         return inProgress >= maxPlayers;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -824,14 +824,14 @@ public class RTPManager {
         }
 
         if (hasActiveRtpFlow(player.getUniqueId()) || plugin.getTeleportManager().hasPendingType(player.getUniqueId(), "RTP")) {
-            player.sendMessage(ColorUtils.toComponent("&cʏᴏᴜʀ ʀᴛᴘ ɪѕ ᴀʟʀᴇᴀᴅʏ ɪɴ ᴘʀᴏɢʀᴇѕѕ."));
+            player.sendMessage(ColorUtils.toComponent("&cYour RTP is already in progress."));
             return false;
         }
 
         if (isInQueue(player.getUniqueId())) {
             int pos = getQueuePosition(player.getUniqueId());
             String message = plugin.getConfigManager().getRtp()
-                    .getString("MESSAGES.ALREADY-IN-QUEUE", "&cʏᴏᴜ ᴀʀᴇ ᴀʟʀᴇᴀᴅʏ ɪɴ ᴛʜᴇ ʀᴛᴘ ᴡᴀɪᴛɪɴɢ ǫᴜᴇᴜᴇ ᴀᴛ ᴘᴏѕɪᴛɪᴏɴ #{position}.")
+                    .getString("MESSAGES.ALREADY-IN-QUEUE", "&cYou are already in the RTP waiting queue at position #{position}.")
                     .replace("{position}", String.valueOf(pos));
             player.sendMessage(ColorUtils.toComponent(message));
             return false;
@@ -841,7 +841,7 @@ public class RTPManager {
         if (cooldownRemaining > 0L) {
             long remainingSeconds = Math.max(1L, (long) Math.ceil(cooldownRemaining / 1000.0D));
             String message = plugin.getConfigManager().getRtp()
-                    .getString("MESSAGES.COOLDOWN", "&cʏᴏᴜ ᴄᴀɴ'ᴛ ʀᴛᴘ ꜰᴏʀ ᴀɴᴏᴛʜᴇʀ {remaining}ѕ.");
+                    .getString("MESSAGES.COOLDOWN", "&cYou can't RTP for another {remaining}s.");
             message = message.replace("{remaining}", String.valueOf(remainingSeconds))
                     .replace("%remaining%", String.valueOf(remainingSeconds));
             player.sendMessage(ColorUtils.toComponent(message));
@@ -865,7 +865,7 @@ public class RTPManager {
             } else {
                 player.sendMessage(ColorUtils.toComponent(
                         plugin.getConfigManager().getRtp()
-                                .getString("MESSAGES.MAX-PLAYERS", "&cᴛᴏᴏ ᴍᴀɴʏ ᴘʟᴀʏᴇʀѕ ᴀʀᴇ ᴜѕɪɴɢ ʀᴛᴘ ʀɪɢʜᴛ ɴᴏᴡ. ᴘʟᴇᴀѕᴇ ᴛʀʏ ᴀɢᴀɪɴ ʟᴀᴛᴇʀ.")
+                                .getString("MESSAGES.MAX-PLAYERS", "&cToo many players are using RTP right now. Please try again later.")
                 ));
                 return false;
             }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
@@ -160,6 +160,9 @@ public class TeleportManager {
                     if (onSuccess != null) {
                         onSuccess.accept(player);
                     }
+                    if ("RTP".equals(normalizedType) && plugin.getRtpManager() != null) {
+                        plugin.getRtpManager().processNextInQueue();
+                    }
                 }));
     }
 
@@ -168,9 +171,12 @@ public class TeleportManager {
         if (task != null) {
             task.cancel();
         }
-        pendingTypes.remove(uuid);
+        String pendingType = pendingTypes.remove(uuid);
         startLocations.remove(uuid);
         restoreRtpChunkThrottle(uuid);
+        if ("RTP".equals(pendingType) && plugin.getRtpManager() != null) {
+            plugin.getRtpManager().processNextInQueue();
+        }
     }
 
     public boolean hasPending(UUID uuid) {

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1808,6 +1808,10 @@ CONFIG:
       SEARCH-FOUND-ACTIONBAR-HIDDEN: '&aSafe location found in {world}! &7preparing
         teleport...'
       SAFE-LOCATION-FOUND-HIDDEN: '&aSafe location found.'
+      QUEUE-JOINED: '&eRTP slots are full. You are in queue at position &#4B72FF#{position}&e
+        (Priority: &f{priority}&e).'
+      QUEUE-POSITION: '&7Waiting for RTP slot... Your current position: &#4B72FF#{position}&7.'
+      ALREADY-IN-QUEUE: '&cYou are already in the RTP waiting queue at position #{position}.'
     RTP-MENU:
       TITLE: '&8Rtp menu'
       BUTTONS:

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -31,6 +31,18 @@ SETTINGS:
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
   LOADED-CHUNK-FALLBACK-AFTER-SAMPLES: 32
+  # Priority queue settings for RTP requests
+  PRIORITY-QUEUE:
+    # Enable or disable the RTP permission priority queue system
+    ENABLED: true
+    # Default priority for players without explicit priority permissions
+    DEFAULT-PRIORITY: 0
+    # Explicit mapping from permission node to priority weight (higher = higher priority)
+    PERMISSIONS:
+      "ultimatedonutsmp.rtp.priority.vip++": 30
+      "ultimatedonutsmp.rtp.priority.vip+": 20
+      "ultimatedonutsmp.rtp.priority.vip": 10
+      "ultimatedonutsmp.rtp.priority.high": 5
 
 # User feedback and status messages
 MESSAGES:
@@ -49,6 +61,9 @@ MESSAGES:
   UNSAFE-LOCATION: '&cThe location at X:{x} Y:{y} Z:{z} was rejected: {reason}'
   SAFE-LOCATION-FOUND-HIDDEN: '&aSafe location found! Teleporting you blindly...'
   SEARCH-FOUND-ACTIONBAR-HIDDEN: '&aFound safe location'
+  QUEUE-JOINED: '&eRTP slots are full. You are in queue at position &#4B72FF#{position}&e (Priority: &f{priority}&e).'
+  QUEUE-POSITION: '&7Waiting for RTP slot... Your current position: &#4B72FF#{position}&7.'
+  ALREADY-IN-QUEUE: '&cYou are already in the RTP waiting queue at position #{position}.'
 
 # List of world names where RTP execution is denied
 DENIED-WORLDS:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPPriorityQueueTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPPriorityQueueTest.java
@@ -1,0 +1,237 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RTPPriorityQueueTest {
+
+    private Server originalServer;
+    private Server mockServer;
+    private org.bukkit.World mockWorld;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalServer = Bukkit.getServer();
+
+        mockWorld = (org.bukkit.World) Proxy.newProxyInstance(
+                org.bukkit.World.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.World.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getName")) {
+                        return "world";
+                    }
+                    if (method.getName().equals("getEnvironment")) {
+                        return org.bukkit.World.Environment.NORMAL;
+                    }
+                    return null;
+                }
+        );
+
+        mockServer = (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getWorlds")) {
+                        return List.of(mockWorld);
+                    }
+                    if (method.getName().equals("getWorld")) {
+                        return mockWorld;
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("Minecraft");
+                    }
+                    return null;
+                }
+        );
+
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, mockServer);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, originalServer);
+    }
+
+    private UltimateDonutSmp createMockPlugin(YamlConfiguration rtpConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+        Constructor<?> newConstructor = reflectionFactory.newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) newConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        Field rtpField = ConfigManager.class.getDeclaredField("rtp");
+        rtpField.setAccessible(true);
+        rtpField.set(configManager, rtpConfig);
+
+        Field configField = ConfigManager.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(configManager, new YamlConfiguration());
+
+        Field soundsField = ConfigManager.class.getDeclaredField("sounds");
+        soundsField.setAccessible(true);
+        soundsField.set(configManager, new YamlConfiguration());
+
+        Field cmField = UltimateDonutSmp.class.getDeclaredField("configManager");
+        cmField.setAccessible(true);
+        cmField.set(plugin, configManager);
+
+        FeatureManager featureManager = new FeatureManager(plugin);
+        Field fmField = UltimateDonutSmp.class.getDeclaredField("featureManager");
+        fmField.setAccessible(true);
+        fmField.set(plugin, featureManager);
+
+        TeleportManager teleportManager = new TeleportManager(plugin);
+        Field tmField = UltimateDonutSmp.class.getDeclaredField("teleportManager");
+        tmField.setAccessible(true);
+        tmField.set(plugin, teleportManager);
+
+        return plugin;
+    }
+
+    private Player createMockPlayer(UUID uuid, String name, Set<String> permissions) {
+        final Player[] playerHolder = new Player[1];
+        Player playerProxy = (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return uuid;
+                    }
+                    if (method.getName().equals("getName")) {
+                        return name;
+                    }
+                    if (method.getName().equals("hasPermission")) {
+                        String perm = (String) args[0];
+                        return permissions.contains(perm.toLowerCase(Locale.ROOT));
+                    }
+                    if (method.getName().equals("getEffectivePermissions")) {
+                        Set<PermissionAttachmentInfo> effective = new HashSet<>();
+                        for (String perm : permissions) {
+                            effective.add(new PermissionAttachmentInfo(playerHolder[0], perm, null, true));
+                        }
+                        return effective;
+                    }
+                    if (method.getName().equals("sendMessage")) {
+                        return null;
+                    }
+                    if (method.getName().equals("isOnline")) {
+                        return true;
+                    }
+                    return null;
+                }
+        );
+        playerHolder[0] = playerProxy;
+        return playerProxy;
+    }
+
+    @Test
+    void testPriorityResolutionFromConfig() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.ENABLED", true);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.DEFAULT-PRIORITY", 0);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip++", 30);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip+", 20);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip", 10);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+
+        UltimateDonutSmp plugin = createMockPlugin(rtpConfig);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        Player regular = createMockPlayer(UUID.randomUUID(), "Player1", Set.of());
+        Player vip = createMockPlayer(UUID.randomUUID(), "PlayerVIP", Set.of("ultimatedonutsmp.rtp.priority.vip"));
+        Player vipPlusPlus = createMockPlayer(UUID.randomUUID(), "PlayerVIPPlusPlus", Set.of("ultimatedonutsmp.rtp.priority.vip++"));
+        Player customNumeric = createMockPlayer(UUID.randomUUID(), "PlayerNumeric", Set.of("ultimatedonutsmp.rtp.priority.50"));
+
+        assertEquals(0, rtpManager.getPlayerPriority(regular));
+        assertEquals(10, rtpManager.getPlayerPriority(vip));
+        assertEquals(30, rtpManager.getPlayerPriority(vipPlusPlus));
+        assertEquals(50, rtpManager.getPlayerPriority(customNumeric));
+    }
+
+    @Test
+    void testPriorityQueueOrderingAndPosition() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.ENABLED", true);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.DEFAULT-PRIORITY", 0);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip++", 30);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip+", 20);
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.PERMISSIONS.ultimatedonutsmp.rtp.priority.vip", 10);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+        rtpConfig.set("SETTINGS.PLAYERS-IN-RTP", 1); // 1 active slot
+
+        UltimateDonutSmp plugin = createMockPlugin(rtpConfig);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        Player dummy = createMockPlayer(UUID.randomUUID(), "Dummy", Set.of());
+        assertTrue(rtpManager.queueCommandTeleport(dummy, "world")); // Occupies active slot 1
+
+        UUID regularId = UUID.randomUUID();
+        UUID vipId = UUID.randomUUID();
+        UUID vipPlusPlusId = UUID.randomUUID();
+
+        Player regular = createMockPlayer(regularId, "Regular", Set.of());
+        Player vip = createMockPlayer(vipId, "VIP", Set.of("ultimatedonutsmp.rtp.priority.vip"));
+        Player vipPlusPlus = createMockPlayer(vipPlusPlusId, "VIP++", Set.of("ultimatedonutsmp.rtp.priority.vip++"));
+
+        // Add regular first, then VIP, then VIP++
+        assertTrue(rtpManager.queueCommandTeleport(regular, "world"));
+        assertTrue(rtpManager.queueCommandTeleport(vip, "world"));
+        assertTrue(rtpManager.queueCommandTeleport(vipPlusPlus, "world"));
+
+        assertEquals(3, rtpManager.getQueueSize());
+        assertTrue(rtpManager.isInQueue(regularId));
+        assertTrue(rtpManager.isInQueue(vipId));
+        assertTrue(rtpManager.isInQueue(vipPlusPlusId));
+
+        // VIP++ should jump to position 1, VIP position 2, Regular position 3
+        assertEquals(1, rtpManager.getQueuePosition(vipPlusPlusId));
+        assertEquals(2, rtpManager.getQueuePosition(vipId));
+        assertEquals(3, rtpManager.getQueuePosition(regularId));
+
+        // Re-queuing an existing player should return false (already in queue)
+        assertFalse(rtpManager.queueCommandTeleport(vip, "world"));
+    }
+
+    @Test
+    void testPriorityQueueDisabled() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("SETTINGS.PRIORITY-QUEUE.ENABLED", false);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+        rtpConfig.set("SETTINGS.PLAYERS-IN-RTP", 1);
+
+        UltimateDonutSmp plugin = createMockPlugin(rtpConfig);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        Player dummy = createMockPlayer(UUID.randomUUID(), "Dummy", Set.of());
+        assertTrue(rtpManager.queueCommandTeleport(dummy, "world")); // Occupies active slot 1
+
+        Player player = createMockPlayer(UUID.randomUUID(), "Player1", Set.of("ultimatedonutsmp.rtp.priority.vip++"));
+
+        assertFalse(rtpManager.isPriorityQueueEnabled());
+        // When queue disabled and slots full, request should fail immediately without adding to queue
+        boolean result = rtpManager.queueCommandTeleport(player, "world");
+        assertFalse(result);
+        assertEquals(0, rtpManager.getQueueSize());
+    }
+}


### PR DESCRIPTION
multiple players executing /rtp simultaneously when active slots were full resulted in immediate request rejection instead of queueing, so adding a permission-based priority queue allows ranked players to jump ahead in line with configurable settings.