### PR TITLE
fix(mobspawn): stop deleting mobs when the toggle is turned off (#97)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
@@ -12,10 +12,15 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.function.Function;
 
+/**
+ * Enforces the per-player mob spawn toggle purely by cancelling {@link CreatureSpawnEvent}. The
+ * toggle governs the spawn cycle only: mobs that are already alive stay alive when a player turns it
+ * off, and turning it back on lets the next natural spawn attempt through immediately. Nothing here
+ * removes entities, so there is no sweep of the loaded world at any point.
+ */
 public class MobSpawnListener implements Listener {
 
     private final UltimateDonutSmp plugin;
@@ -36,10 +41,12 @@ public class MobSpawnListener implements Listener {
 
         if (MobSpawnPolicy.hasCustomName(entity)) return;
 
+        if (!isPreventableSpawnReason(event.getSpawnReason())) return;
+
         refreshSettingsIfNeeded();
 
         if (event.getEntityType() == EntityType.PHANTOM) {
-            if (isPreventableSpawnReason(event.getSpawnReason()) && shouldCancelPhantomSpawn(entity.getLocation())) {
+            if (shouldCancelPhantomSpawn(entity.getLocation())) {
                 event.setCancelled(true);
             }
             return;
@@ -47,36 +54,11 @@ public class MobSpawnListener implements Listener {
 
         if (!MobSpawnPolicy.isHostileMob(entity)) return;
 
-        if (isPreventableSpawnReason(event.getSpawnReason())) {
-            if (shouldCancelMobSpawn(entity.getLocation())) {
-                event.setCancelled(true);
-                return;
-            }
-        }
+        if (MobSpawnPolicy.isBoss(event.getEntityType())) return;
 
-        if (MobSpawnPolicy.isVanillaSpawnerSpawn(event.getSpawnReason())) {
-            MobSpawnPolicy.markVanillaSpawnerMob(plugin, entity);
+        if (shouldCancelMobSpawn(entity.getLocation())) {
+            event.setCancelled(true);
         }
-    }
-
-    /**
-     * Clears hostile mobs that were already loaded around a player who joins with the toggle off.
-     * This is a single scan per join, not a repeating server-wide entity sweep.
-     */
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        plugin.getSpigotScheduler().runEntityLater(player, () -> {
-            if (!player.isOnline()) {
-                return;
-            }
-            PlayerData data = dataProvider.apply(player);
-            if (data == null || data.isMobSpawnEnabled()) {
-                return;
-            }
-            refreshSettingsIfNeeded();
-            MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, mobSpawnRadius);
-        }, 20L);
     }
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -6,7 +6,6 @@ import com.bx.ultimateDonutSmp.models.ThreeChoice;
 import com.bx.ultimateDonutSmp.models.TwoChoice;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
-import com.bx.ultimateDonutSmp.utils.MobSpawnPolicy;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Material;
@@ -154,7 +153,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "DISABLE_MOB_SPAWN" -> {
                 data.setMobSpawnEnabled(!data.isMobSpawnEnabled());
                 if (!data.isMobSpawnEnabled()) {
-                    clearNearbyHostileMobs(player);
                     long limitSeconds = plugin.getConfigManager().getConfig().getLong("SETTINGS.DISABLE-MOB-SPAWN-LIMIT-SECONDS", -1L);
                     if (limitSeconds > 0) {
                         data.setMobSpawnDisabledUntil(System.currentTimeMillis() + (limitSeconds * 1000L));
@@ -554,11 +552,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
                 "ᴛᴇᴀᴍ ᴄʜᴀᴛ ѕᴇɴᴅɪɴɢ ᴍᴏᴅᴇ",
                 plugin.getTeamManager().isTeamChatEnabled(player.getUniqueId())
         );
-    }
-
-    private void clearNearbyHostileMobs(Player player) {
-        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
-        MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, radius);
     }
 
     private void toggle(Player player, String label, boolean enabled, BooleanSetter setter) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SettingsMenu.java
@@ -4,7 +4,6 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
-import com.bx.ultimateDonutSmp.utils.MobSpawnPolicy;
 import com.bx.ultimateDonutSmp.utils.NightVisionUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Material;
@@ -195,7 +194,6 @@ public class SettingsMenu extends BaseMenu {
             case "DISABLE_MOB_SPAWN" -> {
                 data.setMobSpawnEnabled(!data.isMobSpawnEnabled());
                 if (!data.isMobSpawnEnabled()) {
-                    clearNearbyHostileMobs(player);
                     long limitSeconds = plugin.getConfigManager().getConfig().getLong("SETTINGS.DISABLE-MOB-SPAWN-LIMIT-SECONDS", -1L);
                     if (limitSeconds > 0) {
                         data.setMobSpawnDisabledUntil(System.currentTimeMillis() + (limitSeconds * 1000L));
@@ -403,11 +401,6 @@ public class SettingsMenu extends BaseMenu {
         }
 
         player.sendMessage(ColorUtils.toComponent("&7Night vision &aEnabled&7."));
-    }
-
-    private void clearNearbyHostileMobs(Player player) {
-        double radius = plugin.getConfigManager().getConfig().getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50);
-        MobSpawnPolicy.clearNearbyHostileMobs(plugin, player, radius);
     }
 
     private ItemStack toNightVisionPotion(ItemStack item) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
@@ -1,51 +1,18 @@
 package com.bx.ultimateDonutSmp.utils;
 
-import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import org.bukkit.Location;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Collection;
 import java.util.function.Function;
 
 public final class MobSpawnPolicy {
 
-    private static final String VANILLA_SPAWNER_MOB_KEY = "vanilla_spawner_mob";
-    private static final byte TRUE = 1;
-
     private MobSpawnPolicy() {
-    }
-
-    public static boolean isVanillaSpawnerSpawn(CreatureSpawnEvent.SpawnReason reason) {
-        return reason == CreatureSpawnEvent.SpawnReason.SPAWNER;
-    }
-
-    public static void markVanillaSpawnerMob(UltimateDonutSmp plugin, LivingEntity entity) {
-        if (plugin == null || entity == null) {
-            return;
-        }
-        entity.getPersistentDataContainer().set(
-                plugin.getKey(VANILLA_SPAWNER_MOB_KEY),
-                PersistentDataType.BYTE,
-                TRUE
-        );
-    }
-
-    public static boolean isVanillaSpawnerMob(UltimateDonutSmp plugin, LivingEntity entity) {
-        if (plugin == null || entity == null) {
-            return false;
-        }
-        return entity.getPersistentDataContainer().getOrDefault(
-                plugin.getKey(VANILLA_SPAWNER_MOB_KEY),
-                PersistentDataType.BYTE,
-                (byte) 0
-        ) == TRUE;
     }
 
     public static boolean isHostileMob(LivingEntity entity) {
@@ -53,6 +20,22 @@ public final class MobSpawnPolicy {
                 || entity instanceof org.bukkit.entity.Slime
                 || entity instanceof org.bukkit.entity.Ghast
                 || entity instanceof org.bukkit.entity.Hoglin;
+    }
+
+    /**
+     * Bosses stay outside the toggle. They come from one-off world features or player rituals rather
+     * than the ambient spawn cycle the toggle is meant to thin out, so cancelling them would delete
+     * content that never comes back (an elder guardian cancelled at chunk gen leaves the monument
+     * empty forever).
+     */
+    public static boolean isBoss(EntityType type) {
+        if (type == null) {
+            return false;
+        }
+        return switch (type) {
+            case WITHER, ENDER_DRAGON, ELDER_GUARDIAN, WARDEN -> true;
+            default -> false;
+        };
     }
 
     public static boolean hasCustomName(LivingEntity entity) {
@@ -171,65 +154,5 @@ public final class MobSpawnPolicy {
         int playerChunkZ = playerLocation.getBlockZ() >> 4;
         return Math.abs(playerChunkX - spawnChunkX) > chunkRadius
                 || Math.abs(playerChunkZ - spawnChunkZ) > chunkRadius;
-    }
-
-    /**
-     * One-shot removal of the hostile mobs already loaded around {@code player}. Used when a player
-     * turns the toggle off and when they join with it already off, so the toggle stays meaningful
-     * without a repeating server-wide entity scan.
-     */
-    public static void clearNearbyHostileMobs(UltimateDonutSmp plugin, Player player, double radius) {
-        if (plugin == null || player == null || radius <= 0.0D) {
-            return;
-        }
-        double radiusSquared = radius * radius;
-        Location playerLocation = player.getLocation();
-        for (Entity entity : player.getNearbyEntities(radius, radius, radius)) {
-            if (!(entity instanceof LivingEntity living)) {
-                continue;
-            }
-            if (!shouldRemoveFromPeriodicCleanup(plugin, living)) {
-                continue;
-            }
-            if (living.getLocation().distanceSquared(playerLocation) > radiusSquared) {
-                continue;
-            }
-            living.remove();
-        }
-    }
-
-    public static boolean shouldRemoveFromPeriodicCleanup(
-            boolean monster,
-            EntityType type,
-            boolean vanillaSpawnerMob
-    ) {
-        return shouldRemoveFromPeriodicCleanup(monster, type, vanillaSpawnerMob, false);
-    }
-
-    public static boolean shouldRemoveFromPeriodicCleanup(
-            boolean monster,
-            EntityType type,
-            boolean vanillaSpawnerMob,
-            boolean hasCustomName
-    ) {
-        if (!monster || type == null || vanillaSpawnerMob || hasCustomName) {
-            return false;
-        }
-        return switch (type) {
-            case PHANTOM, WITHER, ENDER_DRAGON, ELDER_GUARDIAN, WARDEN -> false;
-            default -> true;
-        };
-    }
-
-    public static boolean shouldRemoveFromPeriodicCleanup(
-            UltimateDonutSmp plugin,
-            LivingEntity entity
-    ) {
-        return entity != null && shouldRemoveFromPeriodicCleanup(
-                isHostileMob(entity),
-                entity.getType(),
-                isVanillaSpawnerMob(plugin, entity),
-                hasCustomName(entity)
-        );
     }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
@@ -4,7 +4,6 @@ import com.bx.ultimateDonutSmp.models.PlayerData;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
@@ -19,30 +18,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MobSpawnPolicyTest {
 
     @Test
-    void onlyVanillaSpawnerReasonReceivesPersistentExemption() {
-        assertTrue(MobSpawnPolicy.isVanillaSpawnerSpawn(CreatureSpawnEvent.SpawnReason.SPAWNER));
-        assertFalse(MobSpawnPolicy.isVanillaSpawnerSpawn(CreatureSpawnEvent.SpawnReason.NATURAL));
-        assertFalse(MobSpawnPolicy.isVanillaSpawnerSpawn(CreatureSpawnEvent.SpawnReason.CUSTOM));
-    }
+    void bossesAreNeverBlockedByTheToggle() {
+        assertTrue(MobSpawnPolicy.isBoss(EntityType.WITHER));
+        assertTrue(MobSpawnPolicy.isBoss(EntityType.ENDER_DRAGON));
+        assertTrue(MobSpawnPolicy.isBoss(EntityType.ELDER_GUARDIAN));
+        assertTrue(MobSpawnPolicy.isBoss(EntityType.WARDEN));
 
-    @Test
-    void periodicCleanupPreservesSpawnerMobsAndExistingExcludedTypes() {
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.ZOMBIE, false));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.ZOMBIE, true));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.ZOMBIE, false, true));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(false, EntityType.ZOMBIE, false));
-
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.PHANTOM, false));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.WITHER, false));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.ENDER_DRAGON, false));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.ELDER_GUARDIAN, false));
-        assertFalse(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.WARDEN, false));
-
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.SLIME, false));
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.GHAST, false));
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.HOGLIN, false));
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.SPIDER, false));
-        assertTrue(MobSpawnPolicy.shouldRemoveFromPeriodicCleanup(true, EntityType.CAVE_SPIDER, false));
+        assertFalse(MobSpawnPolicy.isBoss(null));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.ZOMBIE));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.SLIME));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.GHAST));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.HOGLIN));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.SPIDER));
+        assertFalse(MobSpawnPolicy.isBoss(EntityType.CAVE_SPIDER));
     }
 
     @Test


### PR DESCRIPTION
## Description of Changes

The per-player mob spawn toggle was doing two different jobs. Besides cancelling `CreatureSpawnEvent`, it also removed hostile mobs that were **already alive**, in three places:

```java
case "DISABLE_MOB_SPAWN" -> {
    data.setMobSpawnEnabled(!data.isMobSpawnEnabled());
    if (!data.isMobSpawnEnabled()) {
        clearNearbyHostileMobs(player);   // <- deletes what is already loaded
```

- `PlayerSettingsMenu` and `SettingsMenu` swept the radius on every toggle-off.
- `MobSpawnListener#onJoin` swept it again 20 ticks after a player joined with the toggle already off.

So turning the setting off wiped the mobs standing around the player instead of only stopping new ones — reported in #97 with screenshots. The phantom toggle sitting right next to it never did this; it only prevents spawns, so mob spawn was the odd one out.

What changed:

- **All three removal paths are gone**, together with `MobSpawnPolicy#clearNearbyHostileMobs` and the `shouldRemoveFromPeriodicCleanup` overloads that fed it. The toggle now governs the spawn cycle only: mobs already alive stay alive when it is turned off, and turning it back on lets the next spawn cycle through immediately. No entity scan of any kind is left in this listener.
- The `vanilla_spawner_mob` persistent-data tag existed only to keep spawner mobs out of that sweep. With the sweep gone it is dead weight, so `markVanillaSpawnerMob` / `isVanillaSpawnerMob` / `isVanillaSpawnerSpawn` are removed and `CreatureSpawnEvent` no longer performs a PDC write per spawner mob.
- **Bosses are now exempt from cancellation**, not just from the (now removed) sweep. `ElderGuardian` and `Warden` are `Monster`s, so they were falling into the cancel path alongside zombies. An elder guardian is placed once when its monument generates and never respawns, so cancelling that spawn empties the monument permanently. `WITHER`, `ENDER_DRAGON`, `ELDER_GUARDIAN` and `WARDEN` now short-circuit in `MobSpawnPolicy#isBoss`, which is the "do not block bosses" requirement from the issue — previously it was only applied to the cleanup sweep, never to spawn prevention.
- `isPreventableSpawnReason` is checked once at the top of the handler instead of twice further down. No behavioural change, just one branch instead of two on the hot path.

`MobSpawnPolicy` drops from 236 to 158 lines.

## Bug Details
- Related Issue: #97
- Steps to Reproduce:
  1. Stand somewhere with hostile mobs loaded around you (night, surface).
  2. Open the settings menu and turn **Nearby Mob Spawn Prevention** on (mob spawn = OFF).
  3. Every hostile mob within `SETTINGS.MOB-SPAWN-RADIUS` disappears instantly, instead of simply no new ones spawning.
  4. Same on rejoin: log in with the toggle already off and the mobs loaded around you are deleted about a second later.

## How to Test
1. Run unit tests with the command `mvn test`
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - Let hostile mobs gather around you, then turn the toggle off → the mobs already there **stay alive**; only new spawns stop
   - Keep standing there with the toggle off → no new hostile mobs appear inside the radius
   - Turn the toggle back on → mobs start spawning again on the next spawn cycle, no relog or restart needed
   - Relog with the toggle off → the mobs loaded around you are still there
   - Player A (toggle ON) standing next to Player B (toggle OFF) → spawns near B are still blocked; A's setting does not override B's
   - Build a wither next to a player with the toggle off → it spawns
   - Visit a freshly generated ocean monument with the toggle off → the elder guardians are present
   - Trigger a warden from a shrieker with the toggle off → it emerges
   - Nametagged mobs and plugin mobs spawned with `SpawnReason.CUSTOM` inside the radius → unaffected, as before
   - On **Folia**, run through the above and confirm the console stays clean — the listener no longer touches entities outside the event

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added unit tests (if applicable) and all tests pass. — 138 tests pass; `MobSpawnPolicyTest` swaps its two periodic-cleanup cases for `bossesAreNeverBlockedByTheToggle`
- [ ] I have documented changes in configuration files or `changelog.md` if necessary. — no configuration or changelog change needed