### PR TITLE
fix(leaderboard): add missing bounties type (#124)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1057,6 +1057,7 @@ LEADERBOARDS-MENU:
     killStreak: Kill Streak
     highestKillStreak: Highest Kill Streak
     shards: Shards
+    bounties: Bounties
   BUTTONS:
     MONEY:
       TYPE: money
@@ -1139,6 +1140,7 @@ LEADERBOARDS-MENU:
 | `LEADERBOARDS-MENU.TYPE-NAMES.killStreak` | `str` | Any string text | `'Kill Streak'` | Configures the technical `killStreak` parameter for `LEADERBOARDS-MENU.TYPE-NAMES.killStreak` in `menus.yml`. |
 | `LEADERBOARDS-MENU.TYPE-NAMES.highestKillStreak` | `str` | Any string text | `'Highest Kill Streak'` | Configures the technical `highestKillStreak` parameter for `LEADERBOARDS-MENU.TYPE-NAMES.highestKillStreak` in `menus.yml`. |
 | `LEADERBOARDS-MENU.TYPE-NAMES.shards` | `str` | Any string text | `'Shards'` | Configures the technical `shards` parameter for `LEADERBOARDS-MENU.TYPE-NAMES.shards` in `menus.yml`. |
+| `LEADERBOARDS-MENU.TYPE-NAMES.bounties` | `str` | Any string text | `'Bounties'` | Configures the technical `bounties` parameter for `LEADERBOARDS-MENU.TYPE-NAMES.bounties` in `menus.yml`. |
 | `LEADERBOARDS-MENU.BUTTONS.MONEY.TYPE` | `str` | Any string text | `'money'` | Configures the technical `TYPE` parameter for `LEADERBOARDS-MENU.BUTTONS.MONEY.TYPE` in `menus.yml`. |
 | `LEADERBOARDS-MENU.BUTTONS.MONEY.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DMoney Leaderboard'` | Configures the technical `DISPLAY-NAME` parameter for `LEADERBOARDS-MENU.BUTTONS.MONEY.DISPLAY-NAME` in `menus.yml`. |
 | `LEADERBOARDS-MENU.BUTTONS.MONEY.MATERIAL` | `str` | Any string text | `'EMERALD'` | Configures the technical `MATERIAL` parameter for `LEADERBOARDS-MENU.BUTTONS.MONEY.MATERIAL` in `menus.yml`. |
@@ -1150,7 +1152,7 @@ LEADERBOARDS-MENU:
 | `LEADERBOARDS-MENU.BUTTONS.SHARDS.SLOT` | `int` | Any valid integer number | `'11'` | Configures the technical `SLOT` parameter for `LEADERBOARDS-MENU.BUTTONS.SHARDS.SLOT` in `menus.yml`. |
 | `LEADERBOARDS-MENU.BUTTONS.SHARDS.LORE` | `list` | List of configured items/strings | `['&fClick to view SHARDS leaderboard']` | Configures the technical `LORE` parameter for `LEADERBOARDS-MENU.BUTTONS.SHARDS.LORE` in `menus.yml`. |
 | `LEADERBOARDS-MENU.BUTTONS.KILLS.TYPE` | `str` | Any string text | `'kills'` | Configures the technical `TYPE` parameter for `LEADERBOARDS-MENU.BUTTONS.KILLS.TYPE` in `menus.yml`. |
-| *(49 additional sub-keys configured in section)* | | | | |
+| *(54 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example
 
@@ -1178,6 +1180,7 @@ LEADERBOARDS-MENU:
     killStreak: Kill Streak
     highestKillStreak: Highest Kill Streak
     shards: Shards
+    bounties: Bounties
   BUTTONS:
     MONEY:
       TYPE: money

--- a/docs/wiki/Placeholders-and-Integrations.md
+++ b/docs/wiki/Placeholders-and-Integrations.md
@@ -61,18 +61,23 @@ Used for scoreboards, holograms, and tablists to display top rankings (`1-10`):
 | `%economylb_<type>_<rank>_value%` | `%economylb_money_1_value%` | Formatted score value at rank 1 |
 | `%economylb_<type>_<rank>_display%` | `%economylb_money_1_display%` | Complete leaderboard row |
 
-*Supported Types*: `money`, `shards`, `kills`, `deaths`, `playtime`, `bounties`.
+*Supported Types*: `money`, `shards`, `kills`, `deaths`, `playtime`, `blocksPlaced`, `blocksBroken`, `mobsKilled`, `killStreak`, `highestKillStreak`, `moneySpent`, `moneyMade`, `bounties`.
+
+> `bounties` ranks players by the bounty currently placed on their head and only lists players who actually have one, so a rank past the last active bounty renders as `none`.
 
 ---
 
 ### 3. Personal Rank Expansion (`%economyrank_*%`)
 
-Displays the player's personal numerical leaderboard rank:
+Displays the player's personal numerical leaderboard rank, using the same type names as the leaderboard expansion above:
 - `%economyrank_money%` – Player's money leaderboard rank
 - `%economyrank_shards%` – Player's shards leaderboard rank
 - `%economyrank_kills%` – Player's kills leaderboard rank
 - `%economyrank_deaths%` – Player's deaths leaderboard rank
 - `%economyrank_playtime%` – Player's playtime leaderboard rank
+- `%economyrank_bounties%` – Player's bounty leaderboard rank (`0` when no bounty is placed on them)
+
+Any unranked player returns `0`.
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/BountyManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/BountyManager.java
@@ -12,9 +12,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class BountyManager {
 
@@ -26,7 +26,8 @@ public class BountyManager {
     }
 
     private final UltimateDonutSmp plugin;
-    private final Map<UUID, Bounty> bounties = new HashMap<>();
+    // Read off the main thread by the async leaderboard refresh, so it must stay concurrent.
+    private final Map<UUID, Bounty> bounties = new ConcurrentHashMap<>();
 
     public BountyManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -40,11 +41,11 @@ public class BountyManager {
     }
 
     public Bounty getBounty(UUID targetUuid) {
-        return bounties.get(targetUuid);
+        return targetUuid == null ? null : bounties.get(targetUuid);
     }
 
     public boolean hasBounty(UUID targetUuid) {
-        return bounties.containsKey(targetUuid);
+        return targetUuid != null && bounties.containsKey(targetUuid);
     }
 
     public Collection<Bounty> getAllBounties() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/LeaderboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/LeaderboardManager.java
@@ -1,6 +1,7 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.Bounty;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
 
@@ -29,7 +30,8 @@ public class LeaderboardManager {
         KILL_STREAK("killStreak"),
         HIGHEST_KILL_STREAK("highestKillStreak"),
         MONEY_SPENT("moneySpent"),
-        MONEY_MADE("moneyMade");
+        MONEY_MADE("moneyMade"),
+        BOUNTIES("bounties");
 
         private final String configKey;
 
@@ -112,6 +114,7 @@ public class LeaderboardManager {
             case HIGHEST_KILL_STREAK -> NumberUtils.format(data.getHighestKillStreak());
             case MONEY_SPENT -> formatCurrencyValue(CurrencyManager.CurrencyType.MONEY, data.getMoneySpent(), compact, includeCurrencySymbol);
             case MONEY_MADE -> formatCurrencyValue(CurrencyManager.CurrencyType.MONEY, data.getMoneyMade(), compact, includeCurrencySymbol);
+            case BOUNTIES -> formatCurrencyValue(CurrencyManager.CurrencyType.MONEY, bountyAmount(data), compact, includeCurrencySymbol);
         };
     }
 
@@ -210,6 +213,11 @@ public class LeaderboardManager {
 
                 List<PlayerData> players = new ArrayList<>(merged.values());
                 players.removeIf(data -> data == null || data.getUsername() == null || data.getUsername().isBlank());
+                if (type == LeaderboardType.BOUNTIES) {
+                    // Every player carries a zero bounty, so an unfiltered board would pad the
+                    // ranking with players nobody placed a bounty on.
+                    players.removeIf(data -> bountyAmount(data) <= 0D);
+                }
                 players.sort(comparator(type));
 
                 List<PlayerData> snapshot = List.copyOf(players);
@@ -245,7 +253,22 @@ public class LeaderboardManager {
             case HIGHEST_KILL_STREAK -> data.getHighestKillStreak();
             case MONEY_SPENT -> data.getMoneySpent();
             case MONEY_MADE -> data.getMoneyMade();
+            case BOUNTIES -> bountyAmount(data);
         };
+    }
+
+    private double bountyAmount(PlayerData data) {
+        if (data == null || data.getUuid() == null) {
+            return 0D;
+        }
+
+        BountyManager bountyManager = plugin.getBountyManager();
+        if (bountyManager == null) {
+            return 0D;
+        }
+
+        Bounty bounty = bountyManager.getBounty(data.getUuid());
+        return bounty == null ? 0D : bounty.getAmount();
     }
 
     private String formatCurrencyValue(

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -963,6 +963,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -964,6 +964,10 @@ MENUS:
         DISPLAY-NAME: '&#6BF18DMoney made on /sell'
         LORE:
         - '&fClick to view money made on /sell leaderboard'
+      BOUNTIES:
+        DISPLAY-NAME: '&#6BF18DBounties leaderboard'
+        LORE:
+        - '&fClick to view bounties leaderboard'
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: '&eWorking'

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -828,6 +828,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -827,6 +827,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -964,6 +964,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -828,6 +828,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -827,6 +827,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -826,6 +826,10 @@ MENUS:
         DISPLAY-NAME: "&#6BF18DMoney made on /sell"
         LORE:
         - "&fClick to view money made on /sell leaderboard"
+      BOUNTIES:
+        DISPLAY-NAME: "&#6BF18DBounties leaderboard"
+        LORE:
+        - "&fClick to view bounties leaderboard"
   PROGRESS-MENU:
     WORKING-BUTTON:
       TITLE: "&eWorking"

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -871,6 +871,7 @@ LEADERBOARDS-MENU:
     killStreak: Kill Streak
     highestKillStreak: Highest Kill Streak
     shards: Shards
+    bounties: Bounties
   BUTTONS:
     MONEY:
       TYPE: money
@@ -956,6 +957,13 @@ LEADERBOARDS-MENU:
       SLOT: 23
       LORE:
       - '&fClick to view MONEY MADE ON /SELL leaderboard'
+    BOUNTIES:
+      TYPE: bounties
+      DISPLAY-NAME: '&#6BF18DBounties Leaderboard'
+      MATERIAL: WITHER_SKELETON_SKULL
+      SLOT: 24
+      LORE:
+      - '&fClick to view BOUNTIES leaderboard'
 PROGRESS-MENU:
   PROGRESS-BAR: "■"
   LEVEL:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LeaderboardConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LeaderboardConfigurationTest.java
@@ -1,0 +1,94 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeaderboardConfigurationTest {
+
+    @Test
+    void bountiesIsAResolvableLeaderboardType() {
+        // Regression guard for #124: %economylb_bounties_<n>_display% rendered raw because
+        // the documented "bounties" type was never backed by an enum constant.
+        LeaderboardManager.LeaderboardType bounties = LeaderboardManager.LeaderboardType.BOUNTIES;
+        assertEquals("bounties", bounties.getConfigKey());
+    }
+
+    @Test
+    void everyLeaderboardTypeHasADisplayName() throws Exception {
+        ConfigurationSection typeNames = load("menus.yml")
+                .getConfigurationSection("LEADERBOARDS-MENU.TYPE-NAMES");
+        assertNotNull(typeNames);
+
+        for (LeaderboardManager.LeaderboardType type : LeaderboardManager.LeaderboardType.values()) {
+            String name = typeNames.getString(type.getConfigKey());
+            assertNotNull(name, "missing TYPE-NAMES entry for " + type.getConfigKey());
+            assertTrue(!name.isBlank(), "blank TYPE-NAMES entry for " + type.getConfigKey());
+        }
+    }
+
+    @Test
+    void everyLeaderboardTypeHasAButtonInAUniqueValidSlot() throws Exception {
+        YamlConfiguration menus = load("menus.yml");
+        int size = menus.getInt("LEADERBOARDS-MENU.SIZE");
+        ConfigurationSection buttons = menus.getConfigurationSection("LEADERBOARDS-MENU.BUTTONS");
+        assertNotNull(buttons);
+
+        Map<String, String> typesByKey = new HashMap<>();
+        Set<Integer> usedSlots = new HashSet<>();
+        for (String key : buttons.getKeys(false)) {
+            int slot = buttons.getInt(key + ".SLOT", -1);
+            assertTrue(slot >= 0 && slot < size, key + " has invalid slot " + slot);
+            assertTrue(usedSlots.add(slot), key + " duplicates slot " + slot);
+
+            String type = buttons.getString(key + ".TYPE");
+            assertNotNull(type, key + " has no TYPE");
+            typesByKey.put(normalize(type), key);
+        }
+
+        for (LeaderboardManager.LeaderboardType type : LeaderboardManager.LeaderboardType.values()) {
+            assertTrue(typesByKey.containsKey(normalize(type.getConfigKey())),
+                    "no LEADERBOARDS-MENU button for " + type.getConfigKey());
+        }
+    }
+
+    @Test
+    void placeholderDocsListEveryLeaderboardType() throws Exception {
+        String docs = Files.readString(
+                Path.of("docs/wiki/Placeholders-and-Integrations.md"), StandardCharsets.UTF_8);
+
+        String supportedTypes = docs.lines()
+                .filter(line -> line.startsWith("*Supported Types*"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(supportedTypes, "docs no longer declare the supported leaderboard types");
+
+        for (LeaderboardManager.LeaderboardType type : LeaderboardManager.LeaderboardType.values()) {
+            assertTrue(supportedTypes.contains("`" + type.getConfigKey() + "`"),
+                    "placeholder docs omit leaderboard type " + type.getConfigKey());
+        }
+    }
+
+    private static String normalize(String input) {
+        return input.replaceAll("[^A-Za-z0-9]", "").toLowerCase(Locale.US);
+    }
+
+    private static YamlConfiguration load(String fileName) throws Exception {
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.load(Path.of("src/main/resources", fileName).toFile());
+        return configuration;
+    }
+}


### PR DESCRIPTION
Closes #124

`%economylb_bounties_<n>_display%` rendered as raw text on the server while every
other type worked. The docs listed `bounties` as a supported leaderboard type, but
`LeaderboardType` never had a matching constant, so `parseType("bounties")` returned
empty and the expansion returned `null` — which PlaceholderAPI leaves untouched.

## Changes

- **`LeaderboardManager`** — add the `BOUNTIES` type, sourcing values from
  `BountyManager` and formatting them as money. The board filters out players with no
  bounty; without that, every player would rank with a `0` bounty and pad the list.
- **`BountyManager`** — the bounty map is now a `ConcurrentHashMap`. The async
  leaderboard refresh reads it off the main thread, so the previous `HashMap` was a
  data race (particularly on Folia). `getBounty`/`hasBounty` are null-safe accordingly.
- **`menus.yml` + all 8 language files** — add the Bounties leaderboard button
  (slot 24) and its display names.
- **Docs** — the supported-types list also omitted `blocksPlaced`, `blocksBroken`,
  `mobsKilled`, `killStreak`, `highestKillStreak`, `moneySpent` and `moneyMade`;
  it is now complete and `Config-menus.yml.md` is back in sync.

## Now working

`%economylb_bounties_<n>_{name,value,value_short,rank,display}%`,
`%economy_top_bounties_*%`, `%economyrank_bounties%`, `/leaderboard bounties`
(including tab-completion), and the Bounties button in the leaderboard menu.

## Testing

`mvn package` passes with 145 tests. New `LeaderboardConfigurationTest` asserts every
`LeaderboardType` has a display name, a menu button in a unique valid slot, and an
entry in the placeholder docs — verified to fail when the drift is reintroduced.