### PR TITLE
feat(spawn): drop new players at a random location on first join (#129)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -184,6 +184,10 @@ SETTINGS:
   SPAWN-MENU: true
   # Determines whether Afk Menu is enabled or disabled. Available options: true, false
   AFK-MENU: true
+  # Determines whether players are teleported to the spawn location the first time they
+  # join the server. Ignored while First Join Rtp Enabled is true. Available options:
+  # true, false
+  TELEPORT-SPAWN-ON-FIRST-JOIN: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -214,6 +218,7 @@ SETTINGS:
 | `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `'&a+$%price%'` | Configures the technical `SELL-MESSAGE` parameter for `SETTINGS.SELL-MESSAGE` in `config.yml`. |
 | `SETTINGS.SPAWN-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `SPAWN-MENU` parameter for `SETTINGS.SPAWN-MENU` in `config.yml`. |
 | `SETTINGS.AFK-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `AFK-MENU` parameter for `SETTINGS.AFK-MENU` in `config.yml`. |
+| `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | `true`, `false` | `true` | Teleports a player to the spawn location the first time they join. Does nothing until `/setspawn` has been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Any decimal number | `'1.0'` | Configures the technical `WORTH-DEFAULT-VALUE` parameter for `SETTINGS.WORTH-DEFAULT-VALUE` in `config.yml`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer number | `'50'` | Configures the technical `MOB-SPAWN-RADIUS` parameter for `SETTINGS.MOB-SPAWN-RADIUS` in `config.yml`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer number | `'40'` | Configures the technical `PHANTOM-SPAWN-RADIUS` parameter for `SETTINGS.PHANTOM-SPAWN-RADIUS` in `config.yml`. |
@@ -249,6 +254,85 @@ SETTINGS:
     NAME: '&eChainmail Boots'
     # The numerical val
 ```
+
+---
+
+## Section: `FIRST-JOIN-RTP`
+
+Drops brand new players at a random location the first time they join, instead of leaving them on the vanilla world spawn near `0, 0`.
+The location search reuses the RTP engine but bypasses RTP cooldowns, playtime requirements, and the RTP queue, so a first join is never blocked.
+It does require the `RTP` feature itself to be enabled - with RTP off, the join falls back to `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN`.
+
+### 1. Commented Setup Code Example
+
+```yaml
+FIRST-JOIN-RTP:
+  # Determines whether First Join Rtp is enabled or disabled. Takes priority over Settings
+  # Teleport Spawn On First Join. Available options: true, false
+  ENABLED: false
+  # Determines whether the player is sent to the spawn location when no safe random
+  # location can be found. Available options: true, false
+  FALLBACK-TO-SPAWN: true
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to start...'
+  # The text or value for Success Message, sent once the player has been dropped.
+  # Supports {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid
+  # string text
+  SUCCESS-MESSAGE: '&aWelcome! You spawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. Set
+  # to '' to disable. Available options: Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random spawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop new players in. Leave empty to use the world they join in.
+    # Available options: Any valid string text
+    NAME: ''
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FIRST-JOIN-RTP.ENABLED` | `bool` | `true`, `false` | `false` | Master toggle for the random first-join drop. While `true` it takes priority over `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN`. |
+| `FIRST-JOIN-RTP.FALLBACK-TO-SPAWN` | `bool` | `true`, `false` | `true` | Sends the player to the spawn location when the search finds nothing safe. Set to `false` to leave them where they landed. |
+| `FIRST-JOIN-RTP.SEARCHING-MESSAGE` | `str` | Any string text | `'&7Finding you a safe place to start...'` | Sent as soon as the search starts, so the player knows why they are waiting. Set to `''` to stay silent. |
+| `FIRST-JOIN-RTP.SUCCESS-MESSAGE` | `str` | Any string text | `'&aWelcome! You spawned at &fX:{x} Y:{y} Z:{z}&a.'` | Sent after the teleport succeeds. Supports `{world}`, `{x}`, `{y}`, `{z}`. Set to `''` to stay silent. |
+| `FIRST-JOIN-RTP.FAILED-MESSAGE` | `str` | Any string text | `'&cCould not find a random spawn location for you.'` | Sent when no safe location was found or the teleport failed. Set to `''` to stay silent. |
+| `FIRST-JOIN-RTP.WORLD.NAME` | `str` | Any string text | `''` | World to search in. Leave empty to use whichever world the player joined in. `world`, `nether`, and `end` resolve to the loaded overworld/nether/end. |
+| `FIRST-JOIN-RTP.WORLD.CENTER-X` | `int` | Any valid integer number | `0` | X coordinate the search radius is measured from. |
+| `FIRST-JOIN-RTP.WORLD.CENTER-Z` | `int` | Any valid integer number | `0` | Z coordinate the search radius is measured from. |
+| `FIRST-JOIN-RTP.WORLD.MIN-RADIUS` | `int` | Any valid integer number | `500` | Closest a new player can be dropped to the center. Raise it to keep new players away from spawn. |
+| `FIRST-JOIN-RTP.WORLD.MAX-RADIUS` | `int` | Any valid integer number | `5000` | Furthest a new player can be dropped from the center. Keep it inside your pregenerated area, otherwise the search has to fall back to chunk generation. |
+
+### 3. Practical Setup Example
+
+Spread new players between 1000 and 8000 blocks from spawn in the overworld, and say nothing while searching:
+
+```yaml
+FIRST-JOIN-RTP:
+  ENABLED: true
+  FALLBACK-TO-SPAWN: true
+  SEARCHING-MESSAGE: ''
+  SUCCESS-MESSAGE: '&aWelcome to the server! You start at &fX:{x} Z:{z}&a.'
+  FAILED-MESSAGE: '&cCould not find a random spawn location for you.'
+  WORLD:
+    NAME: 'world'
+    CENTER-X: 0
+    CENTER-Z: 0
+    MIN-RADIUS: 1000
+    MAX-RADIUS: 8000
+```
+
+The search attempt budget, chunk sample budget, and chunk generation behaviour are shared with `/rtp` and stay in [`rtp.yml`](Config-rtp.yml).
 
 ---
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -514,6 +514,10 @@ SETTINGS:
   SPAWN-MENU: true
   # Determines whether Afk Menu is enabled or disabled. Available options: true, false
   AFK-MENU: true
+  # Determines whether players are teleported to the spawn location the first time they
+  # join the server. Ignored while First Join Rtp Enabled is true. Available options:
+  # true, false
+  TELEPORT-SPAWN-ON-FIRST-JOIN: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -543,6 +547,7 @@ SETTINGS:
 | `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `&a+$%price%` | Configures `SELL-MESSAGE` for `SETTINGS`. |
 | `SETTINGS.SPAWN-MENU` | `bool` | true, false | `True` | Configures `SPAWN-MENU` for `SETTINGS`. |
 | `SETTINGS.AFK-MENU` | `bool` | true, false | `True` | Configures `AFK-MENU` for `SETTINGS`. |
+| `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | true, false | `True` | Teleports a player to spawn on their first join. Needs `/setspawn` to have been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Configured values | `1.0` | Configures `WORTH-DEFAULT-VALUE` for `SETTINGS`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer | `50` | Configures `MOB-SPAWN-RADIUS` for `SETTINGS`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer | `40` | Configures `PHANTOM-SPAWN-RADIUS` for `SETTINGS`. |
@@ -803,6 +808,63 @@ RTP-ZONE:
 | `RTP-ZONE.WORLD.MIN-RADIUS` | `int` | Any valid integer | `500` | Configures `MIN-RADIUS` for `RTP-ZONE`. |
 | `RTP-ZONE.WORLD.MAX-RADIUS` | `int` | Any valid integer | `2000` | Configures `MAX-RADIUS` for `RTP-ZONE`. |
 | `RTP-ZONE.TITLE-FADE-OUT-TICKS` | `int` | Any valid integer | `10` | Configures `TITLE-FADE-OUT-TICKS` for `RTP-ZONE`. |
+
+---
+
+## Section: `FIRST-JOIN-RTP` - Random Drop On A Player's First Join
+
+Sends brand new players to a random location the first time they join, instead of leaving them on the vanilla world spawn.
+The search reuses the RTP engine but skips RTP cooldowns, playtime requirements, and the RTP queue.
+It still needs the `RTP` feature enabled - with RTP off, the join falls back to `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN`.
+
+### Fully Commented Setup Code Example
+```yaml
+FIRST-JOIN-RTP:
+  # Determines whether First Join Rtp is enabled or disabled. Takes priority over Settings
+  # Teleport Spawn On First Join. Available options: true, false
+  ENABLED: false
+  # Determines whether the player is sent to the spawn location when no safe random
+  # location can be found. Available options: true, false
+  FALLBACK-TO-SPAWN: true
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to start...'
+  # The text or value for Success Message, sent once the player has been dropped.
+  # Supports {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid
+  # string text
+  SUCCESS-MESSAGE: '&aWelcome! You spawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. Set
+  # to '' to disable. Available options: Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random spawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop new players in. Leave empty to use the world they join in.
+    # Available options: Any valid string text
+    NAME: ''
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
+```
+
+### Key Options
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function |
+| :--- | :--- | :--- | :--- | :--- |
+| `FIRST-JOIN-RTP.ENABLED` | `bool` | true, false | `False` | Master toggle. While `true` it takes priority over `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN`. |
+| `FIRST-JOIN-RTP.FALLBACK-TO-SPAWN` | `bool` | true, false | `True` | Sends the player to spawn when nothing safe is found. |
+| `FIRST-JOIN-RTP.SEARCHING-MESSAGE` | `str` | Any string text | `&7Finding you a safe place to start...` | Sent when the search starts. Empty to stay silent. |
+| `FIRST-JOIN-RTP.SUCCESS-MESSAGE` | `str` | Any string text | `&aWelcome! You spawned at &fX:{x} Y:{...` | Sent after the teleport. Supports `{world}`, `{x}`, `{y}`, `{z}`. |
+| `FIRST-JOIN-RTP.FAILED-MESSAGE` | `str` | Any string text | `&cCould not find a random spawn locat...` | Sent when the search or teleport fails. |
+| `FIRST-JOIN-RTP.WORLD.NAME` | `str` | Any string text | `` | World to search. Empty uses the world the player joined in. |
+| `FIRST-JOIN-RTP.WORLD.CENTER-X` | `int` | Any valid integer | `0` | Configures `CENTER-X` for `FIRST-JOIN-RTP`. |
+| `FIRST-JOIN-RTP.WORLD.CENTER-Z` | `int` | Any valid integer | `0` | Configures `CENTER-Z` for `FIRST-JOIN-RTP`. |
+| `FIRST-JOIN-RTP.WORLD.MIN-RADIUS` | `int` | Any valid integer | `500` | Closest a new player can land to the center. |
+| `FIRST-JOIN-RTP.WORLD.MAX-RADIUS` | `int` | Any valid integer | `5000` | Furthest a new player can land from the center. Keep inside pregenerated terrain. |
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -86,6 +86,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private TeleportManager teleportManager;
     private RTPManager rtpManager;
     private RTPZoneManager rtpZoneManager;
+    private FirstJoinSpawnManager firstJoinSpawnManager;
     private PortalManager portalManager;
     private AmethystToolsManager amethystToolsManager;
     private EnderChestManager enderChestManager;
@@ -257,6 +258,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         teleportManager = new TeleportManager(this);
         rtpManager = new RTPManager(this);
         rtpZoneManager = new RTPZoneManager(this);
+        firstJoinSpawnManager = new FirstJoinSpawnManager(this);
         portalManager = new PortalManager(this);
         portalManager.loadAll();
         initializeLuckPermsTablistRefreshBridge();
@@ -1037,6 +1039,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         keyAllManager.reload();
         shardManager.reloadSettings();
         rtpZoneManager.reloadSettings();
+        firstJoinSpawnManager.reloadSettings();
         enderChestManager.reload();
         if (offenseManager != null) {
             offenseManager.reload();
@@ -1313,6 +1316,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public RTPZoneManager getRtpZoneManager() {
         return rtpZoneManager;
+    }
+
+    public FirstJoinSpawnManager getFirstJoinSpawnManager() {
+        return firstJoinSpawnManager;
     }
 
     public PortalManager getPortalManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -210,8 +210,10 @@ public class PlayerJoinQuitListener implements Listener {
         plugin.getPlayerVisibilityManager().handleJoin(player);
 
         if (!player.hasPlayedBefore()) {
+            boolean randomSpawnStarted = plugin.getFirstJoinSpawnManager() != null
+                    && plugin.getFirstJoinSpawnManager().handleFirstJoin(player);
             boolean spawnOnFirstJoin = plugin.getConfigManager().getConfig().getBoolean("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN", true);
-            if (spawnOnFirstJoin && plugin.getSpawnManager().hasSpawn()) {
+            if (!randomSpawnStarted && spawnOnFirstJoin && plugin.getSpawnManager().hasSpawn()) {
                 Location spawn = plugin.getSpawnManager().getSpawnLocation();
                 if (spawn != null) {
                     plugin.getSpigotScheduler().teleport(player, spawn);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FirstJoinSpawnManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FirstJoinSpawnManager.java
@@ -1,0 +1,138 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Drops brand new players at a random location the first time they join instead of
+ * leaving them on the vanilla world spawn. The search reuses the RTP engine directly,
+ * so first joins are never blocked by RTP cooldowns, playtime requirements, or the
+ * RTP queue.
+ */
+public class FirstJoinSpawnManager {
+
+    private final UltimateDonutSmp plugin;
+    private final Set<UUID> pendingTeleports = ConcurrentHashMap.newKeySet();
+
+    private boolean enabled;
+    private boolean fallbackToSpawn;
+    private String searchingMessage;
+    private String successMessage;
+    private String failedMessage;
+
+    public FirstJoinSpawnManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        reloadSettings();
+    }
+
+    public void reloadSettings() {
+        enabled = plugin.getConfigManager().getConfig().getBoolean("FIRST-JOIN-RTP.ENABLED", false);
+        fallbackToSpawn = plugin.getConfigManager().getConfig().getBoolean("FIRST-JOIN-RTP.FALLBACK-TO-SPAWN", true);
+        searchingMessage = plugin.getConfigManager().getConfig().getString("FIRST-JOIN-RTP.SEARCHING-MESSAGE", "");
+        successMessage = plugin.getConfigManager().getConfig().getString("FIRST-JOIN-RTP.SUCCESS-MESSAGE", "");
+        failedMessage = plugin.getConfigManager().getConfig().getString("FIRST-JOIN-RTP.FAILED-MESSAGE", "");
+        pendingTeleports.clear();
+    }
+
+    public boolean isEnabled() {
+        return enabled
+                && plugin.getRtpManager() != null
+                && plugin.getRtpManager().isEnabled();
+    }
+
+    /**
+     * Handles a player joining the server for the very first time.
+     *
+     * @return true when the random spawn search was started and the caller must not run
+     *         the regular spawn teleport, false when the join should fall through to it
+     */
+    public boolean handleFirstJoin(Player player) {
+        if (player == null || !isEnabled()) {
+            return false;
+        }
+
+        UUID uuid = player.getUniqueId();
+        if (!pendingTeleports.add(uuid)) {
+            return true;
+        }
+
+        RTPManager.SearchSettings settings =
+                plugin.getRtpManager().getFirstJoinSearchSettings(player.getWorld().getName());
+        if (settings == null) {
+            pendingTeleports.remove(uuid);
+            return false;
+        }
+
+        sendMessage(player, searchingMessage, null);
+        plugin.getRtpManager().findSafeLocationAsync(settings).whenComplete((destination, throwable) -> {
+            pendingTeleports.remove(uuid);
+            plugin.getSpigotScheduler().runEntity(player, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (throwable != null || destination == null) {
+                    failFirstJoinTeleport(player);
+                    return;
+                }
+                plugin.getSpigotScheduler().teleport(player, destination).thenAccept(success ->
+                        plugin.getSpigotScheduler().runEntity(player, () -> {
+                            if (!player.isOnline()) {
+                                return;
+                            }
+                            if (!Boolean.TRUE.equals(success)) {
+                                failFirstJoinTeleport(player);
+                                return;
+                            }
+                            SoundUtils.play(player, plugin.getConfigManager().getSound("TELEPORT.SUCCESS"));
+                            sendMessage(player, successMessage, destination);
+                        }));
+            });
+        });
+        return true;
+    }
+
+    private void failFirstJoinTeleport(Player player) {
+        sendMessage(player, failedMessage, null);
+        if (fallbackToSpawn) {
+            teleportToSpawn(player);
+        }
+    }
+
+    private void teleportToSpawn(Player player) {
+        if (plugin.getSpawnManager() == null || !plugin.getSpawnManager().hasSpawn()) {
+            return;
+        }
+        Location spawn = plugin.getSpawnManager().getSpawnLocation();
+        if (spawn != null) {
+            plugin.getSpigotScheduler().teleport(player, spawn);
+        }
+    }
+
+    private void sendMessage(Player player, String message, Location location) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        player.sendMessage(ColorUtils.toComponent(applyPlaceholders(message, location)));
+    }
+
+    static String applyPlaceholders(String message, Location location) {
+        if (message == null || message.isBlank()) {
+            return "";
+        }
+        if (location == null) {
+            return message;
+        }
+        return message
+                .replace("{world}", location.getWorld() == null ? "" : location.getWorld().getName())
+                .replace("{x}", String.valueOf(location.getBlockX()))
+                .replace("{y}", String.valueOf(location.getBlockY()))
+                .replace("{z}", String.valueOf(location.getBlockZ()));
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -433,6 +433,34 @@ public class RTPManager {
         );
     }
 
+    public SearchSettings getFirstJoinSearchSettings(String fallbackWorldName) {
+        int minRadius = plugin.getConfigManager().getConfig().getInt("FIRST-JOIN-RTP.WORLD.MIN-RADIUS", 500);
+        int maxRadius = plugin.getConfigManager().getConfig().getInt("FIRST-JOIN-RTP.WORLD.MAX-RADIUS", 5000);
+        int centerX = plugin.getConfigManager().getConfig().getInt("FIRST-JOIN-RTP.WORLD.CENTER-X", 0);
+        int centerZ = plugin.getConfigManager().getConfig().getInt("FIRST-JOIN-RTP.WORLD.CENTER-Z", 0);
+        int maxAttempts = plugin.getConfigManager().getRtp().getInt("SETTINGS.MAX-ATTEMPTS", DEFAULT_MAX_ATTEMPTS);
+        int maxChunkSamples = plugin.getConfigManager().getRtp().getInt("SETTINGS.MAX-CHUNK-SAMPLES", DEFAULT_MAX_CHUNK_SAMPLES);
+        int attemptIntervalTicks = plugin.getConfigManager().getRtp().getInt("SETTINGS.ATTEMPT-INTERVAL-TICKS", DEFAULT_ATTEMPT_INTERVAL_TICKS);
+        String configuredWorld = plugin.getConfigManager().getConfig().getString("FIRST-JOIN-RTP.WORLD.NAME", "");
+        String worldName = normalizeConfiguredWorldName(
+                configuredWorld == null || configuredWorld.isBlank() ? fallbackWorldName : configuredWorld
+        );
+        if (isDeniedWorld(worldName) || !isWorldAvailable(worldName)) {
+            return null;
+        }
+
+        return new SearchSettings(
+                worldName,
+                minRadius,
+                Math.max(minRadius, maxRadius),
+                centerX,
+                centerZ,
+                normalizeSearchLimit(maxAttempts),
+                normalizeChunkSampleLimit(maxChunkSamples),
+                normalizeAttemptInterval(attemptIntervalTicks)
+        );
+    }
+
     public String describeWorld(String worldName) {
         for (RTPDestination destination : configuredDestinations) {
             if (destination.worldName().equalsIgnoreCase(worldName)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -94,6 +94,10 @@ SETTINGS:
   SPAWN-MENU: true
   # Determines whether Afk Menu is enabled or disabled. Available options: true, false
   AFK-MENU: true
+  # Determines whether players are teleported to the spawn location the first time they
+  # join the server. Ignored while First Join Rtp Enabled is true. Available options:
+  # true, false
+  TELEPORT-SPAWN-ON-FIRST-JOIN: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -657,6 +661,40 @@ RTP-ZONE:
     MAX-RADIUS: 2000
   # The numerical value for Title Fade Out Ticks. Available options: Any valid integer
   TITLE-FADE-OUT-TICKS: 10
+# Configuration section for First Join Rtp. Drops brand new players at a random location
+# the first time they join instead of leaving them on the vanilla world spawn. The search
+# ignores RTP cooldowns, playtime requirements, and the RTP queue, but it does require the
+# RTP feature itself to be enabled.
+FIRST-JOIN-RTP:
+  # Determines whether First Join Rtp is enabled or disabled. Takes priority over Settings
+  # Teleport Spawn On First Join. Available options: true, false
+  ENABLED: false
+  # Determines whether the player is sent to the spawn location when no safe random
+  # location can be found. Available options: true, false
+  FALLBACK-TO-SPAWN: true
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to start...'
+  # The text or value for Success Message, sent once the player has been dropped.
+  # Supports {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid
+  # string text
+  SUCCESS-MESSAGE: '&aWelcome! You spawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. Set
+  # to '' to disable. Available options: Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random spawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop new players in. Leave empty to use the world they join in.
+    # Available options: Any valid string text
+    NAME: ''
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
 # Configuration section for Teleport Cooldown.
 TELEPORT-COOLDOWN:
   # The numerical value for Home. Available options: Any valid integer

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/FirstJoinSpawnManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/FirstJoinSpawnManagerTest.java
@@ -1,0 +1,52 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FirstJoinSpawnManagerTest {
+
+    private static YamlConfiguration bundledConfig() {
+        return YamlConfiguration.loadConfiguration(new File("src/main/resources/config.yml"));
+    }
+
+    @Test
+    void bundledConfigShipsFirstJoinRtpDisabledByDefault() {
+        YamlConfiguration config = bundledConfig();
+        assertTrue(config.contains("FIRST-JOIN-RTP.ENABLED"));
+        assertFalse(config.getBoolean("FIRST-JOIN-RTP.ENABLED"));
+        assertTrue(config.getBoolean("FIRST-JOIN-RTP.FALLBACK-TO-SPAWN"));
+        assertEquals("", config.getString("FIRST-JOIN-RTP.WORLD.NAME"));
+        assertEquals(500, config.getInt("FIRST-JOIN-RTP.WORLD.MIN-RADIUS"));
+        assertEquals(5000, config.getInt("FIRST-JOIN-RTP.WORLD.MAX-RADIUS"));
+    }
+
+    @Test
+    void bundledConfigDocumentsTheLegacySpawnOnFirstJoinToggle() {
+        YamlConfiguration config = bundledConfig();
+        assertTrue(config.contains("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN"));
+        assertTrue(config.getBoolean("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN"));
+    }
+
+    @Test
+    void placeholdersUseBlockCoordinatesOfTheDestination() {
+        Location destination = new Location(null, 128.9, 71.0, -64.2);
+        assertEquals(
+                "dropped at X:128 Y:71 Z:-65 in ",
+                FirstJoinSpawnManager.applyPlaceholders("dropped at X:{x} Y:{y} Z:{z} in {world}", destination)
+        );
+    }
+
+    @Test
+    void placeholdersAreLeftUntouchedWithoutADestination() {
+        assertEquals("still searching {x}", FirstJoinSpawnManager.applyPlaceholders("still searching {x}", null));
+        assertEquals("", FirstJoinSpawnManager.applyPlaceholders("", null));
+        assertEquals("", FirstJoinSpawnManager.applyPlaceholders(null, null));
+    }
+}


### PR DESCRIPTION
Closes #129

## What

Adds a `FIRST-JOIN-RTP` section to `config.yml`. When enabled, a player joining for the very first time is dropped at a random location instead of being left on the vanilla world spawn near `0, 0`.

```yaml
FIRST-JOIN-RTP:
  ENABLED: false
  FALLBACK-TO-SPAWN: true
  SEARCHING-MESSAGE: '&7Finding you a safe place to start...'
  SUCCESS-MESSAGE: '&aWelcome! You spawned at &fX:{x} Y:{y} Z:{z}&a.'
  FAILED-MESSAGE: '&cCould not find a random spawn location for you.'
  WORLD:
    NAME: ''
    CENTER-X: 0
    CENTER-Z: 0
    MIN-RADIUS: 500
    MAX-RADIUS: 5000
```

Placeholders on `SUCCESS-MESSAGE`: `{world}`, `{x}`, `{y}`, `{z}`. An empty message string stays silent.

This also surfaces `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` in `config.yml`. The key already worked, but it only ever existed as a code default in `PlayerJoinQuitListener`, so no admin could discover it — which is a large part of why the issue reads as "you just spawn at ~0 0 0". It only fires once `/setspawn` has been run; without a spawn set, the join fell through silently.

## Design decisions

- **The search bypasses every RTP gate.** A first join goes through the no-player `findSafeLocationAsync(SearchSettings)` overload, so cooldowns, the priority queue and `REQUIRED-PLAYTIME-HOURS` do not apply. Routing it through the normal `/rtp` path would have failed by construction: a brand new player has 0h playtime, so any world with a playtime requirement would reject them.
- **Denied and unavailable worlds refuse to produce settings.** `getFirstJoinSearchSettings` returns `null` for anything in `DENIED-WORLDS` or not loadable, and the join then falls through to the ordinary spawn teleport. This is what stops a new player being scattered inside a lobby, hub or AFK world when another plugin puts them there on join.
- **`ENABLED` wins over `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN`.** Two first-join teleports firing at once would race, so precedence is explicit rather than emergent.
- **The feature still requires RTP to be enabled**, same as `RTP-ZONE`. With RTP off the join falls back to the spawn teleport instead of doing nothing.
- **`FAILED-MESSAGE` does not promise a spawn teleport.** `FALLBACK-TO-SPAWN` is silent because it cannot do anything when no spawn has been set, and a message claiming otherwise would be wrong on exactly the servers hitting this issue.
- **Ships `ENABLED: false`.** The config updater inserts new bundled keys into existing configs, and this changes where every future player starts — it should not switch itself on during an upgrade.

## Implementation notes

- `FirstJoinSpawnManager` follows the `RTPZoneManager` shape: settings cached on `reloadSettings()`, a `pendingTeleports` guard, async search, then `runEntity` + `SpigotScheduler.teleport`. It is registered in the plugin's manager list and re-read by the existing reload path.
- `handleFirstJoin` returns a boolean so the listener knows whether the ordinary spawn teleport still has to run, rather than the listener having to re-derive the config state.
- Radius and center live under `FIRST-JOIN-RTP.WORLD` rather than reusing `rtp.yml`, matching how `RTP-ZONE` carries its own bounds — a first-join drop usually wants a different spread than `/rtp`. Attempt budgets, chunk sampling and generation behaviour stay shared with `/rtp` in `rtp.yml`.
- `WORLD.NAME: ''` resolves to the world the player joined in, so the default works without knowing the server's `level-name`.

## Tests

`FirstJoinSpawnManagerTest` — 4 cases covering the bundled defaults, the newly exposed `TELEPORT-SPAWN-ON-FIRST-JOIN` key, block-coordinate placeholder substitution, and messages left untouched when there is no destination yet.

Full suite: 166 tests, all passing.