### PR TITLE
feat(shards): apply shard booster to player kill rewards (#99)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -164,6 +164,10 @@ SETTINGS:
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text
   SHARDS-KILL-MESSAGE: '&#A303F9+{shards} Shard'
+  # The text or value for Shards Kill Message Boosted, shown instead of Shards Kill
+  # Message while a shard booster multiplies the kill reward. Supports {multiplier}.
+  # Available options: Any valid string text
+  SHARDS-KILL-MESSAGE-BOOSTED: '&#A303F9+{shards} Shards &7(&ax{multiplier}&7)'
   # The numerical value for Shards Kill Cooldown Seconds. Blocks repeated kill rewards
   # against the same victim until the cooldown expires. Set to 0 to disable.
   # Available options: Any valid integer
@@ -203,6 +207,7 @@ SETTINGS:
 | `SETTINGS.HOME-DEFAULT` | `int` | Any valid integer number | `'2'` | Default maximum `/sethome` limit for non-donor players. |
 | `SETTINGS.SHARDS-PER-KILL` | `int` | Any valid integer number | `'1'` | Configures the technical `SHARDS-PER-KILL` parameter for `SETTINGS.SHARDS-PER-KILL` in `config.yml`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE` | `str` | Any string text | `'&#A303F9+{shards} Shard'` | Configures the technical `SHARDS-KILL-MESSAGE` parameter for `SETTINGS.SHARDS-KILL-MESSAGE` in `config.yml`. |
+| `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` | `str` | Any string text | `'&#A303F9+{shards} Shards &7(&ax{multiplier}&7)'` | Action bar shown instead of `SHARDS-KILL-MESSAGE` while a shard booster multiplies the kill reward. Supports `{multiplier}`. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-SECONDS` | `int` | Any valid integer number | `'600'` | Time a killer must wait before the same victim rewards shards again. Set to `0` to reward every kill. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-MESSAGE` | `str` | Any string text | `'&cNo Shard &7(killed recently, {time} left)'` | Action bar shown when a kill reward is skipped by the cooldown. Supports `{time}` and `{seconds}`. Leave empty to stay silent. |
 | `SETTINGS.MONEY-PER-DEFAULT` | `float` | Any decimal number | `'1000.0'` | Configures the technical `MONEY-PER-DEFAULT` parameter for `SETTINGS.MONEY-PER-DEFAULT` in `config.yml`. |
@@ -1010,6 +1015,8 @@ SHARDS:
 | `SHARDS.CUBOIDS.REGIONS.spawn.PAUSED-MESSAGE` | `str` | Any string text | `'&eMove to keep earning shards &7(%m...'` | Configures the technical `PAUSED-MESSAGE` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.PAUSED-MESSAGE` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.AFK-PAUSED-MESSAGE` | `str` | Any string text | `'&cYou are AFK. Move to resume shard...'` | Configures the technical `AFK-PAUSED-MESSAGE` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.AFK-PAUSED-MESSAGE` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.EXCLUDED-WORLD-MESSAGE` | `str` | Any string text | `'&cShards are disabled in this world'` | Configures the technical `EXCLUDED-WORLD-MESSAGE` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.EXCLUDED-WORLD-MESSAGE` in `config.yml`. |
+| `SHARDS.BOOSTER-APPLIES-TO-KILLS` | `bool` | `true`, `false` | `true` | Whether an active shard booster also multiplies player kill rewards. Set to `false` to keep the booster on passive and cuboid shards only. |
+| `SHARDS.BOOSTER-KILL-MULTIPLIER` | `int` | Any valid integer number | `'0'` | Separate booster multiplier used only for kill rewards. Set to `0` to reuse `SHARDS.BOOSTER-MULTIPLIER`. |
 | *(10 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -494,6 +494,10 @@ SETTINGS:
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text
   SHARDS-KILL-MESSAGE: '&#A303F9+{shards} Shard'
+  # The text or value for Shards Kill Message Boosted, shown instead of Shards Kill
+  # Message while a shard booster multiplies the kill reward. Supports {multiplier}.
+  # Available options: Any valid string text
+  SHARDS-KILL-MESSAGE-BOOSTED: '&#A303F9+{shards} Shards &7(&ax{multiplier}&7)'
   # The numerical value for Shards Kill Cooldown Seconds. Blocks repeated kill rewards
   # against the same victim until the cooldown expires. Set to 0 to disable.
   # Available options: Any valid integer
@@ -532,6 +536,7 @@ SETTINGS:
 | `SETTINGS.HOME-DEFAULT` | `int` | Any positive integer | `2` | Default maximum `/sethome` limit for non-donor players. |
 | `SETTINGS.SHARDS-PER-KILL` | `int` | Any valid integer | `1` | Configures `SHARDS-PER-KILL` for `SETTINGS`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE` | `str` | Any string text | `&#A303F9+{shards} Shard` | Configures `SHARDS-KILL-MESSAGE` for `SETTINGS`. |
+| `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` | `str` | Any string text | `&#A303F9+{shards} Shards &7(&ax{multiplier}&7)` | Action bar shown instead of `SHARDS-KILL-MESSAGE` while a shard booster multiplies the kill reward. Supports `{multiplier}`. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-SECONDS` | `int` | Any valid integer | `600` | Time a killer must wait before the same victim rewards shards again. Set to `0` to reward every kill. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-MESSAGE` | `str` | Any string text | `&cNo Shard &7(killed recently, {time} left)` | Action bar shown when a kill reward is skipped by the cooldown. Supports `{time}` and `{seconds}`. Leave empty to stay silent. |
 | `SETTINGS.MONEY-PER-DEFAULT` | `float` | Configured values | `1000.0` | Configures `MONEY-PER-DEFAULT` for `SETTINGS`. |
@@ -905,6 +910,12 @@ SHARDS:
     - duels
   # The numerical value for Booster Multiplier. Available options: Any valid integer
   BOOSTER-MULTIPLIER: 4
+  # Determines whether the shard booster also multiplies player kill rewards.
+  # Available options: true, false
+  BOOSTER-APPLIES-TO-KILLS: true
+  # The numerical value for Booster Kill Multiplier, used only for player kill rewards.
+  # Set to 0 to reuse Booster Multiplier. Available options: Any valid integer
+  BOOSTER-KILL-MULTIPLIER: 0
 # Configuration section for Key All.
 ```
 
@@ -941,6 +952,8 @@ SHARDS:
 | `SHARDS.CUBOIDS.REGIONS.spawn.PAUSED-MESSAGE` | `str` | Any string text | `&eMove to keep earning shards &7(%mov...` | Configures `PAUSED-MESSAGE` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.AFK-PAUSED-MESSAGE` | `str` | Any string text | `&cYou are AFK. Move to resume shard gain` | Configures `AFK-PAUSED-MESSAGE` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.EXCLUDED-WORLD-MESSAGE` | `str` | Any string text | `&cShards are disabled in this world` | Configures `EXCLUDED-WORLD-MESSAGE` for `SHARDS`. |
+| `SHARDS.BOOSTER-APPLIES-TO-KILLS` | `bool` | true, false | `True` | Whether an active shard booster also multiplies player kill rewards. Set to `false` to keep the booster on passive and cuboid shards only. |
+| `SHARDS.BOOSTER-KILL-MULTIPLIER` | `int` | Any valid integer | `0` | Separate booster multiplier used only for kill rewards. Set to `0` to reuse `SHARDS.BOOSTER-MULTIPLIER`. |
 | *(10 additional sub-keys configured in config.yml)* | | | | |
 
 ---

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerDeathListener.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.listeners;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.FeatureManager;
+import com.bx.ultimateDonutSmp.managers.ShardManager;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.models.TwoChoice;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
@@ -79,8 +80,11 @@ public class PlayerDeathListener implements Listener {
                 killerData.addKillStreak();
                 if (plugin.getFeatureManager().isEnabled(FeatureManager.Feature.SHARDS)) {
                     if (plugin.getShardManager().tryClaimKillReward(killer.getUniqueId(), victim.getUniqueId())) {
-                        long shardsPerKill = plugin.getShardManager().rollKillReward();
-                        plugin.getShardManager().giveShards(killer, shardsPerKill, true);
+                        long multiplier = plugin.getShardManager().getKillMultiplier(killer.getUniqueId());
+                        long shardsPerKill = ShardManager.applyMultiplier(
+                                plugin.getShardManager().rollKillReward(), multiplier);
+                        plugin.getShardManager().giveShards(killer, shardsPerKill, false);
+                        plugin.getShardManager().sendKillRewardFeedback(killer, shardsPerKill, multiplier);
                     } else {
                         plugin.getShardManager().sendKillRewardCooldownFeedback(killer, victim.getUniqueId());
                     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
@@ -385,6 +385,75 @@ public class ShardManager {
         return 1;
     }
 
+    public boolean isBoosterAppliedToKills() {
+        return plugin.getConfigManager().getConfig().getBoolean("SHARDS.BOOSTER-APPLIES-TO-KILLS", true);
+    }
+
+    /**
+     * Booster multiplier used for player kill rewards.
+     *
+     * @return the configured kill multiplier, or {@code 1} when no booster applies
+     */
+    public int getKillMultiplier(UUID uuid) {
+        if (!isBoosterAppliedToKills() || !hasBooster(uuid)) {
+            return 1;
+        }
+        FileConfiguration config = plugin.getConfigManager().getConfig();
+        int killMultiplier = config.getInt("SHARDS.BOOSTER-KILL-MULTIPLIER", 0);
+        return Math.max(1, killMultiplier > 0
+                ? killMultiplier
+                : config.getInt("SHARDS.BOOSTER-MULTIPLIER", 4));
+    }
+
+    /** Multiplies a reward without overflowing when the configured range is extreme. */
+    public static long applyMultiplier(long amount, long multiplier) {
+        long safeAmount = Math.max(0L, amount);
+        long safeMultiplier = Math.max(1L, multiplier);
+        if (safeAmount == 0L || safeMultiplier == 1L) {
+            return safeAmount;
+        }
+        return safeAmount > Long.MAX_VALUE / safeMultiplier ? Long.MAX_VALUE : safeAmount * safeMultiplier;
+    }
+
+    public String formatKillRewardMessage(long amount, long multiplier) {
+        boolean boosted = multiplier > 1;
+        String path = boosted
+                ? "SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED"
+                : "SETTINGS.SHARDS-KILL-MESSAGE";
+        String fallback = boosted
+                ? "+{amount_formatted} &7(&ax{multiplier}&7)"
+                : "+{amount_formatted}";
+
+        String message = plugin.getConfigManager().getConfig().getString(path, fallback);
+        if (message == null || message.isBlank()) {
+            message = fallback;
+        }
+        return message
+                .replace("{shards}", String.valueOf(amount))
+                .replace("{amount}", String.valueOf(amount))
+                .replace("{shards_formatted}", plugin.getCurrencyManager().formatShards(amount))
+                .replace("{amount_formatted}", plugin.getCurrencyManager().formatShards(amount))
+                .replace("{multiplier}", String.valueOf(Math.max(1L, multiplier)));
+    }
+
+    public void sendKillRewardFeedback(Player killer, long amount, long multiplier) {
+        if (killer == null) {
+            return;
+        }
+
+        PlayerSettingUtils.sendActionBar(plugin, killer, formatKillRewardMessage(amount, multiplier));
+        if (multiplier <= 1) {
+            // Unboosted kills stay silent, exactly as before the booster applied here.
+            return;
+        }
+
+        String sound = plugin.getConfigManager().getSound("SHARDS.REWARD-BOOSTED");
+        if (sound == null || sound.isBlank()) {
+            sound = "minecraft:entity.player.levelup|0.85|1.45";
+        }
+        SoundUtils.play(killer, sound);
+    }
+
     public void syncBooster(Player player) {
         PlayerData data = plugin.getPlayerDataManager().get(player);
         if (data == null) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -74,6 +74,10 @@ SETTINGS:
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text
   SHARDS-KILL-MESSAGE: '&#A303F9+{shards} Shard'
+  # The text or value for Shards Kill Message Boosted, shown instead of Shards Kill
+  # Message while a shard booster multiplies the kill reward. Supports {multiplier}.
+  # Available options: Any valid string text
+  SHARDS-KILL-MESSAGE-BOOSTED: '&#A303F9+{shards} Shards &7(&ax{multiplier}&7)'
   # The numerical value for Shards Kill Cooldown Seconds. Blocks repeated kill rewards
   # against the same victim until the cooldown expires. Set to 0 to disable.
   # Available options: Any valid integer
@@ -434,6 +438,12 @@ SHARDS:
     - duels
   # The numerical value for Booster Multiplier. Available options: Any valid integer
   BOOSTER-MULTIPLIER: 4
+  # Determines whether the shard booster also multiplies player kill rewards.
+  # Available options: true, false
+  BOOSTER-APPLIES-TO-KILLS: true
+  # The numerical value for Booster Kill Multiplier, used only for player kill rewards.
+  # Set to 0 to reuse Booster Multiplier. Available options: Any valid integer
+  BOOSTER-KILL-MULTIPLIER: 0
 # Configuration section for Key All.
 KEY-ALL:
   # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ShardManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ShardManagerTest.java
@@ -73,6 +73,26 @@ class ShardManagerTest {
     }
 
     @Test
+    void multipliesKillRewardsWithoutOverflowing() {
+        assertEquals(40L, ShardManager.applyMultiplier(10L, 4L));
+        assertEquals(10L, ShardManager.applyMultiplier(10L, 1L));
+        assertEquals(0L, ShardManager.applyMultiplier(0L, 4L));
+    }
+
+    @Test
+    void treatsInvalidMultipliersAsNoBoost() {
+        assertEquals(10L, ShardManager.applyMultiplier(10L, 0L));
+        assertEquals(10L, ShardManager.applyMultiplier(10L, -3L));
+        assertEquals(0L, ShardManager.applyMultiplier(-10L, 4L));
+    }
+
+    @Test
+    void saturatesInsteadOfWrappingOnExtremeRewards() {
+        assertEquals(Long.MAX_VALUE, ShardManager.applyMultiplier(Long.MAX_VALUE, 4L));
+        assertEquals(Long.MAX_VALUE - 1L, ShardManager.applyMultiplier((Long.MAX_VALUE - 1L) / 2L, 2L));
+    }
+
+    @Test
     void reportsRemainingCooldownRoundedUpToWholeSeconds() {
         long cooldown = 600_000L;
         long firstKill = 1_000_000L;


### PR DESCRIPTION
## Description of Changes
Resolves #99. The shard booster now multiplies shards earned from player kills, matching how it already works for passive (everywhere) and cuboid shard rewards.

- `ShardManager#getKillMultiplier` resolves the kill multiplier (`SHARDS.BOOSTER-KILL-MULTIPLIER` when > 0, otherwise `SHARDS.BOOSTER-MULTIPLIER`), returning `1` when no booster is active or the feature is disabled.
- `ShardManager#applyMultiplier` multiplies with saturation at `Long.MAX_VALUE`, so an extreme `SHARDS-PER-KILL-MAX` cannot overflow.
- `PlayerDeathListener` applies the multiplier **after** the roll, so `SHARDS-PER-KILL-MIN/MAX` keeps its meaning as the base range.
- `ShardManager#sendKillRewardFeedback` shows `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` and plays the `SHARDS.REWARD-BOOSTED` sound on boosted kills. Unboosted kills are unchanged — same message, still no sound.
- The existing per-victim kill cooldown (#95) is untouched; only kills that already pass `tryClaimKillReward` are multiplied.

New config keys (all backwards compatible, defaults preserve current balance unless a booster is active):

| Key | Default | Purpose |
| :--- | :--- | :--- |
| `SHARDS.BOOSTER-APPLIES-TO-KILLS` | `true` | Master toggle for this feature |
| `SHARDS.BOOSTER-KILL-MULTIPLIER` | `0` | Separate PvP multiplier; `0` reuses `BOOSTER-MULTIPLIER` |
| `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` | `&#A303F9+{shards} Shards &7(&ax{multiplier}&7)` | Boosted kill action bar, supports `{multiplier}` |

## Type of Change
- [x] New Feature (Non-breaking change which adds functionality)

## How to Test
1. Run unit tests with the command `mvn test`
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - Kill a player without a booster and confirm the reward and action bar are unchanged.
   - Activate a shard booster, kill a different player, and confirm the reward is multiplied by `BOOSTER-MULTIPLIER` and the boosted action bar plus sound appear.
   - Set `SHARDS.BOOSTER-APPLIES-TO-KILLS: false`, reload, and confirm kill rewards drop back to the base amount while passive/cuboid shards stay boosted.
   - Set `SHARDS.BOOSTER-KILL-MULTIPLIER: 2` with `BOOSTER-MULTIPLIER: 4` and confirm kills use 2x while passive shards still use 4x.
   - Kill the same victim twice within `SHARDS-KILL-COOLDOWN-SECONDS` and confirm the cooldown message still suppresses the second reward.

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added unit tests (if applicable) and all tests pass.
- [x] I have documented changes in configuration files or `changelog.md` if necessary.