### PR TITLE
fix(spawners): enforce silk touch for ops and vanilla spawners (#113)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -94,6 +94,14 @@ This page contains the complete reference guide for all commands, aliases, synta
 
 ---
 
+## Spawner Permissions
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.spawner.bypass` | `false` | Break spawners without a Silk Touch pickaxe while `SETTINGS.REQUIRE_SILK_TOUCH` is enabled in `spawners.yml`. Registered with `default: false`, so operators do not receive it automatically. Assign it explicitly via LuckPerms. |
+
+---
+
 ## Media Rank & Badge Permissions
 
 Media permissions are registered with `default: false` and require explicit assignment via LuckPerms (or explicit permission attachment). Being an OP player does not automatically grant media badge status.

--- a/docs/wiki/Config-spawners.yml.md
+++ b/docs/wiki/Config-spawners.yml.md
@@ -54,7 +54,7 @@ SETTINGS:
 | `SETTINGS.MAX_STACK_PER_BLOCK` | `int` | Any valid integer number | `'100000'` | Configures the technical `MAX_STACK_PER_BLOCK` parameter for `SETTINGS.MAX_STACK_PER_BLOCK` in `spawners.yml`. |
 | `SETTINGS.STORAGE_CAP_PER_LOOT_KEY` | `int` | Any valid integer number | `'1000000'` | Configures the technical `STORAGE_CAP_PER_LOOT_KEY` parameter for `SETTINGS.STORAGE_CAP_PER_LOOT_KEY` in `spawners.yml`. |
 | `SETTINGS.DROP_ON_BREAK_IF_INVENTORY_FULL` | `bool` | `true`, `false` | `true` | Configures the technical `DROP_ON_BREAK_IF_INVENTORY_FULL` parameter for `SETTINGS.DROP_ON_BREAK_IF_INVENTORY_FULL` in `spawners.yml`. |
-| `SETTINGS.REQUIRE_SILK_TOUCH` | `bool` | `true`, `false` | `true` | Configures the technical `REQUIRE_SILK_TOUCH` parameter for `SETTINGS.REQUIRE_SILK_TOUCH` in `spawners.yml`. |
+| `SETTINGS.REQUIRE_SILK_TOUCH` | `bool` | `true`, `false` | `true` | Requires a Silk Touch pickaxe to break spawners, covering both plugin-managed and vanilla spawners. Creative mode and `ultimatedonutsmp.spawner.bypass` are exempt; operators are not. |
 | `SETTINGS.CANCEL_MOB_SPAWN` | `bool` | `true`, `false` | `true` | Cancels physical mob entity spawning in the world and routes loot directly to virtual storage, eliminating mob AI server lag. |
 | `SETTINGS.XP_ENABLED` | `bool` | `true`, `false` | `true` | Configures the technical `XP_ENABLED` parameter for `SETTINGS.XP_ENABLED` in `spawners.yml`. |
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -71,8 +71,8 @@ This page provides answers and troubleshooting steps for common questions, confi
 ### Question: Why do custom spawners break into default pig spawners or fail to drop when mined?
 
 #### Solutions:
-- **Silk Touch Requirement**: By default, breaking stacked spawners requires a pickaxe enchanted with Silk Touch unless the player has administrator permission (`ultimatedonutsmp.admin.spawner` or `ultimatedonutsmp.spawner.bypass`).
-- **Check `spawners.yml`**: Ensure `SILK-TOUCH-REQUIRED: true/false` is configured according to your server rules.
+- **Silk Touch Requirement**: By default, breaking spawners requires a pickaxe enchanted with Silk Touch. Only Creative mode and the `ultimatedonutsmp.spawner.bypass` permission are exempt. Operators are **not** exempt: that node is registered with `default: false` and must be assigned explicitly via LuckPerms.
+- **Check `spawners.yml`**: Ensure `SETTINGS.REQUIRE_SILK_TOUCH: true/false` is configured according to your server rules.
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/SpawnerBlockListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/SpawnerBlockListener.java
@@ -1,6 +1,7 @@
 package com.bx.ultimateDonutSmp.listeners;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.SpawnerManager;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -103,11 +104,17 @@ public class SpawnerBlockListener implements Listener {
         if (plugin.getSpawnStashManager() != null && plugin.getSpawnStashManager().isActiveBlock(block)) {
             return;
         }
+        Player player = event.getPlayer();
         if (plugin.getSpawnerManager().getSpawner(block) == null) {
+            if (block.getType() == Material.SPAWNER
+                    && plugin.getSpawnerManager().isRequireSilkTouch()
+                    && !plugin.getSpawnerManager().hasSilkTouchAccess(player)) {
+                event.setCancelled(true);
+                player.sendMessage(ColorUtils.toComponent(SpawnerManager.SILK_TOUCH_REQUIRED_MESSAGE));
+            }
             return;
         }
 
-        Player player = event.getPlayer();
         var result = plugin.getSpawnerManager().breakSpawner(player, block);
         if (!result.success()) {
             event.setCancelled(true);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -56,6 +56,9 @@ import java.util.logging.Level;
 
 public class SpawnerManager {
 
+    public static final String SILK_TOUCH_BYPASS_PERMISSION = "ultimatedonutsmp.spawner.bypass";
+    public static final String SILK_TOUCH_REQUIRED_MESSAGE = "&cYou need Silk Touch to break this spawner!";
+
     public record ActionResult(boolean success, String message, int consumedAmount, boolean fullyDestroyed) {
         public ActionResult(boolean success, String message, int consumedAmount) {
             this(success, message, consumedAmount, true);
@@ -274,6 +277,24 @@ public class SpawnerManager {
 
     public boolean isCancelMobSpawn() {
         return cancelMobSpawn;
+    }
+
+    public boolean isRequireSilkTouch() {
+        return requireSilkTouch;
+    }
+
+    public boolean hasSilkTouchAccess(Player player) {
+        if (player == null) {
+            return false;
+        }
+        if (player.getGameMode() == GameMode.CREATIVE
+                || PermissionUtils.has(player, SILK_TOUCH_BYPASS_PERMISSION)) {
+            return true;
+        }
+        ItemStack heldTool = player.getInventory().getItemInMainHand();
+        return heldTool != null
+                && heldTool.getType().name().endsWith("_PICKAXE")
+                && heldTool.containsEnchantment(org.bukkit.enchantments.Enchantment.SILK_TOUCH);
     }
 
     public boolean isXpEnabled() {
@@ -818,22 +839,8 @@ public class SpawnerManager {
             return fail("&cyou do not have permission to break that spawner.");
         }
 
-        boolean hasSilkTouch = false;
-        if (player != null) {
-            if (player.getGameMode() == GameMode.CREATIVE
-                    || PermissionUtils.has(player, "ultimatedonutsmp.admin.spawner")
-                    || PermissionUtils.has(player, "ultimatedonutsmp.spawner.bypass")) {
-                hasSilkTouch = true;
-            } else {
-                ItemStack heldTool = player.getInventory().getItemInMainHand();
-                if (heldTool != null && heldTool.getType().name().endsWith("_PICKAXE") && heldTool.containsEnchantment(org.bukkit.enchantments.Enchantment.SILK_TOUCH)) {
-                    hasSilkTouch = true;
-                }
-            }
-        }
-
-        if (requireSilkTouch && !hasSilkTouch) {
-            return fail("&cYou must use a Silk Touch pickaxe to break spawners.");
+        if (requireSilkTouch && !hasSilkTouchAccess(player)) {
+            return fail(SILK_TOUCH_REQUIRED_MESSAGE);
         }
 
         long totalStack = instance.getStackAmount();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -871,6 +871,9 @@ permissions:
   ultimatedonutsmp.admin.spawner.seeall:
     description: Bypass spawner anti-ESP concealment
     default: op
+  ultimatedonutsmp.spawner.bypass:
+    description: Break spawners without a Silk Touch pickaxe while REQUIRE_SILK_TOUCH is enabled
+    default: false
   ultimatedonutsmp.admin.crate:
     description: Manage crate balances, settings, and chest bindings
     default: op

--- a/src/main/resources/spawners.yml
+++ b/src/main/resources/spawners.yml
@@ -21,6 +21,7 @@ SETTINGS:
   # Determines whether Drop On Break If Inventory Full is enabled or disabled. Available options: true, false
   DROP_ON_BREAK_IF_INVENTORY_FULL: true
   # Determines whether a Silk Touch pickaxe is required to break and collect spawners.
+  # Applies to vanilla spawners as well. Only Creative mode and the ultimatedonutsmp.spawner.bypass permission are exempt (operators are not).
   REQUIRE_SILK_TOUCH: true
   # Determines whether physical vanilla mob spawning is cancelled (set to true for virtual storage anti-lag drops, set to false to allow physical mobs to spawn in world).
   CANCEL_MOB_SPAWN: true


### PR DESCRIPTION
## Description of Changes
`SETTINGS.REQUIRE_SILK_TOUCH` did not actually block spawner breaking in two cases:

1. **Operators bypassed it silently.** The bypass added in 7b607d5e accepted `ultimatedonutsmp.admin.spawner`, which is registered `default: op`, so any operator was treated as holding Silk Touch — no warning, spawner breaks. This is the path a server owner hits when testing their own config.
2. **Vanilla spawners were never covered.** `SpawnerBlockListener#onBlockBreak` returned early when the block was not plugin-managed, so a spawner from the creative inventory or worldgen ignored the setting entirely.

The silk-touch check now lives in `SpawnerManager#hasSilkTouchAccess`, shared by both paths. Only Creative mode and `ultimatedonutsmp.spawner.bypass` are exempt; that node is registered with `default: false` and kept out of the `ultimatedonutsmp.admin.*` bundle so operators do not inherit it.

**Behaviour change to note in the release notes:** admins removing vanilla spawners while building in Survival now need Creative mode or an explicit `ultimatedonutsmp.spawner.bypass` grant.

## Bug Details
- Related Issue: #113
- Steps to Reproduce:
  1. Set `SETTINGS.REQUIRE_SILK_TOUCH: true` in `spawners.yml`.
  2. As an operator in Survival, place a plugin spawner and mine it with a plain pickaxe → it breaks with no warning.
  3. As any player, place a spawner from the creative inventory and mine it with a plain pickaxe → it breaks with no warning.

## How to Test
1. Run unit tests with the command `mvn test`
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - With `REQUIRE_SILK_TOUCH: true`, mine a plugin spawner as an **operator** using a plain pickaxe → break is cancelled, spawner stays, red message `You need Silk Touch to break this spawner!`
   - Repeat with a **vanilla** spawner (creative inventory or dungeon) → same result
   - Repeat with a Silk Touch pickaxe → spawner breaks and is returned as an item
   - Grant `ultimatedonutsmp.spawner.bypass` via LuckPerms and mine without Silk Touch → break succeeds
   - Switch to Creative mode and mine without Silk Touch → break succeeds
   - Set `REQUIRE_SILK_TOUCH: false` → vanilla spawner breaking behaves as before this change

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit tests (if applicable) and all tests pass.
- [x] I have documented changes in configuration files or `changelog.md` if necessary.