### PR TITLE
fix(clearlag): keep freshly dropped items out of the cleanup sweep (#111)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1284,3 +1284,89 @@ TABLIST:
 
 ---
 
+## Section: `CLEAR-LAG`
+
+### 1. Commented Setup Code Example
+
+```yaml
+CLEAR-LAG:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: true
+  # The numerical value for Every. Available options: Any valid integer
+  EVERY: 5
+  # Determines whether Animals is enabled or disabled. Available options: true, false
+  ANIMALS: false
+  # Determines whether Monsters is enabled or disabled. Available options: true, false
+  MONSTERS: false
+  # Determines whether Dropped Items is enabled or disabled. Available options: true, false
+  DROPPED-ITEMS: true
+  # The numerical value for Min Item Age Seconds. Dropped items younger than this are kept,
+  # so items dropped just before a cleanup are not wiped. Set to 0 to disable the delay.
+  # Available options: Any valid integer
+  MIN-ITEM-AGE-SECONDS: 60
+  # Configuration section for Excluded Worlds.
+  EXCLUDED-WORLDS:
+  - duels
+  EXCLUDE-NAMED: true
+  EXCLUDE-TAMED: true
+  EXCLUDE-VILLAGERS: true
+  # Configuration section for Excluded Entity Types. Entity types listed here are never
+  # cleared, for example ALLAY or IRON_GOLEM.
+  EXCLUDED-ENTITY-TYPES: []
+  # Configuration section for Excluded Item Materials. Dropped items of these materials are
+  # never cleared, for example NETHERITE_INGOT or ELYTRA.
+  EXCLUDED-ITEM-MATERIALS: []
+# Configuration section for Combat Manager.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `CLEAR-LAG.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for the cleanup task and `/clearlag`. The `CLEAR_LAG` feature toggle must also be enabled. |
+| `CLEAR-LAG.EVERY` | `int` | Any valid integer | `5` | Minutes between cleanup runs. Countdown warnings are broadcast 60, 30, 15, 10, 5, 4, 3, 2 and 1 second before each run. Values below `1` are treated as `1`. |
+| `CLEAR-LAG.ANIMALS` | `bool` | `true`, `false` | `false` | Removes passive animals during a cleanup run. |
+| `CLEAR-LAG.MONSTERS` | `bool` | `true`, `false` | `false` | Removes monsters, slimes and flying hostiles during a cleanup run. |
+| `CLEAR-LAG.DROPPED-ITEMS` | `bool` | `true`, `false` | `true` | Removes dropped item entities during a cleanup run. |
+| `CLEAR-LAG.MIN-ITEM-AGE-SECONDS` | `int` | Any valid integer | `60` | Grace period for dropped items. Items that have existed for fewer seconds than this are skipped, so items dropped shortly before a run survive until the next one. Set to `0` to clear items regardless of age. |
+| `CLEAR-LAG.EXCLUDED-WORLDS` | `list` | List of configured items/strings | `['duels']` | World names that are skipped entirely, so nothing inside them is ever cleared. |
+| `CLEAR-LAG.EXCLUDE-NAMED` | `bool` | `true`, `false` | `true` | Skips entities that carry a custom name. |
+| `CLEAR-LAG.EXCLUDE-TAMED` | `bool` | `true`, `false` | `true` | Skips tamed entities such as pets and horses. |
+| `CLEAR-LAG.EXCLUDE-VILLAGERS` | `bool` | `true`, `false` | `true` | Skips villagers, wandering traders and NPCs. |
+| `CLEAR-LAG.EXCLUDED-ENTITY-TYPES` | `list` | List of configured items/strings | `[]` | Entity type names that are never cleared, for example `ALLAY` or `IRON_GOLEM`. Matched case-insensitively against the entity type. |
+| `CLEAR-LAG.EXCLUDED-ITEM-MATERIALS` | `list` | List of configured items/strings | `[]` | Material names that are never cleared when they lie on the ground, for example `NETHERITE_INGOT` or `ELYTRA`. Matched case-insensitively against the dropped stack. |
+
+### 3. Practical Setup Example
+
+```yaml
+CLEAR-LAG:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: true
+  # The numerical value for Every. Available options: Any valid integer
+  EVERY: 5
+  # Determines whether Animals is enabled or disabled. Available options: true, false
+  ANIMALS: false
+  # Determines whether Monsters is enabled or disabled. Available options: true, false
+  MONSTERS: false
+  # Determines whether Dropped Items is enabled or disabled. Available options: true, false
+  DROPPED-ITEMS: true
+  # The numerical value for Min Item Age Seconds. Dropped items younger than this are kept,
+  # so items dropped just before a cleanup are not wiped. Set to 0 to disable the delay.
+  # Available options: Any valid integer
+  MIN-ITEM-AGE-SECONDS: 60
+  # Configuration section for Excluded Worlds.
+  EXCLUDED-WORLDS:
+  - duels
+  EXCLUDE-NAMED: true
+  EXCLUDE-TAMED: true
+  EXCLUDE-VILLAGERS: true
+  # Configuration section for Excluded Entity Types. Entity types listed here are never
+  # cleared, for example ALLAY or IRON_GOLEM.
+  EXCLUDED-ENTITY-TYPES: []
+  # Configuration section for Excluded Item Materials. Dropped items of these materials are
+  # never cleared, for example NETHERITE_INGOT or ELYTRA.
+  EXCLUDED-ITEM-MATERIALS: []
+# Configuration section for Combat Manager.
+```
+
+---

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ClearLagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ClearLagManager.java
@@ -25,7 +25,7 @@ public class ClearLagManager {
     }
 
     public int getIntervalMinutes() {
-        return plugin.getConfigManager().getConfig().getInt("CLEAR-LAG.EVERY", 5);
+        return Math.max(1, plugin.getConfigManager().getConfig().getInt("CLEAR-LAG.EVERY", 5));
     }
 
     public boolean clearAnimals() {
@@ -38,6 +38,10 @@ public class ClearLagManager {
 
     public boolean clearDroppedItems() {
         return plugin.getConfigManager().getConfig().getBoolean("CLEAR-LAG.DROPPED-ITEMS", true);
+    }
+
+    public int getMinItemAgeSeconds() {
+        return Math.max(0, plugin.getConfigManager().getConfig().getInt("CLEAR-LAG.MIN-ITEM-AGE-SECONDS", 60));
     }
 
     public List<String> getExcludedWorlds() {
@@ -71,10 +75,14 @@ public class ClearLagManager {
         boolean checkVillagers = excludeVillagers();
         List<String> excludedTypes = getExcludedEntityTypes();
         List<String> excludedMaterials = getExcludedItemMaterials();
+        long minItemAgeTicks = (long) getMinItemAgeSeconds() * 20L;
 
         if (plugin.getSpigotScheduler().isFolia()) {
             java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
-            java.util.concurrent.atomic.AtomicInteger pending = new java.util.concurrent.atomic.AtomicInteger(0);
+            // Starts at 1 so the scheduling loop below holds a slot of its own. Entity tasks can
+            // finish while later entities are still being queued, so without that slot the counter
+            // reaches zero early and broadcasts a partial total more than once.
+            java.util.concurrent.atomic.AtomicInteger pending = new java.util.concurrent.atomic.AtomicInteger(1);
 
             for (World world : Bukkit.getWorlds()) {
                 if (excludedWorlds.contains(world.getName())) continue;
@@ -101,7 +109,7 @@ public class ClearLagManager {
 
                             boolean remove = false;
                             if (entity instanceof Item item) {
-                                if (clearDroppedItems()) {
+                                if (clearDroppedItems() && item.getTicksLived() >= minItemAgeTicks) {
                                     String materialName = item.getItemStack().getType().name();
                                     boolean materialExcluded = false;
                                     for (String mat : excludedMaterials) {
@@ -136,8 +144,8 @@ public class ClearLagManager {
                     });
                 }
             }
-            if (pending.get() == 0) {
-                broadcastSuccess(0);
+            if (pending.decrementAndGet() == 0) {
+                broadcastSuccess(count.get());
             }
             return 0;
         }
@@ -170,7 +178,7 @@ public class ClearLagManager {
 
                 boolean remove = false;
                 if (entity instanceof Item item) {
-                    if (clearDroppedItems()) {
+                    if (clearDroppedItems() && item.getTicksLived() >= minItemAgeTicks) {
                         String materialName = item.getItemStack().getType().name();
                         boolean materialExcluded = false;
                         for (String mat : excludedMaterials) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -577,12 +577,22 @@ CLEAR-LAG:
   MONSTERS: false
   # Determines whether Dropped Items is enabled or disabled. Available options: true, false
   DROPPED-ITEMS: true
+  # The numerical value for Min Item Age Seconds. Dropped items younger than this are kept,
+  # so items dropped just before a cleanup are not wiped. Set to 0 to disable the delay.
+  # Available options: Any valid integer
+  MIN-ITEM-AGE-SECONDS: 60
   # Configuration section for Excluded Worlds.
   EXCLUDED-WORLDS:
   - duels
   EXCLUDE-NAMED: true
   EXCLUDE-TAMED: true
   EXCLUDE-VILLAGERS: true
+  # Configuration section for Excluded Entity Types. Entity types listed here are never
+  # cleared, for example ALLAY or IRON_GOLEM.
+  EXCLUDED-ENTITY-TYPES: []
+  # Configuration section for Excluded Item Materials. Dropped items of these materials are
+  # never cleared, for example NETHERITE_INGOT or ELYTRA.
+  EXCLUDED-ITEM-MATERIALS: []
 # Configuration section for Combat Manager.
 COMBAT-MANAGER:
   # Determines whether Enabled is enabled or disabled. Available options: true, false


### PR DESCRIPTION
Closes #111

## Problem

`ClearLagTask` counts down `CLEAR-LAG.EVERY` minutes and then hands off to `ClearLagManager.clearEntities()`, which removes every `Item` entity in every non-excluded world. Nothing looks at how long an item has been on the ground, so an item dropped one second before the timer reaches zero is deleted along with the rest. Dropping items to trade or to free inventory space is enough to lose them.

Two smaller defects sit in the same path:

- `CLEAR-LAG.EVERY` is read raw. `EVERY: 0` — a plausible guess for "off" — resets the countdown to `0`, so the sweep runs every second, forever.
- `EXCLUDED-ENTITY-TYPES` and `EXCLUDED-ITEM-MATERIALS` have been read by `ClearLagManager` since fa2c51f but were never added to the shipped `config.yml`, so the intended workaround — whitelist the materials you care about — is undiscoverable.

## Changes

- **Grace period for dropped items.** New `CLEAR-LAG.MIN-ITEM-AGE-SECONDS` (default `60`). Both the Folia and Paper sweeps skip items whose `getTicksLived()` is below the threshold, so a fresh drop survives the current cycle and only becomes eligible once it has been on the ground long enough. `0` restores the old behaviour.
- **Clamp the interval.** `getIntervalMinutes()` returns `Math.max(1, …)`, so `0` or a negative value can no longer turn the task into a per-second wipe.
- **Ship the exclusion keys.** `EXCLUDED-ENTITY-TYPES` and `EXCLUDED-ITEM-MATERIALS` are now in `config.yml` as empty lists with comments. `ConfigManager.mergeBundledDefaults` copies them into existing configs on the next start, and empty defaults mean no behaviour change for servers that do not use them.
- **Fix the Folia success broadcast.** `pending` now starts at `1` and the scheduling loop releases its own slot after enumeration. Entity tasks can finish while later entities are still being queued, so the counter previously reached zero early and broadcast a partial total more than once per sweep.
- **Document the section.** `docs/wiki/Config-config.yml.md` had no `CLEAR-LAG` entry at all; it now documents all twelve keys.

## Not changed

Mob and animal clearing, the named / tamed / villager exclusions, world exclusions, the countdown warning schedule and the `/clearlag` command are untouched. Items still despawn on the vanilla timer as before.

## Known limitation

On Folia, if an entity is retired between enumeration and scheduling, `EntityScheduler#run` returns `null`, the task never runs and the counter never reaches zero, so no success message is broadcast for that sweep. That leak predates this PR; closing it means changing `SpigotScheduler` to surface scheduling failures instead of returning a `NoopTask`.