### PR TITLE
feat(staffmode): add custom command items to the staff hotbar (#128)

### DIFF
--- a/docs/wiki/Config-staff-mode.yml.md
+++ b/docs/wiki/Config-staff-mode.yml.md
@@ -262,6 +262,130 @@ ITEMS:
 
 ---
 
+## Section: `CUSTOM-ITEMS`
+
+Admin defined hotbar items that run commands when a staff member uses them. Every entry is
+free-form: the key is the item id, so add as many as you have free hotbar slots.
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Configuration section for Custom Items.
+# Admin defined hotbar items that run commands. Each entry is free-form: the key is the item id,
+# and the id is what identifies the item in-game, so keep it unique.
+# Slots already taken by the tools above (see STAFF-MODE.HOTBAR-SLOTS) are refused, and so are
+# duplicate slots, so move a built-in tool first if you need its slot.
+# SECURITY: EXECUTE-AS: CONSOLE runs the command with full console rights, which means any staff
+# member holding the item bypasses their own permissions. Always pair CONSOLE items with a
+# PERMISSION so only the ranks you trust receive them.
+CUSTOM-ITEMS:
+  # Example entry. Set ENABLED to true to hand it out, or delete the whole block to remove it.
+  EXAMPLE:
+    # Determines whether Enabled is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The numerical value for Slot. Available options: Any valid integer between 0 and 8
+    SLOT: 2
+    MATERIAL: DIRT
+    NAME: '&eCustom Command'
+    LORE:
+    - '&7Click to execute custom command'
+    # Determines who runs the commands. Available options: PLAYER, CONSOLE
+    EXECUTE-AS: PLAYER
+    # The permission needed to receive and use this item. Leave empty to allow every staff member.
+    PERMISSION: ''
+    # Determines whether the item must be right-clicked on a player. Available options: true, false
+    REQUIRE-TARGET: false
+    # The commands to run, without a leading slash.
+    # Placeholders: {player}, {player_uuid}, {world}, and, when REQUIRE-TARGET is true,
+    # {target} and {target_uuid}.
+    COMMANDS:
+    - 'say Hello from {player}'
+```
+
+### 2. Key Options & Technical Breakdown
+
+`<id>` is the config key you choose for the entry, for example `INVSEE`. It is uppercased
+internally, so `invsee` and `INVSEE` are the same item.
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `CUSTOM-ITEMS.<id>.ENABLED` | `bool` | `true`, `false` | `true` | Whether the item is handed out at all. A disabled entry is skipped silently, so you can park items you are still writing. |
+| `CUSTOM-ITEMS.<id>.SLOT` | `int` | `0` - `8` | none (required) | The hotbar slot the item occupies. Slots already used by a built-in tool (`STAFF-MODE.HOTBAR-SLOTS`) or by another custom item are refused, and the entry is skipped with a console warning. With the default layout, slots `2`, `3`, `5` and `6` are free. |
+| `CUSTOM-ITEMS.<id>.MATERIAL` | `str` | Any valid material name | `'STONE'` | The item material. `PLAYER_HEAD` renders the staff member's own head. An unknown material falls back to `STONE` and logs a warning. |
+| `CUSTOM-ITEMS.<id>.NAME` | `str` | Any string text | `'&f<id>'` | The item display name. Supports `&` colour codes. |
+| `CUSTOM-ITEMS.<id>.LORE` | `list` | List of strings | `[]` | The item lore. Supports `&` colour codes. |
+| `CUSTOM-ITEMS.<id>.EXECUTE-AS` | `str` | `PLAYER`, `CONSOLE` | `'PLAYER'` | Who runs the commands. `PLAYER` runs them as the staff member, so their own permissions still apply. `CONSOLE` runs them with full server rights. A typo here drops the item instead of guessing, so a misspelled value never silently runs a command with the wrong rights. |
+| `CUSTOM-ITEMS.<id>.PERMISSION` | `str` | Any permission node | `''` | The permission required to receive the item. Staff without it never get the item in the first place, so they cannot fire it. Leave empty to give it to every staff member. |
+| `CUSTOM-ITEMS.<id>.REQUIRE-TARGET` | `bool` | `true`, `false` | `false` | When `true`, the item only works when right-clicked on a player, and using it on air sends `MESSAGES.CUSTOM-ITEM-NO-TARGET`. Turn this on for anything that uses `{target}`. |
+| `CUSTOM-ITEMS.<id>.COMMANDS` | `list` | List of strings | none (required) | The commands to run, in order. A leading `/` is stripped, and blank entries are ignored. An entry with no runnable command is skipped with a console warning. |
+
+**Placeholders usable in `COMMANDS`**
+
+| Placeholder | Replaced with |
+| :--- | :--- |
+| `{player}` | The staff member's name. |
+| `{player_uuid}` | The staff member's UUID. |
+| `{world}` | The world the staff member is standing in. |
+| `{target}` | The right-clicked player's name. Only filled when the item was used on a player; a command that still contains `{target}` is skipped and logged instead of being sent to the server. |
+| `{target_uuid}` | The right-clicked player's UUID. Only filled when the item was used on a player. |
+
+**Security note.** `EXECUTE-AS: CONSOLE` bypasses the staff member's own permissions entirely, so an
+item running `op {target}` would hand out operator to anyone holding it. Pair every `CONSOLE` item
+with a `PERMISSION` so only the ranks you trust ever receive it.
+
+**Reload behaviour.** `/staffmode reload` re-reads the definitions and rebuilds the hotbar of every
+staff member currently in staff mode, so edits apply without anyone toggling off. Your own entries
+are never restored or overwritten by the config updater, so deleting `EXAMPLE` keeps it deleted.
+
+### 3. Practical Setup Example
+
+```yaml
+CUSTOM-ITEMS:
+  # Right-click a player to open their inventory. Runs as the staff member, so their own
+  # /invsee permission still decides whether it works.
+  INVSEE:
+    ENABLED: true
+    SLOT: 2
+    MATERIAL: CHEST
+    NAME: '&eInspect Inventory'
+    LORE:
+    - '&7Right-click a player to open their inventory'
+    EXECUTE-AS: PLAYER
+    PERMISSION: ''
+    REQUIRE-TARGET: true
+    COMMANDS:
+    - 'invsee {target}'
+  # A console item, so it is locked behind its own permission.
+  BAN:
+    ENABLED: true
+    SLOT: 3
+    MATERIAL: REDSTONE_BLOCK
+    NAME: '&cBan Player'
+    LORE:
+    - '&7Right-click a player to ban them'
+    EXECUTE-AS: CONSOLE
+    PERMISSION: ultimatedonutsmp.staff.mode.custom.ban
+    REQUIRE-TARGET: true
+    COMMANDS:
+    - 'ban {target} Caught by staff'
+    - 'staffchat {player} banned {target}'
+  # No target needed, so it fires on any right-click.
+  SPAWN:
+    ENABLED: true
+    SLOT: 5
+    MATERIAL: COMPASS
+    NAME: '&eReturn to Spawn'
+    LORE:
+    - '&7Click to teleport back to spawn'
+    EXECUTE-AS: PLAYER
+    PERMISSION: ''
+    REQUIRE-TARGET: false
+    COMMANDS:
+    - 'spawn'
+```
+
+---
+
 ## Section: `MENUS`
 
 ### 1. Commented Setup Code Example
@@ -454,6 +578,8 @@ MESSAGES:
     Your inventory was restored.'
   # The text or value for Tool Locked. Available options: Any valid string text
   TOOL-LOCKED: '&cYour staff tools are locked while Staff Mode is active.'
+  # The text or value for Custom Item No Target. Available options: Any valid string text
+  CUSTOM-ITEM-NO-TARGET: '&cRight-click a player to use this tool.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aStaff mode config reloaded.'
 ```
@@ -478,6 +604,7 @@ MESSAGES:
 | `MESSAGES.RESTORE-FAILED` | `str` | Any string text | `'&cStaff mode restore failed. Contac...'` | Configures the technical `RESTORE-FAILED` parameter for `MESSAGES.RESTORE-FAILED` in `staff-mode.yml`. |
 | `MESSAGES.RECOVERED-AFTER-RESTART` | `str` | Any string text | `'&eStaff mode was disabled because t...'` | Configures the technical `RECOVERED-AFTER-RESTART` parameter for `MESSAGES.RECOVERED-AFTER-RESTART` in `staff-mode.yml`. |
 | `MESSAGES.TOOL-LOCKED` | `str` | Any string text | `'&cYour staff tools are locked while...'` | Configures the technical `TOOL-LOCKED` parameter for `MESSAGES.TOOL-LOCKED` in `staff-mode.yml`. |
+| `MESSAGES.CUSTOM-ITEM-NO-TARGET` | `str` | Any string text | `'&cRight-click a player to use this...'` | Sent when a `CUSTOM-ITEMS` entry with `REQUIRE-TARGET: true` is used on air instead of on a player. |
 | `MESSAGES.RELOAD-SUCCESS` | `str` | Any string text | `'&aStaff mode config reloaded.'` | Configures the technical `RELOAD-SUCCESS` parameter for `MESSAGES.RELOAD-SUCCESS` in `staff-mode.yml`. |
 
 ### 3. Practical Setup Example

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
@@ -159,12 +159,9 @@ public class StaffModeListener implements Listener {
             return;
         }
 
-        long now = System.currentTimeMillis();
-        Long last = lastInteractTimes.get(player.getUniqueId());
-        if (last != null && (now - last) < INTERACT_COOLDOWN_MS) {
+        if (isOnInteractCooldown(player)) {
             return;
         }
-        lastInteractTimes.put(player.getUniqueId(), now);
 
         if (isLeftClickFreeze) {
             plugin.getStaffModeManager().openFrozenPlayers(player);
@@ -212,6 +209,7 @@ public class StaffModeListener implements Listener {
                     ));
                 }
             }
+            case CUSTOM -> plugin.getStaffModeManager().useCustomItem(player, event.getItem(), null);
             default -> {
             }
         }
@@ -236,7 +234,20 @@ public class StaffModeListener implements Listener {
         }
 
         event.setCancelled(true);
-        if (toolType != StaffToolType.FREEZE || !(event.getRightClicked() instanceof Player target)) {
+        if (!(event.getRightClicked() instanceof Player target)) {
+            return;
+        }
+
+        if (toolType == StaffToolType.CUSTOM) {
+            if (isOnInteractCooldown(player)) {
+                return;
+            }
+            plugin.getStaffModeManager().useCustomItem(
+                    player, player.getInventory().getItemInMainHand(), target);
+            return;
+        }
+
+        if (toolType != StaffToolType.FREEZE) {
             return;
         }
 
@@ -295,6 +306,16 @@ public class StaffModeListener implements Listener {
         if (result != null) {
             staff.sendMessage(ColorUtils.toComponent(freezeManager.buildToggleMessage(result)));
         }
+    }
+
+    private boolean isOnInteractCooldown(Player player) {
+        long now = System.currentTimeMillis();
+        Long last = lastInteractTimes.get(player.getUniqueId());
+        if (last != null && (now - last) < INTERACT_COOLDOWN_MS) {
+            return true;
+        }
+        lastInteractTimes.put(player.getUniqueId(), now);
+        return false;
     }
 
     private Player resolveDamager(Entity entity) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1835,6 +1835,14 @@ public class ConfigManager {
             return true;
         }
 
+        // Staff mode custom items are live server content. The bundled example is only a starting
+        // point and must not be merged back after admins edit or delete it. The CUSTOM-ITEMS section
+        // itself stays mergeable so configs that predate the feature still receive it once.
+        if ("staff-mode.yml".equals(resourceName)
+                && path.startsWith("CUSTOM-ITEMS.")) {
+            return true;
+        }
+
         // Network server entries can be expanded per deployment.
         if ("network.yml".equals(resourceName)
                 && path.startsWith("NETWORK-STATUS.SERVERS.")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/StaffModeManager.java
@@ -7,6 +7,7 @@ import com.bx.ultimateDonutSmp.menus.FrozenPlayersMenu;
 import com.bx.ultimateDonutSmp.menus.StaffListMenu;
 import com.bx.ultimateDonutSmp.models.FreezeState;
 import com.bx.ultimateDonutSmp.models.StaffModeState;
+import com.bx.ultimateDonutSmp.staff.StaffCustomItem;
 import com.bx.ultimateDonutSmp.staff.StaffInventorySnapshot;
 import com.bx.ultimateDonutSmp.staff.StaffModeSession;
 import com.bx.ultimateDonutSmp.staff.StaffToolType;
@@ -37,12 +38,14 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Level;
 
 public class StaffModeManager {
 
@@ -58,6 +61,7 @@ public class StaffModeManager {
     private final Map<UUID, StaffModeState> activeStates = new HashMap<>();
     private final Map<UUID, StaffModeSession> runtimeSessions = new HashMap<>();
     private final Set<UUID> restartRecoveryOnly = new HashSet<>();
+    private final Map<String, StaffCustomItem> customItems = new LinkedHashMap<>();
     private BukkitTask vanishActionBarTask;
 
     public StaffModeManager(UltimateDonutSmp plugin) {
@@ -795,6 +799,7 @@ public class StaffModeManager {
     }
 
     private void reloadInternal(boolean startup) {
+        reloadCustomItems();
         Set<UUID> preservedRecoveryOnly = new HashSet<>(restartRecoveryOnly);
         runtimeSessions.clear();
         activeStates.clear();
@@ -1151,6 +1156,13 @@ public class StaffModeManager {
             inventory.setItem(slot, buildToolItem(player, toolType));
         }
 
+        for (StaffCustomItem customItem : customItems.values()) {
+            if (!canUseCustomItem(player, customItem)) {
+                continue;
+            }
+            inventory.setItem(customItem.slot(), buildCustomItem(player, customItem));
+        }
+
         inventory.setHeldItemSlot(Math.max(0, Math.min(8, getToolSlot(StaffToolType.VANISH))));
         player.updateInventory();
     }
@@ -1206,6 +1218,133 @@ public class StaffModeManager {
         meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
         meta.getPersistentDataContainer().set(toolKey(), PersistentDataType.STRING, toolType.name());
         item.setItemMeta(meta);
+    }
+
+    private void reloadCustomItems() {
+        customItems.clear();
+
+        Set<Integer> reservedSlots = new HashSet<>();
+        for (StaffToolType toolType : TOOL_ORDER) {
+            reservedSlots.add(getToolSlot(toolType));
+        }
+
+        for (StaffCustomItem customItem : StaffCustomItem.parseAll(
+                getConfig().getConfigurationSection("CUSTOM-ITEMS"),
+                reservedSlots,
+                warning -> plugin.getLogger().warning(warning))) {
+            customItems.put(customItem.id(), customItem);
+        }
+    }
+
+    public List<StaffCustomItem> getCustomItems() {
+        return List.copyOf(customItems.values());
+    }
+
+    /**
+     * Custom items are hidden from staff who lack their configured permission, so a staff member
+     * never carries a tool they are not allowed to fire.
+     */
+    public boolean canUseCustomItem(Player player, StaffCustomItem customItem) {
+        if (player == null || customItem == null) {
+            return false;
+        }
+        return !customItem.hasPermission() || PermissionUtils.has(player, customItem.permission());
+    }
+
+    public StaffCustomItem resolveCustomItem(ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return null;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return null;
+        }
+
+        String id = meta.getPersistentDataContainer().get(customItemKey(), PersistentDataType.STRING);
+        return id == null ? null : customItems.get(id.trim().toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Runs the commands behind a custom item.
+     *
+     * @param target the right-clicked player, or {@code null} when the item was used on air
+     * @return true when at least one command was dispatched
+     */
+    public boolean useCustomItem(Player staff, ItemStack item, Player target) {
+        StaffCustomItem customItem = resolveCustomItem(item);
+        if (staff == null || customItem == null) {
+            return false;
+        }
+
+        if (!canUseCustomItem(staff, customItem)) {
+            staff.sendMessage(ColorUtils.toComponent(
+                    getMessage("NO-PERMISSION", "&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ."), staff));
+            return false;
+        }
+
+        if (customItem.requireTarget() && target == null) {
+            staff.sendMessage(ColorUtils.toComponent(
+                    getMessage("CUSTOM-ITEM-NO-TARGET", "&cʀɪɢʜᴛ-ᴄʟɪᴄᴋ ᴀ ᴘʟᴀʏᴇʀ ᴛᴏ ᴜѕᴇ ᴛʜɪѕ ᴛᴏᴏʟ."), staff));
+            return false;
+        }
+
+        boolean dispatched = false;
+        for (String command : customItem.commands()) {
+            String resolved = applyCustomItemPlaceholders(command, staff, target);
+            if (resolved.isBlank()) {
+                continue;
+            }
+            if (resolved.contains("{target}") || resolved.contains("{target_uuid}")) {
+                // A target placeholder with no target left would be sent to the server verbatim.
+                plugin.getLogger().warning("Staff mode custom item '" + customItem.id()
+                        + "' uses a target placeholder without REQUIRE-TARGET, skipping '" + resolved + "'.");
+                continue;
+            }
+
+            try {
+                if (customItem.executeAs() == StaffCustomItem.ExecuteAs.CONSOLE) {
+                    plugin.getSpigotScheduler().dispatchConsoleCommand(resolved);
+                } else {
+                    plugin.getSpigotScheduler().dispatchPlayerCommand(staff, resolved);
+                }
+                dispatched = true;
+            } catch (Exception exception) {
+                plugin.getLogger().log(Level.WARNING, "Staff mode custom item '" + customItem.id()
+                        + "' failed to run '" + resolved + "'", exception);
+            }
+        }
+
+        return dispatched;
+    }
+
+    private String applyCustomItemPlaceholders(String command, Player staff, Player target) {
+        String resolved = command
+                .replace("{player}", staff.getName())
+                .replace("{player_uuid}", staff.getUniqueId().toString())
+                .replace("{world}", staff.getWorld().getName());
+
+        if (target != null) {
+            resolved = resolved
+                    .replace("{target}", target.getName())
+                    .replace("{target_uuid}", target.getUniqueId().toString());
+        }
+        return resolved.trim();
+    }
+
+    private ItemStack buildCustomItem(Player player, StaffCustomItem customItem) {
+        ItemStack item = customItem.material() == Material.PLAYER_HEAD
+                ? ItemUtils.createPlayerHead(player, customItem.name(), customItem.lore())
+                : ItemUtils.createItem(customItem.material(), customItem.name(), customItem.lore());
+
+        tagToolItem(item, StaffToolType.CUSTOM);
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.getPersistentDataContainer().set(customItemKey(), PersistentDataType.STRING, customItem.id());
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 
     private boolean isEligibleRandomTeleportTarget(Player viewer, Player target) {
@@ -1290,11 +1429,17 @@ public class StaffModeManager {
             case STAFF_LIST -> 4;
             case BETTER_VIEW -> 7;
             case RANDOM_TELEPORT -> 8;
+            // Custom items carry their own SLOT, so this branch only exists to keep the switch exhaustive.
+            case CUSTOM -> 0;
         };
     }
 
     private NamespacedKey toolKey() {
         return plugin.getKey("staff_tool_type");
+    }
+
+    private NamespacedKey customItemKey() {
+        return plugin.getKey("staff_custom_item");
     }
 
     private String resolveSourceServer() {

--- a/src/main/java/com/bx/ultimateDonutSmp/staff/StaffCustomItem.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/staff/StaffCustomItem.java
@@ -1,0 +1,172 @@
+package com.bx.ultimateDonutSmp.staff;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * An admin defined staff mode hotbar item that runs one or more commands when it is used.
+ *
+ * <p>Definitions live under {@code CUSTOM-ITEMS} in {@code staff-mode.yml}. Unlike the built-in
+ * tools these are not backed by an enum constant, so the config key doubles as the identity that
+ * is written into the item's persistent data container.</p>
+ */
+public record StaffCustomItem(
+        String id,
+        int slot,
+        Material material,
+        String name,
+        List<String> lore,
+        List<String> commands,
+        ExecuteAs executeAs,
+        String permission,
+        boolean requireTarget
+) {
+
+    /** Who the configured commands are dispatched as. */
+    public enum ExecuteAs {
+        PLAYER,
+        CONSOLE;
+
+        public static ExecuteAs parse(String raw, ExecuteAs fallback) {
+            if (raw == null || raw.isBlank()) {
+                return fallback;
+            }
+            try {
+                return ExecuteAs.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException exception) {
+                return null;
+            }
+        }
+    }
+
+    public StaffCustomItem {
+        lore = lore == null ? List.of() : List.copyOf(lore);
+        commands = commands == null ? List.of() : List.copyOf(commands);
+    }
+
+    public boolean hasPermission() {
+        return permission != null && !permission.isBlank();
+    }
+
+    /**
+     * Reads every enabled definition under {@code section}, dropping the ones that cannot be used.
+     *
+     * @param section        the {@code CUSTOM-ITEMS} section, may be {@code null}
+     * @param reservedSlots  hotbar slots already taken by the built-in staff tools
+     * @param warningSink    receives one message per rejected definition
+     * @return the usable definitions, in config order
+     */
+    public static List<StaffCustomItem> parseAll(ConfigurationSection section,
+                                                 Set<Integer> reservedSlots,
+                                                 Consumer<String> warningSink) {
+        if (section == null) {
+            return List.of();
+        }
+
+        Set<Integer> taken = new HashSet<>(reservedSlots == null ? Set.of() : reservedSlots);
+        List<StaffCustomItem> parsed = new ArrayList<>();
+
+        for (String key : section.getKeys(false)) {
+            ConfigurationSection definition = section.getConfigurationSection(key);
+            if (definition == null) {
+                warn(warningSink, key, "it is not a configuration section");
+                continue;
+            }
+            if (!definition.getBoolean("ENABLED", true)) {
+                continue;
+            }
+
+            String id = key.trim().toUpperCase(Locale.ROOT);
+
+            int slot = definition.getInt("SLOT", -1);
+            if (slot < 0 || slot > 8) {
+                warn(warningSink, key, "SLOT " + slot + " is outside the hotbar (0-8)");
+                continue;
+            }
+            if (!taken.add(slot)) {
+                warn(warningSink, key, "SLOT " + slot + " is already used by another staff mode item");
+                continue;
+            }
+
+            List<String> commands = readCommands(definition);
+            if (commands.isEmpty()) {
+                warn(warningSink, key, "it has no COMMANDS to run");
+                continue;
+            }
+
+            ExecuteAs executeAs = ExecuteAs.parse(definition.getString("EXECUTE-AS"), ExecuteAs.PLAYER);
+            if (executeAs == null) {
+                warn(warningSink, key, "EXECUTE-AS must be PLAYER or CONSOLE");
+                continue;
+            }
+
+            Material material = Material.matchMaterial(
+                    String.valueOf(definition.getString("MATERIAL", "STONE")).trim().toUpperCase(Locale.ROOT));
+            if (material == null) {
+                if (warningSink != null) {
+                    warningSink.accept("Staff mode custom item '" + key + "' has an unknown MATERIAL '"
+                            + definition.getString("MATERIAL") + "', falling back to STONE.");
+                }
+                material = Material.STONE;
+            }
+
+            parsed.add(new StaffCustomItem(
+                    id,
+                    slot,
+                    material,
+                    definition.getString("NAME", "&f" + id),
+                    definition.getStringList("LORE"),
+                    commands,
+                    executeAs,
+                    definition.getString("PERMISSION", ""),
+                    definition.getBoolean("REQUIRE-TARGET", false)
+            ));
+        }
+
+        return Collections.unmodifiableList(parsed);
+    }
+
+    private static List<String> readCommands(ConfigurationSection definition) {
+        List<String> raw = new ArrayList<>(definition.getStringList("COMMANDS"));
+        if (raw.isEmpty()) {
+            String single = definition.getString("COMMANDS");
+            if (single != null && !single.isBlank()) {
+                raw.add(single);
+            }
+        }
+
+        List<String> commands = new ArrayList<>();
+        for (String command : raw) {
+            String normalized = normalizeCommand(command);
+            if (!normalized.isEmpty()) {
+                commands.add(normalized);
+            }
+        }
+        return commands;
+    }
+
+    private static String normalizeCommand(String command) {
+        if (command == null) {
+            return "";
+        }
+        String trimmed = command.trim();
+        while (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1).trim();
+        }
+        return trimmed;
+    }
+
+    private static void warn(Consumer<String> warningSink, String key, String reason) {
+        if (warningSink != null) {
+            warningSink.accept("Skipping staff mode custom item '" + key + "' because " + reason + ".");
+        }
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/staff/StaffToolType.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/staff/StaffToolType.java
@@ -7,7 +7,12 @@ public enum StaffToolType {
     FREEZE("FREEZE"),
     STAFF_LIST("STAFF_LIST"),
     BETTER_VIEW("BETTER_VIEW"),
-    RANDOM_TELEPORT("RANDOM_TELEPORT");
+    RANDOM_TELEPORT("RANDOM_TELEPORT"),
+    /**
+     * Marker for admin defined items from {@code CUSTOM-ITEMS}. The concrete definition is
+     * identified by a second persistent data tag rather than by this constant.
+     */
+    CUSTOM("CUSTOM");
 
     private final String configKey;
 

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2092,6 +2092,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cRechtsklicke einen Spieler, um dieses Werkzeug zu benutzen."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2230,6 +2230,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: '&eStaff mode was disabled because the server restarted.
         your inventory was restored.'
       TOOL-LOCKED: '&cYour staff tools are locked while staff mode is active.'
+      CUSTOM-ITEM-NO-TARGET: '&cRight-click a player to use this tool.'
       RELOAD-SUCCESS: '&aStaff mode config reloaded.'
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1956,6 +1956,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cHaz clic derecho en un jugador para usar esta herramienta."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1956,6 +1956,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cFaites un clic droit sur un joueur pour utiliser cet outil."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2093,6 +2093,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are loaff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cKlik kanan seorang pemain untuk memakai alat ini."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1956,6 +1956,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cClique com o botão direito em um jogador para usar esta ferramenta."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1955,6 +1955,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted.
         your inventory was restored."
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active."
+      CUSTOM-ITEM-NO-TARGET: "&cНажмите правой кнопкой по игроку, чтобы использовать этот инструмент."
       RELOAD-SUCCESS: "&aStaff mode config reloaded."
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1950,6 +1950,7 @@ CONFIG:
       RECOVERED-AFTER-RESTART: "&eStaff mode was disabled because the server restarted。
         your inventory was restored。"
       TOOL-LOCKED: "&cYour staff tools are locked while staff mode is active。"
+      CUSTOM-ITEM-NO-TARGET: "&c右键点击一名玩家以使用该工具。"
       RELOAD-SUCCESS: "&aStaff mode config reloaded。"
   SERVER_WIPE:
     MESSAGES:

--- a/src/main/resources/staff-mode.yml
+++ b/src/main/resources/staff-mode.yml
@@ -124,6 +124,36 @@ ITEMS:
     NAME: '&eRandom Teleport'
     LORE:
     - '&7Click to teleport to a random player'
+# Configuration section for Custom Items.
+# Admin defined hotbar items that run commands. Each entry is free-form: the key is the item id,
+# and the id is what identifies the item in-game, so keep it unique.
+# Slots already taken by the tools above (see STAFF-MODE.HOTBAR-SLOTS) are refused, and so are
+# duplicate slots, so move a built-in tool first if you need its slot.
+# SECURITY: EXECUTE-AS: CONSOLE runs the command with full console rights, which means any staff
+# member holding the item bypasses their own permissions. Always pair CONSOLE items with a
+# PERMISSION so only the ranks you trust receive them.
+CUSTOM-ITEMS:
+  # Example entry. Set ENABLED to true to hand it out, or delete the whole block to remove it.
+  EXAMPLE:
+    # Determines whether Enabled is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The numerical value for Slot. Available options: Any valid integer between 0 and 8
+    SLOT: 2
+    MATERIAL: DIRT
+    NAME: '&eCustom Command'
+    LORE:
+    - '&7Click to execute custom command'
+    # Determines who runs the commands. Available options: PLAYER, CONSOLE
+    EXECUTE-AS: PLAYER
+    # The permission needed to receive and use this item. Leave empty to allow every staff member.
+    PERMISSION: ''
+    # Determines whether the item must be right-clicked on a player. Available options: true, false
+    REQUIRE-TARGET: false
+    # The commands to run, without a leading slash.
+    # Placeholders: {player}, {player_uuid}, {world}, and, when REQUIRE-TARGET is true,
+    # {target} and {target_uuid}.
+    COMMANDS:
+    - 'say Hello from {player}'
 # Configuration section for Menus.
 MENUS:
   # Configuration section for Staff List.
@@ -236,5 +266,7 @@ MESSAGES:
     Your inventory was restored.'
   # The text or value for Tool Locked. Available options: Any valid string text
   TOOL-LOCKED: '&cYour staff tools are locked while Staff Mode is active.'
+  # The text or value for Custom Item No Target. Available options: Any valid string text
+  CUSTOM-ITEM-NO-TARGET: '&cRight-click a player to use this tool.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aStaff mode config reloaded.'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
@@ -220,7 +220,7 @@ class LanguageManagerTest {
                 "NETWORK.LOCAL_DISPLAY_NAME",
                 "NETWORK-STATUS.LOCAL-DISPLAY-NAME"
         ));
-        added += mergeText(target, "CONFIG.STAFF_MODE", "staff-mode.yml", false, List.of());
+        added += mergeText(target, "CONFIG.STAFF_MODE", "staff-mode.yml", false, List.of("CUSTOM-ITEMS"));
         added += mergeText(target, "CONFIG.SERVER_WIPE", "server-wipe.yml", false, List.of());
         added += mergeText(target, "CONFIG.WORTH", "worth.yml", false, List.of("BLOCK-ITEMS"));
         added += LanguageManager.mergeShopText(target, loadResource("shop.yml"));

--- a/src/test/java/com/bx/ultimateDonutSmp/staff/StaffCustomItemTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/staff/StaffCustomItemTest.java
@@ -1,0 +1,222 @@
+package com.bx.ultimateDonutSmp.staff;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StaffCustomItemTest {
+
+    private static final Set<Integer> BUILT_IN_SLOTS = Set.of(0, 1, 4, 7, 8);
+
+    @Test
+    void parsesAFullDefinition() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  invsee:
+                    SLOT: 2
+                    MATERIAL: CHEST
+                    NAME: '&eInventory'
+                    LORE:
+                    - '&7Right-click a player'
+                    EXECUTE-AS: CONSOLE
+                    PERMISSION: ultimatedonutsmp.staff.mode.custom.invsee
+                    REQUIRE-TARGET: true
+                    COMMANDS:
+                    - '/invsee {target}'
+                """, warnings);
+
+        assertEquals(1, items.size());
+        StaffCustomItem item = items.get(0);
+        assertEquals("INVSEE", item.id());
+        assertEquals(2, item.slot());
+        assertEquals(Material.CHEST, item.material());
+        assertEquals(List.of("&7Right-click a player"), item.lore());
+        assertEquals(StaffCustomItem.ExecuteAs.CONSOLE, item.executeAs());
+        assertTrue(item.hasPermission());
+        assertTrue(item.requireTarget());
+        assertEquals(List.of("invsee {target}"), item.commands(), "leading slashes must be stripped");
+        assertTrue(warnings.isEmpty(), () -> "unexpected warnings: " + warnings);
+    }
+
+    @Test
+    void appliesDefaultsForOptionalKeys() throws Exception {
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  minimal:
+                    SLOT: 3
+                    COMMANDS:
+                    - 'spawn'
+                """, new ArrayList<>());
+
+        assertEquals(1, items.size());
+        StaffCustomItem item = items.get(0);
+        assertEquals(Material.STONE, item.material());
+        assertEquals(StaffCustomItem.ExecuteAs.PLAYER, item.executeAs(), "commands must default to the staff member");
+        assertFalse(item.hasPermission());
+        assertFalse(item.requireTarget());
+    }
+
+    @Test
+    void acceptsASingleStringCommand() throws Exception {
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  single:
+                    SLOT: 3
+                    COMMANDS: 'heal {player}'
+                """, new ArrayList<>());
+
+        assertEquals(List.of("heal {player}"), items.get(0).commands());
+    }
+
+    @Test
+    void skipsDisabledEntriesWithoutWarning() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  off:
+                    ENABLED: false
+                    SLOT: 3
+                    COMMANDS:
+                    - 'spawn'
+                """, warnings);
+
+        assertTrue(items.isEmpty());
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void rejectsSlotsOutsideTheHotbar() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  missing-slot:
+                    COMMANDS:
+                    - 'spawn'
+                  too-high:
+                    SLOT: 9
+                    COMMANDS:
+                    - 'spawn'
+                """, warnings);
+
+        assertTrue(items.isEmpty());
+        assertEquals(2, warnings.size());
+    }
+
+    @Test
+    void rejectsSlotsHeldByBuiltInToolsAndOtherCustomItems() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  clashes-with-vanish:
+                    SLOT: 0
+                    COMMANDS:
+                    - 'spawn'
+                  first:
+                    SLOT: 2
+                    COMMANDS:
+                    - 'spawn'
+                  second:
+                    SLOT: 2
+                    COMMANDS:
+                    - 'spawn'
+                """, warnings);
+
+        assertEquals(1, items.size());
+        assertEquals("FIRST", items.get(0).id());
+        assertEquals(2, warnings.size());
+    }
+
+    @Test
+    void rejectsEntriesWithoutRunnableCommands() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  no-commands:
+                    SLOT: 2
+                  blank-commands:
+                    SLOT: 3
+                    COMMANDS:
+                    - '   '
+                    - '/'
+                """, warnings);
+
+        assertTrue(items.isEmpty());
+        assertEquals(2, warnings.size());
+    }
+
+    @Test
+    void rejectsAnUnknownExecuteAsInsteadOfGuessing() throws Exception {
+        // Falling back to PLAYER would be surprising, and falling back to CONSOLE would be unsafe,
+        // so a typo must drop the item rather than run it with the wrong rights.
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  typo:
+                    SLOT: 2
+                    EXECUTE-AS: SERVER
+                    COMMANDS:
+                    - 'spawn'
+                """, warnings);
+
+        assertTrue(items.isEmpty());
+        assertEquals(1, warnings.size());
+    }
+
+    @Test
+    void keepsAnUnknownMaterialUsableWithAWarning() throws Exception {
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  bad-material:
+                    SLOT: 2
+                    MATERIAL: NOT_A_REAL_BLOCK
+                    COMMANDS:
+                    - 'spawn'
+                """, warnings);
+
+        assertEquals(1, items.size());
+        assertEquals(Material.STONE, items.get(0).material());
+        assertEquals(1, warnings.size());
+    }
+
+    @Test
+    void bundledExampleIsValidAndShipsDisabled() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "staff-mode.yml").toFile());
+
+        assertNotNull(config.getConfigurationSection("CUSTOM-ITEMS"),
+                "staff-mode.yml must document the CUSTOM-ITEMS section");
+        assertFalse(config.getBoolean("CUSTOM-ITEMS.EXAMPLE.ENABLED", true),
+                "the bundled example must ship disabled so a config restore never arms a command item");
+        assertNotNull(config.getString("MESSAGES.CUSTOM-ITEM-NO-TARGET"),
+                "the require-target rejection needs a configurable message");
+
+        List<String> warnings = new ArrayList<>();
+        StaffCustomItem.parseAll(config.getConfigurationSection("CUSTOM-ITEMS"), BUILT_IN_SLOTS, warnings::add);
+        assertTrue(warnings.isEmpty(), () -> "bundled example is misconfigured: " + warnings);
+
+        // The example is only useful if it loads once an admin flips ENABLED.
+        config.set("CUSTOM-ITEMS.EXAMPLE.ENABLED", true);
+        List<StaffCustomItem> enabled = StaffCustomItem.parseAll(
+                config.getConfigurationSection("CUSTOM-ITEMS"), BUILT_IN_SLOTS, warnings::add);
+        assertEquals(1, enabled.size(), () -> "bundled example does not load when enabled: " + warnings);
+        assertEquals(StaffCustomItem.ExecuteAs.PLAYER, enabled.get(0).executeAs());
+    }
+
+    private static List<StaffCustomItem> parse(String yaml, List<String> warnings) throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.loadFromString(yaml);
+        return StaffCustomItem.parseAll(config.getConfigurationSection("CUSTOM-ITEMS"), BUILT_IN_SLOTS, warnings::add);
+    }
+}


### PR DESCRIPTION
Closes #128

## What

Adds a `CUSTOM-ITEMS` section to `staff-mode.yml`. Each entry is admin-defined — the config key is the item id — and places a command-running item in the staff mode hotbar.

```yaml
CUSTOM-ITEMS:
  INVSEE:
    ENABLED: true
    SLOT: 2
    MATERIAL: CHEST
    NAME: '&eInspect Inventory'
    LORE:
    - '&7Right-click a player to open their inventory'
    EXECUTE-AS: PLAYER      # or CONSOLE
    PERMISSION: ''
    REQUIRE-TARGET: true
    COMMANDS:
    - 'invsee {target}'
```

Placeholders: `{player}`, `{player_uuid}`, `{world}`, `{target}`, `{target_uuid}`.

The requested format was reshaped to match the existing config conventions: uppercase keys, `COMMANDS` as a list so one item can chain several, and a per-item `SLOT` since custom items are dynamic and cannot live in `STAFF-MODE.HOTBAR-SLOTS`.

## Safety decisions

- **`PERMISSION` hides the item**, it does not just block the click. Staff without it never receive the item, so they cannot fire it. The check is repeated on use in case ranks changed mid-session.
- **`EXECUTE-AS: CONSOLE` bypasses the holder's own permissions entirely** — an item running `op {target}` would hand out operator to anyone carrying it. Default is `PLAYER`, and the config and wiki both flag this.
- **A typo in `EXECUTE-AS` drops the item.** Defaulting to `PLAYER` would be surprising and defaulting to `CONSOLE` would be unsafe, so neither is guessed.
- **A command still containing `{target}` is skipped and logged** instead of being dispatched — that is the case where an admin uses `{target}` but forgets `REQUIRE-TARGET`.
- **The bundled example ships `ENABLED: false`**, because the config updater re-inserts a deleted `CUSTOM-ITEMS:` header and an enabled example would silently arm a command item on upgrade.

## Implementation notes

- `StaffToolType.CUSTOM` reuses the existing tool plumbing, so `LOCK-TOOLS`, drop/move blocking and damage cancelling apply to custom items without new listener paths. The concrete definition is carried in a second persistent data tag (`staff_custom_item`) since the id is a free-form string, not an enum constant.
- Slot conflicts against built-in tools and against other custom items are refused at load with a console warning. With the default layout, slots 2, 3, 5 and 6 are free.
- `CUSTOM-ITEMS.*` is registered in `ConfigManager.isUserManagedBundledPath` so admin entries are never restored after deletion — the same class of bug as #123. The section header stays mergeable so existing configs receive it once.
- `/staffmode reload` re-reads definitions and rebuilds the hotbar of everyone currently in staff mode.

## Tests

`StaffCustomItemTest` — 10 cases covering full and minimal parsing, single-string `COMMANDS`, disabled entries, out-of-range slots, conflicts with built-in and custom slots, missing commands, the `EXECUTE-AS` rejection, unknown-material fallback, and the bundled example.

Full suite: 162 tests, all passing.