### PR TITLE
fix: optimize per-player mob spawn handling (#97)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
@@ -49,29 +49,29 @@ public class MobSpawnListener implements Listener {
     }
 
     private boolean shouldCancelPhantomSpawn(Location location) {
-        Player nearestPlayer = getNearestPlayer2D(
-                location,
-                plugin.getConfigManager().getConfig().getDouble("SETTINGS.PHANTOM-SPAWN-RADIUS", 40)
-        );
-        if (nearestPlayer == null) {
+        if (location == null || location.getWorld() == null) {
             return false;
         }
-
-        PlayerData data = plugin.getPlayerDataManager().get(nearestPlayer);
-        return data != null && !data.isPhantomEnabled();
+        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.PHANTOM-SPAWN-RADIUS", 40);
+        return MobSpawnPolicy.shouldCancelPhantomSpawn(
+                location,
+                location.getWorld().getPlayers(),
+                radius,
+                p -> plugin.getPlayerDataManager().get(p)
+        );
     }
 
     private boolean shouldCancelMobSpawn(Location location) {
-        Player nearestPlayer = getNearestPlayer(
-                location,
-                plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50)
-        );
-        if (nearestPlayer == null) {
+        if (location == null || location.getWorld() == null) {
             return false;
         }
-
-        PlayerData data = plugin.getPlayerDataManager().get(nearestPlayer);
-        return data != null && !data.isMobSpawnEnabled();
+        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
+        return MobSpawnPolicy.shouldCancelMobSpawn(
+                location,
+                location.getWorld().getPlayers(),
+                radius,
+                p -> plugin.getPlayerDataManager().get(p)
+        );
     }
 
     private boolean isPreventableSpawnReason(CreatureSpawnEvent.SpawnReason reason) {
@@ -80,44 +80,6 @@ public class MobSpawnListener implements Listener {
             case CUSTOM, SPAWNER_EGG, BUILD_WITHER, BREEDING -> false;
             default -> true;
         };
-    }
-
-    private Player getNearestPlayer(Location location, double radius) {
-        double radiusSquared = radius * radius;
-        Player nearestPlayer = null;
-        double nearestDistance = radiusSquared;
-
-        for (Player player : location.getWorld().getPlayers()) {
-            double distance = player.getLocation().distanceSquared(location);
-            if (distance > radiusSquared || distance >= nearestDistance) {
-                continue;
-            }
-
-            nearestPlayer = player;
-            nearestDistance = distance;
-        }
-
-        return nearestPlayer;
-    }
-
-    private Player getNearestPlayer2D(Location location, double radius) {
-        double radiusSquared = radius * radius;
-        Player nearestPlayer = null;
-        double nearestDistance = radiusSquared;
-
-        for (Player player : location.getWorld().getPlayers()) {
-            double dx = player.getLocation().getX() - location.getX();
-            double dz = player.getLocation().getZ() - location.getZ();
-            double distance2D = dx * dx + dz * dz;
-            if (distance2D > radiusSquared || distance2D >= nearestDistance) {
-                continue;
-            }
-
-            nearestPlayer = player;
-            nearestDistance = distance2D;
-        }
-
-        return nearestPlayer;
     }
 
     private void startCleanupTask() {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
@@ -1,11 +1,17 @@
 package com.bx.ultimateDonutSmp.utils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Collection;
+import java.util.function.Function;
 
 public final class MobSpawnPolicy {
 
@@ -53,6 +59,73 @@ public final class MobSpawnPolicy {
             return false;
         }
         return entity.getCustomName() != null && !entity.getCustomName().isEmpty();
+    }
+
+    public static boolean shouldCancelMobSpawn(
+            Location spawnLocation,
+            Collection<? extends Player> players,
+            double radius,
+            Function<Player, PlayerData> dataProvider
+    ) {
+        if (spawnLocation == null || players == null || players.isEmpty()) {
+            return false;
+        }
+        double radiusSquared = radius * radius;
+        for (Player player : players) {
+            if (player == null) continue;
+            PlayerData data = dataProvider != null ? dataProvider.apply(player) : null;
+            if (data == null || data.isMobSpawnEnabled()) {
+                continue;
+            }
+            Location playerLoc = player.getLocation();
+            if (playerLoc == null) {
+                continue;
+            }
+            if (playerLoc.getWorld() != null && spawnLocation.getWorld() != null
+                    && !playerLoc.getWorld().equals(spawnLocation.getWorld())) {
+                continue;
+            }
+            double dx = playerLoc.getX() - spawnLocation.getX();
+            double dy = playerLoc.getY() - spawnLocation.getY();
+            double dz = playerLoc.getZ() - spawnLocation.getZ();
+            if (dx * dx + dy * dy + dz * dz <= radiusSquared) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean shouldCancelPhantomSpawn(
+            Location spawnLocation,
+            Collection<? extends Player> players,
+            double radius,
+            Function<Player, PlayerData> dataProvider
+    ) {
+        if (spawnLocation == null || players == null || players.isEmpty()) {
+            return false;
+        }
+        double radiusSquared = radius * radius;
+        for (Player player : players) {
+            if (player == null) continue;
+            PlayerData data = dataProvider != null ? dataProvider.apply(player) : null;
+            if (data == null || data.isPhantomEnabled()) {
+                continue;
+            }
+            Location playerLoc = player.getLocation();
+            if (playerLoc == null) {
+                continue;
+            }
+            if (playerLoc.getWorld() != null && spawnLocation.getWorld() != null
+                    && !playerLoc.getWorld().equals(spawnLocation.getWorld())) {
+                continue;
+            }
+            double dx = playerLoc.getX() - spawnLocation.getX();
+            double dz = playerLoc.getZ() - spawnLocation.getZ();
+            if (dx * dx + dz * dz <= radiusSquared) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean shouldRemoveFromPeriodicCleanup(

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
@@ -1,8 +1,16 @@
 package com.bx.ultimateDonutSmp.utils;
 
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,5 +42,70 @@ class MobSpawnPolicyTest {
         assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.HOGLIN, false));
         assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.SPIDER, false));
         assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.CAVE_SPIDER, false));
+    }
+
+    @Test
+    void nearestPlayerMobSpawnOnButFartherPlayerMobSpawnOffCancelsSpawn() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+
+        Player playerA = createMockPlayer(new Location(null, 10, 0, 0));
+        Player playerB = createMockPlayer(new Location(null, 30, 0, 0));
+
+        PlayerData dataA = new PlayerData(UUID.randomUUID(), "PlayerA");
+        dataA.setMobSpawnEnabled(true);
+
+        PlayerData dataB = new PlayerData(UUID.randomUUID(), "PlayerB");
+        dataB.setMobSpawnEnabled(false);
+
+        Map<Player, PlayerData> dataMap = Map.of(playerA, dataA, playerB, dataB);
+
+        // Player A is closer (10m) & ON, but Player B is within 50m & OFF.
+        // Spawn MUST be cancelled!
+        assertTrue(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(playerA, playerB), 50.0, dataMap::get));
+    }
+
+    @Test
+    void allPlayersMobSpawnOnAllowsSpawn() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+
+        Player playerA = createMockPlayer(new Location(null, 10, 0, 0));
+        PlayerData dataA = new PlayerData(UUID.randomUUID(), "PlayerA");
+        dataA.setMobSpawnEnabled(true);
+
+        Map<Player, PlayerData> dataMap = Map.of(playerA, dataA);
+
+        assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(playerA), 50.0, dataMap::get));
+    }
+
+    @Test
+    void playerMobSpawnOffOutsideRadiusAllowsSpawn() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+
+        Player playerB = createMockPlayer(new Location(null, 60, 0, 0));
+        PlayerData dataB = new PlayerData(UUID.randomUUID(), "PlayerB");
+        dataB.setMobSpawnEnabled(false);
+
+        Map<Player, PlayerData> dataMap = Map.of(playerB, dataB);
+
+        assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(playerB), 50.0, dataMap::get));
+    }
+
+    private Player createMockPlayer(Location location) {
+        return (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if ("getLocation".equals(method.getName())) {
+                        return location;
+                    }
+                    if ("equals".equals(method.getName()) && args != null && args.length == 1) {
+                        return proxy == args[0];
+                    }
+                    if ("hashCode".equals(method.getName())) {
+                        return System.identityHashCode(proxy);
+                    }
+                    return null;
+                }
+        );
     }
 }


### PR DESCRIPTION
when a hostile mob attempted to spawn near multiple players, checking only the single nearest player allowed mobs to spawn within a player's mob spawn radius if a closer player had mob spawn enabled. this change evaluates mob spawn cancellation across all online players in the world within radius while optimizing performance by skipping distance calculations for players who have mob spawn enabled.