### PR TITLE
fix(config): stop restoring deleted key-all crates on reload (#123)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1808,6 +1808,14 @@ public class ConfigManager {
             return true;
         }
 
+        // Key-all random weights are keyed by live crate ids, so the bundled common/rare/epic
+        // examples must not be merged back after admins delete or replace them. The KEYS section
+        // itself stays mergeable so configs that predate the feature still receive it once.
+        if ("config.yml".equals(resourceName)
+                && path.startsWith("KEY-ALL.RANDOM.KEYS.")) {
+            return true;
+        }
+
         // Billford trade definitions are live server content. The bundled BILLFORD tree is only
         // an initial example and must not be merged back after admins edit/delete it.
         if ("billford.yml".equals(resourceName)

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -368,6 +368,63 @@ class ConfigManagerTest {
         }
     }
 
+    @Test
+    void mergeBundledDefaultsKeepsDeletedKeyAllCratesDeleted() throws Exception {
+        List<String> currentLines = lines(
+                "KEY-ALL:",
+                "  ENABLED: true",
+                "  RANDOM:",
+                "    KEYS:",
+                "      # The numerical value for Common. Available options: Any valid integer",
+                "      common: 90",
+                "      gold: 10"
+        );
+        List<String> bundledLines = lines(
+                "KEY-ALL:",
+                "  ENABLED: true",
+                "  RANDOM:",
+                "    KEYS:",
+                "      # The numerical value for Common. Available options: Any valid integer",
+                "      common: 60",
+                "      # The numerical value for Rare. Available options: Any valid integer",
+                "      rare: 30",
+                "      # The numerical value for Epic. Available options: Any valid integer",
+                "      epic: 10"
+        );
+
+        int changes = mergeBundledDefaults("config.yml", currentLines, bundledLines);
+
+        assertEquals(0, changes);
+        assertFalse(currentLines.contains("      rare: 30"));
+        assertFalse(currentLines.contains("      epic: 10"));
+        assertTrue(currentLines.contains("      common: 90"));
+        assertTrue(currentLines.contains("      gold: 10"));
+    }
+
+    @Test
+    void mergeBundledDefaultsStillAddsMissingKeyAllRandomSection() throws Exception {
+        List<String> currentLines = lines(
+                "KEY-ALL:",
+                "  ENABLED: true"
+        );
+        List<String> bundledLines = lines(
+                "KEY-ALL:",
+                "  ENABLED: true",
+                "  RANDOM:",
+                "    KEYS:",
+                "      common: 60",
+                "      rare: 30",
+                "      epic: 10"
+        );
+
+        int changes = mergeBundledDefaults("config.yml", currentLines, bundledLines);
+
+        assertTrue(changes > 0);
+        assertTrue(currentLines.contains("      common: 60"));
+        assertTrue(currentLines.contains("      rare: 30"));
+        assertTrue(currentLines.contains("      epic: 10"));
+    }
+
     private static int mergeBundledDefaults(
             String resourceName,
             List<String> currentLines,


### PR DESCRIPTION
Fixes #123

## Problem

Deleting entries under `KEY-ALL.RANDOM.KEYS` in `config.yml` did not stick — every
`/ultimatedonutsmp reload` restored them, logging `Added 2 missing bundled default path(s)`.

## Root cause

`mergeBundledDefaults` re-inserts any bundled `config.yml` path the live file does not contain.
`isUserManagedBundledPath` is the opt-out list that protects live admin content (`CRATES.*`,
`BILLFORD.*`, `ARENA_SETTINGS.*`, shop menus), but `KEY-ALL.RANDOM.KEYS` was never on it — so the
bundled `common` / `rare` / `epic` examples were merged back on every sync.

Those keys are crate IDs resolved against `crates.yml` at runtime, i.e. the same class of live
server content already protected for `crates.yml`. Admin-added keys such as `gold` survived only
because unknown paths are never removed.

## Fix

Added `KEY-ALL.RANDOM.KEYS.*` to the user-managed path list, scoped to children only
(`startsWith("KEY-ALL.RANDOM.KEYS.")`, trailing dot included). The `KEYS` section itself stays
mergeable, so a config predating the feature still receives it once, while individual crate
weights are never resurrected after deletion.

## Testing

Two regression tests in `ConfigManagerTest`:
- deleted `rare` / `epic` stay deleted and admin-added `gold` is preserved
- a config missing `KEY-ALL.RANDOM` entirely still receives the full default section

Reverting the guard makes the first test fail with `expected: <0> but was: <2>` — the same count as
the reporter's log. Full suite: 141 tests, 0 failures.