### PR TITLE
feat(rtp): give each rank its own cooldown via permissions (#131)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -107,6 +107,29 @@ This page contains the complete reference guide for all commands, aliases, synta
 
 ---
 
+## RTP Rank Permissions
+
+These nodes are not registered in `plugin.yml` and are read straight off the player, so they work with
+LuckPerms or any other permission plugin. Assign them per rank.
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.rtp.cooldown.<seconds>` | `false` | Override the `/rtp` cooldown for this player, in seconds. `ultimatedonutsmp.rtp.cooldown.3` gives a 3 second cooldown, and `ultimatedonutsmp.rtp.cooldown.0` removes the cooldown entirely. |
+| `ultimatedonutsmp.rtp.priority.<weight>` | `false` | Position in the RTP waiting queue when all slots are busy. Higher weight is served first. |
+
+When a player holds more than one cooldown node the **lowest** value wins, so stacked ranks always give
+the player the fastest cooldown they are entitled to. A player with no cooldown node falls back to the
+per-world `WORLD-SETTINGS.<world>.COOLDOWN` value in `rtp.yml`.
+
+Named rank nodes can be mapped to a cooldown instead of using numeric nodes. See
+`SETTINGS.RANK-COOLDOWNS.PERMISSIONS` in [Config-rtp.yml](Config-rtp.yml) — the shipped defaults map
+`ultimatedonutsmp.rtp.cooldown.vip`, `.vip+` and `.vip++` to 15, 10 and 3 seconds.
+
+Set `SETTINGS.RANK-COOLDOWNS.ENABLED: false` in `rtp.yml` to ignore every cooldown permission and use
+the per-world value for everyone.
+
+---
+
 ## Media Rank & Badge Permissions
 
 Media permissions are registered with `default: false` and require explicit assignment via LuckPerms (or explicit permission attachment). Being an OP player does not automatically grant media badge status.

--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -110,6 +110,81 @@ SETTINGS:
 
 ---
 
+## Section: `SETTINGS.RANK-COOLDOWNS`
+
+Per-rank `/rtp` cooldowns resolved from permissions, so different ranks can have different cooldowns
+without a separate config entry per rank.
+
+### 1. Commented Setup Code Example
+
+```yaml
+  # Per-rank RTP cooldown overrides resolved from permissions
+  RANK-COOLDOWNS:
+    # Enable or disable permission based RTP cooldown overrides
+    ENABLED: true
+    # Explicit mapping from permission node to RTP cooldown in seconds
+    # Players can also be given ultimatedonutsmp.rtp.cooldown.<seconds> directly, for example
+    # ultimatedonutsmp.rtp.cooldown.3 for a 3 second cooldown
+    # The lowest value the player has wins, and 0 removes the cooldown entirely
+    # Players without any of these permissions keep the per-world COOLDOWN below
+    PERMISSIONS:
+      "ultimatedonutsmp.rtp.cooldown.vip++": 3
+      "ultimatedonutsmp.rtp.cooldown.vip+": 10
+      "ultimatedonutsmp.rtp.cooldown.vip": 15
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SETTINGS.RANK-COOLDOWNS.ENABLED` | `bool` | `true`, `false` | `true` | Master toggle. When `false` every player uses the per-world `WORLD-SETTINGS.<world>.COOLDOWN` value and all cooldown permissions are ignored. |
+| `SETTINGS.RANK-COOLDOWNS.PERMISSIONS` | `section` | Permission node to seconds | See example | Maps an arbitrary permission node to an RTP cooldown in seconds. Use this to reuse rank nodes you already have instead of adding numeric nodes. |
+
+### 3. Resolution Order
+
+1. Every entry under `PERMISSIONS` the player holds is collected.
+2. Every `ultimatedonutsmp.rtp.cooldown.<seconds>` node the player holds is collected. A non-numeric or
+   negative suffix is ignored.
+3. The **lowest** collected value becomes the player cooldown, so stacked ranks always give the player
+   the fastest cooldown they are entitled to.
+4. If the player holds none of these nodes, the per-world `WORLD-SETTINGS.<world>.COOLDOWN` value applies.
+
+A permission value fully replaces the per-world value, in both directions. `ultimatedonutsmp.rtp.cooldown.60`
+gives a 60 second cooldown even where the world is configured at 30, and `ultimatedonutsmp.rtp.cooldown.0`
+removes the cooldown entirely.
+
+The cooldown is evaluated on every `/rtp` attempt rather than frozen when the previous teleport finished,
+so a rank change applies immediately, including to a cooldown already counting down.
+
+### 4. Practical Setup Example
+
+Give the default rank a 60 second cooldown, VIP 15 seconds and staff no cooldown at all:
+
+```yaml
+SETTINGS:
+  RANK-COOLDOWNS:
+    ENABLED: true
+    PERMISSIONS:
+      "group.vip": 15
+      "group.staff": 0
+
+WORLD-SETTINGS:
+  world:
+    COOLDOWN: 60
+```
+
+Or skip the config entirely and drive it from LuckPerms alone:
+
+```
+/lp group default permission set ultimatedonutsmp.rtp.cooldown.60
+/lp group vip permission set ultimatedonutsmp.rtp.cooldown.15
+/lp group staff permission set ultimatedonutsmp.rtp.cooldown.0
+```
+
+The `{cooldown}` placeholder in the RTP menu shows the viewing player their own resolved cooldown.
+
+---
+
 ## Section: `MESSAGES`
 
 ### 1. Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1843,6 +1843,15 @@ public class ConfigManager {
             return true;
         }
 
+        // Rank cooldown permission entries are live server content keyed by the ranks a server
+        // actually runs, so the bundled vip examples must not be merged back after admins delete
+        // or replace them. The RANK-COOLDOWNS section itself stays mergeable so configs that
+        // predate the feature still receive it once.
+        if ("rtp.yml".equals(resourceName)
+                && path.startsWith("SETTINGS.RANK-COOLDOWNS.PERMISSIONS.")) {
+            return true;
+        }
+
         // Network server entries can be expanded per deployment.
         if ("network.yml".equals(resourceName)
                 && path.startsWith("NETWORK-STATUS.SERVERS.")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -88,6 +87,7 @@ public class RTPManager {
     private static final String PRELOAD_MAX_TICKS_SETTING = "SETTINGS.PRELOAD-MAX-TICKS";
     private static final String POST_TELEPORT_CHUNK_THROTTLE_SETTING = "SETTINGS.POST-TELEPORT-CHUNK-THROTTLE";
     private static final String POST_TELEPORT_VIEW_DISTANCE_SETTING = "SETTINGS.POST-TELEPORT-VIEW-DISTANCE";
+    private static final String COOLDOWN_PERMISSION_PREFIX = "ultimatedonutsmp.rtp.cooldown.";
     private static final int DEFAULT_GENERATE_FALLBACK_AFTER_SAMPLES = 32;
     private static final int DEFAULT_MAX_GENERATE_FALLBACK_SAMPLES = 32;
 
@@ -123,7 +123,7 @@ public class RTPManager {
             .thenComparingLong(RTPQueueEntry::queueTimeMillis);
 
     private final UltimateDonutSmp plugin;
-    private final Map<UUID, Map<String, Long>> cooldownsByPlayer = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<String, Long>> lastRtpUseByPlayer = new ConcurrentHashMap<>();
     private final Map<UUID, BukkitTask> activeSearchTasks = new ConcurrentHashMap<>();
     private final Map<UUID, BukkitTask> activeResultTasks = new ConcurrentHashMap<>();
     private final Map<UUID, CompletableFuture<Location>> activeDirectSearches = new ConcurrentHashMap<>();
@@ -142,7 +142,7 @@ public class RTPManager {
     public void reload() {
         clearAllSearches();
         clearQueue();
-        cooldownsByPlayer.clear();
+        lastRtpUseByPlayer.clear();
         locationPreCache.clear();
         preCacheInFlight.clear();
         configuredDestinations = loadConfiguredDestinations();
@@ -381,6 +381,63 @@ public class RTPManager {
     public int getWorldCooldownSeconds(String worldName) {
         ConfigurationSection settings = getWorldSettingsSection(worldName);
         return settings == null ? 0 : Math.max(0, settings.getInt("COOLDOWN", 0));
+    }
+
+    public boolean isRankCooldownsEnabled() {
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return true;
+        }
+        return plugin.getConfigManager().getRtp().getBoolean("SETTINGS.RANK-COOLDOWNS.ENABLED", true);
+    }
+
+    public int getPlayerCooldownSeconds(Player player, String worldName) {
+        int worldCooldown = getWorldCooldownSeconds(worldName);
+        if (player == null || !isRankCooldownsEnabled()) {
+            return worldCooldown;
+        }
+
+        int lowest = Integer.MAX_VALUE;
+
+        ConfigurationSection rtpConfig = plugin == null || plugin.getConfigManager() == null
+                ? null
+                : plugin.getConfigManager().getRtp();
+        ConfigurationSection section = rtpConfig == null
+                ? null
+                : rtpConfig.getConfigurationSection("SETTINGS.RANK-COOLDOWNS.PERMISSIONS");
+        if (section != null) {
+            Map<String, Object> values = section.getValues(true);
+            for (Map.Entry<String, Object> entry : values.entrySet()) {
+                if (entry.getValue() instanceof Number number) {
+                    String permNode = entry.getKey();
+                    if (player.hasPermission(permNode)) {
+                        int val = Math.max(0, number.intValue());
+                        if (val < lowest) {
+                            lowest = val;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (org.bukkit.permissions.PermissionAttachmentInfo pai : player.getEffectivePermissions()) {
+            String perm = pai.getPermission();
+            if (perm == null || !pai.getValue()) {
+                continue;
+            }
+            String normalized = perm.toLowerCase(Locale.ROOT);
+            if (!normalized.startsWith(COOLDOWN_PERMISSION_PREFIX)) {
+                continue;
+            }
+            try {
+                int val = Integer.parseInt(normalized.substring(COOLDOWN_PERMISSION_PREFIX.length()).trim());
+                if (val >= 0 && val < lowest) {
+                    lowest = val;
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return lowest == Integer.MAX_VALUE ? worldCooldown : lowest;
     }
 
     public SearchSettings getWorldSearchSettings(String worldName) {
@@ -865,7 +922,7 @@ public class RTPManager {
             return false;
         }
 
-        long cooldownRemaining = getCooldownRemainingMillis(player.getUniqueId(), worldName);
+        long cooldownRemaining = getCooldownRemainingMillis(player, worldName);
         if (cooldownRemaining > 0L) {
             long remainingSeconds = Math.max(1L, (long) Math.ceil(cooldownRemaining / 1000.0D));
             String message = plugin.getConfigManager().getRtp()
@@ -1138,7 +1195,7 @@ public class RTPManager {
     }
 
     private void finishSearch(Player player, String worldName, Location found) {
-        applyCooldown(player.getUniqueId(), worldName);
+        markRtpUsed(player.getUniqueId(), worldName);
 
         String foundMessage = plugin.getConfigManager().getRtp()
                 .getString("MESSAGES.SAFE-LOCATION-FOUND", "&aѕᴀꜰᴇ ʟᴏᴄᴀᴛɪᴏɴ ꜰᴏᴜɴᴅ ᴀᴛ: x:{x} ʏ:{y} ᴢ:{z}")
@@ -2012,37 +2069,44 @@ public class RTPManager {
                 .trim();
     }
 
-    private long getCooldownRemainingMillis(UUID playerId, String worldName) {
-        Map<String, Long> cooldowns = cooldownsByPlayer.get(playerId);
-        if (cooldowns == null) {
+    private long getCooldownRemainingMillis(Player player, String worldName) {
+        if (player == null) {
+            return 0L;
+        }
+
+        UUID playerId = player.getUniqueId();
+        Map<String, Long> lastUses = lastRtpUseByPlayer.get(playerId);
+        if (lastUses == null) {
             return 0L;
         }
 
         String key = normalizeWorldKey(worldName);
-        Long expiresAt = cooldowns.get(key);
-        if (expiresAt == null) {
+        Long lastUsedAt = lastUses.get(key);
+        if (lastUsedAt == null) {
             return 0L;
         }
 
-        long remaining = expiresAt - System.currentTimeMillis();
+        int cooldownSeconds = getPlayerCooldownSeconds(player, worldName);
+        long remaining = cooldownSeconds <= 0
+                ? 0L
+                : (lastUsedAt + (cooldownSeconds * 1000L)) - System.currentTimeMillis();
         if (remaining <= 0L) {
-            cooldowns.remove(key);
-            if (cooldowns.isEmpty()) {
-                cooldownsByPlayer.remove(playerId);
+            lastUses.remove(key);
+            if (lastUses.isEmpty()) {
+                lastRtpUseByPlayer.remove(playerId);
             }
             return 0L;
         }
         return remaining;
     }
 
-    private void applyCooldown(UUID playerId, String worldName) {
-        int cooldownSeconds = getWorldCooldownSeconds(worldName);
-        if (cooldownSeconds <= 0) {
+    private void markRtpUsed(UUID playerId, String worldName) {
+        if (playerId == null) {
             return;
         }
 
-        cooldownsByPlayer.computeIfAbsent(playerId, ignored -> new HashMap<>())
-                .put(normalizeWorldKey(worldName), System.currentTimeMillis() + (cooldownSeconds * 1000L));
+        lastRtpUseByPlayer.computeIfAbsent(playerId, ignored -> new ConcurrentHashMap<>())
+                .put(normalizeWorldKey(worldName), System.currentTimeMillis());
     }
 
     private boolean isQueueFull(UUID playerId) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/RTPMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/RTPMenu.java
@@ -79,7 +79,7 @@ public class RTPMenu extends BaseMenu {
                 .replace("{min_radius}", minRadius)
                 .replace("{max_radius}", maxRadius)
                 .replace("{required_playtime}", reqPlaytimeStr)
-                .replace("{cooldown}", String.valueOf(plugin.getRtpManager().getWorldCooldownSeconds(destination.worldName())))
+                .replace("{cooldown}", String.valueOf(plugin.getRtpManager().getPlayerCooldownSeconds(player, destination.worldName())))
                 .replace("{status}", destination.enabled() ? "&aᴇɴᴀʙʟᴇᴅ" : "&cᴅɪѕᴀʙʟᴇᴅ");
     }
 

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -43,6 +43,19 @@ SETTINGS:
       "ultimatedonutsmp.rtp.priority.vip+": 20
       "ultimatedonutsmp.rtp.priority.vip": 10
       "ultimatedonutsmp.rtp.priority.high": 5
+  # Per-rank RTP cooldown overrides resolved from permissions
+  RANK-COOLDOWNS:
+    # Enable or disable permission based RTP cooldown overrides
+    ENABLED: true
+    # Explicit mapping from permission node to RTP cooldown in seconds
+    # Players can also be given ultimatedonutsmp.rtp.cooldown.<seconds> directly, for example
+    # ultimatedonutsmp.rtp.cooldown.3 for a 3 second cooldown
+    # The lowest value the player has wins, and 0 removes the cooldown entirely
+    # Players without any of these permissions keep the per-world COOLDOWN below
+    PERMISSIONS:
+      "ultimatedonutsmp.rtp.cooldown.vip++": 3
+      "ultimatedonutsmp.rtp.cooldown.vip+": 10
+      "ultimatedonutsmp.rtp.cooldown.vip": 15
 
 # User feedback and status messages
 MESSAGES:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPRankCooldownTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPRankCooldownTest.java
@@ -1,0 +1,251 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RTPRankCooldownTest {
+
+    private Server originalServer;
+    private Server mockServer;
+    private org.bukkit.World mockWorld;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalServer = Bukkit.getServer();
+
+        mockWorld = (org.bukkit.World) Proxy.newProxyInstance(
+                org.bukkit.World.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.World.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getName")) {
+                        return "world";
+                    }
+                    if (method.getName().equals("getEnvironment")) {
+                        return org.bukkit.World.Environment.NORMAL;
+                    }
+                    return null;
+                }
+        );
+
+        mockServer = (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getWorlds")) {
+                        return List.of(mockWorld);
+                    }
+                    if (method.getName().equals("getWorld")) {
+                        return mockWorld;
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("Minecraft");
+                    }
+                    return null;
+                }
+        );
+
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, mockServer);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, originalServer);
+    }
+
+    private UltimateDonutSmp createMockPlugin(YamlConfiguration rtpConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+        Constructor<?> newConstructor = reflectionFactory.newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) newConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        Field rtpField = ConfigManager.class.getDeclaredField("rtp");
+        rtpField.setAccessible(true);
+        rtpField.set(configManager, rtpConfig);
+
+        Field configField = ConfigManager.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(configManager, new YamlConfiguration());
+
+        Field soundsField = ConfigManager.class.getDeclaredField("sounds");
+        soundsField.setAccessible(true);
+        soundsField.set(configManager, new YamlConfiguration());
+
+        Field cmField = UltimateDonutSmp.class.getDeclaredField("configManager");
+        cmField.setAccessible(true);
+        cmField.set(plugin, configManager);
+
+        FeatureManager featureManager = new FeatureManager(plugin);
+        Field fmField = UltimateDonutSmp.class.getDeclaredField("featureManager");
+        fmField.setAccessible(true);
+        fmField.set(plugin, featureManager);
+
+        TeleportManager teleportManager = new TeleportManager(plugin);
+        Field tmField = UltimateDonutSmp.class.getDeclaredField("teleportManager");
+        tmField.setAccessible(true);
+        tmField.set(plugin, teleportManager);
+
+        return plugin;
+    }
+
+    private Player createMockPlayer(UUID uuid, String name, Set<String> permissions) {
+        final Player[] playerHolder = new Player[1];
+        Player playerProxy = (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return uuid;
+                    }
+                    if (method.getName().equals("getName")) {
+                        return name;
+                    }
+                    if (method.getName().equals("hasPermission")) {
+                        String perm = (String) args[0];
+                        return permissions.contains(perm.toLowerCase(Locale.ROOT));
+                    }
+                    if (method.getName().equals("getEffectivePermissions")) {
+                        Set<PermissionAttachmentInfo> effective = new HashSet<>();
+                        for (String perm : permissions) {
+                            effective.add(new PermissionAttachmentInfo(playerHolder[0], perm, null, true));
+                        }
+                        return effective;
+                    }
+                    if (method.getName().equals("sendMessage")) {
+                        return null;
+                    }
+                    if (method.getName().equals("isOnline")) {
+                        return true;
+                    }
+                    return null;
+                }
+        );
+        playerHolder[0] = playerProxy;
+        return playerProxy;
+    }
+
+    private YamlConfiguration baseConfig() {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+        rtpConfig.set("WORLD-SETTINGS.world.COOLDOWN", 30);
+        rtpConfig.set("SETTINGS.RANK-COOLDOWNS.ENABLED", true);
+        rtpConfig.set("SETTINGS.RANK-COOLDOWNS.PERMISSIONS.ultimatedonutsmp.rtp.cooldown.vip++", 3);
+        rtpConfig.set("SETTINGS.RANK-COOLDOWNS.PERMISSIONS.ultimatedonutsmp.rtp.cooldown.vip+", 10);
+        rtpConfig.set("SETTINGS.RANK-COOLDOWNS.PERMISSIONS.ultimatedonutsmp.rtp.cooldown.vip", 15);
+        return rtpConfig;
+    }
+
+    @Test
+    void testWorldCooldownUsedWithoutPermissions() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+        Player regular = createMockPlayer(UUID.randomUUID(), "Regular", Set.of());
+
+        assertEquals(30, rtpManager.getPlayerCooldownSeconds(regular, "world"));
+        assertEquals(30, rtpManager.getWorldCooldownSeconds("world"));
+    }
+
+    @Test
+    void testCooldownResolvedFromConfiguredPermissionMap() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player vip = createMockPlayer(UUID.randomUUID(), "VIP", Set.of("ultimatedonutsmp.rtp.cooldown.vip"));
+        Player vipPlus = createMockPlayer(UUID.randomUUID(), "VIPPlus", Set.of("ultimatedonutsmp.rtp.cooldown.vip+"));
+        Player vipPlusPlus = createMockPlayer(UUID.randomUUID(), "VIPPlusPlus", Set.of("ultimatedonutsmp.rtp.cooldown.vip++"));
+
+        assertEquals(15, rtpManager.getPlayerCooldownSeconds(vip, "world"));
+        assertEquals(10, rtpManager.getPlayerCooldownSeconds(vipPlus, "world"));
+        assertEquals(3, rtpManager.getPlayerCooldownSeconds(vipPlusPlus, "world"));
+    }
+
+    @Test
+    void testCooldownResolvedFromNumberedPermission() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player numeric = createMockPlayer(UUID.randomUUID(), "Numeric", Set.of("ultimatedonutsmp.rtp.cooldown.7"));
+        assertEquals(7, rtpManager.getPlayerCooldownSeconds(numeric, "world"));
+    }
+
+    @Test
+    void testLowestValueWinsAcrossStackedPermissions() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player stacked = createMockPlayer(UUID.randomUUID(), "Stacked", Set.of(
+                "ultimatedonutsmp.rtp.cooldown.vip",
+                "ultimatedonutsmp.rtp.cooldown.vip+",
+                "ultimatedonutsmp.rtp.cooldown.5"
+        ));
+        assertEquals(5, rtpManager.getPlayerCooldownSeconds(stacked, "world"));
+    }
+
+    @Test
+    void testPermissionOverridesWorldCooldownInBothDirections() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player slower = createMockPlayer(UUID.randomUUID(), "Slower", Set.of("ultimatedonutsmp.rtp.cooldown.60"));
+        assertEquals(60, rtpManager.getPlayerCooldownSeconds(slower, "world"));
+
+        Player faster = createMockPlayer(UUID.randomUUID(), "Faster", Set.of("ultimatedonutsmp.rtp.cooldown.5"));
+        assertEquals(5, rtpManager.getPlayerCooldownSeconds(faster, "world"));
+    }
+
+    @Test
+    void testZeroPermissionRemovesCooldownEntirely() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player bypass = createMockPlayer(UUID.randomUUID(), "Bypass", Set.of("ultimatedonutsmp.rtp.cooldown.0"));
+        assertEquals(0, rtpManager.getPlayerCooldownSeconds(bypass, "world"));
+    }
+
+    @Test
+    void testMalformedNumberedPermissionIsIgnored() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+
+        Player malformed = createMockPlayer(UUID.randomUUID(), "Malformed", Set.of(
+                "ultimatedonutsmp.rtp.cooldown.abc",
+                "ultimatedonutsmp.rtp.cooldown.-5",
+                "ultimatedonutsmp.rtp.cooldown."
+        ));
+        assertEquals(30, rtpManager.getPlayerCooldownSeconds(malformed, "world"));
+    }
+
+    @Test
+    void testDisabledRankCooldownsFallBackToWorldSetting() throws Exception {
+        YamlConfiguration rtpConfig = baseConfig();
+        rtpConfig.set("SETTINGS.RANK-COOLDOWNS.ENABLED", false);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+
+        Player vipPlusPlus = createMockPlayer(UUID.randomUUID(), "VIPPlusPlus", Set.of(
+                "ultimatedonutsmp.rtp.cooldown.vip++",
+                "ultimatedonutsmp.rtp.cooldown.1"
+        ));
+        assertFalse(rtpManager.isRankCooldownsEnabled());
+        assertEquals(30, rtpManager.getPlayerCooldownSeconds(vipPlusPlus, "world"));
+    }
+
+    @Test
+    void testNullPlayerFallsBackToWorldSetting() throws Exception {
+        RTPManager rtpManager = new RTPManager(createMockPlugin(baseConfig()));
+        assertEquals(30, rtpManager.getPlayerCooldownSeconds(null, "world"));
+    }
+}


### PR DESCRIPTION
Closes #131

## Summary

`/rtp` cooldown was a single per-world number, so every rank waited the same amount of time. This resolves the cooldown from the player's permissions instead, falling back to the per-world value when the player has none.

Implemented against the Bukkit permission API rather than the LuckPerms API, so it works with any permission plugin. It follows the same shape as the existing `ultimatedonutsmp.rtp.priority.<n>` resolution already in `RTPManager`.

## How it resolves

1. Every entry under `SETTINGS.RANK-COOLDOWNS.PERMISSIONS` the player holds is collected.
2. Every `ultimatedonutsmp.rtp.cooldown.<seconds>` node the player holds is collected. Non-numeric and negative suffixes are ignored.
3. The **lowest** collected value wins, so stacked ranks always give a player the fastest cooldown they are entitled to.
4. With no matching node, the per-world `WORLD-SETTINGS.<world>.COOLDOWN` value applies as before.

A permission value fully replaces the per-world value in both directions: `ultimatedonutsmp.rtp.cooldown.60` gives a 60s cooldown even where the world is set to 30, and `ultimatedonutsmp.rtp.cooldown.0` removes the cooldown entirely — no separate bypass node needed.

## Changes

- `RTPManager` — new `getPlayerCooldownSeconds(Player, String)` and `isRankCooldownsEnabled()`.
- `RTPManager` — the cooldown store now records *when* a player last used RTP instead of a baked-in expiry timestamp, and the remaining time is computed against the player's current effective cooldown. A rank change therefore applies immediately, including to a cooldown already counting down.
- `RTPMenu` — the `{cooldown}` placeholder now shows the viewing player their own resolved cooldown instead of the world default.
- `rtp.yml` — new `SETTINGS.RANK-COOLDOWNS` block with an `ENABLED` toggle and a permission-to-seconds map, mirroring the existing `SETTINGS.PRIORITY-QUEUE` layout.
- `ConfigManager` — `SETTINGS.RANK-COOLDOWNS.PERMISSIONS.*` marked user-managed so the config updater does not restore the bundled vip examples after an admin deletes or replaces them.
- Wiki — documented the new config section and the permission nodes.

## Config

```yaml
SETTINGS:
  RANK-COOLDOWNS:
    ENABLED: true
    PERMISSIONS:
      "ultimatedonutsmp.rtp.cooldown.vip++": 3
      "ultimatedonutsmp.rtp.cooldown.vip+": 10
      "ultimatedonutsmp.rtp.cooldown.vip": 15
```

Or drive it from LuckPerms alone:

```
/lp group default permission set ultimatedonutsmp.rtp.cooldown.60
/lp group vip permission set ultimatedonutsmp.rtp.cooldown.15
/lp group staff permission set ultimatedonutsmp.rtp.cooldown.0
```

Set `SETTINGS.RANK-COOLDOWNS.ENABLED: false` to ignore every cooldown permission and use the per-world value for everyone.

## Testing

New `RTPRankCooldownTest` covers 9 cases: world fallback, the config permission map, numbered nodes, lowest-wins across stacked ranks, override in both directions, the `0` bypass, malformed suffixes, the disabled toggle, and a null player.

`mvn test` — 175 tests, 0 failures.

## Compatibility

Existing configs keep working unchanged. Servers that set no cooldown permissions see identical behaviour to before.