### PR TITLE
fix(folia): stop resolving inventory holders off-region (#117)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/BillfordManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/BillfordManager.java
@@ -173,7 +173,9 @@ public class BillfordManager {
             });
         }
 
-        Bukkit.getOnlinePlayers().forEach(player -> {
+        // resolving the holder of a block backed inventory reads the world and closing a
+        // view mutates the player, so hop onto each player's own region thread first
+        plugin.getSpigotScheduler().forEachOnlinePlayer(player -> {
             if (player.getOpenInventory().getTopInventory().getHolder() instanceof BillfordMenu) {
                 player.closeInventory();
             }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -89,6 +90,7 @@ public class SpawnerManager {
     private final AtomicLong temporarySpawnerIdSequence = new AtomicLong(-1L);
     private final Set<Long> temporarySpawnerIds = new HashSet<>();
     private final Map<Long, List<SpawnerLootEntry>> pendingLootMap = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Map<UUID, SpawnerStorageMenu> openStorageMenus = new java.util.concurrent.ConcurrentHashMap<>();
     private boolean serverWipeMode;
     private boolean enabled;
     private boolean xpEnabled;
@@ -1287,12 +1289,42 @@ public class SpawnerManager {
         refreshOpenStorageMenus();
     }
 
+    public void registerOpenStorageMenu(Player player, SpawnerStorageMenu menu) {
+        if (player == null || menu == null) {
+            return;
+        }
+        openStorageMenus.put(player.getUniqueId(), menu);
+    }
+
+    public void unregisterOpenStorageMenu(Player player, SpawnerStorageMenu menu) {
+        if (player == null || menu == null) {
+            return;
+        }
+        openStorageMenus.remove(player.getUniqueId(), menu);
+    }
+
     public void refreshOpenStorageMenus() {
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            Inventory top = player.getOpenInventory().getTopInventory();
-            if (top != null && top.getHolder() instanceof SpawnerStorageMenu storageMenu) {
-                storageMenu.refresh(player);
+        if (openStorageMenus.isEmpty()) {
+            return;
+        }
+
+        // this runs on the global/generation thread, so look the menus up from our own
+        // registry instead of asking every open inventory for its holder: block backed
+        // inventories (shulker box, chest, ...) read the world to answer that, which
+        // Folia refuses outside the region owning the block.
+        for (Map.Entry<UUID, SpawnerStorageMenu> entry : openStorageMenus.entrySet()) {
+            Player player = Bukkit.getPlayer(entry.getKey());
+            if (player == null || !player.isOnline()) {
+                openStorageMenus.remove(entry.getKey(), entry.getValue());
+                continue;
             }
+
+            SpawnerStorageMenu menu = entry.getValue();
+            plugin.getSpigotScheduler().runEntity(player, () -> {
+                if (player.isOnline()) {
+                    menu.refresh(player);
+                }
+            });
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
@@ -39,6 +39,17 @@ public class SpawnerStorageMenu extends BaseMenu {
         return page;
     }
 
+    @Override
+    public void open(Player player) {
+        super.open(player);
+        plugin.getSpawnerManager().registerOpenStorageMenu(player, this);
+    }
+
+    @Override
+    public void onClose(Player player) {
+        plugin.getSpawnerManager().unregisterOpenStorageMenu(player, this);
+    }
+
     public void refresh(Player player) {
         if (player == null || !player.isOnline()) {
             return;
@@ -54,12 +65,12 @@ public class SpawnerStorageMenu extends BaseMenu {
             return;
         }
 
+        // compare the view by identity rather than through getHolder(): resolving the
+        // holder of a block backed inventory reads the world, which Folia only allows
+        // from the region owning that block
         Inventory topInventory = player.getOpenInventory().getTopInventory();
-        if (topInventory == null || !(topInventory.getHolder() instanceof SpawnerStorageMenu storageMenu)) {
-            return;
-        }
-
-        if (storageMenu.spawnerId != spawnerId) {
+        if (topInventory != getInventory()) {
+            plugin.getSpawnerManager().unregisterOpenStorageMenu(player, this);
             return;
         }
 


### PR DESCRIPTION
## Description of Changes
The spawner storage GUI auto-refresh runs every second on the **global** scheduler and asked every online player's open inventory for its holder:

```java
Inventory top = player.getOpenInventory().getTopInventory();
if (top != null && top.getHolder() instanceof SpawnerStorageMenu storageMenu) {
    storageMenu.refresh(player);
}
```

For a block backed inventory — shulker box, chest, barrel — CraftBukkit answers `getHolder()` by reading the block state out of the world (`CraftInventory#getHolder` → `BlockEntity#getOwner` → `CraftBlock#getState`). Folia only permits that from the region thread owning the block, so an open shulker box produced a main thread check failure once per second and aborted the refresh tick before any spawner menu was updated. Nothing was functionally broken, but the console was flooded for as long as the inventory stayed open.

What changed:

- `SpawnerManager` now keeps a registry of open storage menus (filled in `SpawnerStorageMenu#open`, dropped in `#onClose`, pruned for offline players) and refreshes each one on its player's own region thread through `SpigotScheduler#runEntity`. Inventories belonging to other plugins or to the world are never touched.
- `SpawnerStorageMenu#refresh` compares the open view by identity (`topInventory != getInventory()`) instead of going through `getHolder()` — the same pattern `EnderChestManager` and `InvseeManager` already use.
- `BillfordManager#advanceTrade` had the identical bug on a slower fuse: its rotation sweep resolved holders and called `closeInventory()` for every online player straight from the global timer. It now goes through `SpigotScheduler#forEachOnlinePlayer`, like `OrdersManager` does.

Side benefit on Paper/Spigot: the old loop built a full block state snapshot every second for every player with any container open. That is gone.

The remaining `getHolder()` call sites were audited — they all run inside events or already on `runEntity`/`runEntityTimer`, so they are region safe.

## Bug Details
- Related Issue: #117
- Steps to Reproduce:
  1. Run the plugin on Folia (reported on folia 26.1.2) with the spawner module enabled.
  2. Open any placed shulker box and keep it open.
  3. The console repeats, once per second: `Thread failed main thread check: Cannot read world asynchronously ...` followed by `Global task for UltimateDonutSmp generated an exception`, pointing at `SpawnerManager.refreshOpenStorageMenus`.

## How to Test
1. Run unit tests with the command `mvn test`
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - On **Folia**, open a placed shulker box and leave it open for ~30 seconds → console stays clean, no `TickThread` errors
   - Repeat with a chest, barrel and ender chest
   - Open a spawner storage GUI and let the spawner generate loot → the contents still update on their own every second
   - Page through the storage (previous/next), toggle a filter, use collect / drop / sell → the GUI keeps auto-refreshing after each action, and a menu the player closed stops refreshing
   - Let the Billford trade rotate while a player has a shulker box open → no error, and an open Billford menu is still closed
   - Repeat the spawner storage checks on **Paper** to confirm no regression

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added unit tests (if applicable) and all tests pass. — the existing suite passes (139 tests); no new test was added because the project has no Bukkit mocking framework to simulate an inventory view
- [ ] I have documented changes in configuration files or `changelog.md` if necessary. — no configuration or changelog change needed