### PR TITLE
fix(tablist): clear stale header/footer and name cache on quit (#100)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/TablistManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/TablistManager.java
@@ -484,6 +484,8 @@ public class TablistManager {
         removeCachedSkinTexture(playerId);
         skinHeadTextureRefreshTimes.remove(playerId);
         luckPermsCommandOverrides.remove(playerId);
+        lastHeaderFooterCache.remove(playerId);
+        lastNameCache.remove(playerId);
     }
 
     public String createPermissionRefreshSnapshot(Player player) {


### PR DESCRIPTION
TablistManager.removePlayer() cleared the skin-head and LuckPerms maps but
left lastHeaderFooterCache and lastNameCache untouched. On rejoin the client
starts with a blank tablist while the manager still holds the old key, so
update() and updateTablistName() return early and never resend the header,
footer, or list name.

The default header embeds %online%, which is baked into the cache key, so the
tablist only recovered when the player count happened to differ from the value
at quit time - matching the reported intermittent behaviour.

Clearing both caches on quit also stops the two maps from growing unbounded
with every unique player since server start.

Fixes #100