### PR TITLE
feat(enderchest): give each rank its own chest size via permissions (#132)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -130,6 +130,33 @@ the per-world value for everyone.
 
 ---
 
+## Ender Chest Size Permissions
+
+These nodes are not registered in `plugin.yml` and are read straight off the player, so they work with
+LuckPerms or any other permission plugin. Assign them per rank.
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.enderchest.rows.<1-6>` | `false` | Size of the player's Ender Chest, in rows. `ultimatedonutsmp.enderchest.rows.3` gives 27 slots, the same as a vanilla Ender Chest, and `ultimatedonutsmp.enderchest.rows.6` gives the full 54. |
+
+One row is 9 slots, so the six tiers are 9, 18, 27, 36, 45 and 54 slots. When a player holds more than
+one node the **highest** value wins, so a player with both `.rows.2` and `.rows.5` gets 45 slots. A
+value above 6 is treated as 6. A player with no row node falls back to `ENDER-CHEST.DEFAULT-ROWS` in
+`ender-chest.yml`, which ships as 6 — lower it if you want these permissions to hand out bigger chests
+as a rank perk.
+
+Wildcards do not grant a tier. `ultimatedonutsmp.*` leaves the player on the default size, the same way
+it does for `ultimatedonutsmp.homes.<amount>`, so a staff wildcard cannot quietly resize everyone.
+
+Named rank nodes can be mapped to a row count instead of using numeric nodes. See
+`ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS` in [Config-ender-chest.yml](Config-ender-chest.yml) — the
+shipped defaults map `ultimatedonutsmp.enderchest.rows.vip`, `.vip+` and `.vip++` to 4, 5 and 6 rows.
+
+Set `ENDER-CHEST.ROW-PERMISSIONS.ENABLED: false` in `ender-chest.yml` to ignore every row permission
+and give everyone `DEFAULT-ROWS`.
+
+---
+
 ## Media Rank & Badge Permissions
 
 Media permissions are registered with `default: false` and require explicit assignment via LuckPerms (or explicit permission attachment). Being an OP player does not automatically grant media badge status.

--- a/docs/wiki/Config-ender-chest.yml.md
+++ b/docs/wiki/Config-ender-chest.yml.md
@@ -13,7 +13,10 @@ Each section details the exact commented setup code block, allowed option values
 ENDER-CHEST:
   # Determines whether Enabled is enabled or disabled. Available options: true, false
   ENABLED: true
-  # The numerical value for Default Rows. Available options: Any valid integer
+  # Rows every player gets when no ROW-PERMISSIONS entry applies to them
+  # 6 rows is 54 slots, already the largest a chest can be, so lower this if you want
+  # ROW-PERMISSIONS below to hand out bigger chests as a rank perk
+  # Available options: 1 to 6
   DEFAULT-ROWS: 6
   TITLE: '&5Ender Chest'
   # Determines whether Intercept Vanilla Open is enabled or disabled. Available options: true, false
@@ -26,6 +29,25 @@ ENDER-CHEST:
   PERMISSION: ultimatedonutsmp.enderchest
   # The numerical value for Auto Save Ticks. Available options: Any valid integer
   AUTO-SAVE-TICKS: 1200
+  # Per-rank Ender Chest size resolved from permissions
+  ROW-PERMISSIONS:
+    # Enable or disable permission based Ender Chest sizes
+    ENABLED: true
+    # What happens when a player's permissions no longer cover the size their chest was saved at,
+    # for example after a rank expires
+    # KEEP-SIZE keeps the chest at the larger size so nothing can be lost
+    # RETURN-ITEMS shrinks the chest and hands back everything that no longer fits
+    # Available options: KEEP-SIZE, RETURN-ITEMS
+    ON-DOWNGRADE: KEEP-SIZE
+    # Explicit mapping from permission node to Ender Chest rows
+    # Players can also be given ultimatedonutsmp.enderchest.rows.<1-6> directly, for example
+    # ultimatedonutsmp.enderchest.rows.4 for a 36 slot chest
+    # The highest value the player has wins
+    # Players without any of these permissions keep DEFAULT-ROWS above
+    PERMISSIONS:
+      "ultimatedonutsmp.enderchest.rows.vip++": 6
+      "ultimatedonutsmp.enderchest.rows.vip+": 5
+      "ultimatedonutsmp.enderchest.rows.vip": 4
   # Configuration section for Ecsee.
   ECSEE:
     # Determines whether Enabled is enabled or disabled. Available options: true, false
@@ -43,7 +65,7 @@ ENDER-CHEST:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `ENDER-CHEST.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `ENDER-CHEST` system. Set to `true` to enable, `false` to disable. |
-| `ENDER-CHEST.DEFAULT-ROWS` | `int` | Any valid integer number | `'6'` | Configures the technical `DEFAULT-ROWS` parameter for `ENDER-CHEST.DEFAULT-ROWS` in `ender-chest.yml`. |
+| `ENDER-CHEST.DEFAULT-ROWS` | `int` | `1` to `6` | `'6'` | Rows every player gets when no `ROW-PERMISSIONS` entry applies to them. One row is 9 slots, so `6` is 54 slots, already the largest a chest can be. Lower it if you want `ROW-PERMISSIONS` to hand out bigger chests as a rank perk. |
 | `ENDER-CHEST.TITLE` | `str` | Any string text | `'&5Ender Chest'` | Configures the technical `TITLE` parameter for `ENDER-CHEST.TITLE` in `ender-chest.yml`. |
 | `ENDER-CHEST.INTERCEPT-VANILLA-OPEN` | `bool` | `true`, `false` | `true` | Configures the technical `INTERCEPT-VANILLA-OPEN` parameter for `ENDER-CHEST.INTERCEPT-VANILLA-OPEN` in `ender-chest.yml`. |
 | `ENDER-CHEST.ALLOW-COMMAND` | `bool` | `true`, `false` | `true` | Configures the technical `ALLOW-COMMAND` parameter for `ENDER-CHEST.ALLOW-COMMAND` in `ender-chest.yml`. |
@@ -61,7 +83,10 @@ ENDER-CHEST:
 ENDER-CHEST:
   # Determines whether Enabled is enabled or disabled. Available options: true, false
   ENABLED: true
-  # The numerical value for Default Rows. Available options: Any valid integer
+  # Rows every player gets when no ROW-PERMISSIONS entry applies to them
+  # 6 rows is 54 slots, already the largest a chest can be, so lower this if you want
+  # ROW-PERMISSIONS below to hand out bigger chests as a rank perk
+  # Available options: 1 to 6
   DEFAULT-ROWS: 6
   TITLE: '&5Ender Chest'
   # Determines whether Intercept Vanilla Open is enabled or disabled. Available options: true, false
@@ -74,11 +99,135 @@ ENDER-CHEST:
   PERMISSION: ultimatedonutsmp.enderchest
   # The numerical value for Auto Save Ticks. Available options: Any valid integer
   AUTO-SAVE-TICKS: 1200
+  # Per-rank Ender Chest size resolved from permissions
+  ROW-PERMISSIONS:
+    # Enable or disable permission based Ender Chest sizes
+    ENABLED: true
+    # What happens when a player's permissions no longer cover the size their chest was saved at,
+    # for example after a rank expires
+    # KEEP-SIZE keeps the chest at the larger size so nothing can be lost
+    # RETURN-ITEMS shrinks the chest and hands back everything that no longer fits
+    # Available options: KEEP-SIZE, RETURN-ITEMS
+    ON-DOWNGRADE: KEEP-SIZE
+    # Explicit mapping from permission node to Ender Chest rows
+    # Players can also be given ultimatedonutsmp.enderchest.rows.<1-6> directly, for example
+    # ultimatedonutsmp.enderchest.rows.4 for a 36 slot chest
+    # The highest value the player has wins
+    # Players without any of these permissions keep DEFAULT-ROWS above
+    PERMISSIONS:
+      "ultimatedonutsmp.enderchest.rows.vip++": 6
+      "ultimatedonutsmp.enderchest.rows.vip+": 5
+      "ultimatedonutsmp.enderchest.rows.vip": 4
   # Configuration section for Ecsee.
   ECSEE:
     # Determines whether Enabled is enabled or disabled. Available options: true, false
     ENABLED: 
 ```
+
+---
+
+## Section: `ENDER-CHEST.ROW-PERMISSIONS`
+
+Per-rank Ender Chest sizes resolved from permissions, so different ranks can have different chest sizes
+without a separate config entry per rank.
+
+### 1. Commented Setup Code Example
+
+```yaml
+  # Per-rank Ender Chest size resolved from permissions
+  ROW-PERMISSIONS:
+    # Enable or disable permission based Ender Chest sizes
+    ENABLED: true
+    # What happens when a player's permissions no longer cover the size their chest was saved at,
+    # for example after a rank expires
+    # KEEP-SIZE keeps the chest at the larger size so nothing can be lost
+    # RETURN-ITEMS shrinks the chest and hands back everything that no longer fits
+    # Available options: KEEP-SIZE, RETURN-ITEMS
+    ON-DOWNGRADE: KEEP-SIZE
+    # Explicit mapping from permission node to Ender Chest rows
+    # Players can also be given ultimatedonutsmp.enderchest.rows.<1-6> directly, for example
+    # ultimatedonutsmp.enderchest.rows.4 for a 36 slot chest
+    # The highest value the player has wins
+    # Players without any of these permissions keep DEFAULT-ROWS above
+    PERMISSIONS:
+      "ultimatedonutsmp.enderchest.rows.vip++": 6
+      "ultimatedonutsmp.enderchest.rows.vip+": 5
+      "ultimatedonutsmp.enderchest.rows.vip": 4
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ENDER-CHEST.ROW-PERMISSIONS.ENABLED` | `bool` | `true`, `false` | `true` | Master toggle. When `false` every player gets `DEFAULT-ROWS` and all row permissions are ignored. |
+| `ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE` | `str` | `KEEP-SIZE`, `RETURN-ITEMS` | `'KEEP-SIZE'` | What happens when a player's permissions no longer cover the size their chest was saved at. See **Losing a rank** below. |
+| `ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS` | `section` | Permission node to rows | See example | Maps an arbitrary permission node to a row count. Use this to reuse rank nodes you already have instead of adding numeric nodes. |
+
+### 3. Row Sizes
+
+| Rows | Slots | Equivalent |
+| :--- | :--- | :--- |
+| `1` | 9 | One hotbar |
+| `2` | 18 | |
+| `3` | 27 | A vanilla Ender Chest |
+| `4` | 36 | |
+| `5` | 45 | |
+| `6` | 54 | A double chest, the largest a chest can be |
+
+### 4. Resolution Order
+
+1. Every entry under `PERMISSIONS` the player holds is collected.
+2. Every `ultimatedonutsmp.enderchest.rows.<1-6>` node the player holds is collected. A non-numeric
+   suffix is ignored, and a value above 6 counts as 6.
+3. The **highest** collected value becomes the player size, so a player with both `.rows.2` and
+   `.rows.4` gets 36 slots.
+4. If the player holds none of these nodes, `DEFAULT-ROWS` applies.
+
+Wildcards do not grant a tier. `ultimatedonutsmp.*` leaves the player on `DEFAULT-ROWS`, the same way it
+does for `ultimatedonutsmp.homes.<amount>`, so a staff wildcard cannot quietly resize everyone.
+
+The size is evaluated every time the chest is opened, so a rank change applies on the next open.
+
+### 5. Losing a Rank
+
+A chest remembers the size it was last saved at. If a player's permissions later cover fewer rows than
+that — an expired rank, a removed node, a lowered `DEFAULT-ROWS` — `ON-DOWNGRADE` decides what happens:
+
+- `KEEP-SIZE` (default) leaves the chest at the larger size. Nothing can be lost, and the player keeps
+  the extra space until an admin clears it.
+- `RETURN-ITEMS` shrinks the chest to the size the player is now entitled to and hands back everything
+  that no longer fits, into their inventory or onto the ground if their inventory is full. They are told
+  what happened through `MESSAGES.ROWS-DOWNGRADED`.
+
+`RETURN-ITEMS` writes the smaller chest to the database before handing anything back, so a failed
+hand-back cannot duplicate items, and a failed write leaves the chest at its old size.
+
+### 6. Practical Setup Example
+
+Give the default rank a vanilla-sized chest and sell the bigger ones as a rank perk:
+
+```yaml
+ENDER-CHEST:
+  DEFAULT-ROWS: 3
+  ROW-PERMISSIONS:
+    ENABLED: true
+    ON-DOWNGRADE: RETURN-ITEMS
+    PERMISSIONS:
+      "group.vip": 4
+      "group.vip+": 5
+      "group.mvp": 6
+```
+
+Or skip the config entirely and drive it from LuckPerms alone:
+
+```
+/lp group vip permission set ultimatedonutsmp.enderchest.rows.4
+/lp group vip+ permission set ultimatedonutsmp.enderchest.rows.5
+/lp group mvp permission set ultimatedonutsmp.enderchest.rows.6
+```
+
+`/ecsee <player>` always opens a target's chest at its real stored size, so staff see exactly what the
+player sees.
 
 ---
 
@@ -100,6 +249,9 @@ MESSAGES:
   SAVE-FAILED: '&cFailed to save your Ender Chest. Contact staff.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aEnder Chest config reloaded.'
+  # Shown when a chest shrinks and the items that no longer fit are handed back
+  # The text or value for Rows Downgraded. Available options: Any valid string text
+  ROWS-DOWNGRADED: '&eYour Ender Chest is now {rows} rows. {amount} item(s) that no longer fit were returned to you.'
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -112,6 +264,7 @@ MESSAGES:
 | `MESSAGES.OPEN-FAILED` | `str` | Any string text | `'&cFailed to open your Ender Chest. ...'` | Configures the technical `OPEN-FAILED` parameter for `MESSAGES.OPEN-FAILED` in `ender-chest.yml`. |
 | `MESSAGES.SAVE-FAILED` | `str` | Any string text | `'&cFailed to save your Ender Chest. ...'` | Configures the technical `SAVE-FAILED` parameter for `MESSAGES.SAVE-FAILED` in `ender-chest.yml`. |
 | `MESSAGES.RELOAD-SUCCESS` | `str` | Any string text | `'&aEnder Chest config reloaded.'` | Configures the technical `RELOAD-SUCCESS` parameter for `MESSAGES.RELOAD-SUCCESS` in `ender-chest.yml`. |
+| `MESSAGES.ROWS-DOWNGRADED` | `str` | Any string text | `'&eYour Ender Chest is now {rows} row...'` | Sent when `ROW-PERMISSIONS.ON-DOWNGRADE` is `RETURN-ITEMS` and a shrinking chest hands items back. `{rows}` is the new row count and `{amount}` is how many items were returned. |
 
 ### 3. Practical Setup Example
 
@@ -129,6 +282,9 @@ MESSAGES:
   SAVE-FAILED: '&cFailed to save your Ender Chest. Contact staff.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aEnder Chest config reloaded.'
+  # Shown when a chest shrinks and the items that no longer fit are handed back
+  # The text or value for Rows Downgraded. Available options: Any valid string text
+  ROWS-DOWNGRADED: '&eYour Ender Chest is now {rows} rows. {amount} item(s) that no longer fit were returned to you.'
 ```
 
 ---

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1852,6 +1852,13 @@ public class ConfigManager {
             return true;
         }
 
+        // Ender Chest row permission entries are keyed by a server's own ranks for the same reason,
+        // so the bundled vip examples must not come back once admins delete or replace them.
+        if ("ender-chest.yml".equals(resourceName)
+                && path.startsWith("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS.")) {
+            return true;
+        }
+
         // Network server entries can be expanded per deployment.
         if ("network.yml".equals(resourceName)
                 && path.startsWith("NETWORK-STATUS.SERVERS.")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/EnderChestManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/EnderChestManager.java
@@ -16,12 +16,15 @@ import org.bukkit.World;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Lidded;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -35,6 +38,11 @@ public class EnderChestManager {
 
     private static final int MIN_ROWS = 1;
     private static final int MAX_ROWS = 6;
+    private static final String ROWS_PERMISSION_PREFIX = "ultimatedonutsmp.enderchest.rows.";
+    // Scanned well past MAX_ROWS so a node like rows.9 clamps to the biggest chest instead of
+    // silently falling through to DEFAULT-ROWS.
+    private static final int MAX_ROWS_PERMISSION_VALUE = 54;
+    private static final String RETURN_ITEMS_MODE = "RETURN-ITEMS";
 
     private final UltimateDonutSmp plugin;
     private final Map<UUID, EnderChestSession> activeSessions = new HashMap<>();
@@ -184,8 +192,7 @@ public class EnderChestManager {
             if (dbRows == -1) {
                 throw new java.sql.SQLException("Database load error when reading Ender Chest rows");
             }
-            int defaultRows = getDefaultRows();
-            int rows = clampRows(dbRows <= 0 ? defaultRows : Math.max(dbRows, defaultRows));
+            int rows = resolveOpenRows(player, dbRows);
             EnderChestHolder holder = new EnderChestHolder(uuid, rows);
             Inventory inventory = Bukkit.createInventory(
                     holder,
@@ -437,8 +444,7 @@ public class EnderChestManager {
             saveSession(activeTargetSession);
         } else {
             ItemStack[] sanitizedContents = sanitizeContents(session.getInventory().getContents());
-            int defaultRows = getDefaultRows();
-            int rows = clampRows(Math.max(plugin.getDatabaseManager().loadEnderChestRows(targetUuid, defaultRows), defaultRows));
+            int rows = clampRows(session.getInventory().getSize() / 9);
             plugin.getDatabaseManager().saveEnderChest(targetUuid, rows, sanitizedContents);
         }
     }
@@ -791,6 +797,60 @@ public class EnderChestManager {
         return getConfig().getString("ENDER-CHEST.CLOSE-SOUND", "minecraft:block.ender_chest.close|1.0|1.0");
     }
 
+    public boolean isRowPermissionsEnabled() {
+        FileConfiguration config = getConfig();
+        return config == null || config.getBoolean("ENDER-CHEST.ROW-PERMISSIONS.ENABLED", true);
+    }
+
+    public boolean returnsOverflowOnDowngrade() {
+        FileConfiguration config = getConfig();
+        if (config == null) {
+            return false;
+        }
+        return RETURN_ITEMS_MODE.equalsIgnoreCase(
+                config.getString("ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE", "KEEP-SIZE").trim()
+        );
+    }
+
+    /**
+     * Highest row count the player is entitled to by permission, or 0 when no row permission applies.
+     */
+    public int getPermissionRows(Player player) {
+        if (player == null || !isRowPermissionsEnabled()) {
+            return 0;
+        }
+
+        int resolved = clampToTier(PermissionUtils.resolveHighestExactNumberedPermission(
+                player, ROWS_PERMISSION_PREFIX, MAX_ROWS_PERMISSION_VALUE));
+
+        FileConfiguration config = getConfig();
+        ConfigurationSection section = config == null
+                ? null
+                : config.getConfigurationSection("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS");
+        if (section != null) {
+            for (Map.Entry<String, Object> entry : section.getValues(true).entrySet()) {
+                if (!(entry.getValue() instanceof Number number)) {
+                    continue;
+                }
+                if (!PermissionUtils.hasExact(player, entry.getKey())) {
+                    continue;
+                }
+                resolved = Math.max(resolved, clampToTier(number.intValue()));
+            }
+        }
+
+        return resolved;
+    }
+
+    /**
+     * Rows the player should get right now: their permission tier, or the configured default when
+     * they hold no row permission at all.
+     */
+    public int getEntitledRows(Player player) {
+        int permissionRows = getPermissionRows(player);
+        return permissionRows > 0 ? clampRows(permissionRows) : getDefaultRows();
+    }
+
     public int getDefaultRows() {
         FileConfiguration ecConfig = getConfig();
         if (ecConfig != null) {
@@ -835,6 +895,81 @@ public class EnderChestManager {
                 .getString("ENDER-CHEST.ECSEE.TITLE", "&8ender chest of {player}")
                 .replace("{player}", resolvedTargetName)
                 .replace("{target}", resolvedTargetName);
+    }
+
+    /**
+     * Picks the size an ender chest opens at. Stored rows are the size the chest was last saved at,
+     * so honouring them keeps items reachable when nothing entitles the player to that size any more.
+     * Only ON-DOWNGRADE: RETURN-ITEMS shrinks the chest, and only after the overflow has been handed
+     * back and the smaller layout has actually reached the database.
+     */
+    private int resolveOpenRows(Player player, int dbRows) {
+        int defaultRows = getDefaultRows();
+        int storedRows = clampRows(dbRows <= 0 ? defaultRows : dbRows);
+        int entitledRows = clampRows(getEntitledRows(player));
+
+        if (entitledRows < storedRows
+                && returnsOverflowOnDowngrade()
+                && applyRowDowngrade(player, entitledRows)) {
+            return entitledRows;
+        }
+
+        return clampRows(Math.max(entitledRows, storedRows));
+    }
+
+    /**
+     * Trims a chest down to {@code newRows}, returning anything that no longer fits. The smaller
+     * layout is written first so a failed hand-back cannot duplicate items; a failed write leaves the
+     * chest at its old size instead.
+     */
+    private boolean applyRowDowngrade(Player player, int newRows) {
+        UUID uuid = player.getUniqueId();
+        int keptSize = clampRows(newRows) * 9;
+
+        ItemStack[] rawContents = plugin.getDatabaseManager().loadEnderChestContents(uuid, MAX_ROWS * 9);
+        if (rawContents == null) {
+            return false;
+        }
+
+        ItemStack[] storedContents = sanitizeLoadedContents(uuid, rawContents);
+        ItemStack[] kept = Arrays.copyOf(storedContents, keptSize);
+        List<ItemStack> overflow = new ArrayList<>();
+        for (int slot = keptSize; slot < storedContents.length; slot++) {
+            ItemStack item = storedContents[slot];
+            if (item != null && !item.getType().isAir()) {
+                overflow.add(item);
+            }
+        }
+
+        if (!plugin.getDatabaseManager().saveEnderChest(uuid, clampRows(newRows), kept)) {
+            return false;
+        }
+
+        if (!overflow.isEmpty()) {
+            giveBackOverflow(player, overflow);
+            player.sendMessage(ColorUtils.toComponent(formatMessage(
+                    "ROWS-DOWNGRADED",
+                    "&eʏᴏᴜʀ ᴇɴᴅᴇʀ ᴄʜᴇѕᴛ ɪѕ ɴᴏᴡ {rows} ʀᴏᴡѕ. {amount} ɪᴛᴇᴍ(ѕ) ᴛʜᴀᴛ ɴᴏ ʟᴏɴɢᴇʀ ꜰɪᴛ ᴡᴇʀᴇ ʀᴇᴛᴜʀɴᴇᴅ ᴛᴏ ʏᴏᴜ.",
+                    "{rows}", String.valueOf(clampRows(newRows)),
+                    "{amount}", String.valueOf(overflow.size())
+            )));
+        }
+
+        return true;
+    }
+
+    private void giveBackOverflow(Player player, List<ItemStack> overflow) {
+        for (ItemStack item : overflow) {
+            Map<Integer, ItemStack> leftovers = player.getInventory().addItem(item);
+            for (ItemStack leftover : leftovers.values()) {
+                player.getWorld().dropItemNaturally(player.getLocation(), leftover);
+            }
+        }
+        player.updateInventory();
+    }
+
+    private int clampToTier(int rows) {
+        return rows <= 0 ? 0 : clampRows(rows);
     }
 
     private int clampRows(int rows) {

--- a/src/main/resources/ender-chest.yml
+++ b/src/main/resources/ender-chest.yml
@@ -2,7 +2,10 @@
 ENDER-CHEST:
   # Determines whether Enabled is enabled or disabled. Available options: true, false
   ENABLED: true
-  # The numerical value for Default Rows. Available options: Any valid integer
+  # Rows every player gets when no ROW-PERMISSIONS entry applies to them
+  # 6 rows is 54 slots, already the largest a chest can be, so lower this if you want
+  # ROW-PERMISSIONS below to hand out bigger chests as a rank perk
+  # Available options: 1 to 6
   DEFAULT-ROWS: 6
   TITLE: '&5Ender Chest'
   # Determines whether Intercept Vanilla Open is enabled or disabled. Available options: true, false
@@ -15,6 +18,25 @@ ENDER-CHEST:
   PERMISSION: ultimatedonutsmp.enderchest
   # The numerical value for Auto Save Ticks. Available options: Any valid integer
   AUTO-SAVE-TICKS: 1200
+  # Per-rank Ender Chest size resolved from permissions
+  ROW-PERMISSIONS:
+    # Enable or disable permission based Ender Chest sizes
+    ENABLED: true
+    # What happens when a player's permissions no longer cover the size their chest was saved at,
+    # for example after a rank expires
+    # KEEP-SIZE keeps the chest at the larger size so nothing can be lost
+    # RETURN-ITEMS shrinks the chest and hands back everything that no longer fits
+    # Available options: KEEP-SIZE, RETURN-ITEMS
+    ON-DOWNGRADE: KEEP-SIZE
+    # Explicit mapping from permission node to Ender Chest rows
+    # Players can also be given ultimatedonutsmp.enderchest.rows.<1-6> directly, for example
+    # ultimatedonutsmp.enderchest.rows.4 for a 36 slot chest
+    # The highest value the player has wins
+    # Players without any of these permissions keep DEFAULT-ROWS above
+    PERMISSIONS:
+      "ultimatedonutsmp.enderchest.rows.vip++": 6
+      "ultimatedonutsmp.enderchest.rows.vip+": 5
+      "ultimatedonutsmp.enderchest.rows.vip": 4
   # Configuration section for Ecsee.
   ECSEE:
     # Determines whether Enabled is enabled or disabled. Available options: true, false
@@ -38,3 +60,6 @@ MESSAGES:
   SAVE-FAILED: '&cFailed to save your Ender Chest. Contact staff.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aEnder Chest config reloaded.'
+  # Shown when a chest shrinks and the items that no longer fit are handed back
+  # The text or value for Rows Downgraded. Available options: Any valid string text
+  ROWS-DOWNGRADED: '&eYour Ender Chest is now {rows} rows. {amount} item(s) that no longer fit were returned to you.'

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1828,6 +1828,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eDeine Endertruhe hat jetzt {rows} Reihen. {amount} Gegenstand/Gegenstände, die nicht mehr hineinpassen, wurden dir zurückgegeben."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1955,6 +1955,8 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: '&cPlayer &f{player} &cwas not found.'
       ECSEE-OPEN-FAILED: '&cFailed to open &f{target}''s &cender chest. please try
         again.'
+      ROWS-DOWNGRADED: '&eYour Ender Chest is now {rows} rows. {amount} item(s) that
+        no longer fit were returned to you.'
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1692,6 +1692,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eTu cofre de ender ahora tiene {rows} filas. Se te devolvieron {amount} objeto(s) que ya no caben."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1692,6 +1692,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eVotre coffre de l'Ender fait maintenant {rows} rangées. {amount} objet(s) qui ne rentrent plus vous ont été rendus."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1829,6 +1829,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eEnder chest kamu sekarang {rows} baris. {amount} item yang tidak muat lagi sudah dikembalikan ke kamu."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1692,6 +1692,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eSeu baú do fim agora tem {rows} linhas. {amount} item(ns) que não cabem mais foram devolvidos a você."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1691,6 +1691,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&eВаш эндер-сундук теперь {rows} рядов. {amount} предмет(ов), которые больше не помещаются, возвращены вам."
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1686,6 +1686,7 @@ CONFIG:
       ECSEE-PLAYER-NOT-FOUND: "&cPlayer &f{player} &cwas not found."
       ECSEE-OPEN-FAILED: "&cFailed to open &f{target}'s &cender chest. please try
         again."
+      ROWS-DOWNGRADED: "&e你的末影箱现在是 {rows} 行。{amount} 个放不下的物品已归还给你。"
   INVSEE:
     INVSEE:
       TITLE: '&8Inventory of {player}'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/EnderChestRowPermissionTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/EnderChestRowPermissionTest.java
@@ -1,0 +1,220 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnderChestRowPermissionTest {
+
+    private EnderChestManager createManager(YamlConfiguration enderChestConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+
+        Constructor<?> pluginConstructor = reflectionFactory
+                .newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) pluginConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        Field enderChestField = ConfigManager.class.getDeclaredField("enderChest");
+        enderChestField.setAccessible(true);
+        enderChestField.set(configManager, enderChestConfig);
+
+        Field configManagerField = UltimateDonutSmp.class.getDeclaredField("configManager");
+        configManagerField.setAccessible(true);
+        configManagerField.set(plugin, configManager);
+
+        // The real constructor calls reload(), which needs a live server; only the config reading
+        // helpers are under test here.
+        Constructor<?> managerConstructor = reflectionFactory
+                .newConstructorForSerialization(EnderChestManager.class, objectConstructor);
+        EnderChestManager manager = (EnderChestManager) managerConstructor.newInstance();
+
+        Field pluginField = EnderChestManager.class.getDeclaredField("plugin");
+        pluginField.setAccessible(true);
+        pluginField.set(manager, plugin);
+
+        return manager;
+    }
+
+    private Player createMockPlayer(Set<String> permissions) {
+        final Player[] playerHolder = new Player[1];
+        Player playerProxy = (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return UUID.randomUUID();
+                    }
+                    if (method.getName().equals("hasPermission")) {
+                        return permissions.contains(((String) args[0]).toLowerCase(Locale.ROOT));
+                    }
+                    if (method.getName().equals("getEffectivePermissions")) {
+                        Set<PermissionAttachmentInfo> effective = new HashSet<>();
+                        for (String permission : permissions) {
+                            effective.add(new PermissionAttachmentInfo(playerHolder[0], permission, null, true));
+                        }
+                        return effective;
+                    }
+                    if (method.getName().equals("isOnline")) {
+                        return true;
+                    }
+                    return null;
+                }
+        );
+        playerHolder[0] = playerProxy;
+        return playerProxy;
+    }
+
+    private YamlConfiguration baseConfig() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("ENDER-CHEST.DEFAULT-ROWS", 3);
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.ENABLED", true);
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE", "KEEP-SIZE");
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.enderchest.rows.vip++", 6);
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.enderchest.rows.vip+", 5);
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.enderchest.rows.vip", 4);
+        return config;
+    }
+
+    @Test
+    void defaultRowsUsedWithoutPermissions() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player regular = createMockPlayer(Set.of());
+
+        assertEquals(0, manager.getPermissionRows(regular));
+        assertEquals(3, manager.getEntitledRows(regular));
+    }
+
+    @Test
+    void rowsResolvedFromConfiguredPermissionMap() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+
+        assertEquals(4, manager.getEntitledRows(
+                createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.vip"))));
+        assertEquals(5, manager.getEntitledRows(
+                createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.vip+"))));
+        assertEquals(6, manager.getEntitledRows(
+                createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.vip++"))));
+    }
+
+    @Test
+    void rowsResolvedFromNumberedPermission() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player numbered = createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.5"));
+
+        assertEquals(5, manager.getEntitledRows(numbered));
+    }
+
+    @Test
+    void highestValueWinsAcrossStackedPermissions() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player stacked = createMockPlayer(Set.of(
+                "ultimatedonutsmp.enderchest.rows.2",
+                "ultimatedonutsmp.enderchest.rows.vip",
+                "ultimatedonutsmp.enderchest.rows.4"
+        ));
+
+        assertEquals(4, manager.getEntitledRows(stacked));
+    }
+
+    @Test
+    void permissionRowsCanSitBelowTheDefault() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player limited = createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.1"));
+
+        assertEquals(1, manager.getEntitledRows(limited));
+    }
+
+    @Test
+    void rowsAreClampedToASingleChest() throws Exception {
+        YamlConfiguration config = baseConfig();
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.enderchest.rows.owner", 99);
+        EnderChestManager manager = createManager(config);
+
+        assertEquals(6, manager.getEntitledRows(
+                createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.owner"))));
+        assertEquals(6, manager.getEntitledRows(
+                createMockPlayer(Set.of("ultimatedonutsmp.enderchest.rows.9"))));
+    }
+
+    @Test
+    void malformedNumberedPermissionIsIgnored() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player malformed = createMockPlayer(Set.of(
+                "ultimatedonutsmp.enderchest.rows.abc",
+                "ultimatedonutsmp.enderchest.rows.-2",
+                "ultimatedonutsmp.enderchest.rows."
+        ));
+
+        assertEquals(3, manager.getEntitledRows(malformed));
+    }
+
+    @Test
+    void wildcardDoesNotGrantARowTier() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        Player wildcard = createMockPlayer(Set.of("ultimatedonutsmp.*"));
+
+        assertEquals(3, manager.getEntitledRows(wildcard));
+    }
+
+    @Test
+    void disabledRowPermissionsFallBackToTheDefault() throws Exception {
+        YamlConfiguration config = baseConfig();
+        config.set("ENDER-CHEST.ROW-PERMISSIONS.ENABLED", false);
+        EnderChestManager manager = createManager(config);
+        Player vip = createMockPlayer(Set.of(
+                "ultimatedonutsmp.enderchest.rows.vip++",
+                "ultimatedonutsmp.enderchest.rows.6"
+        ));
+
+        assertFalse(manager.isRowPermissionsEnabled());
+        assertEquals(3, manager.getEntitledRows(vip));
+    }
+
+    @Test
+    void nullPlayerFallsBackToTheDefault() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+
+        assertEquals(0, manager.getPermissionRows(null));
+        assertEquals(3, manager.getEntitledRows(null));
+    }
+
+    @Test
+    void downgradeModeDefaultsToKeepingTheLargerSize() throws Exception {
+        EnderChestManager manager = createManager(baseConfig());
+        assertFalse(manager.returnsOverflowOnDowngrade());
+
+        YamlConfiguration returning = baseConfig();
+        returning.set("ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE", "RETURN-ITEMS");
+        assertTrue(createManager(returning).returnsOverflowOnDowngrade());
+    }
+
+    @Test
+    void bundledConfigShipsTheRowPermissionSection() throws Exception {
+        YamlConfiguration bundled = new YamlConfiguration();
+        bundled.load(new File("src/main/resources/ender-chest.yml"));
+
+        assertTrue(bundled.getBoolean("ENDER-CHEST.ROW-PERMISSIONS.ENABLED"));
+        assertEquals("KEEP-SIZE", bundled.getString("ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE"));
+        assertTrue(bundled.isConfigurationSection("ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS"));
+        assertTrue(bundled.getString("MESSAGES.ROWS-DOWNGRADED", "").contains("{rows}"));
+    }
+}


### PR DESCRIPTION
Closes #132

Adds LuckPerms-driven Ender Chest sizes so a rank can carry its own chest size instead of every player sharing `DEFAULT-ROWS`.

## Permissions

`ultimatedonutsmp.enderchest.rows.<1-6>` sets the size in rows, so the six tiers land on 9, 18, 27, 36, 45 and 54 slots. The highest node a player holds wins, a value above 6 counts as 6, and a player with no node keeps `DEFAULT-ROWS`. Wildcards do not grant a tier, matching how `ultimatedonutsmp.homes.<amount>` already behaves.

Named rank nodes can be mapped to a row count through `ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS` instead, the same shape `SETTINGS.RANK-COOLDOWNS.PERMISSIONS` uses in `rtp.yml`. `ENDER-CHEST.ROW-PERMISSIONS.ENABLED: false` turns the whole thing off.

The issue asked for `ultimatedonutsmp.ec.0` through `.ec.5`. Two things pushed the naming elsewhere: `PermissionUtils.resolveHighestExactNumberedPermission` is 1-based and returns 0 for "no match", so a `.0` tier cannot be represented, and `ec.` reads as `ecsee` at a glance. `rows.<1-6>` names the row count directly and matches the existing `homes.<amount>` convention. Anyone who wants the exact nodes from the issue can still map them in `PERMISSIONS`.

## Losing a rank

Sizes that can go down are the risky half of this feature. `loadEnderChestContents` skips slots past the requested size and `saveEnderChest` deletes every row before reinserting, so a shrinking chest would have destroyed everything past the cut on the next autosave. `ENDER-CHEST.ROW-PERMISSIONS.ON-DOWNGRADE` decides what happens instead:

- `KEEP-SIZE` (default) holds the chest at the larger size, which is what the old `Math.max(dbRows, defaultRows)` did, so existing servers see no change.
- `RETURN-ITEMS` shrinks the chest and hands back whatever no longer fits, into the inventory or onto the ground. The smaller layout is written to the database first, so a failed hand-back cannot duplicate items and a failed write leaves the chest at its old size.

`saveInspectionSession` now takes the row count from the inspection inventory rather than forcing it back up to `DEFAULT-ROWS`, which would have silently regrown a chest that had just been trimmed.

## Notes

`DEFAULT-ROWS` already ships as 6, the largest a chest can be, so nothing changes until a server lowers it and hands the bigger sizes out per rank. The config comment and the wiki both say so, since "I added the permissions and nothing happened" is the obvious first support ticket.

New `MESSAGES.ROWS-DOWNGRADED` is translated across all 8 bundled languages. Covered by `EnderChestRowPermissionTest` (12 cases); full suite is 187 green.
