### PR TITLE
perf(mobspawn): replace per-second entity sweep with event filter (#97)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
@@ -4,28 +4,39 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.MobSpawnPolicy;
 import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.util.function.Function;
 
 public class MobSpawnListener implements Listener {
 
     private final UltimateDonutSmp plugin;
+    private final Function<Player, PlayerData> dataProvider;
+
+    private volatile FileConfiguration cachedConfig;
+    private volatile double mobSpawnRadius = 50.0D;
+    private volatile double phantomSpawnRadius = 40.0D;
 
     public MobSpawnListener(UltimateDonutSmp plugin) {
         this.plugin = plugin;
-        startCleanupTask();
+        this.dataProvider = p -> plugin.getPlayerDataManager().get(p);
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onMobSpawn(CreatureSpawnEvent event) {
         if (!(event.getEntity() instanceof LivingEntity entity)) return;
 
         if (MobSpawnPolicy.hasCustomName(entity)) return;
+
+        refreshSettingsIfNeeded();
 
         if (event.getEntityType() == EntityType.PHANTOM) {
             if (isPreventableSpawnReason(event.getSpawnReason()) && shouldCancelPhantomSpawn(entity.getLocation())) {
@@ -48,16 +59,50 @@ public class MobSpawnListener implements Listener {
         }
     }
 
+    /**
+     * Clears hostile mobs that were already loaded around a player who joins with the toggle off.
+     * This is a single scan per join, not a repeating server-wide entity sweep.
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        plugin.getSpigotScheduler().runEntityLater(player, () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+            PlayerData data = dataProvider.apply(player);
+            if (data == null || data.isMobSpawnEnabled()) {
+                return;
+            }
+            refreshSettingsIfNeeded();
+            MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, mobSpawnRadius);
+        }, 20L);
+    }
+
+    /**
+     * Re-reads the radii only when {@link com.bx.ultimateDonutSmp.managers.ConfigManager} swapped in a
+     * new {@link FileConfiguration}, so the hot path costs a reference compare instead of a YAML path
+     * lookup per spawn attempt.
+     */
+    private void refreshSettingsIfNeeded() {
+        FileConfiguration current = plugin.getConfigManager().getConfig();
+        if (current == cachedConfig || current == null) {
+            return;
+        }
+        mobSpawnRadius = Math.max(0.0D, current.getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50));
+        phantomSpawnRadius = Math.max(0.0D, current.getDouble("SETTINGS.PHANTOM-SPAWN-RADIUS", 40));
+        cachedConfig = current;
+    }
+
     private boolean shouldCancelPhantomSpawn(Location location) {
         if (location == null || location.getWorld() == null) {
             return false;
         }
-        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.PHANTOM-SPAWN-RADIUS", 40);
         return MobSpawnPolicy.shouldCancelPhantomSpawn(
                 location,
                 location.getWorld().getPlayers(),
-                radius,
-                p -> plugin.getPlayerDataManager().get(p)
+                phantomSpawnRadius,
+                dataProvider
         );
     }
 
@@ -65,12 +110,11 @@ public class MobSpawnListener implements Listener {
         if (location == null || location.getWorld() == null) {
             return false;
         }
-        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
         return MobSpawnPolicy.shouldCancelMobSpawn(
                 location,
                 location.getWorld().getPlayers(),
-                radius,
-                p -> plugin.getPlayerDataManager().get(p)
+                mobSpawnRadius,
+                dataProvider
         );
     }
 
@@ -80,42 +124,5 @@ public class MobSpawnListener implements Listener {
             case CUSTOM, SPAWNER_EGG, BUILD_WITHER, BREEDING -> false;
             default -> true;
         };
-    }
-
-    private void startCleanupTask() {
-        plugin.getSpigotScheduler().runGlobalTimer(this::cleanupNearbyHostileMobs, 20L, 20L);
-    }
-
-    private void cleanupNearbyHostileMobs() {
-        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
-        double radiusSquared = radius * radius;
-
-        plugin.getSpigotScheduler().forEachOnlinePlayer(player -> {
-            PlayerData data = plugin.getPlayerDataManager().get(player);
-            if (data == null || data.isMobSpawnEnabled()) {
-                return;
-            }
-
-            removeNearbyHostiles(player, radius, radiusSquared);
-        });
-    }
-
-    private void removeNearbyHostiles(Player player, double radius, double radiusSquared) {
-        Location playerLocation = player.getLocation();
-
-        for (org.bukkit.entity.Entity nearby : player.getNearbyEntities(radius, radius, radius)) {
-            if (!(nearby instanceof LivingEntity entity) || !isRemovableHostileMob(entity)) {
-                continue;
-            }
-            if (entity.getLocation().distanceSquared(playerLocation) > radiusSquared) {
-                continue;
-            }
-
-            entity.remove();
-        }
-    }
-
-    private boolean isRemovableHostileMob(LivingEntity entity) {
-        return MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(plugin, entity);
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -11,8 +11,6 @@ import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
@@ -560,19 +558,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
 
     private void clearNearbyHostileMobs(Player player) {
         double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
-        double radiusSquared = radius * radius;
-        for (Entity entity : player.getNearbyEntities(radius, radius, radius)) {
-            if (!(entity instanceof LivingEntity living)) {
-                continue;
-            }
-            if (!MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(plugin, living)) {
-                continue;
-            }
-            if (living.getLocation().distanceSquared(player.getLocation()) > radiusSquared) {
-                continue;
-            }
-            living.remove();
-        }
+        MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, radius);
     }
 
     private void toggle(Player player, String label, boolean enabled, BooleanSetter setter) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
@@ -9,8 +9,6 @@ import com.bx.ultimateDonutSmp.utils.NightVisionUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
@@ -409,21 +407,7 @@ public class SettingsMenu extends BaseMenu {
 
     private void clearNearbyHostileMobs(Player player) {
         double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
-        double radiusSquared = radius * radius;
-
-        for (Entity entity : player.getNearbyEntities(radius, radius, radius)) {
-            if (!(entity instanceof LivingEntity living)) {
-                continue;
-            }
-            if (!MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(plugin, living)) {
-                continue;
-            }
-            if (living.getLocation().distanceSquared(player.getLocation()) > radiusSquared) {
-                continue;
-            }
-
-            living.remove();
-        }
+        MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, radius);
     }
 
     private ItemStack toNightVisionPotion(ItemStack item) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.utils;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
@@ -67,22 +68,29 @@ public final class MobSpawnPolicy {
             double radius,
             Function<Player, PlayerData> dataProvider
     ) {
-        if (spawnLocation == null || players == null || players.isEmpty()) {
+        if (spawnLocation == null || radius <= 0.0D || players == null || players.isEmpty()) {
             return false;
         }
         double radiusSquared = radius * radius;
+        int chunkRadius = chunkRadius(radius);
+        int spawnChunkX = spawnLocation.getBlockX() >> 4;
+        int spawnChunkZ = spawnLocation.getBlockZ() >> 4;
+        Location buffer = new Location(null, 0.0D, 0.0D, 0.0D);
         for (Player player : players) {
             if (player == null) continue;
             PlayerData data = dataProvider != null ? dataProvider.apply(player) : null;
             if (data == null || data.isMobSpawnEnabled()) {
                 continue;
             }
-            Location playerLoc = player.getLocation();
+            Location playerLoc = locationOf(player, buffer);
             if (playerLoc == null) {
                 continue;
             }
             if (playerLoc.getWorld() != null && spawnLocation.getWorld() != null
                     && !playerLoc.getWorld().equals(spawnLocation.getWorld())) {
+                continue;
+            }
+            if (isOutsideChunkRadius(playerLoc, spawnChunkX, spawnChunkZ, chunkRadius)) {
                 continue;
             }
             double dx = playerLoc.getX() - spawnLocation.getX();
@@ -101,22 +109,29 @@ public final class MobSpawnPolicy {
             double radius,
             Function<Player, PlayerData> dataProvider
     ) {
-        if (spawnLocation == null || players == null || players.isEmpty()) {
+        if (spawnLocation == null || radius <= 0.0D || players == null || players.isEmpty()) {
             return false;
         }
         double radiusSquared = radius * radius;
+        int chunkRadius = chunkRadius(radius);
+        int spawnChunkX = spawnLocation.getBlockX() >> 4;
+        int spawnChunkZ = spawnLocation.getBlockZ() >> 4;
+        Location buffer = new Location(null, 0.0D, 0.0D, 0.0D);
         for (Player player : players) {
             if (player == null) continue;
             PlayerData data = dataProvider != null ? dataProvider.apply(player) : null;
             if (data == null || data.isPhantomEnabled()) {
                 continue;
             }
-            Location playerLoc = player.getLocation();
+            Location playerLoc = locationOf(player, buffer);
             if (playerLoc == null) {
                 continue;
             }
             if (playerLoc.getWorld() != null && spawnLocation.getWorld() != null
                     && !playerLoc.getWorld().equals(spawnLocation.getWorld())) {
+                continue;
+            }
+            if (isOutsideChunkRadius(playerLoc, spawnChunkX, spawnChunkZ, chunkRadius)) {
                 continue;
             }
             double dx = playerLoc.getX() - spawnLocation.getX();
@@ -126,6 +141,61 @@ public final class MobSpawnPolicy {
             }
         }
         return false;
+    }
+
+    /**
+     * Reads the player position into {@code buffer} so a spawn check over N players allocates one
+     * {@link Location} instead of N. Falls back to {@link Player#getLocation()} when the buffered
+     * overload is unavailable.
+     */
+    private static Location locationOf(Player player, Location buffer) {
+        Location buffered = player.getLocation(buffer);
+        return buffered != null ? buffered : player.getLocation();
+    }
+
+    /**
+     * Chunk span that fully contains {@code radius}, used as an integer-only pre-filter before the
+     * squared-distance math.
+     */
+    private static int chunkRadius(double radius) {
+        return (((int) Math.ceil(radius)) >> 4) + 1;
+    }
+
+    private static boolean isOutsideChunkRadius(
+            Location playerLocation,
+            int spawnChunkX,
+            int spawnChunkZ,
+            int chunkRadius
+    ) {
+        int playerChunkX = playerLocation.getBlockX() >> 4;
+        int playerChunkZ = playerLocation.getBlockZ() >> 4;
+        return Math.abs(playerChunkX - spawnChunkX) > chunkRadius
+                || Math.abs(playerChunkZ - spawnChunkZ) > chunkRadius;
+    }
+
+    /**
+     * One-shot removal of the hostile mobs already loaded around {@code player}. Used when a player
+     * turns the toggle off and when they join with it already off, so the toggle stays meaningful
+     * without a repeating server-wide entity scan.
+     */
+    public static void clearNearbyHostileMobs(UltimateDonutSmp plugin, Player player, double radius) {
+        if (plugin == null || player == null || radius <= 0.0D) {
+            return;
+        }
+        double radiusSquared = radius * radius;
+        Location playerLocation = player.getLocation();
+        for (Entity entity : player.getNearbyEntities(radius, radius, radius)) {
+            if (!(entity instanceof LivingEntity living)) {
+                continue;
+            }
+            if (!shouldRemoveFromPeriodicCleanup(plugin, living)) {
+                continue;
+            }
+            if (living.getLocation().distanceSquared(playerLocation) > radiusSquared) {
+                continue;
+            }
+            living.remove();
+        }
     }
 
     public static boolean shouldRemoveFromPeriodicCleanup(

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,6 +89,87 @@ class MobSpawnPolicyTest {
         Map<Player, PlayerData> dataMap = Map.of(playerB, dataB);
 
         assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(playerB), 50.0, dataMap::get));
+    }
+
+    @Test
+    void nonPositiveRadiusDisablesTheFilter() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+
+        Player playerB = createMockPlayer(new Location(null, 0, 0, 0));
+        PlayerData dataB = new PlayerData(UUID.randomUUID(), "PlayerB");
+        dataB.setMobSpawnEnabled(false);
+
+        Map<Player, PlayerData> dataMap = Map.of(playerB, dataB);
+
+        assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(playerB), 0.0, dataMap::get));
+        assertFalse(MobSpawnPolicy.shouldCancelPhantomSpawn(spawnLoc, List.of(playerB), 0.0, dataMap::get));
+    }
+
+    @Test
+    void chunkPreFilterNeverDropsAPlayerInsideTheRadius() {
+        PlayerData disabled = new PlayerData(UUID.randomUUID(), "Disabled");
+        disabled.setMobSpawnEnabled(false);
+
+        // Walk the whole radius on each axis: the integer chunk pre-filter must not reject any
+        // position that the squared-distance check would still consider in range.
+        for (double radius : new double[]{1.0, 15.0, 16.0, 50.0, 300.0}) {
+            for (double offset = 0.0; offset <= radius; offset += 0.5) {
+                Player player = createMockPlayer(new Location(null, offset, 0, offset));
+                Map<Player, PlayerData> dataMap = Map.of(player, disabled);
+
+                boolean inRange = (offset * offset * 2) <= radius * radius;
+                assertEquals(
+                        inRange,
+                        MobSpawnPolicy.shouldCancelMobSpawn(
+                                new Location(null, 0, 0, 0), List.of(player), radius, dataMap::get),
+                        "radius=" + radius + " offset=" + offset
+                );
+            }
+        }
+    }
+
+    @Test
+    void eachPlayerSettingIsEvaluatedIndependently() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+
+        Player near = createMockPlayer(new Location(null, 5, 0, 0));
+        Player far = createMockPlayer(new Location(null, 500, 0, 0));
+
+        PlayerData nearOn = new PlayerData(UUID.randomUUID(), "NearOn");
+        nearOn.setMobSpawnEnabled(true);
+        PlayerData farOff = new PlayerData(UUID.randomUUID(), "FarOff");
+        farOff.setMobSpawnEnabled(false);
+
+        Map<Player, PlayerData> dataMap = Map.of(near, nearOn, far, farOff);
+
+        // The only player with the toggle OFF sits outside the radius, so the spawn is allowed even
+        // though a player is standing right on top of the spawn location.
+        assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(near, far), 50.0, dataMap::get));
+
+        // Flip the near player OFF and the same spawn is now blocked by that player alone.
+        nearOn.setMobSpawnEnabled(false);
+        assertTrue(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(near, far), 50.0, dataMap::get));
+    }
+
+    @Test
+    void missingPlayerDataNeverBlocksASpawn() {
+        Location spawnLoc = new Location(null, 0, 0, 0);
+        Player player = createMockPlayer(new Location(null, 1, 0, 0));
+
+        assertFalse(MobSpawnPolicy.shouldCancelMobSpawn(spawnLoc, List.of(player), 50.0, p -> null));
+        assertFalse(MobSpawnPolicy.shouldCancelPhantomSpawn(spawnLoc, List.of(player), 40.0, p -> null));
+    }
+
+    @Test
+    void phantomFilterIgnoresVerticalDistance() {
+        Player player = createMockPlayer(new Location(null, 0, 200, 0));
+        PlayerData data = new PlayerData(UUID.randomUUID(), "Player");
+        data.setPhantomEnabled(false);
+
+        Map<Player, PlayerData> dataMap = Map.of(player, data);
+
+        assertTrue(MobSpawnPolicy.shouldCancelPhantomSpawn(
+                new Location(null, 0, 0, 0), List.of(player), 40.0, dataMap::get));
     }
 
     private Player createMockPlayer(Location location) {


### PR DESCRIPTION
Closes #97

## Problem

The per-player mob spawn toggle registered a global timer on plugin start that ran every 20 ticks. For each online player with the toggle off it called `getNearbyEntities(50, 50, 50)` — a 100-block cube scan, once per second, per player. On a server with a large entity count that scan, not the spawn filtering, was the expensive part.

The `CreatureSpawnEvent` filter itself already had the semantics the issue asks for: it walks the players in the spawn world, checks each player's own `isMobSpawnEnabled()`, and uses squared distance. It does not pick the nearest player and does not apply one player's setting globally.

## Changes

- **Remove the periodic cleanup task.** `startCleanupTask` / `cleanupNearbyHostileMobs` / `removeNearbyHostiles` are gone. Nothing scans entities on a timer anymore.
- **Keep the toggle meaningful without a timer.** The two settings menus already cleared nearby hostiles on toggle-off; a single scan on join (delayed 20 ticks, only when the toggle is off) covers players who log in with it already disabled.
- **Cache the radii.** `refreshSettingsIfNeeded()` is a reference compare against the `FileConfiguration` that `ConfigManager` swaps on reload, replacing a YAML path lookup on every spawn attempt. Reloads still apply immediately; the radius is still config-driven.
- **Cut allocations in the event.** The `PlayerData` lookup lambda is a field instead of a per-event capturing lambda, and the player loop reuses one `Location` buffer via `getLocation(buffer)` — one allocation instead of one per player.
- **Cheap pre-filter.** Integer chunk-distance check before the squared-distance math, and `radius <= 0` short-circuits the whole filter.
- **`HIGHEST` + `ignoreCancelled`.** A spawn another plugin already cancelled costs nothing.
- **De-duplicate.** `clearNearbyHostileMobs` moved from `SettingsMenu` and `PlayerSettingsMenu` into `MobSpawnPolicy`.

## Not changed

Entity classification, `SpawnReason` filtering, custom-name / boss / spawner exclusions, phantom handling and vanilla-spawner marking are untouched.

## Known behaviour change

Hostile mobs that wander into a player's radius from outside are no longer removed. Closing that gap requires exactly the periodic scan this PR removes; the reference implementation in #97 does not handle it either.