### PR TITLE
feat(settings): configure option defaults and removal in menus.yml (#107)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -871,6 +871,13 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Every setting below accepts two optional keys:
+    #   DEFAULT: <value>  Starting value for players who never touched the setting.
+    #   ENABLED: false    Removes the option from /settings and pins every player to DEFAULT.
+    # Example, hide advancement messages and keep them off for everyone:
+    # ADVANCEMENT_MESSAGES:
+    #   DEFAULT: OFF
+    #   ENABLED: false
     # Custom redirect buttons can also be added here:
     # EXTERNAL_FLY:
     #   DISPLAY-NAME: '&bFlight Mode'
@@ -992,6 +999,13 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Every setting below accepts two optional keys:
+    #   DEFAULT: <value>  Starting value for players who never touched the setting.
+    #   ENABLED: false    Removes the option from /settings and pins every player to DEFAULT.
+    # Example, hide advancement messages and keep them off for everyone:
+    # ADVANCEMENT_MESSAGES:
+    #   DEFAULT: OFF
+    #   ENABLED: false
     # Custom redirect buttons can also be added here:
     # EXTERNAL_FLY:
     #   DISPLAY-NAME: '&bFlight Mode'
@@ -1026,6 +1040,52 @@ SETTINGS-MENU:
     TEAM_CHAT_VISIBILITY:
     
 ```
+
+### 4. Per-Setting Defaults & Removing Options
+
+Every entry under `SETTINGS-MENU.BUTTONS` accepts two optional keys on top of the display keys
+documented above.
+
+| Key | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SETTINGS-MENU.BUTTONS.<SETTING>.DEFAULT` | `str` / `bool` | `true`, `false`, `ANYONE`, `FRIENDS_FOLLOWED`, `OFF` | Built-in default (`true` / `ANYONE` for most settings) | Value a player starts with before they ever open `/settings`. |
+| `SETTINGS-MENU.BUTTONS.<SETTING>.ENABLED` | `bool` | `true`, `false` | `true` | `false` removes the option from `/settings` and pins every player to `DEFAULT`. |
+
+**Which values a setting accepts.** On/off buttons take `true` or `false` (`on`/`off`, `yes`/`no`
+and `enabled`/`disabled` are accepted too). The privacy buttons — `PRIVATE_MESSAGES`,
+`TPA_REQUESTS`, `TPA_HERE_REQUESTS`, `PAYMENTS`, `ADVANCEMENT_MESSAGES` and
+`JOIN_LEAVE_MESSAGES` — take `ANYONE`, `FRIENDS_FOLLOWED` or `OFF`, and `DEATH_MESSAGES` takes
+`FRIENDS_FOLLOWED` or `OFF`. On those buttons `true` is shorthand for `ANYONE`
+(`FRIENDS_FOLLOWED` for `DEATH_MESSAGES`) and `false` is shorthand for `OFF`. `DISABLE_MOB_SPAWN`
+and `DISABLE_PHANTOM_SPAWN` follow the button label, so `DEFAULT: true` means the prevention is
+on and the mobs stop spawning. An unusable value is ignored and logged as a console warning.
+
+**Turning a setting off for everyone.** `DEFAULT` alone only affects players who have never
+touched that setting; existing players keep whatever they last chose. Pair it with
+`ENABLED: false` to also pin players who already toggled it:
+
+```yaml
+SETTINGS-MENU:
+  BUTTONS:
+    ADVANCEMENT_MESSAGES:
+      DEFAULT: OFF
+      ENABLED: false
+    JOIN_LEAVE_MESSAGES:
+      DEFAULT: OFF
+      ENABLED: false
+```
+
+Notes:
+
+- Use `ENABLED: false` rather than deleting the block. Deleted blocks are restored from the
+  bundled defaults the next time the plugin loads, which is also how new settings reach an
+  existing `menus.yml`.
+- While an option is disabled its `DEFAULT` is authoritative: the value is re-applied every time
+  a player is loaded and on every `/uds reload`, and the button is neither drawn nor clickable.
+  A player's stored choice is not deliberately rewritten, but routine data saves can overwrite
+  it, so treat re-enabling an option as a reset for the players affected.
+- `QUICK_AUCTION_PURCHASE` and `QUICK_AUCTION_SELL` are stored by the auction house instead of
+  the player profile, so they support `ENABLED` but not `DEFAULT`.
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -1077,6 +1077,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
             initializeLunarRichPresenceManager();
         }
 
+        if (playerDataManager != null) {
+            playerDataManager.refreshRemovedSettingOptions();
+        }
+
         for (Player player : getServer().getOnlinePlayers()) {
             tablistManager.updateTablistName(player);
             worthManager.clearWorthDisplay(player);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/EconomyManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/EconomyManager.java
@@ -6,6 +6,7 @@ import com.bx.ultimateDonutSmp.models.EconomyReason;
 import com.bx.ultimateDonutSmp.models.EconomyTransactionResult;
 import com.bx.ultimateDonutSmp.models.EconomyTransferResult;
 import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.utils.PlayerSettingDefaults;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -498,6 +499,7 @@ public class EconomyManager {
 
         String username = resolveDisplayName(uuid, displayNameHint);
         PlayerData created = new PlayerData(uuid, username);
+        PlayerSettingDefaults.applyDefaults(plugin, created);
         double startMoney = plugin.getConfigManager().getConfig()
                 .getDouble("SETTINGS.MONEY-PER-DEFAULT", 1000.0D);
         created.setMoney(roundCurrency(startMoney));

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerDataManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerDataManager.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.utils.PlayerSettingDefaults;
 import org.bukkit.entity.Player;
 
 import java.util.Collection;
@@ -30,6 +31,7 @@ public class PlayerDataManager {
         data = plugin.getDatabaseManager().loadPlayer(uuid);
         if (data == null) {
             data = new PlayerData(uuid, player.getName());
+            PlayerSettingDefaults.applyDefaults(plugin, data);
             double startMoney = plugin.getConfigManager().getConfig()
                     .getDouble("SETTINGS.MONEY-PER-DEFAULT", 1000.0);
             data.setMoney(startMoney);
@@ -37,6 +39,7 @@ public class PlayerDataManager {
         } else {
             data.setUsername(player.getName());
         }
+        PlayerSettingDefaults.applyDisabledOptions(plugin, data);
         data.setSessionStartMillis(System.currentTimeMillis());
         cache.put(uuid, data);
         return data;
@@ -76,6 +79,13 @@ public class PlayerDataManager {
 
     public boolean isLoaded(UUID uuid) {
         return cache.containsKey(uuid);
+    }
+
+    /** Re-pins options removed with ENABLED: false after menus.yml was reloaded. */
+    public void refreshRemovedSettingOptions() {
+        for (PlayerData data : cache.values()) {
+            PlayerSettingDefaults.applyDisabledOptions(plugin, data);
+        }
     }
 
     /** Periodic dirty-save without committing sessions */

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -8,6 +8,7 @@ import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
 import com.bx.ultimateDonutSmp.utils.MobSpawnPolicy;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import com.bx.ultimateDonutSmp.utils.PlayerSettingDefaults;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -69,7 +70,8 @@ public final class PlayerSettingsMenu extends BaseMenu {
         if (buttons == null) {
             return;
         }
-        if (buttons.contains("QUICK_AUCTION_PURCHASE") || buttons.contains("QUICK_AUCTION_SELL")) {
+        if (containsEnabledButton(buttons, "QUICK_AUCTION_PURCHASE")
+                || containsEnabledButton(buttons, "QUICK_AUCTION_SELL")) {
             loadPreference(player);
         }
 
@@ -93,10 +95,14 @@ public final class PlayerSettingsMenu extends BaseMenu {
             return;
         }
 
-        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
-
         ConfigurationSection section = plugin.getConfigManager().getMenus()
                 .getConfigurationSection(MENU_PATH + ".BUTTONS." + key);
+        if (!PlayerSettingDefaults.isOptionEnabled(section)) {
+            return;
+        }
+
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+
         if (section != null && section.contains("COMMAND")) {
             String commandStr = section.getString("COMMAND");
             if (commandStr != null && !commandStr.isBlank()) {
@@ -607,7 +613,14 @@ public final class PlayerSettingsMenu extends BaseMenu {
         return TwoChoice.values()[nextOrdinal];
     }
 
+    private boolean containsEnabledButton(ConfigurationSection buttons, String key) {
+        return buttons.contains(key) && PlayerSettingDefaults.isOptionEnabled(buttons, key);
+    }
+
     private boolean shouldRenderButton(String key, ConfigurationSection section) {
+        if (!PlayerSettingDefaults.isOptionEnabled(section)) {
+            return false;
+        }
         if (section != null && (section.contains("COMMAND") || section.contains("STATUS-PLACEHOLDER"))) {
             return true;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
@@ -1,0 +1,348 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.ThreeChoice;
+import com.bx.ultimateDonutSmp.models.TwoChoice;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Reads the optional {@code DEFAULT} and {@code ENABLED} keys admins may place under each
+ * {@code SETTINGS-MENU.BUTTONS} entry in menus.yml.
+ *
+ * <p>{@code DEFAULT} decides what a setting looks like for players who have never touched it,
+ * {@code ENABLED: false} removes the option from /settings entirely and pins every player to the
+ * configured default.</p>
+ */
+public final class PlayerSettingDefaults {
+
+    public static final String BUTTONS_PATH = "SETTINGS-MENU.BUTTONS";
+
+    private static final String DEFAULT_KEY = "DEFAULT";
+    private static final String ENABLED_KEY = "ENABLED";
+
+    private static final Map<String, Binding> BINDINGS = createBindings();
+
+    private PlayerSettingDefaults() {
+    }
+
+    /** Whether the button described by {@code buttonSection} should still be offered to players. */
+    public static boolean isOptionEnabled(ConfigurationSection buttonSection) {
+        return buttonSection == null || buttonSection.getBoolean(ENABLED_KEY, true);
+    }
+
+    public static boolean isOptionEnabled(ConfigurationSection buttons, String key) {
+        return buttons == null || isOptionEnabled(buttons.getConfigurationSection(key));
+    }
+
+    public static boolean isOptionEnabled(UltimateDonutSmp plugin, String key) {
+        return isOptionEnabled(buttons(plugin), key);
+    }
+
+    /** Applies every configured {@code DEFAULT} to a player who has no stored settings yet. */
+    public static void applyDefaults(UltimateDonutSmp plugin, PlayerData data) {
+        applyDefaults(buttons(plugin), data, warningSink(plugin));
+    }
+
+    public static void applyDefaults(ConfigurationSection buttons, PlayerData data) {
+        applyDefaults(buttons, data, null);
+    }
+
+    public static void applyDefaults(ConfigurationSection buttons, PlayerData data, Consumer<String> warnings) {
+        if (buttons == null || data == null) {
+            return;
+        }
+        for (String key : buttons.getKeys(false)) {
+            ConfigurationSection section = buttons.getConfigurationSection(key);
+            if (section == null || !section.contains(DEFAULT_KEY)) {
+                continue;
+            }
+            applyConfiguredDefault(key, section, data, warnings);
+        }
+    }
+
+    /**
+     * Pins every option turned off with {@code ENABLED: false} back to its configured default, so a
+     * removed option behaves the same for players who had already toggled it.
+     *
+     * <p>The previous dirty flag is restored afterwards: the override lives in memory and never
+     * schedules a database write on its own.</p>
+     */
+    public static void applyDisabledOptions(UltimateDonutSmp plugin, PlayerData data) {
+        applyDisabledOptions(buttons(plugin), data, warningSink(plugin));
+    }
+
+    public static void applyDisabledOptions(ConfigurationSection buttons, PlayerData data) {
+        applyDisabledOptions(buttons, data, null);
+    }
+
+    public static void applyDisabledOptions(ConfigurationSection buttons, PlayerData data, Consumer<String> warnings) {
+        if (buttons == null || data == null) {
+            return;
+        }
+
+        boolean wasDirty = data.isDirty();
+        PlayerData pristine = null;
+        for (String key : buttons.getKeys(false)) {
+            ConfigurationSection section = buttons.getConfigurationSection(key);
+            if (section == null || isOptionEnabled(section)) {
+                continue;
+            }
+            if (section.contains(DEFAULT_KEY)) {
+                applyConfiguredDefault(key, section, data, warnings);
+                continue;
+            }
+            Binding binding = BINDINGS.get(key);
+            if (binding == null) {
+                continue;
+            }
+            if (pristine == null) {
+                pristine = new PlayerData(data.getUuid(), data.getUsername());
+            }
+            binding.copier().copy(data, pristine);
+        }
+        data.setDirty(wasDirty);
+    }
+
+    private static void applyConfiguredDefault(
+            String key,
+            ConfigurationSection section,
+            PlayerData data,
+            Consumer<String> warnings
+    ) {
+        Binding binding = BINDINGS.get(key);
+        Object configured = section.get(DEFAULT_KEY);
+        if (binding == null) {
+            warn(warnings, "Ignoring " + BUTTONS_PATH + "." + key + "." + DEFAULT_KEY
+                    + ": this setting does not support a configurable default.");
+            return;
+        }
+        String raw = configured == null ? "" : String.valueOf(configured).trim().toLowerCase(Locale.ROOT);
+        if (!binding.applier().apply(data, raw)) {
+            warn(warnings, "Ignoring " + BUTTONS_PATH + "." + key + "." + DEFAULT_KEY
+                    + ": '" + configured + "' is not a valid value for this setting.");
+        }
+    }
+
+    private static ConfigurationSection buttons(UltimateDonutSmp plugin) {
+        if (plugin == null || plugin.getConfigManager() == null) {
+            return null;
+        }
+        return plugin.getConfigManager().getMenus().getConfigurationSection(BUTTONS_PATH);
+    }
+
+    private static Consumer<String> warningSink(UltimateDonutSmp plugin) {
+        return plugin == null ? null : message -> plugin.getLogger().warning(message);
+    }
+
+    private static void warn(Consumer<String> warnings, String message) {
+        if (warnings != null) {
+            warnings.accept(message);
+        }
+    }
+
+    private static Map<String, Binding> createBindings() {
+        Map<String, Binding> bindings = new LinkedHashMap<>();
+
+        bindings.put("PUBLIC_CHAT", bool(PlayerData::isPublicChatEnabled, PlayerData::setPublicChatEnabled));
+        bindings.put("PRIVATE_MESSAGES", threeChoice(
+                PlayerData::getPrivateMessagesChoice, PlayerData::setPrivateMessagesChoice));
+        bindings.put("SERVER_BROADCASTS", bool(
+                PlayerData::isServerBroadcastsEnabled, PlayerData::setServerBroadcastsEnabled));
+        bindings.put("TEAM_CHAT_VISIBILITY", bool(PlayerData::isTeamChatVisible, PlayerData::setTeamChatVisible));
+        bindings.put("LUNAR_TEAMMATES", bool(
+                PlayerData::isLunarTeammatesEnabled, PlayerData::setLunarTeammatesEnabled));
+        bindings.put("TPA_CONFIRM_MENUS", bool(
+                PlayerData::isTpaConfirmMenuEnabled, PlayerData::setTpaConfirmMenuEnabled));
+        bindings.put("DESTROY_PEARL_ON_DEATH", bool(
+                PlayerData::isDestroyPearlOnDeath, PlayerData::setDestroyPearlOnDeath));
+        bindings.put("PAY_CONFIRM_MENUS", bool(
+                PlayerData::isPayConfirmMenuEnabled, PlayerData::setPayConfirmMenuEnabled));
+        bindings.put("AUTO_CONFIRM_TPAS", new Binding(
+                (data, raw) -> {
+                    Boolean value = parseBoolean(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    data.setTpauto(value);
+                    data.setAutoTpaHereEnabled(value);
+                    return true;
+                },
+                (target, source) -> {
+                    target.setTpauto(source.isTpauto());
+                    target.setAutoTpaHereEnabled(source.isAutoTpaHereEnabled());
+                }));
+        bindings.put("HOTBAR_MESSAGES", bool(
+                PlayerData::isHotbarMessagesEnabled, PlayerData::setHotbarMessagesEnabled));
+        bindings.put("NOTIFICATION_SOUNDS", bool(
+                PlayerData::isNotificationSoundsEnabled, PlayerData::setNotificationSoundsEnabled));
+        bindings.put("FOLLOW_ALERT_SETTINGS", bool(
+                PlayerData::isFollowAlertsEnabled, PlayerData::setFollowAlertsEnabled));
+        bindings.put("DISPLAY_DONUT_PLUS", bool(
+                PlayerData::isDisplayDonutPlusEnabled, PlayerData::setDisplayDonutPlusEnabled));
+        bindings.put("CHAINMAIL_ON_RESPAWN", bool(
+                PlayerData::isChainmailOnRespawnEnabled, PlayerData::setChainmailOnRespawnEnabled));
+        bindings.put("EXPLOSION_PARTICLES", bool(
+                PlayerData::isExplosionParticlesEnabled, PlayerData::setExplosionParticlesEnabled));
+        bindings.put("EXPLOSION_SOUNDS", bool(
+                PlayerData::isExplosionSoundsEnabled, PlayerData::setExplosionSoundsEnabled));
+        bindings.put("TELEPORT_ALERTS", bool(
+                PlayerData::isTeleportAlertsEnabled, PlayerData::setTeleportAlertsEnabled));
+        bindings.put("FAST_CRYSTALS", bool(PlayerData::isFastCrystalsEnabled, PlayerData::setFastCrystalsEnabled));
+        bindings.put("RANDOMIZED_COORDS", bool(PlayerData::isRandomizedCoords, PlayerData::setRandomizedCoords));
+        bindings.put("TPA_REQUESTS", threeChoice(
+                PlayerData::getTpaRequestsChoice, PlayerData::setTpaRequestsChoice));
+        bindings.put("TPA_HERE_REQUESTS", threeChoice(
+                PlayerData::getTpaHereRequestsChoice, PlayerData::setTpaHereRequestsChoice));
+        bindings.put("PAYMENTS", threeChoice(PlayerData::getPaymentsChoice, PlayerData::setPaymentsChoice));
+        bindings.put("WORTH_DISPLAY", bool(PlayerData::isWorthDisplayEnabled, PlayerData::setWorthDisplayEnabled));
+        bindings.put("JOIN_LEAVE_MESSAGES", threeChoice(
+                PlayerData::getJoinLeaveMessagesChoice, PlayerData::setJoinLeaveMessagesChoice));
+        bindings.put("PAY_ALERTS", bool(PlayerData::isPayAlertsEnabled, PlayerData::setPayAlertsEnabled));
+        bindings.put("ADVANCEMENT_MESSAGES", threeChoice(
+                PlayerData::getAdvancementMessagesChoice, PlayerData::setAdvancementMessagesChoice));
+        bindings.put("AUCTION_NOTIFICATIONS", bool(
+                PlayerData::isAuctionNotificationsEnabled, PlayerData::setAuctionNotificationsEnabled));
+        bindings.put("AMETHYST_BREAK_MESSAGES", bool(
+                PlayerData::isAmethystBreakMessagesEnabled, PlayerData::setAmethystBreakMessagesEnabled));
+        bindings.put("DUEL_REQUESTS", bool(PlayerData::isDuelRequestsEnabled, PlayerData::setDuelRequestsEnabled));
+        bindings.put("DEATH_MESSAGES", twoChoice(
+                PlayerData::getDeathMessagesChoice, PlayerData::setDeathMessagesChoice));
+        bindings.put("KEY_ALL_NOTIFICATIONS", bool(
+                PlayerData::isKeyAllNotificationsEnabled, PlayerData::setKeyAllNotificationsEnabled));
+        bindings.put("ORDER_NOTIFICATIONS", bool(
+                PlayerData::isOrderNotificationsEnabled, PlayerData::setOrderNotificationsEnabled));
+        // The two spawn buttons read as "prevention is on", so the stored flag is the inverse.
+        bindings.put("DISABLE_MOB_SPAWN", new Binding(
+                (data, raw) -> {
+                    Boolean value = parseBoolean(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    data.setMobSpawnEnabled(!value);
+                    data.setMobSpawnDisabledUntil(0L);
+                    return true;
+                },
+                (target, source) -> {
+                    target.setMobSpawnEnabled(source.isMobSpawnEnabled());
+                    target.setMobSpawnDisabledUntil(source.getMobSpawnDisabledUntil());
+                }));
+        bindings.put("DISABLE_PHANTOM_SPAWN", new Binding(
+                (data, raw) -> {
+                    Boolean value = parseBoolean(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    data.setPhantomEnabled(!value);
+                    data.setPhantomDisabledUntil(0L);
+                    return true;
+                },
+                (target, source) -> {
+                    target.setPhantomEnabled(source.isPhantomEnabled());
+                    target.setPhantomDisabledUntil(source.getPhantomDisabledUntil());
+                }));
+        bindings.put("NIGHT_VISION", bool(PlayerData::isNightVisionEnabled, PlayerData::setNightVisionEnabled));
+        bindings.put("BOUNTY_ALERTS", bool(PlayerData::isBountyAlertsEnabled, PlayerData::setBountyAlertsEnabled));
+
+        return Map.copyOf(bindings);
+    }
+
+    private static Binding bool(Predicate<PlayerData> getter, BooleanSetter setter) {
+        return new Binding(
+                (data, raw) -> {
+                    Boolean value = parseBoolean(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    setter.set(data, value);
+                    return true;
+                },
+                (target, source) -> setter.set(target, getter.test(source)));
+    }
+
+    private static Binding threeChoice(
+            Function<PlayerData, ThreeChoice> getter,
+            BiConsumer<PlayerData, ThreeChoice> setter
+    ) {
+        return new Binding(
+                (data, raw) -> {
+                    ThreeChoice value = parseThreeChoice(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    setter.accept(data, value);
+                    return true;
+                },
+                (target, source) -> setter.accept(target, getter.apply(source)));
+    }
+
+    private static Binding twoChoice(
+            Function<PlayerData, TwoChoice> getter,
+            BiConsumer<PlayerData, TwoChoice> setter
+    ) {
+        return new Binding(
+                (data, raw) -> {
+                    TwoChoice value = parseTwoChoice(raw);
+                    if (value == null) {
+                        return false;
+                    }
+                    setter.accept(data, value);
+                    return true;
+                },
+                (target, source) -> setter.accept(target, getter.apply(source)));
+    }
+
+    private static Boolean parseBoolean(String raw) {
+        return switch (raw) {
+            case "true", "yes", "on", "enable", "enabled", "1" -> Boolean.TRUE;
+            case "false", "no", "off", "disable", "disabled", "0" -> Boolean.FALSE;
+            default -> null;
+        };
+    }
+
+    private static ThreeChoice parseThreeChoice(String raw) {
+        return switch (raw) {
+            case "anyone", "everyone", "all", "true", "yes", "on", "enable", "enabled", "1" -> ThreeChoice.ANYONE;
+            case "friends_followed", "friends-followed", "friends/followed", "friends", "followed"
+                    -> ThreeChoice.FRIENDS_FOLLOWED;
+            case "off", "none", "false", "no", "disable", "disabled", "0" -> ThreeChoice.OFF;
+            default -> null;
+        };
+    }
+
+    private static TwoChoice parseTwoChoice(String raw) {
+        return switch (raw) {
+            case "friends_followed", "friends-followed", "friends/followed", "friends", "followed",
+                 "true", "yes", "on", "enable", "enabled", "1" -> TwoChoice.FRIENDS_FOLLOWED;
+            case "off", "none", "false", "no", "disable", "disabled", "0" -> TwoChoice.OFF;
+            default -> null;
+        };
+    }
+
+    @FunctionalInterface
+    private interface BooleanSetter {
+        void set(PlayerData data, boolean value);
+    }
+
+    @FunctionalInterface
+    private interface ValueApplier {
+        /** @return false when the configured text is not a valid value for this setting */
+        boolean apply(PlayerData data, String rawValue);
+    }
+
+    @FunctionalInterface
+    private interface ValueCopier {
+        void copy(PlayerData target, PlayerData source);
+    }
+
+    private record Binding(ValueApplier applier, ValueCopier copier) {
+    }
+}

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -572,6 +572,20 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Every setting below accepts two optional keys:
+    #   DEFAULT: <value>  Starting value for players who never touched the setting.
+    #                     On/off buttons take true or false. The privacy buttons
+    #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS,
+    #                     ADVANCEMENT_MESSAGES, JOIN_LEAVE_MESSAGES) take ANYONE,
+    #                     FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES takes
+    #                     FRIENDS_FOLLOWED or OFF. true/false also work as shortcuts.
+    #   ENABLED: false    Removes the option from /settings and pins every player to the
+    #                     DEFAULT above. Use this instead of deleting the block - deleted
+    #                     blocks are restored from the bundled defaults on the next start.
+    # Example, hide advancement messages and keep them off for everyone:
+    # ADVANCEMENT_MESSAGES:
+    #   DEFAULT: OFF
+    #   ENABLED: false
     # Custom redirect buttons can also be added here:
     # EXTERNAL_FLY:
     #   DISPLAY-NAME: '&bFlight Mode'

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaultsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaultsTest.java
@@ -1,0 +1,156 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.ThreeChoice;
+import com.bx.ultimateDonutSmp.models.TwoChoice;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlayerSettingDefaultsTest {
+
+    @Test
+    void bundledMenusKeepEverySettingEnabledWithBuiltInDefaults() throws Exception {
+        YamlConfiguration menus = new YamlConfiguration();
+        menus.load(Path.of("src/main/resources", "menus.yml").toFile());
+
+        ConfigurationSection buttons = menus.getConfigurationSection(PlayerSettingDefaults.BUTTONS_PATH);
+        assertNotNull(buttons);
+        for (String key : buttons.getKeys(false)) {
+            assertTrue(PlayerSettingDefaults.isOptionEnabled(buttons, key), key);
+        }
+
+        PlayerData data = newPlayer();
+        PlayerData untouched = newPlayer();
+        List<String> warnings = new ArrayList<>();
+        PlayerSettingDefaults.applyDefaults(buttons, data, warnings::add);
+
+        assertEquals(List.of(), warnings);
+        assertEquals(untouched.getAdvancementMessagesChoice(), data.getAdvancementMessagesChoice());
+        assertEquals(untouched.isPublicChatEnabled(), data.isPublicChatEnabled());
+    }
+
+    @Test
+    void configuredDefaultsApplyToBooleanAndChoiceSettings() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("ADVANCEMENT_MESSAGES.DEFAULT", "OFF");
+        buttons.set("JOIN_LEAVE_MESSAGES.DEFAULT", false);
+        buttons.set("PRIVATE_MESSAGES.DEFAULT", "FRIENDS_FOLLOWED");
+        buttons.set("DEATH_MESSAGES.DEFAULT", "off");
+        buttons.set("PUBLIC_CHAT.DEFAULT", false);
+        buttons.set("NIGHT_VISION.DEFAULT", "on");
+
+        PlayerData data = newPlayer();
+        PlayerSettingDefaults.applyDefaults(buttons, data);
+
+        assertEquals(ThreeChoice.OFF, data.getAdvancementMessagesChoice());
+        assertEquals(ThreeChoice.OFF, data.getJoinLeaveMessagesChoice());
+        assertEquals(ThreeChoice.FRIENDS_FOLLOWED, data.getPrivateMessagesChoice());
+        assertEquals(TwoChoice.OFF, data.getDeathMessagesChoice());
+        assertFalse(data.isPublicChatEnabled());
+        assertTrue(data.isNightVisionEnabled());
+    }
+
+    @Test
+    void spawnPreventionDefaultsFollowTheButtonLabel() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("DISABLE_MOB_SPAWN.DEFAULT", true);
+        buttons.set("DISABLE_PHANTOM_SPAWN.DEFAULT", true);
+
+        PlayerData data = newPlayer();
+        PlayerSettingDefaults.applyDefaults(buttons, data);
+
+        assertFalse(data.isMobSpawnEnabled());
+        assertFalse(data.isPhantomEnabled());
+        assertEquals(0L, data.getMobSpawnDisabledUntil());
+        assertEquals(0L, data.getPhantomDisabledUntil());
+    }
+
+    @Test
+    void autoConfirmTpasDefaultCoversBothStoredFlags() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("AUTO_CONFIRM_TPAS.DEFAULT", true);
+
+        PlayerData data = newPlayer();
+        PlayerSettingDefaults.applyDefaults(buttons, data);
+
+        assertTrue(data.isTpauto());
+        assertTrue(data.isAutoTpaHereEnabled());
+    }
+
+    @Test
+    void unusableDefaultsAreReportedAndLeaveTheSettingAlone() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("ADVANCEMENT_MESSAGES.DEFAULT", "sometimes");
+        buttons.set("QUICK_AUCTION_SELL.DEFAULT", true);
+
+        PlayerData data = newPlayer();
+        List<String> warnings = new ArrayList<>();
+        PlayerSettingDefaults.applyDefaults(buttons, data, warnings::add);
+
+        assertEquals(ThreeChoice.ANYONE, data.getAdvancementMessagesChoice());
+        assertEquals(2, warnings.size());
+    }
+
+    @Test
+    void disabledOptionsPinPlayersToTheConfiguredDefault() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("ADVANCEMENT_MESSAGES.DEFAULT", "OFF");
+        buttons.set("ADVANCEMENT_MESSAGES.ENABLED", false);
+        buttons.set("PUBLIC_CHAT.ENABLED", false);
+
+        PlayerData data = newPlayer();
+        data.setAdvancementMessagesChoice(ThreeChoice.ANYONE);
+        data.setPublicChatEnabled(false);
+        data.setDirty(false);
+
+        PlayerSettingDefaults.applyDisabledOptions(buttons, data);
+
+        assertEquals(ThreeChoice.OFF, data.getAdvancementMessagesChoice());
+        // No DEFAULT configured, so PUBLIC_CHAT falls back to the built-in value.
+        assertTrue(data.isPublicChatEnabled());
+        assertFalse(data.isDirty(), "pinning a removed option must not schedule a database write");
+    }
+
+    @Test
+    void enabledOptionsKeepPlayerChoices() {
+        ConfigurationSection buttons = buttons();
+        buttons.set("ADVANCEMENT_MESSAGES.DEFAULT", "OFF");
+
+        PlayerData data = newPlayer();
+        data.setAdvancementMessagesChoice(ThreeChoice.FRIENDS_FOLLOWED);
+
+        PlayerSettingDefaults.applyDisabledOptions(buttons, data);
+
+        assertEquals(ThreeChoice.FRIENDS_FOLLOWED, data.getAdvancementMessagesChoice());
+    }
+
+    @Test
+    void missingSectionsAndNullDataAreIgnored() {
+        PlayerData data = newPlayer();
+        PlayerSettingDefaults.applyDefaults((ConfigurationSection) null, data);
+        PlayerSettingDefaults.applyDisabledOptions((ConfigurationSection) null, data);
+        PlayerSettingDefaults.applyDefaults(buttons(), null);
+
+        assertTrue(PlayerSettingDefaults.isOptionEnabled((ConfigurationSection) null));
+        assertTrue(PlayerSettingDefaults.isOptionEnabled(buttons(), "ADVANCEMENT_MESSAGES"));
+    }
+
+    private static ConfigurationSection buttons() {
+        return new YamlConfiguration().createSection("BUTTONS");
+    }
+
+    private static PlayerData newPlayer() {
+        return new PlayerData(UUID.randomUUID(), "SettingsTester");
+    }
+}


### PR DESCRIPTION
## Description of Changes
Server owners can now decide per option in `menus.yml` what a `/settings` toggle starts as, and
remove options they do not want players to have at all. Closes #107.

## Feature Details
- What feature does this add:
  - `DEFAULT: <value>` under any `SETTINGS-MENU.BUTTONS` entry sets the value a player starts with
    before they ever open `/settings`. On/off buttons take `true`/`false`; the privacy buttons
    (`PRIVATE_MESSAGES`, `TPA_REQUESTS`, `TPA_HERE_REQUESTS`, `PAYMENTS`, `ADVANCEMENT_MESSAGES`,
    `JOIN_LEAVE_MESSAGES`) take `ANYONE` / `FRIENDS_FOLLOWED` / `OFF`, and `DEATH_MESSAGES` takes
    `FRIENDS_FOLLOWED` / `OFF`, with `true`/`false` accepted as shortcuts. An unusable value is
    ignored and logged as a console warning.
  - `ENABLED: false` removes the option from `/settings` entirely (not rendered, not clickable) and
    pins every player to the configured `DEFAULT`, so it also covers players who had already
    toggled it. It is re-applied when a player loads and on `/uds reload`. The override is
    in-memory and restores the previous dirty flag, so it never schedules a database write by
    itself.
  - `DISABLE_MOB_SPAWN` and `DISABLE_PHANTOM_SPAWN` follow their button label, so `DEFAULT: true`
    means the prevention is on.
  - `QUICK_AUCTION_PURCHASE` and `QUICK_AUCTION_SELL` support `ENABLED` but not `DEFAULT`, because
    they are stored by the auction house instead of the player profile.
- Configuration changes:
  - `menus.yml`: documentation comments only under `SETTINGS-MENU.BUTTONS`. No new keys are written
    into existing installs, so nothing changes until an admin opts in.
  - `docs/wiki/Config-menus.yml.md`: new section "Per-Setting Defaults & Removing Options".

## How to Test
1. Run unit tests with the command `mvn test` — 147 tests pass, including the new
   `PlayerSettingDefaultsTest` (8 cases covering booleans, three/two-state choices, the inverted
   spawn buttons, invalid values and the pinning behaviour).
2. Deploy the plugin to a test server (Paper/Spigot/Folia)
3. Perform the following test steps:
   - Open `/settings` on a fresh account and confirm every option looks exactly as before.
   - Add to `menus.yml`, then run `/uds reload`:
     ```yaml
     SETTINGS-MENU:
       BUTTONS:
         ADVANCEMENT_MESSAGES:
           DEFAULT: OFF
           ENABLED: false
         JOIN_LEAVE_MESSAGES:
           DEFAULT: OFF
     ```
   - Confirm the Advancement Messages button is gone from `/settings` and its slot is empty, and
     that no advancement broadcast reaches players who previously had it on.
   - Join with a brand-new account and confirm Join/Leave Messages starts at `Off`, while an
     existing account keeps whatever it had chosen.
   - Set `DEFAULT: sometimes` on any option, reload, and confirm the value is ignored with a
     warning in console instead of breaking the menu.

## Self-Review Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added unit tests (if applicable) and all tests pass.
- [x] I have documented changes in configuration files or `changelog.md` if necessary.