### PR TITLE
fix(worth): stop baking worth lore into real items so they stack (#108)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -512,6 +512,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         pm.registerEvents(new MobSpawnListener(this), this);
         pm.registerEvents(new PlayerSettingEffectsListener(this), this);
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+            worthManager.setPacketDisplayActive(true);
             pm.registerEvents(new WorthPacketDisplay(this), this);
         } else {
             pm.registerEvents(new WorthDisplayListener(this), this);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -17,22 +17,15 @@ import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionType;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -46,13 +39,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
-import java.util.regex.Pattern;
 import java.util.logging.Level;
 
 public class ShopManager {
 
-    private static final String NULL_LORE = "__NULL__";
-    private static final String LORE_SEPARATOR = ";";
     private static final Set<String> CATEGORY_META_KEYS = Set.of("MENU-TITLE", "MENU-SIZE", "ORDER");
     private static final Set<String> MENU_META_KEYS = Set.of(
             "TITLE",
@@ -288,15 +278,11 @@ public class ShopManager {
     private final UltimateDonutSmp plugin;
     private final ShopPreferenceRepository preferenceRepository;
     private final Map<UUID, ShopPreference> preferenceCache = new ConcurrentHashMap<>();
-    private final NamespacedKey worthDisplayAppliedKey;
-    private final NamespacedKey worthDisplayOriginalLoreKey;
 
     public ShopManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
         this.preferenceRepository = new ShopPreferenceRepository(plugin);
         this.preferenceRepository.initialize().join();
-        this.worthDisplayAppliedKey = new NamespacedKey(plugin, "worth_display_applied");
-        this.worthDisplayOriginalLoreKey = new NamespacedKey(plugin, "worth_display_original_lore");
         reload();
     }
 
@@ -1115,168 +1101,6 @@ public class ShopManager {
         return plugin.getWorthManager().getWorthLoreLine(item);
     }
 
-    private boolean isWorthDisplayEnabled(Player player) {
-        PlayerData data = plugin.getPlayerDataManager().get(player);
-        return data != null && data.isWorthDisplayEnabled();
-    }
-
-    private ItemStack updateWorthDisplay(ItemStack item, boolean enabled) {
-        if (item == null || item.getType().isAir()) {
-            return item;
-        }
-
-        String loreLine = enabled ? getWorthLoreLine(item) : null;
-        if (loreLine == null || loreLine.isBlank()) {
-            return stripWorthDisplay(item);
-        }
-
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) {
-            return item;
-        }
-
-        List<String> currentLore = meta.getLore();
-        List<String> originalLore = readOriginalLore(meta);
-        if (originalLore == null) {
-            originalLore = currentLore;
-        }
-        originalLore = stripExistingWorthLore(originalLore);
-
-        List<String> desiredLore = originalLore == null ? new ArrayList<>() : new ArrayList<>(originalLore);
-        desiredLore.add(ColorUtils.toComponent(loreLine));
-
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        String serializedOriginalLore = serializeLore(originalLore);
-        String storedOriginalLore = container.get(worthDisplayOriginalLoreKey, PersistentDataType.STRING);
-        boolean alreadyApplied = container.has(worthDisplayAppliedKey, PersistentDataType.BYTE);
-        if (alreadyApplied
-                && Objects.equals(storedOriginalLore, serializedOriginalLore)
-                && Objects.equals(currentLore, desiredLore)) {
-            return item;
-        }
-
-        ItemStack updated = item.clone();
-        ItemMeta updatedMeta = updated.getItemMeta();
-        if (updatedMeta == null) {
-            return item;
-        }
-
-        PersistentDataContainer updatedContainer = updatedMeta.getPersistentDataContainer();
-        updatedContainer.set(worthDisplayAppliedKey, PersistentDataType.BYTE, (byte) 1);
-        updatedContainer.set(worthDisplayOriginalLoreKey, PersistentDataType.STRING, serializedOriginalLore);
-        updatedMeta.setLore(desiredLore);
-        updated.setItemMeta(updatedMeta);
-        return updated;
-    }
-
-    private List<String> readOriginalLore(ItemMeta meta) {
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        String stored = container.get(worthDisplayOriginalLoreKey, PersistentDataType.STRING);
-        if (stored != null) {
-            return deserializeLore(stored);
-        }
-
-        if (!container.has(worthDisplayAppliedKey, PersistentDataType.BYTE)) {
-            return meta.getLore();
-        }
-
-        List<String> currentLore = meta.getLore();
-        if (currentLore == null || currentLore.isEmpty()) {
-            return null;
-        }
-
-        return new ArrayList<>(currentLore.subList(0, currentLore.size() - 1));
-    }
-
-    private String serializeLore(List<String> lore) {
-        if (lore == null) {
-            return NULL_LORE;
-        }
-        if (lore.isEmpty()) {
-            return "";
-        }
-
-        List<String> encoded = new ArrayList<>();
-        for (String line : lore) {
-            encoded.add(Base64.getEncoder().encodeToString((line == null ? "" : line).getBytes(StandardCharsets.UTF_8)));
-        }
-        return String.join(LORE_SEPARATOR, encoded);
-    }
-
-    private List<String> deserializeLore(String serialized) {
-        if (serialized == null) {
-            return null;
-        }
-        if (NULL_LORE.equals(serialized)) {
-            return null;
-        }
-        if (serialized.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        List<String> lore = new ArrayList<>();
-        for (String token : serialized.split(LORE_SEPARATOR, -1)) {
-            lore.add(new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8));
-        }
-        return lore;
-    }
-
-    private String replaceWorthPlaceholders(
-            String format,
-            String totalPrice,
-            String unitPrice,
-            String amount,
-            String itemName
-    ) {
-        String resolved = replacePlaceholderVariants(format, "price", totalPrice);
-        resolved = replacePlaceholderVariants(resolved, "unit_price", unitPrice);
-        resolved = replacePlaceholderVariants(resolved, "amount", amount);
-        return replacePlaceholderVariants(resolved, "item", itemName);
-    }
-
-    private String replacePlaceholderVariants(String text, String key, String value) {
-        return text
-                .replace("%" + key + "%", value)
-                .replace("${" + key + "}", value)
-                .replace("{" + key + "}", value);
-    }
-
-    private List<String> stripExistingWorthLore(List<String> lore) {
-        if (lore == null || lore.isEmpty()) {
-            return lore;
-        }
-
-        Pattern worthLorePattern = buildWorthLorePattern();
-        List<String> sanitized = new ArrayList<>();
-        boolean changed = false;
-        for (String line : lore) {
-            if (isWorthLoreLine(line, worthLorePattern)) {
-                changed = true;
-                continue;
-            }
-            sanitized.add(line);
-        }
-        return changed ? sanitized : lore;
-    }
-
-    private boolean isWorthLoreLine(String line, Pattern worthLorePattern) {
-        String plain = ColorUtils.strip(line);
-        if (containsBrokenWorthPlaceholder(plain)) {
-            return true;
-        }
-
-        return worthLorePattern.matcher(plain).matches();
-    }
-
-    private boolean containsBrokenWorthPlaceholder(String plain) {
-        return plain.contains("${price}")
-                || plain.contains("%price%")
-                || plain.contains("{price}")
-                || plain.contains("${unit_price}")
-                || plain.contains("%unit_price%")
-                || plain.contains("{unit_price}");
-    }
-
     private double findWorthRecursively(ConfigurationSection section, ItemStack item) {
         if (section == null || item == null || item.getType().isAir()) {
             return -1;
@@ -1500,100 +1324,6 @@ public class ShopManager {
 
         removeSoldItems.run();
         return commitSale(player, sale, sendFeedback);
-    }
-
-    private String getWorthLoreFormat() {
-        FileConfiguration worthConfig = plugin.getConfigManager().getWorth();
-
-        String format = firstNonBlank(
-                worthConfig.getString("WORTH-LORE.FORMAT"),
-                worthConfig.getString("DISPLAY.FORMAT"),
-                worthConfig.getString("FORMAT")
-        );
-        if (format != null) {
-            return normalizeWorthLoreFormat(format);
-        }
-
-        return normalizeWorthLoreFormat(
-                plugin.getConfigManager().getConfig()
-                        .getString("WORTH-LORE.FORMAT", "&7worth: &a{price_formatted}")
-        );
-    }
-
-    private String firstNonBlank(String... candidates) {
-        for (String candidate : candidates) {
-            if (candidate != null && !candidate.isBlank()) {
-                return candidate;
-            }
-        }
-        return null;
-    }
-
-    private String normalizeWorthLoreFormat(String format) {
-        if (format == null || format.isBlank()) {
-            return "&7worth: &a{price_formatted}";
-        }
-
-        return format;
-    }
-
-    private Pattern buildWorthLorePattern() {
-        String format = stripColorCodes(getWorthLoreFormat());
-        List<String> placeholders = List.of(
-                "%unit_price%", "${unit_price}", "{unit_price}",
-                "%unit_price_formatted%", "${unit_price_formatted}", "{unit_price_formatted}",
-                "%price%", "${price}", "{price}",
-                "%price_formatted%", "${price_formatted}", "{price_formatted}",
-                "%amount%", "${amount}", "{amount}",
-                "%item%", "${item}", "{item}"
-        );
-
-        StringBuilder regex = new StringBuilder("^");
-        int index = 0;
-        while (index < format.length()) {
-            int nextPlaceholderIndex = -1;
-            String nextPlaceholder = null;
-            for (String placeholder : placeholders) {
-                int candidateIndex = format.indexOf(placeholder, index);
-                if (candidateIndex < 0) {
-                    continue;
-                }
-                if (nextPlaceholderIndex < 0 || candidateIndex < nextPlaceholderIndex) {
-                    nextPlaceholderIndex = candidateIndex;
-                    nextPlaceholder = placeholder;
-                }
-            }
-
-            if (nextPlaceholderIndex < 0) {
-                regex.append(Pattern.quote(format.substring(index)));
-                break;
-            }
-
-            String staticPart = format.substring(index, nextPlaceholderIndex);
-            if (isPricePlaceholder(nextPlaceholder) && staticPart.endsWith("$")) {
-                staticPart = staticPart.substring(0, staticPart.length() - 1);
-                regex.append(Pattern.quote(staticPart));
-                regex.append("\\$?");
-            } else {
-                regex.append(Pattern.quote(staticPart));
-            }
-
-            regex.append(".+?");
-            index = nextPlaceholderIndex + nextPlaceholder.length();
-        }
-
-        regex.append("$");
-        return Pattern.compile(regex.toString());
-    }
-
-    private String stripColorCodes(String text) {
-        return text
-                .replaceAll("(?i)&#[0-9a-f]{6}", "")
-                .replaceAll("(?i)&[0-9a-fk-or]", "");
-    }
-
-    private boolean isPricePlaceholder(String placeholder) {
-        return placeholder.contains("price");
     }
 
     public double sellInventory(Player player, boolean handOnly) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
@@ -114,6 +114,7 @@ public class WorthManager {
     private final java.util.Map<WorthCacheKey, java.util.Optional<SellCategory>> sellCategoryCache = new java.util.concurrent.ConcurrentHashMap<>();
     private final java.util.Set<Material> blockedMaterialsCache = java.util.concurrent.ConcurrentHashMap.newKeySet();
     private boolean blockedMaterialsLoaded = false;
+    private volatile boolean packetDisplayActive = false;
 
     private static final DirectWorthData NULL_DIRECT_WORTH = new DirectWorthData(-1.0, "", "", "");
 
@@ -156,6 +157,11 @@ public class WorthManager {
         sellCategoryCache.clear();
         blockedMaterialsCache.clear();
         blockedMaterialsLoaded = false;
+    }
+
+    // toggled on at startup when the packet display is active, so worth is rendered per packet only
+    public void setPacketDisplayActive(boolean active) {
+        this.packetDisplayActive = active;
     }
 
     public double getWorth(Material material) {
@@ -1166,6 +1172,11 @@ public class WorthManager {
     }
 
     private ItemStack updateWorthDisplay(ItemStack item, boolean enabled) {
+        // the packet display renders worth client side, writing it into the real item breaks vanilla stacking
+        if (packetDisplayActive) {
+            return stripWorthDisplay(item);
+        }
+
         if (item == null || item.getType().isAir()) {
             return item;
         }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WorthManagerTest {
@@ -94,6 +95,29 @@ class WorthManagerTest {
 
         org.bukkit.inventory.ItemStack gold = new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 5);
         assertFalse(worthManager.isSimilarIgnoringWorth(item1, gold));
+    }
+
+    @Test
+    void packetDisplayModeLeavesRealItemsUntouchedSoTheyStillStack() throws Exception {
+        setupMockServer();
+
+        org.bukkit.configuration.file.YamlConfiguration worthConfig = new org.bukkit.configuration.file.YamlConfiguration();
+        worthConfig.set("TYPE.MINERALS.DIAMOND", 10.0);
+
+        UltimateDonutSmp plugin = createMockPlugin(worthConfig);
+        WorthManager worthManager = new WorthManager(plugin);
+        worthManager.setPacketDisplayActive(true);
+
+        java.lang.reflect.Method updateWorthDisplay = WorthManager.class.getDeclaredMethod(
+                "updateWorthDisplay", org.bukkit.inventory.ItemStack.class, boolean.class);
+        updateWorthDisplay.setAccessible(true);
+
+        org.bukkit.inventory.ItemStack partialStack = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND, 5);
+        org.bukkit.inventory.ItemStack fullStack = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND, 36);
+
+        assertSame(partialStack, updateWorthDisplay.invoke(worthManager, partialStack, true));
+        assertSame(fullStack, updateWorthDisplay.invoke(worthManager, fullStack, true));
+        assertTrue(partialStack.isSimilar(fullStack));
     }
 
     private void setupMockServer() throws Exception {


### PR DESCRIPTION
## Description of Changes

Items with a worth value would sometimes refuse to stack. The worth line was
written into the real `ItemStack` as lore plus PDC tags, and that line contains
the stack **total** (`unitWorth * amount`), not the unit price. Two stacks of the
same item with different amounts therefore carried different lore, so
`ItemStack.isSimilar()` returned false and the server refused to merge them.
Because `WorthPacketDisplay` re-renders the line on every outgoing packet, the
two stacks still looked identical on screen — which is why this reads as "items
just don't stack" with no visible cause.

ProtocolLib is a hard requirement (the plugin disables itself without it), so
worth is meant to be rendered per packet and never written to the item. Six paths
still called `WorthManager.syncWorthDisplay(player)`, which writes into the live
inventory: shop purchases, crate rewards, toggling Worth Display on (both settings
menus), invsee, and plugin reload. A single reload baked lore into every online
player's entire inventory.

`WorthManager.updateWorthDisplay` — the single function that writes the lore — now
short-circuits to `stripWorthDisplay` when the packet display is active, covering
all six paths at once. Because it strips instead of applying, those same paths now
heal items that are already broken; together with strip-on-join and
sanitize-on-container-open, existing stuck stacks clean themselves up after the
update. The non-ProtocolLib fallback listener is unaffected.

The second commit deletes a never-called copy of the same worth-lore code in
`ShopManager` (270 lines, pure deletion). It has no such guard and would
reintroduce this bug if anything ever called it. The delegating wrappers that are
actually used (`syncWorthDisplay`, `clearWorthDisplay`, `sanitizeInventory`,
`stripWorthDisplay`, `getWorthLoreLine`, `getWorth`) are kept.

Fixes #108

## Bug Details
- Related Issue: #108
- Steps to Reproduce:
  1. Trigger a worth-lore bake: run a plugin reload, buy from the shop, open a
     crate, or toggle Worth Display on in settings.
  2. Open a chest and take out two stacks of the same item.
  3. Split them unevenly across your inventory.
  4. Quick-move them back into the chest.
  5. They stay as separate partial stacks and never merge, even though they look
     identical.

## How to Test
1. Run unit tests with the command `mvn test` — 139 tests, including the new
   `packetDisplayModeLeavesRealItemsUntouchedSoTheyStillStack` regression test.
2. Deploy the plugin to a test server (Paper/Spigot/Folia) with ProtocolLib.
3. Perform the following test steps:
   - Reproduce the steps above and confirm the stacks now merge.
   - Confirm the worth line still renders correctly in inventories, chests, and
     shulkers.
   - Confirm items that were already broken before the update heal after rejoining.
   - Confirm `/sell` and shop pricing are unchanged (worth is resolved from
     material/enchants/potion type, never from lore).

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added unit tests (if applicable) and all tests pass.
- [ ] I have documented changes in configuration files or `changelog.md` if necessary.