### PR TITLE
fix(leaderboard): keep cached entries on invalidate so the menu renders (#106)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/LeaderboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/LeaderboardManager.java
@@ -6,7 +6,6 @@ import com.bx.ultimateDonutSmp.utils.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -46,14 +45,22 @@ public class LeaderboardManager {
     public record LeaderboardEntry(int position, PlayerData playerData) {
     }
 
-    private record CachedLeaderboard(long cachedAtMillis, List<PlayerData> players) {
-        private boolean isExpired(long now) {
-            return now - cachedAtMillis >= CACHE_TTL_MS;
+    private record CachedLeaderboard(long cachedAtMillis, List<PlayerData> players, boolean stale) {
+        private CachedLeaderboard(long cachedAtMillis, List<PlayerData> players) {
+            this(cachedAtMillis, players, false);
+        }
+
+        private boolean needsRefresh(long now) {
+            return stale || now - cachedAtMillis >= CACHE_TTL_MS;
+        }
+
+        private CachedLeaderboard markStale() {
+            return stale ? this : new CachedLeaderboard(cachedAtMillis, players, true);
         }
     }
 
     private final UltimateDonutSmp plugin;
-    private final Map<LeaderboardType, CachedLeaderboard> leaderboardCache = new EnumMap<>(LeaderboardType.class);
+    private final Map<LeaderboardType, CachedLeaderboard> leaderboardCache = new java.util.concurrent.ConcurrentHashMap<>();
     private final java.util.Set<LeaderboardType> refreshingTypes = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
     public LeaderboardManager(UltimateDonutSmp plugin) {
@@ -154,14 +161,20 @@ public class LeaderboardManager {
         return numericValue(type, data);
     }
 
+    // Keeps the last snapshot readable while a refresh runs; dropping it here made the
+    // next menu open render "no leaderboard data" until the async reload finished.
     public void invalidate(LeaderboardType type) {
-        if (type != null) {
-            leaderboardCache.remove(type);
+        if (type == null) {
+            return;
         }
+        leaderboardCache.computeIfPresent(type, (key, cached) -> cached.markStale());
     }
 
     public void invalidateAll() {
-        leaderboardCache.clear();
+        leaderboardCache.replaceAll((key, cached) -> cached.markStale());
+        for (LeaderboardType type : LeaderboardType.values()) {
+            triggerAsyncRefresh(type);
+        }
     }
 
     private List<PlayerData> getSortedPlayers(LeaderboardType type) {
@@ -175,7 +188,7 @@ public class LeaderboardManager {
             return List.of();
         }
 
-        if (cachedLeaderboard.isExpired(now)) {
+        if (cachedLeaderboard.needsRefresh(now)) {
             triggerAsyncRefresh(type);
         }
         return cachedLeaderboard.players();


### PR DESCRIPTION
## Description of Changes
Fixes #106. The leaderboard rendered "no leaderboard data" on the first open after any data change (money, shards, kills), and only showed entries when reopened.

`LeaderboardManager#invalidate` removed the cache entry outright. The next read hit the `cachedLeaderboard == null` branch, which queues an async reload and returns `List.of()` immediately, while `LeaderboardTypeMenu#build` renders synchronously — so the barrier item was drawn before the reload landed. `EconomyManager#saveLoadedAccount` calls `invalidate(MONEY)` on every balance save, which is why any economy activity reproduced it.

- `CachedLeaderboard` gains a `stale` flag; `isExpired` becomes `needsRefresh` (stale **or** past the 2s TTL).
- `invalidate` marks the snapshot stale via `computeIfPresent` instead of removing it. Reads keep serving the last snapshot and still trigger the background refresh, so the menu always has entries.
- `invalidateAll` marks every type stale and queues a refresh, so `/udsmp reload` no longer causes the same blank first open, and a server wipe repopulates right after the commit.
- `leaderboardCache` switched from `EnumMap` to `ConcurrentHashMap`. It is written from the async database executor and read from the server thread; an unsynchronised `EnumMap` does not support that.

Snapshots hold live `PlayerData` references for online players (`PlayerDataManager#getAll` returns the live cache), so displayed values are current even off a stale snapshot — only sort ordering can lag by the pre-existing 2s TTL. No config keys added or changed.

## Type of Change
- [x] Bug Fix (Non-breaking change which fixes an issue)

## How to Test
1. Run unit tests with the command `mvn test`
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - Change your balance (`/eco give`, or buy/sell something), then run `/leaderboard` and open the Money category. Entries must appear on the **first** open.
   - Run `/addshards <player> <amount>`, then open `/leaderboard` → Shards. Entries must appear on the first open.
   - Confirm your own updated value is shown immediately, and rank ordering settles within ~2 seconds.
   - Run `/udsmp reload`, then open `/leaderboard`. It must render on the first open instead of showing the barrier.
   - Confirm leaderboard PlaceholderAPI placeholders do not blank to `0` right after a balance change.
   - Page forward/back in a leaderboard category and confirm paging is unchanged.

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit tests (if applicable) and all tests pass.
- [x] I have documented changes in configuration files or `changelog.md` if necessary.