### PR TITLE
fix(folia): dispatch commands on the global tick thread (#105)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/AnvilModerationManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/AnvilModerationManager.java
@@ -2,7 +2,6 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
@@ -101,9 +100,7 @@ public class AnvilModerationManager {
         String template = punishments.get(index);
         String resolvedCommand = template.replace("%player%", player.getName());
 
-        plugin.getSpigotScheduler().runEntity(player, () -> {
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), resolvedCommand);
-        });
+        plugin.getSpigotScheduler().dispatchConsoleCommand(resolvedCommand);
     }
 
     public List<String> getBannedWords() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateManager.java
@@ -1042,7 +1042,7 @@ public class CrateManager {
                     .replace("{reward}", reward.id())
                     .replace("{reward_name}", getReadableRewardName(reward))
                     .replace("{amount}", String.valueOf(Math.max(1, grant.item().amount())));
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), resolved);
+            plugin.getSpigotScheduler().dispatchConsoleCommand(resolved);
         }
         return true;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/KeyAllManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/KeyAllManager.java
@@ -351,7 +351,7 @@ public class KeyAllManager {
             return;
         }
 
-        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), resolved);
+        plugin.getSpigotScheduler().dispatchConsoleCommand(resolved);
     }
 
     private String resolveCommandReward(String command, Player player, SelectedKeyReward reward) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -804,7 +804,7 @@ public class ShopManager {
 
         String command = resolveShopCommand(player, item.command(), quantity);
         try {
-            boolean dispatched = Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            boolean dispatched = plugin.getSpigotScheduler().dispatchConsoleCommand(command);
             return dispatched
                     ? RewardDeliveryResult.ok()
                     : RewardDeliveryResult.failure("command returned false: " + command);

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -103,16 +103,16 @@ public final class PlayerSettingsMenu extends BaseMenu {
                 commandStr = commandStr.replace("{player}", player.getName()).replace("%player%", player.getName());
                 if (commandStr.toLowerCase(java.util.Locale.ROOT).startsWith("[console] ")) {
                     String cmd = commandStr.substring(10).trim();
-                    org.bukkit.Bukkit.dispatchCommand(org.bukkit.Bukkit.getConsoleSender(), cmd);
+                    plugin.getSpigotScheduler().dispatchConsoleCommand(cmd);
                 } else if (commandStr.toLowerCase(java.util.Locale.ROOT).startsWith("[player] ")) {
                     String cmd = commandStr.substring(9).trim();
                     if (cmd.startsWith("/")) cmd = cmd.substring(1);
-                    player.performCommand(cmd);
+                    plugin.getSpigotScheduler().dispatchPlayerCommand(player, cmd);
                 } else {
                     String cmd = commandStr.startsWith("/") ? commandStr.substring(1) : commandStr;
-                    player.performCommand(cmd);
+                    plugin.getSpigotScheduler().dispatchPlayerCommand(player, cmd);
                 }
-                org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+                plugin.getSpigotScheduler().runEntity(player, () -> {
                     if (player.isOnline()) {
                         build(player);
                     }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
@@ -78,16 +78,16 @@ public class SettingsMenu extends BaseMenu {
                 commandStr = commandStr.replace("{player}", player.getName()).replace("%player%", player.getName());
                 if (commandStr.toLowerCase(java.util.Locale.ROOT).startsWith("[console] ")) {
                     String cmd = commandStr.substring(10).trim();
-                    org.bukkit.Bukkit.dispatchCommand(org.bukkit.Bukkit.getConsoleSender(), cmd);
+                    plugin.getSpigotScheduler().dispatchConsoleCommand(cmd);
                 } else if (commandStr.toLowerCase(java.util.Locale.ROOT).startsWith("[player] ")) {
                     String cmd = commandStr.substring(9).trim();
                     if (cmd.startsWith("/")) cmd = cmd.substring(1);
-                    player.performCommand(cmd);
+                    plugin.getSpigotScheduler().dispatchPlayerCommand(player, cmd);
                 } else {
                     String cmd = commandStr.startsWith("/") ? commandStr.substring(1) : commandStr;
-                    player.performCommand(cmd);
+                    plugin.getSpigotScheduler().dispatchPlayerCommand(player, cmd);
                 }
-                org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+                plugin.getSpigotScheduler().runEntity(player, () -> {
                     if (player.isOnline()) {
                         build(player);
                     }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
@@ -223,6 +223,62 @@ public final class SpigotScheduler {
         return !isFolia() || foliaBridge.isOwnedByCurrentRegion(location);
     }
 
+    /**
+     * Runs a console command. Folia only allows command dispatch from the global tick thread,
+     * so on Folia the dispatch is handed to the global region scheduler instead of running inline.
+     *
+     * @return the dispatch result when the command ran inline, or {@code true} when it was scheduled
+     */
+    public boolean dispatchConsoleCommand(String command) {
+        if (command == null || command.isBlank()) {
+            return false;
+        }
+
+        String resolved = command;
+        if (!isFolia() && Bukkit.isPrimaryThread()) {
+            return Bukkit.dispatchCommand(Bukkit.getConsoleSender(), resolved);
+        }
+
+        runGlobal(() -> {
+            try {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), resolved);
+            } catch (Exception exception) {
+                plugin.getLogger().log(Level.WARNING, "Failed to dispatch console command '" + resolved + "'", exception);
+            }
+        });
+        return true;
+    }
+
+    /**
+     * Runs a command as the given player. Carries the same Folia threading rules as
+     * {@link #dispatchConsoleCommand(String)}.
+     *
+     * @return the dispatch result when the command ran inline, or {@code true} when it was scheduled
+     */
+    public boolean dispatchPlayerCommand(Player player, String command) {
+        if (player == null || command == null || command.isBlank()) {
+            return false;
+        }
+
+        String resolved = command;
+        if (!isFolia() && Bukkit.isPrimaryThread()) {
+            return player.performCommand(resolved);
+        }
+
+        runGlobal(() -> {
+            if (!player.isOnline()) {
+                return;
+            }
+            try {
+                player.performCommand(resolved);
+            } catch (Exception exception) {
+                plugin.getLogger().log(Level.WARNING, "Failed to dispatch command '" + resolved
+                        + "' as " + player.getName(), exception);
+            }
+        });
+        return true;
+    }
+
     private static long ticksToMillis(long ticks) {
         return Math.max(0L, ticks) * MILLIS_PER_TICK;
     }


### PR DESCRIPTION
## Description of Changes
On Folia, `Bukkit.dispatchCommand` may only be called from the global tick thread — `RegionizedServer.ensureGlobalTickThread` throws otherwise. Crate rewards are claimed on the player's *entity* scheduler (`CrateGachaMenu` → `runEntityLater` → `claimReward` → `grantCommandReward`), so every COMMAND-type reward threw `IllegalStateException: Dispatching command async`. `CrateManager` caught the exception, left `granted = false`, refunded the key and returned `REWARD_GRANT_FAILED` — so COMMAND crate rewards could never be granted on Folia.

Added `dispatchConsoleCommand(String)` and `dispatchPlayerCommand(Player, String)` to `SpigotScheduler`. On Spigot/Paper they dispatch inline from the main thread and preserve the real `boolean` result; on Folia they hand the call to the global region scheduler. All six dispatch sites now route through them:

| File | Note |
|---|---|
| `CrateManager` | the reported bug |
| `AnvilModerationManager` | dispatch was wrapped in `runEntity`, which guaranteed the failure — hop removed |
| `KeyAllManager` | same bug class |
| `ShopManager` | same bug class |
| `PlayerSettingsMenu` | also fixes `performCommand` and `Bukkit.getScheduler().runTask` from a region thread |
| `SettingsMenu` | same as above |

**Behaviour note:** on Folia the command now runs on the next global tick instead of inline, so `ShopManager`'s `"command returned false"` check only remains strict on Spigot/Paper. Spigot/Paper behaviour is otherwise unchanged.

## Bug Details
- Related Issue: #105
- Steps to Reproduce: on Folia, open any crate whose reward `grant.type` is `COMMAND` and claim it. The command never executes; the player gets "failed to grant that reward. your key has been returned." and the console logs `IllegalStateException: Dispatching command async`.

## How to Test
1. Build with `mvn clean package`
2. Deploy to a Folia test server (26.1.2+)
3. Perform the following test steps:
   - Open a crate with a `COMMAND` reward — the command must execute and the key must be consumed, with no `Dispatching command async` in the console.
   - Buy a shop item backed by a command reward.
   - Run a key-all with a configured command reward.
   - Click a settings-menu button with `COMMAND: "[console] ..."` and one with `[player] ...`; the menu must rebuild afterwards.
   - Trigger an anvil-moderation punishment.
4. Repeat on Paper to confirm no regression — dispatch there is still inline and synchronous.

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit tests (if applicable) and all tests pass.
- [ ] I have documented changes in configuration files or `changelog.md` if necessary.