### PR TITLE
feat(punishments): browse every punishment on the server in one list (#133)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -64,7 +64,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/fakeplayer` | `/fakeplayer` (Alias `/fplayer`) | Spawn fake player bait entities | `ultimatedonutsmp.command.fakeplayer` |
 | `/amod` | `/amod <add\|reload>` | Manage the anvil rename word filter | `ultimatedonutsmp.command.amod` |
 | `/offend` | `/offend <player> <reason> [time]` | Issue preset offense-based punishment with escalating duration | `ultimatedonutsmp.staff.punishments.offend` |
-| `/punishments` | `/punishments <player>` | View punishment history GUI for target player | `ultimatedonutsmp.staff.punishments.view` |
+| `/punishments` | `/punishments [player]` | Browse every punishment on the server, or one player's history | `ultimatedonutsmp.staff.punishments.view` |
 | `/ban` | `/ban <player> [reason]` | Issue permanent ban | `ultimatedonutsmp.staff.punishments.ban` |
 | `/tempban` | `/tempban <player> <time> [reason]` | Issue temporary ban | `ultimatedonutsmp.staff.punishments.ban` |
 | `/mute` | `/mute <player> [reason]` | Issue permanent mute | `ultimatedonutsmp.staff.punishments.mute` |

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -29,6 +29,33 @@ Freezes the target player on top of an ice block and disables movement, block br
 
 ---
 
+## Punishments
+
+### 1. Punishment List (`/punishments`)
+Run `/punishments` with no arguments to browse every punishment on the server in one GUI, newest first. Each entry shows the punished player, the type, the reason, the staff member who issued it, the date, and the expiry (`Never` for a permanent punishment).
+
+Controls sit along the bottom row:
+
+| Button | Action |
+| --- | --- |
+| State Filter | Cycles All / Active / Inactive. Inactive covers both expired and manually removed records |
+| Type Filter | Cycles All / Ban / Mute / Warn / Kick / Blacklist |
+| Sort Order | Switches between newest and oldest first |
+| Search | Left-click opens a sign to type a player name, right-click clears it |
+| Refresh | Re-reads the list |
+
+Search matches any part of the stored player name and ignores case, so `rod` finds `Cuteboyrodney`. A full UUID also works. Left-clicking an entry opens that player's full history; shift-right-clicking deletes the record if the viewer holds `ultimatedonutsmp.staff.punishments.delete`.
+
+Pages are read in the background rather than on the server thread, so the menu opens on a loading placeholder and fills in once the query returns. On a large history the first frame may be visible for a moment.
+
+### 2. Player History (`/punishments <player>`)
+Passing a player name opens that player's history on its own, with the same state and type filters. This is also reachable from the profile viewer.
+
+- Both views require `ultimatedonutsmp.staff.punishments.view`.
+- Both are styled from `PUNISHMENTS-LIST-MENU` and `PUNISHMENT-HISTORY-MENU` in `menus.yml`.
+
+---
+
 ## Chat & Anvil Moderation
 
 ### 1. Chat Filtering (`filter.yml`)

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentHistoryCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentHistoryCommand.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.PunishmentHistoryMenu;
+import com.bx.ultimateDonutSmp.menus.PunishmentsListMenu;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -37,10 +38,7 @@ public class PunishmentHistoryCommand implements CommandExecutor {
         }
 
         if (args.length == 0) {
-            player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessageOrDefault(
-                    "PUNISHMENTS.USAGE",
-                    "&cᴜѕᴀɢᴇ: /" + label + " <player>"
-            )));
+            new PunishmentsListMenu(plugin).open(player);
             return true;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -487,6 +487,7 @@ public class DatabaseManager {
         execute("CREATE INDEX IF NOT EXISTS idx_punishments_target_issued ON punishments(target_uuid, issued_at DESC)");
         execute("CREATE INDEX IF NOT EXISTS idx_punishments_target_type ON punishments(target_uuid, type)");
         execute("CREATE INDEX IF NOT EXISTS idx_punishments_target_name ON punishments(target_name_snapshot)");
+        execute("CREATE INDEX IF NOT EXISTS idx_punishments_issued ON punishments(issued_at DESC)");
         execute(
             "CREATE TABLE IF NOT EXISTS freeze_states (" +
             "  target_uuid TEXT PRIMARY KEY," +
@@ -3714,6 +3715,54 @@ public class DatabaseManager {
         return records;
     }
 
+    public int countAllPunishments(PunishmentQuery query, String search, long now) {
+        StringBuilder sql = new StringBuilder("SELECT COUNT(*) FROM punishments");
+        List<Object> parameters = new ArrayList<>();
+        appendGlobalPunishmentFilters(sql, parameters, search, query, now);
+
+        try (PreparedStatement ps = connection.prepareStatement(sql.toString())) {
+            bindParameters(ps, parameters);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to count server-wide punishments", e);
+        }
+
+        return 0;
+    }
+
+    public List<PunishmentRecord> loadAllPunishments(PunishmentQuery query, String search, int limit, int offset, long now) {
+        List<PunishmentRecord> records = new ArrayList<>();
+
+        StringBuilder sql = new StringBuilder("SELECT * FROM punishments");
+        List<Object> parameters = new ArrayList<>();
+        appendGlobalPunishmentFilters(sql, parameters, search, query, now);
+
+        PunishmentSortOrder sortOrder = query == null ? PunishmentSortOrder.NEWEST : query.sortOrder();
+        sql.append(sortOrder == PunishmentSortOrder.OLDEST
+                ? " ORDER BY issued_at ASC, id ASC"
+                : " ORDER BY issued_at DESC, id DESC");
+        sql.append(" LIMIT ? OFFSET ?");
+        parameters.add(Math.max(1, limit));
+        parameters.add(Math.max(0, offset));
+
+        try (PreparedStatement ps = connection.prepareStatement(sql.toString())) {
+            bindParameters(ps, parameters);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    records.add(mapPunishmentRow(rs));
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to load server-wide punishments", e);
+        }
+
+        return records;
+    }
+
     // â”€â”€ Cuboids â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     public record CuboidData(String world, int x1, int y1, int z1, int x2, int y2, int z2) {}
@@ -4187,6 +4236,36 @@ public class DatabaseManager {
         }
         sql.append(")");
 
+        appendPunishmentQueryFilters(sql, parameters, query, now);
+    }
+
+    private void appendGlobalPunishmentFilters(StringBuilder sql,
+                                               List<Object> parameters,
+                                               String search,
+                                               PunishmentQuery query,
+                                               long now) {
+        String term = search == null ? "" : search.trim();
+        if (!term.isEmpty()) {
+            sql.append(" WHERE (LOWER(target_name_snapshot) LIKE LOWER(?) ESCAPE '!'");
+            parameters.add("%" + escapeLikeTerm(term) + "%");
+
+            UUID searchUuid = parseUuidOrNull(term);
+            if (searchUuid != null) {
+                sql.append(" OR target_uuid = ?");
+                parameters.add(searchUuid.toString());
+            }
+            sql.append(")");
+        } else {
+            sql.append(" WHERE 1=1");
+        }
+
+        appendPunishmentQueryFilters(sql, parameters, query, now);
+    }
+
+    private void appendPunishmentQueryFilters(StringBuilder sql,
+                                              List<Object> parameters,
+                                              PunishmentQuery query,
+                                              long now) {
         if (query == null) {
             return;
         }
@@ -4202,6 +4281,18 @@ public class DatabaseManager {
         } else if (query.stateFilter() == PunishmentFilterState.INACTIVE) {
             sql.append(" AND (removed_at IS NOT NULL OR (expires_at IS NOT NULL AND expires_at <= ?))");
             parameters.add(now);
+        }
+    }
+
+    private static String escapeLikeTerm(String term) {
+        return term.replace("!", "!!").replace("%", "!%").replace("_", "!_");
+    }
+
+    private static UUID parseUuidOrNull(String value) {
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PunishmentManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PunishmentManager.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
 public class PunishmentManager {
@@ -131,6 +132,49 @@ public class PunishmentManager {
                 Math.max(0, offset),
                 System.currentTimeMillis()
         );
+    }
+
+    public int countAll(PunishmentQuery query, String search) {
+        return plugin.getDatabaseManager().countAllPunishments(
+                query == null ? PunishmentQuery.defaultQuery() : query,
+                search,
+                System.currentTimeMillis()
+        );
+    }
+
+    public List<PunishmentRecord> getAll(PunishmentQuery query, String search, int limit, int offset) {
+        return plugin.getDatabaseManager().loadAllPunishments(
+                query == null ? PunishmentQuery.defaultQuery() : query,
+                search,
+                Math.max(1, limit),
+                Math.max(0, offset),
+                System.currentTimeMillis()
+        );
+    }
+
+    /**
+     * Reads one page of the server-wide punishment list off the main thread. The whole table is in
+     * play here rather than a single indexed target, so a synchronous read would stall the server on
+     * anything but a small history.
+     */
+    public CompletableFuture<PunishmentPage> getAllAsync(PunishmentQuery query, String search, int limit, int offset) {
+        int pageSize = Math.max(1, limit);
+        CompletableFuture<PunishmentPage> future = new CompletableFuture<>();
+        plugin.getDatabaseManager().executeAsync(() -> {
+            try {
+                int total = countAll(query, search);
+                // Filters and deletions can shrink the result set under a viewer who is deep into the
+                // pages, so snap the offset back to the last real page boundary instead of paging past
+                // the end.
+                int lastPageOffset = Math.max(0, (Math.max(0, total - 1) / pageSize) * pageSize);
+                int safeOffset = Math.max(0, Math.min(offset, lastPageOffset));
+                future.complete(new PunishmentPage(getAll(query, search, pageSize, safeOffset), total, safeOffset));
+            } catch (Exception e) {
+                plugin.getLogger().log(java.util.logging.Level.WARNING, "Failed to load server-wide punishment page", e);
+                future.complete(new PunishmentPage(List.of(), 0, 0));
+            }
+        });
+        return future;
     }
 
     public Optional<PunishmentRecord> getActiveRecord(UUID targetUuid, PunishmentType type) {
@@ -363,6 +407,8 @@ public class PunishmentManager {
         }
         return null;
     }
+
+    public record PunishmentPage(List<PunishmentRecord> records, int total, int offset) {}
 
     public record PunishmentCreateRequest(
             UUID targetUuid,

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentHistoryMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentHistoryMenu.java
@@ -7,7 +7,6 @@ import com.bx.ultimateDonutSmp.managers.PunishmentManager;
 import com.bx.ultimateDonutSmp.models.PunishmentQuery;
 import com.bx.ultimateDonutSmp.models.PunishmentRecord;
 import com.bx.ultimateDonutSmp.models.PunishmentState;
-import com.bx.ultimateDonutSmp.models.PunishmentType;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
@@ -18,20 +17,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
 public class PunishmentHistoryMenu extends BaseMenu {
 
     private static final String MENU_PATH = "PUNISHMENT-HISTORY-MENU";
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM d yyyy, HH:mm:ss", Locale.US);
 
     private static final int BACK_SLOT = 45;
     private static final int FILTER_STATE_SLOT = 46;
@@ -272,7 +266,7 @@ public class PunishmentHistoryMenu extends BaseMenu {
     private ItemStack createPunishmentItem(PunishmentRecord record) {
         PunishmentState state = plugin.getPunishmentManager().getState(record);
         String materialPath = MENU_PATH + ".PUNISHMENT-ITEM.MATERIALS." + record.getType().name();
-        Material material = ItemUtils.parseMaterial(menus().getString(materialPath, defaultMaterial(record.getType())));
+        Material material = ItemUtils.parseMaterial(menus().getString(materialPath, PunishmentItemRenderer.defaultMaterial(record.getType())));
         String displayNameTemplate = menus().getString(MENU_PATH + ".PUNISHMENT-ITEM.DISPLAY-NAME", "{status_color}{type}");
         List<String> loreTemplate = defaultIfEmpty(
                 menus().getStringList(MENU_PATH + ".PUNISHMENT-ITEM.LORE"),
@@ -319,41 +313,13 @@ public class PunishmentHistoryMenu extends BaseMenu {
     }
 
     private String replacePunishmentPlaceholders(String value, PunishmentRecord record, PunishmentState state) {
-        if (value == null) {
-            return "";
-        }
-
-        String removedBy = safeText(record.getRemovedByNameSnapshot());
-        String removalReason = safeText(record.getRemovalReason());
-        String removedAt = formatOptionalTimestamp(record.getRemovedAt(), "N/A");
-
-        if (state == PunishmentState.EXPIRED) {
-            if (removedBy.equals("N/A")) {
-                removedBy = "System";
-            }
-            if (removalReason.equals("N/A")) {
-                removalReason = "Expired";
-            }
-            if (removedAt.equals("N/A")) {
-                removedAt = formatOptionalTimestamp(record.getExpiresAt(), "N/A");
-            }
-        }
-
-        return replaceMenuPlaceholders(value)
-                .replace("{status_color}", statusColor(record, state))
-                .replace("{type}", plugin.getPunishmentManager().getDisplayType(record))
-                .replace("{reason}", record.getReason())
-                .replace("{issuer}", safeText(record.getIssuerNameSnapshot()))
-                .replace("{issued_at}", formatOptionalTimestamp(record.getIssuedAt(), "unknown"))
-                .replace("{expires_at}", formatOptionalTimestamp(record.getExpiresAt(), "Never"))
-                .replace("{eXpires_at}", formatOptionalTimestamp(record.getExpiresAt(), "Never"))
-                .replace("{status}", state.getDisplayName())
-                .replace("{removed_by}", removedBy)
-                .replace("{removal_reason}", removalReason)
-                .replace("{removed_at}", removedAt)
-                .replace("{id}", String.valueOf(record.getId()))
-                .replace("{scope}", record.getScope().name())
-                .replace("{source_server}", record.getSourceServer());
+        return PunishmentItemRenderer.applyRecord(
+                replaceMenuPlaceholders(value),
+                record,
+                state,
+                plugin.getPunishmentManager().getDisplayType(record),
+                plugin.getPunishmentManager().resolveTargetName(targetUuid)
+        );
     }
 
     private List<String> replacePunishmentPlaceholders(List<String> lines, PunishmentRecord record, PunishmentState state) {
@@ -366,83 +332,6 @@ public class PunishmentHistoryMenu extends BaseMenu {
 
     private String currentTypeFilterLabel() {
         return query.typeFilter() == null ? "All" : query.typeFilter().name();
-    }
-
-    private String defaultMaterial(PunishmentType type) {
-        return switch (type) {
-            case BAN -> "IRON_BARS";
-            case MUTE -> "PAPER";
-            case WARN -> "YELLOW_DYE";
-            case KICK -> "LEATHER_BOOTS";
-            case BLACKLIST -> "BARRIER";
-        };
-    }
-
-    private String statusColor(PunishmentRecord record, PunishmentState state) {
-        if (state == PunishmentState.EXPIRED) {
-            return "&6";
-        }
-        if (state == PunishmentState.REMOVED) {
-            return "&7";
-        }
-
-        return switch (record.getType()) {
-            case BAN, BLACKLIST -> "&c";
-            case MUTE -> "&d";
-            case WARN -> "&e";
-            case KICK -> "&6";
-        };
-    }
-
-    private String toSmallCaps(String input) {
-        if (input == null) return "";
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < input.length(); i++) {
-            char c = input.charAt(i);
-            char lower = Character.toLowerCase(c);
-            switch (lower) {
-                case 'a': sb.append('ᴀ'); break;
-                case 'b': sb.append('ʙ'); break;
-                case 'c': sb.append('ᴄ'); break;
-                case 'd': sb.append('ᴅ'); break;
-                case 'e': sb.append('ᴇ'); break;
-                case 'f': sb.append('ꜰ'); break;
-                case 'g': sb.append('ɢ'); break;
-                case 'h': sb.append('ʜ'); break;
-                case 'i': sb.append('ɪ'); break;
-                case 'j': sb.append('ᴊ'); break;
-                case 'k': sb.append('ᴋ'); break;
-                case 'l': sb.append('ʟ'); break;
-                case 'm': sb.append('ᴍ'); break;
-                case 'n': sb.append('ɴ'); break;
-                case 'o': sb.append('ᴏ'); break;
-                case 'p': sb.append('ᴘ'); break;
-                case 'q': sb.append('ǫ'); break;
-                case 'r': sb.append('ʀ'); break;
-                case 's': sb.append('ѕ'); break;
-                case 't': sb.append('ᴛ'); break;
-                case 'u': sb.append('ᴜ'); break;
-                case 'v': sb.append('ᴠ'); break;
-                case 'w': sb.append('ᴡ'); break;
-                case 'x': sb.append('x'); break;
-                case 'y': sb.append('ʏ'); break;
-                case 'z': sb.append('ᴢ'); break;
-                default: sb.append(c); break;
-            }
-        }
-        return sb.toString();
-    }
-
-    private String formatOptionalTimestamp(Long timestamp, String fallback) {
-        if (timestamp == null || timestamp <= 0L) {
-            return toSmallCaps(fallback);
-        }
-        String formatted = DATE_FORMATTER.format(Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()));
-        return toSmallCaps(formatted);
-    }
-
-    private String safeText(String value) {
-        return value == null || value.isBlank() ? "N/A" : value;
     }
 
     private List<String> defaultIfEmpty(List<String> configured, List<String> fallback) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentItemRenderer.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentItemRenderer.java
@@ -1,0 +1,154 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.models.PunishmentRecord;
+import com.bx.ultimateDonutSmp.models.PunishmentState;
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Shared rendering for punishment records so the per-player history and the server-wide list show the
+ * same fields, colours and date format.
+ */
+final class PunishmentItemRenderer {
+
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("MMM d yyyy, HH:mm:ss", Locale.US);
+
+    private PunishmentItemRenderer() {}
+
+    static String applyRecord(String value,
+                              PunishmentRecord record,
+                              PunishmentState state,
+                              String displayType,
+                              String playerName) {
+        if (value == null) {
+            return "";
+        }
+
+        String removedBy = safeText(record.getRemovedByNameSnapshot());
+        String removalReason = safeText(record.getRemovalReason());
+        String removedAt = formatTimestamp(record.getRemovedAt(), "N/A");
+
+        if (state == PunishmentState.EXPIRED) {
+            if (removedBy.equals("N/A")) {
+                removedBy = "System";
+            }
+            if (removalReason.equals("N/A")) {
+                removalReason = "Expired";
+            }
+            if (removedAt.equals("N/A")) {
+                removedAt = formatTimestamp(record.getExpiresAt(), "N/A");
+            }
+        }
+
+        return value
+                .replace("{player}", playerName == null ? "" : playerName)
+                .replace("{status_color}", statusColor(record, state))
+                .replace("{type}", displayType)
+                .replace("{reason}", record.getReason())
+                .replace("{issuer}", safeText(record.getIssuerNameSnapshot()))
+                .replace("{issued_at}", formatTimestamp(record.getIssuedAt(), "unknown"))
+                .replace("{expires_at}", formatTimestamp(record.getExpiresAt(), "Never"))
+                .replace("{eXpires_at}", formatTimestamp(record.getExpiresAt(), "Never"))
+                .replace("{status}", state.getDisplayName())
+                .replace("{removed_by}", removedBy)
+                .replace("{removal_reason}", removalReason)
+                .replace("{removed_at}", removedAt)
+                .replace("{id}", String.valueOf(record.getId()))
+                .replace("{scope}", record.getScope().name())
+                .replace("{source_server}", record.getSourceServer());
+    }
+
+    static List<String> applyRecord(List<String> lines,
+                                    PunishmentRecord record,
+                                    PunishmentState state,
+                                    String displayType,
+                                    String playerName) {
+        List<String> replaced = new ArrayList<>();
+        for (String line : lines) {
+            replaced.add(applyRecord(line, record, state, displayType, playerName));
+        }
+        return replaced;
+    }
+
+    static String defaultMaterial(PunishmentType type) {
+        return switch (type) {
+            case BAN -> "IRON_BARS";
+            case MUTE -> "PAPER";
+            case WARN -> "YELLOW_DYE";
+            case KICK -> "LEATHER_BOOTS";
+            case BLACKLIST -> "BARRIER";
+        };
+    }
+
+    static String statusColor(PunishmentRecord record, PunishmentState state) {
+        if (state == PunishmentState.EXPIRED) {
+            return "&6";
+        }
+        if (state == PunishmentState.REMOVED) {
+            return "&7";
+        }
+
+        return switch (record.getType()) {
+            case BAN, BLACKLIST -> "&c";
+            case MUTE -> "&d";
+            case WARN -> "&e";
+            case KICK -> "&6";
+        };
+    }
+
+    static String formatTimestamp(Long timestamp, String fallback) {
+        if (timestamp == null || timestamp <= 0L) {
+            return toSmallCaps(fallback);
+        }
+        return toSmallCaps(DATE_FORMATTER.format(Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault())));
+    }
+
+    static String safeText(String value) {
+        return value == null || value.isBlank() ? "N/A" : value;
+    }
+
+    static String toSmallCaps(String input) {
+        if (input == null) return "";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            switch (Character.toLowerCase(c)) {
+                case 'a': sb.append('ᴀ'); break;
+                case 'b': sb.append('ʙ'); break;
+                case 'c': sb.append('ᴄ'); break;
+                case 'd': sb.append('ᴅ'); break;
+                case 'e': sb.append('ᴇ'); break;
+                case 'f': sb.append('ꜰ'); break;
+                case 'g': sb.append('ɢ'); break;
+                case 'h': sb.append('ʜ'); break;
+                case 'i': sb.append('ɪ'); break;
+                case 'j': sb.append('ᴊ'); break;
+                case 'k': sb.append('ᴋ'); break;
+                case 'l': sb.append('ʟ'); break;
+                case 'm': sb.append('ᴍ'); break;
+                case 'n': sb.append('ɴ'); break;
+                case 'o': sb.append('ᴏ'); break;
+                case 'p': sb.append('ᴘ'); break;
+                case 'q': sb.append('ǫ'); break;
+                case 'r': sb.append('ʀ'); break;
+                case 's': sb.append('ѕ'); break;
+                case 't': sb.append('ᴛ'); break;
+                case 'u': sb.append('ᴜ'); break;
+                case 'v': sb.append('ᴠ'); break;
+                case 'w': sb.append('ᴡ'); break;
+                case 'x': sb.append('x'); break;
+                case 'y': sb.append('ʏ'); break;
+                case 'z': sb.append('ᴢ'); break;
+                default: sb.append(c); break;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentsListMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PunishmentsListMenu.java
@@ -1,0 +1,428 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PunishmentManager;
+import com.bx.ultimateDonutSmp.models.PunishmentQuery;
+import com.bx.ultimateDonutSmp.models.PunishmentRecord;
+import com.bx.ultimateDonutSmp.models.PunishmentState;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import com.bx.ultimateDonutSmp.utils.SignInputUtil;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Server-wide punishment browser. Unlike {@link PunishmentHistoryMenu} this is not scoped to one
+ * target, so every page is read off the main thread and rendered once the results land.
+ */
+public class PunishmentsListMenu extends BaseMenu {
+
+    private static final String MENU_PATH = "PUNISHMENTS-LIST-MENU";
+    private static final int MAX_SEARCH_LENGTH = 32;
+
+    private static final int BACK_SLOT = 45;
+    private static final int FILTER_STATE_SLOT = 46;
+    private static final int FILTER_TYPE_SLOT = 47;
+    private static final int PREVIOUS_PAGE_SLOT = 48;
+    private static final int REFRESH_SLOT = 49;
+    private static final int PAGE_INFO_SLOT = 50;
+    private static final int SEARCH_SLOT = 51;
+    private static final int NEXT_PAGE_SLOT = 52;
+    private static final int SORT_SLOT = 53;
+
+    private PunishmentQuery query = PunishmentQuery.defaultQuery();
+    private String search = "";
+    private int page;
+    private int totalPages = 1;
+    private int totalItems;
+    private boolean loading = true;
+    private boolean hasPreviousPage;
+    private boolean hasNextPage;
+
+    private List<PunishmentRecord> records = new ArrayList<>();
+    private final Map<Integer, PunishmentRecord> visibleRecords = new HashMap<>();
+
+    public PunishmentsListMenu(UltimateDonutSmp plugin) {
+        super(plugin, configuredTitle(plugin), configuredSize(plugin));
+    }
+
+    @Override
+    public void open(Player player) {
+        loading = true;
+        build(player);
+        player.openInventory(inventory);
+        reload(player);
+    }
+
+    /** Fetches the current page in the background and repaints the open inventory when it arrives. */
+    private void reload(Player player) {
+        loading = true;
+        build(player);
+
+        int maxItems = maxItemsPerPage();
+        plugin.getPunishmentManager()
+                .getAllAsync(query, search, maxItems, page * maxItems)
+                .thenAccept(result -> plugin.getSpigotScheduler().runEntity(player, () -> {
+                    if (!isViewing(player)) {
+                        return;
+                    }
+                    records = result.records();
+                    totalItems = result.total();
+                    page = result.offset() / maxItems;
+                    totalPages = Math.max(1, (int) Math.ceil(totalItems / (double) maxItems));
+                    hasPreviousPage = page > 0;
+                    hasNextPage = (page + 1) * maxItems < totalItems;
+                    loading = false;
+                    build(player);
+                }));
+    }
+
+    private boolean isViewing(Player player) {
+        return player.isOnline() && player.getOpenInventory().getTopInventory().getHolder() == this;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        visibleRecords.clear();
+        fill(Material.GRAY_STAINED_GLASS_PANE);
+
+        if (loading) {
+            buildLoadingState();
+        } else if (records.isEmpty()) {
+            buildEmptyState();
+        } else {
+            int maxItems = maxItemsPerPage();
+            for (int index = 0; index < records.size() && index < maxItems; index++) {
+                PunishmentRecord record = records.get(index);
+                visibleRecords.put(index, record);
+                set(index, createPunishmentItem(record));
+            }
+        }
+
+        buildButton(BACK_SLOT, "BACK", "ARROW", "&cᴄʟᴏѕᴇ", List.of("&7ᴄʟᴏѕᴇ ᴛʜɪѕ ᴍᴇɴᴜ."));
+        buildButton(FILTER_STATE_SLOT, "FILTER-STATE", "HOPPER", "&dѕᴛᴀᴛᴇ ꜰɪʟᴛᴇʀ",
+                List.of("&7ᴄᴜʀʀᴇɴᴛ: &f{state_filter}", "&aᴄʟɪᴄᴋ ᴛᴏ ᴄʜᴀɴɢᴇ"));
+        buildButton(FILTER_TYPE_SLOT, "FILTER-TYPE", "BOOK", "&dᴛʏᴘᴇ ꜰɪʟᴛᴇʀ",
+                List.of("&7ᴄᴜʀʀᴇɴᴛ: &f{type_filter}", "&aᴄʟɪᴄᴋ ᴛᴏ ᴄʜᴀɴɢᴇ"));
+        buildButton(REFRESH_SLOT, "REFRESH", "CLOCK", "&dʀᴇꜰʀᴇѕʜ",
+                List.of("&7ʀᴇʟᴏᴀᴅ ᴛʜᴇ ᴘᴜɴɪѕʜᴍᴇɴᴛ ʟɪѕᴛ."));
+        buildButton(SEARCH_SLOT, "SEARCH", "NAME_TAG", "&dѕᴇᴀʀᴄʜ",
+                List.of("&7ᴄᴜʀʀᴇɴᴛ: &f{search}", "&aʟᴇꜰᴛ-ᴄʟɪᴄᴋ ᴛᴏ ѕᴇᴀʀᴄʜ ᴀ ᴘʟᴀʏᴇʀ", "&cʀɪɢʜᴛ-ᴄʟɪᴄᴋ ᴛᴏ ᴄʟᴇᴀʀ"));
+        buildButton(SORT_SLOT, "SORT", "COMPARATOR", "&dѕᴏʀᴛ",
+                List.of("&7ᴄᴜʀʀᴇɴᴛ: &f{sort_order}", "&aᴄʟɪᴄᴋ ᴛᴏ ᴄʜᴀɴɢᴇ"));
+        buildPageButtons();
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        PunishmentRecord record = visibleRecords.get(slot);
+        if (record != null) {
+            handleRecordClick(record, player, clickType);
+            return;
+        }
+
+        if (slot == BACK_SLOT) {
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            player.closeInventory();
+            return;
+        }
+
+        if (loading) {
+            return;
+        }
+
+        if (slot == FILTER_STATE_SLOT) {
+            query = query.nextStateFilter();
+            page = 0;
+            clickFeedback(player);
+            reload(player);
+            return;
+        }
+
+        if (slot == FILTER_TYPE_SLOT) {
+            query = query.nextTypeFilter();
+            page = 0;
+            clickFeedback(player);
+            reload(player);
+            return;
+        }
+
+        if (slot == SORT_SLOT) {
+            query = query.nextSortOrder();
+            page = 0;
+            clickFeedback(player);
+            reload(player);
+            return;
+        }
+
+        if (slot == SEARCH_SLOT) {
+            handleSearchClick(player, clickType);
+            return;
+        }
+
+        if (slot == REFRESH_SLOT) {
+            clickFeedback(player);
+            reload(player);
+            return;
+        }
+
+        if (slot == PREVIOUS_PAGE_SLOT && hasPreviousPage) {
+            page--;
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.PAGE-TURN"));
+            reload(player);
+            return;
+        }
+
+        if (slot == NEXT_PAGE_SLOT && hasNextPage) {
+            page++;
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.PAGE-TURN"));
+            reload(player);
+        }
+    }
+
+    private void handleSearchClick(Player player, ClickType clickType) {
+        if (clickType.isRightClick()) {
+            if (search.isEmpty()) {
+                return;
+            }
+            search = "";
+            page = 0;
+            clickFeedback(player);
+            reload(player);
+            return;
+        }
+
+        List<String> signLines = defaultIfEmpty(
+                menus().getStringList(MENU_PATH + ".SEARCH-SIGN.LINES"),
+                List.of("", "^^^^^^^^^^^^^^", "Player Name", "")
+        );
+        int inputLine = menus().getInt(MENU_PATH + ".SEARCH-SIGN.INPUT-LINE", 0);
+
+        SignInputUtil.open(plugin, player, signLines, inputLine, text -> {
+            if (text != null && !text.isBlank() && !text.equalsIgnoreCase("cancel")) {
+                String trimmed = text.trim();
+                search = trimmed.length() > MAX_SEARCH_LENGTH ? trimmed.substring(0, MAX_SEARCH_LENGTH) : trimmed;
+                page = 0;
+            }
+            open(player);
+        });
+    }
+
+    private void handleRecordClick(PunishmentRecord record, Player player, ClickType clickType) {
+        if (clickType == ClickType.SHIFT_RIGHT) {
+            deleteRecord(record, player);
+            return;
+        }
+
+        if (clickType.isLeftClick() && record.getTargetUuid() != null) {
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            new PunishmentHistoryMenu(plugin, record.getTargetUuid(), false).open(player);
+        }
+    }
+
+    private void deleteRecord(PunishmentRecord record, Player player) {
+        if (!PermissionUtils.has(player, PunishmentManager.DELETE_PERMISSION)) {
+            player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessageOrDefault(
+                    "PUNISHMENTS.NO-DELETE-PERMISSION",
+                    "&cʏᴏᴜ ᴅᴏ ɴᴏᴛ ʜᴀᴠᴇ ᴘᴇʀᴍɪѕѕɪᴏɴ ᴛᴏ ᴅᴇʟᴇᴛᴇ ᴘᴜɴɪѕʜᴍᴇɴᴛ ʜɪѕᴛᴏʀʏ ʀᴇᴄᴏʀᴅѕ."
+            )));
+            return;
+        }
+
+        long recordId = record.getId();
+        if (!plugin.getPunishmentManager().deleteRecord(recordId)) {
+            player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessageOrDefault(
+                    "PUNISHMENTS.DELETE-FAILED",
+                    "&cꜰᴀɪʟᴇᴅ ᴛᴏ ᴅᴇʟᴇᴛᴇ ᴘᴜɴɪѕʜᴍᴇɴᴛ ʀᴇᴄᴏʀᴅ #{id}.",
+                    "{id}", String.valueOf(recordId)
+            )));
+            return;
+        }
+
+        player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessageOrDefault(
+                "PUNISHMENTS.DELETED-RECORD",
+                "&aᴅᴇʟᴇᴛᴇᴅ ᴘᴜɴɪѕʜᴍᴇɴᴛ ʜɪѕᴛᴏʀʏ ʀᴇᴄᴏʀᴅ &f#{id}&a.",
+                "{id}", String.valueOf(recordId)
+        )));
+        clickFeedback(player);
+        reload(player);
+    }
+
+    private void clickFeedback(Player player) {
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+    }
+
+    private void buildLoadingState() {
+        set(inventory.getSize() / 2, ItemUtils.createItem(
+                ItemUtils.parseMaterial(menus().getString(MENU_PATH + ".LOADING-BUTTON.MATERIAL", "CLOCK")),
+                replaceMenuPlaceholders(menus().getString(MENU_PATH + ".LOADING-BUTTON.DISPLAY-NAME", "&eʟᴏᴀᴅɪɴɢ ᴘᴜɴɪѕʜᴍᴇɴᴛѕ")),
+                replaceMenuPlaceholders(defaultIfEmpty(
+                        menus().getStringList(MENU_PATH + ".LOADING-BUTTON.LORE"),
+                        List.of("&7ʀᴇᴀᴅɪɴɢ ᴛʜᴇ ᴘᴜɴɪѕʜᴍᴇɴᴛ ᴛᴀʙʟᴇ.")
+                ))
+        ));
+    }
+
+    private void buildEmptyState() {
+        List<String> fallbackLore = search.isEmpty()
+                ? List.of("&7ɴᴏ ᴘᴜɴɪѕʜᴍᴇɴᴛѕ ᴍᴀᴛᴄʜ ᴛʜᴇ ᴄᴜʀʀᴇɴᴛ ꜰɪʟᴛᴇʀѕ.")
+                : List.of("&7ɴᴏ ᴘᴜɴɪѕʜᴍᴇɴᴛѕ ᴍᴀᴛᴄʜ &f{search}&7.");
+
+        set(inventory.getSize() / 2, ItemUtils.createItem(
+                ItemUtils.parseMaterial(menus().getString(MENU_PATH + ".EMPTY-BUTTON.MATERIAL", "BARRIER")),
+                replaceMenuPlaceholders(menus().getString(MENU_PATH + ".EMPTY-BUTTON.DISPLAY-NAME", "&cɴᴏ ᴘᴜɴɪѕʜᴍᴇɴᴛѕ ꜰᴏᴜɴᴅ")),
+                replaceMenuPlaceholders(defaultIfEmpty(menus().getStringList(MENU_PATH + ".EMPTY-BUTTON.LORE"), fallbackLore))
+        ));
+    }
+
+    private void buildButton(int slot, String key, String fallbackMaterial, String fallbackName, List<String> fallbackLore) {
+        set(slot, ItemUtils.createItem(
+                ItemUtils.parseMaterial(menus().getString(MENU_PATH + ".BUTTONS." + key + ".MATERIAL", fallbackMaterial)),
+                replaceMenuPlaceholders(menus().getString(MENU_PATH + ".BUTTONS." + key + ".DISPLAY-NAME", fallbackName)),
+                replaceMenuPlaceholders(defaultIfEmpty(menus().getStringList(MENU_PATH + ".BUTTONS." + key + ".LORE"), fallbackLore))
+        ));
+    }
+
+    private void buildPageButtons() {
+        Material material = ItemUtils.parseMaterial(menus().getString("GLOBAL.PAGE-MENU.MATERIAL", "ARROW"));
+
+        if (hasPreviousPage) {
+            set(PREVIOUS_PAGE_SLOT, ItemUtils.createItem(
+                    material,
+                    menus().getString("GLOBAL.PAGE-MENU.BACK-BUTTON", "&aʙᴀᴄᴋ"),
+                    menus().getStringList("GLOBAL.PAGE-MENU.BACK-LORE")
+            ));
+        }
+
+        set(PAGE_INFO_SLOT, ItemUtils.createItem(
+                Material.BOOK,
+                "&eᴘᴀɢᴇ " + (page + 1) + "&7/&e" + totalPages,
+                List.of(
+                        "&fʀᴇᴄᴏʀᴅѕ: &7" + NumberUtils.format(totalItems),
+                        "&fᴛʏᴘᴇ: &7" + currentTypeFilterLabel(),
+                        "&fѕᴛᴀᴛᴇ: &7" + query.stateFilter().getDisplayName(),
+                        "&fѕᴏʀᴛ: &7" + query.sortOrder().getDisplayName(),
+                        "&fѕᴇᴀʀᴄʜ: &7" + currentSearchLabel()
+                )
+        ));
+
+        if (hasNextPage) {
+            set(NEXT_PAGE_SLOT, ItemUtils.createItem(
+                    material,
+                    menus().getString("GLOBAL.PAGE-MENU.NEXT-BUTTON", "&aɴᴇxᴛ"),
+                    menus().getStringList("GLOBAL.PAGE-MENU.NEXT-LORE")
+            ));
+        }
+    }
+
+    private ItemStack createPunishmentItem(PunishmentRecord record) {
+        PunishmentState state = plugin.getPunishmentManager().getState(record);
+        String materialPath = MENU_PATH + ".PUNISHMENT-ITEM.MATERIALS." + record.getType().name();
+        Material material = ItemUtils.parseMaterial(
+                menus().getString(materialPath, PunishmentItemRenderer.defaultMaterial(record.getType())));
+
+        String displayName = menus().getString(
+                MENU_PATH + ".PUNISHMENT-ITEM.DISPLAY-NAME", "{status_color}{player} &8- &f{type}");
+        List<String> lore = defaultIfEmpty(
+                menus().getStringList(MENU_PATH + ".PUNISHMENT-ITEM.LORE"),
+                List.of(
+                        "&7ʀᴇᴀѕᴏɴ: &f{reason}",
+                        "&7ɪѕѕᴜᴇᴅ ʙʏ: &f{issuer}",
+                        "&7ᴅᴀᴛᴇ: &f{issued_at}",
+                        "&7ᴇxᴘɪʀᴇѕ: &f{expires_at}",
+                        "&7ѕᴛᴀᴛᴜѕ: {status_color}{status}",
+                        "&7ɪᴅ: &f#{id}",
+                        "",
+                        "&aʟᴇꜰᴛ-ᴄʟɪᴄᴋ ᴛᴏ ᴠɪᴇᴡ ꜰᴜʟʟ ʜɪѕᴛᴏʀʏ",
+                        "&cѕʜɪꜰᴛ-ʀɪɢʜᴛ-ᴄʟɪᴄᴋ ᴛᴏ ᴅᴇʟᴇᴛᴇ ᴛʜɪѕ ʀᴇᴄᴏʀᴅ"
+                )
+        );
+
+        String targetName = displayNameFor(record);
+        String displayType = plugin.getPunishmentManager().getDisplayType(record);
+
+        return ItemUtils.createItem(
+                material,
+                PunishmentItemRenderer.applyRecord(replaceMenuPlaceholders(displayName), record, state, displayType, targetName),
+                PunishmentItemRenderer.applyRecord(replaceMenuPlaceholders(lore), record, state, displayType, targetName)
+        );
+    }
+
+    /**
+     * Uses the name stored with the record rather than a fresh lookup: this list renders up to a full
+     * page at a time and a per-row name resolve would be a database round trip each.
+     */
+    private String displayNameFor(PunishmentRecord record) {
+        String snapshot = record.getTargetNameSnapshot();
+        if (snapshot != null && !snapshot.isBlank()) {
+            return snapshot;
+        }
+        UUID uuid = record.getTargetUuid();
+        return uuid == null ? "unknown" : uuid.toString().substring(0, 8);
+    }
+
+    private String replaceMenuPlaceholders(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replace("{type_filter}", currentTypeFilterLabel())
+                .replace("{state_filter}", query.stateFilter().getDisplayName())
+                .replace("{sort_order}", query.sortOrder().getDisplayName())
+                .replace("{search}", currentSearchLabel())
+                .replace("{page}", String.valueOf(page + 1))
+                .replace("{pages}", String.valueOf(totalPages))
+                .replace("{total}", NumberUtils.format(totalItems));
+    }
+
+    private List<String> replaceMenuPlaceholders(List<String> lines) {
+        List<String> replaced = new ArrayList<>();
+        for (String line : lines) {
+            replaced.add(replaceMenuPlaceholders(line));
+        }
+        return replaced;
+    }
+
+    private String currentTypeFilterLabel() {
+        return query.typeFilter() == null ? "All" : query.typeFilter().name();
+    }
+
+    private String currentSearchLabel() {
+        return search.isEmpty() ? "None" : search;
+    }
+
+    private int maxItemsPerPage() {
+        return Math.max(1, Math.min(45, menus().getInt(MENU_PATH + ".MAX-ITEMS-PER-PAGE", 45)));
+    }
+
+    private List<String> defaultIfEmpty(List<String> configured, List<String> fallback) {
+        return configured == null || configured.isEmpty() ? fallback : configured;
+    }
+
+    private FileConfiguration menus() {
+        return plugin.getConfigManager().getMenus();
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin) {
+        return plugin.getConfigManager().getMenus().getString(MENU_PATH + ".TITLE", "&8ᴀʟʟ ᴘᴜɴɪѕʜᴍᴇɴᴛѕ");
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int size = plugin.getConfigManager().getMenus().getInt(MENU_PATH + ".SIZE", 54);
+        return size >= 27 && size % 9 == 0 ? size : 54;
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1409,6 +1409,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Alle Strafen"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cSchließen"
+        LORE:
+        - "&7Dieses Menü schließen"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DStatusfilter"
+        LORE:
+        - "&7Aktuell: &f{state_filter}"
+        - "&aKlicken zum Ändern"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DSortierung"
+        LORE:
+        - "&7Aktuell: &f{sort_order}"
+        - "&aKlicken zum Ändern"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DSuche"
+        LORE:
+        - "&7Aktuell: &f{search}"
+        - "&aLinksklick, um einen Spieler zu suchen"
+        - "&cRechtsklick zum Zurücksetzen"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DAktualisieren"
+        LORE:
+        - "&7Die Strafenliste neu laden"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Spielername"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Grund: &f{reason}"
+      - "&7Vergeben von: &f{issuer}"
+      - "&7Datum: &f{issued_at}"
+      - "&7Läuft ab: &f{expires_at}"
+      - "&7Status: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&aLinksklick für den vollständigen Verlauf"
+      - "&cShift-Rechtsklick, um diesen Eintrag zu löschen"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eStrafen werden geladen"
+      LORE:
+      - "&7Die Strafentabelle wird gelesen."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cKeine Strafen gefunden"
+      LORE:
+      - "&7Keine Strafen entsprechen den aktuellen Filtern."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2539,7 +2592,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&cVerwendung: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1530,6 +1530,59 @@ MENUS:
         - '&7Total Items: &f{item_count}'
     PANEL-MENU:
       TITLE: '&8Spawners'
+  PUNISHMENTS-LIST-MENU:
+    TITLE: '&8All Punishments'
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: '&cClose'
+        LORE:
+        - '&7Close this menu'
+      FILTER-STATE:
+        DISPLAY-NAME: '&#6BF18DState Filter'
+        LORE:
+        - '&7Current: &f{state_filter}'
+        - '&aClick to change'
+      SORT:
+        DISPLAY-NAME: '&#6BF18DSort Order'
+        LORE:
+        - '&7Current: &f{sort_order}'
+        - '&aClick to change'
+      SEARCH:
+        DISPLAY-NAME: '&#6BF18DSearch'
+        LORE:
+        - '&7Current: &f{search}'
+        - '&aLeft-click to search a player'
+        - '&cRight-click to clear'
+      REFRESH:
+        DISPLAY-NAME: '&#6BF18DRefresh'
+        LORE:
+        - '&7Reload the punishment list'
+    SEARCH-SIGN:
+      LINES:
+      - ''
+      - ^^^^^^^^^^^^^^
+      - Player Name
+      - ''
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: '{status_color}{player} &8- &f{type}'
+      LORE:
+      - '&7Reason: &f{reason}'
+      - '&7Issued by: &f{issuer}'
+      - '&7Date: &f{issued_at}'
+      - '&7Expires: &f{expires_at}'
+      - '&7Status: {status_color}{status}'
+      - '&7ID: &f#{id}'
+      - ''
+      - '&aLeft-click to view full history'
+      - '&cShift-right-click to delete this record'
+    LOADING-BUTTON:
+      DISPLAY-NAME: '&eLoading Punishments'
+      LORE:
+      - '&7Reading the punishment table.'
+    EMPTY-BUTTON:
+      DISPLAY-NAME: '&cNo Punishments Found'
+      LORE:
+      - '&7No punishments match the current filters.'
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2744,7 +2797,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: '&cUsage: /punishments <player>'
+    USAGE: '&cUsage: /punishments [player]'
     USAGE-BAN: '&cUsage: /ban <player> [reason]'
     USAGE-TEMPBAN: '&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)'

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1274,6 +1274,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Todos los castigos"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cCerrar"
+        LORE:
+        - "&7Cerrar este menú"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DFiltro de estado"
+        LORE:
+        - "&7Actual: &f{state_filter}"
+        - "&aClic para cambiar"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DOrden"
+        LORE:
+        - "&7Actual: &f{sort_order}"
+        - "&aClic para cambiar"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DBuscar"
+        LORE:
+        - "&7Actual: &f{search}"
+        - "&aClic izquierdo para buscar un jugador"
+        - "&cClic derecho para limpiar"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DActualizar"
+        LORE:
+        - "&7Recargar la lista de castigos"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Nombre jugador"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Motivo: &f{reason}"
+      - "&7Impuesto por: &f{issuer}"
+      - "&7Fecha: &f{issued_at}"
+      - "&7Caduca: &f{expires_at}"
+      - "&7Estado: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&aClic izquierdo para ver el historial completo"
+      - "&cShift + clic derecho para borrar este registro"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eCargando castigos"
+      LORE:
+      - "&7Leyendo la tabla de castigos."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cNo se encontraron castigos"
+      LORE:
+      - "&7Ningún castigo coincide con los filtros actuales."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2404,7 +2457,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&cUso: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1273,6 +1273,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Toutes les sanctions"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cFermer"
+        LORE:
+        - "&7Fermer ce menu"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DFiltre d'état"
+        LORE:
+        - "&7Actuel : &f{state_filter}"
+        - "&aCliquez pour changer"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DTri"
+        LORE:
+        - "&7Actuel : &f{sort_order}"
+        - "&aCliquez pour changer"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DRechercher"
+        LORE:
+        - "&7Actuel : &f{search}"
+        - "&aClic gauche pour rechercher un joueur"
+        - "&cClic droit pour effacer"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DActualiser"
+        LORE:
+        - "&7Recharger la liste des sanctions"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Nom du joueur"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Motif : &f{reason}"
+      - "&7Sanctionné par : &f{issuer}"
+      - "&7Date : &f{issued_at}"
+      - "&7Expire : &f{expires_at}"
+      - "&7Statut : {status_color}{status}"
+      - "&7ID : &f#{id}"
+      - ""
+      - "&aClic gauche pour voir l'historique complet"
+      - "&cMaj + clic droit pour supprimer cet enregistrement"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eChargement des sanctions"
+      LORE:
+      - "&7Lecture de la table des sanctions."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cAucune sanction trouvée"
+      LORE:
+      - "&7Aucune sanction ne correspond aux filtres actuels."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2404,7 +2457,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage : /punishments <player>"
+    USAGE: "&cUtilisation : /punishments [player]"
     USAGE-BAN: "&cUsage : /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage : /tempban <player> <time> [reason] &7(time : 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1410,6 +1410,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Semua Hukuman"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cTutup"
+        LORE:
+        - "&7Tutup menu ini"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DFilter Status"
+        LORE:
+        - "&7Saat ini: &f{state_filter}"
+        - "&aKlik untuk mengubah"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DUrutan"
+        LORE:
+        - "&7Saat ini: &f{sort_order}"
+        - "&aKlik untuk mengubah"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DCari"
+        LORE:
+        - "&7Saat ini: &f{search}"
+        - "&aKlik kiri untuk mencari pemain"
+        - "&cKlik kanan untuk menghapus"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DMuat Ulang"
+        LORE:
+        - "&7Muat ulang daftar hukuman"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Nama Pemain"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Alasan: &f{reason}"
+      - "&7Diberikan oleh: &f{issuer}"
+      - "&7Tanggal: &f{issued_at}"
+      - "&7Berakhir: &f{expires_at}"
+      - "&7Status: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&aKlik kiri untuk melihat riwayat lengkap"
+      - "&cShift klik kanan untuk menghapus catatan ini"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eMemuat hukuman"
+      LORE:
+      - "&7Membaca tabel hukuman."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cHukuman tidak ditemukan"
+      LORE:
+      - "&7Tidak ada hukuman yang cocok dengan filter saat ini."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2537,7 +2590,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&cPenggunaan: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1274,6 +1274,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Todas as punições"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cFechar"
+        LORE:
+        - "&7Fechar este menu"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DFiltro de estado"
+        LORE:
+        - "&7Atual: &f{state_filter}"
+        - "&aClique para alterar"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DOrdenação"
+        LORE:
+        - "&7Atual: &f{sort_order}"
+        - "&aClique para alterar"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DBuscar"
+        LORE:
+        - "&7Atual: &f{search}"
+        - "&aClique esquerdo para buscar um jogador"
+        - "&cClique direito para limpar"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DAtualizar"
+        LORE:
+        - "&7Recarregar a lista de punições"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Nome do jogador"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Motivo: &f{reason}"
+      - "&7Aplicada por: &f{issuer}"
+      - "&7Data: &f{issued_at}"
+      - "&7Expira: &f{expires_at}"
+      - "&7Estado: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&aClique esquerdo para ver o histórico completo"
+      - "&cShift + clique direito para excluir este registro"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eCarregando punições"
+      LORE:
+      - "&7Lendo a tabela de punições."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cNenhuma punição encontrada"
+      LORE:
+      - "&7Nenhuma punição corresponde aos filtros atuais."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2405,7 +2458,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&cUso: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15h30)"

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1273,6 +1273,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8Все наказания"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&cЗакрыть"
+        LORE:
+        - "&7Закрыть это меню"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18DФильтр состояния"
+        LORE:
+        - "&7Текущий: &f{state_filter}"
+        - "&aНажмите, чтобы изменить"
+      SORT:
+        DISPLAY-NAME: "&#6BF18DСортировка"
+        LORE:
+        - "&7Текущая: &f{sort_order}"
+        - "&aНажмите, чтобы изменить"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18DПоиск"
+        LORE:
+        - "&7Текущий: &f{search}"
+        - "&aЛКМ — найти игрока"
+        - "&cПКМ — очистить"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18DОбновить"
+        LORE:
+        - "&7Перезагрузить список наказаний"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "Имя игрока"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7Причина: &f{reason}"
+      - "&7Выдал: &f{issuer}"
+      - "&7Дата: &f{issued_at}"
+      - "&7Истекает: &f{expires_at}"
+      - "&7Состояние: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&aЛКМ — открыть полную историю"
+      - "&cShift + ПКМ — удалить эту запись"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&eЗагрузка наказаний"
+      LORE:
+      - "&7Чтение таблицы наказаний."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&cНаказания не найдены"
+      LORE:
+      - "&7Нет наказаний, соответствующих текущим фильтрам."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2402,7 +2455,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
     NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
       records.'
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&cИспользование: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1272,6 +1272,59 @@ MENUS:
       LORE:
       - "&7Are you sure you want"
       - "&7To end your life?"
+  PUNISHMENTS-LIST-MENU:
+    TITLE: "&8全部处罚"
+    BUTTONS:
+      BACK:
+        DISPLAY-NAME: "&c关闭"
+        LORE:
+        - "&7关闭此菜单"
+      FILTER-STATE:
+        DISPLAY-NAME: "&#6BF18D状态筛选"
+        LORE:
+        - "&7当前: &f{state_filter}"
+        - "&a点击切换"
+      SORT:
+        DISPLAY-NAME: "&#6BF18D排序"
+        LORE:
+        - "&7当前: &f{sort_order}"
+        - "&a点击切换"
+      SEARCH:
+        DISPLAY-NAME: "&#6BF18D搜索"
+        LORE:
+        - "&7当前: &f{search}"
+        - "&a左键点击搜索玩家"
+        - "&c右键点击清除"
+      REFRESH:
+        DISPLAY-NAME: "&#6BF18D刷新"
+        LORE:
+        - "&7重新加载处罚列表"
+    SEARCH-SIGN:
+      LINES:
+      - ""
+      - "^^^^^^^^^^^^^^"
+      - "玩家名称"
+      - ""
+    PUNISHMENT-ITEM:
+      DISPLAY-NAME: "{status_color}{player} &8- &f{type}"
+      LORE:
+      - "&7原因: &f{reason}"
+      - "&7执行人: &f{issuer}"
+      - "&7日期: &f{issued_at}"
+      - "&7到期: &f{expires_at}"
+      - "&7状态: {status_color}{status}"
+      - "&7ID: &f#{id}"
+      - ""
+      - "&a左键点击查看完整记录"
+      - "&cShift+右键点击删除此记录"
+    LOADING-BUTTON:
+      DISPLAY-NAME: "&e正在加载处罚"
+      LORE:
+      - "&7正在读取处罚数据表."
+    EMPTY-BUTTON:
+      DISPLAY-NAME: "&c未找到处罚"
+      LORE:
+      - "&7没有处罚符合当前筛选条件."
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2392,7 +2445,7 @@ MESSAGES:
     NO-REMOVE-PERMISSION: "&cYou do not have permission to remove punishments。"
     NO-DELETE-PERMISSION: "&cYou do not have permission to delete punishment history
       records。"
-    USAGE: "&cUsage: /punishments <player>"
+    USAGE: "&c用法: /punishments [player]"
     USAGE-BAN: "&cUsage: /ban <player> [reason]"
     USAGE-TEMPBAN: "&cUsage: /tempban <player> <time> [reason] &7(time: 30s, 15m,
       2h, 5d, or 5d 15m 30s)"

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1944,6 +1944,81 @@ PUNISHMENT-HISTORY-MENU:
     DISPLAY-NAME: '&cNo Punishment History'
     LORE:
     - '&7This player has no punishment records.'
+PUNISHMENTS-LIST-MENU:
+  TITLE: '&8All Punishments'
+  SIZE: 54
+  MAX-ITEMS-PER-PAGE: 45
+  BUTTONS:
+    BACK:
+      MATERIAL: ARROW
+      DISPLAY-NAME: '&cClose'
+      LORE:
+      - '&7Close this menu'
+    FILTER-STATE:
+      MATERIAL: HOPPER
+      DISPLAY-NAME: '&#6BF18DState Filter'
+      LORE:
+      - '&7Current: &f{state_filter}'
+      - '&aClick to change'
+    FILTER-TYPE:
+      MATERIAL: BOOK
+      DISPLAY-NAME: '&#6BF18DType Filter'
+      LORE:
+      - '&7Current: &f{type_filter}'
+      - '&aClick to change'
+    SORT:
+      MATERIAL: COMPARATOR
+      DISPLAY-NAME: '&#6BF18DSort Order'
+      LORE:
+      - '&7Current: &f{sort_order}'
+      - '&aClick to change'
+    SEARCH:
+      MATERIAL: NAME_TAG
+      DISPLAY-NAME: '&#6BF18DSearch'
+      LORE:
+      - '&7Current: &f{search}'
+      - '&aLeft-click to search a player'
+      - '&cRight-click to clear'
+    REFRESH:
+      MATERIAL: CLOCK
+      DISPLAY-NAME: '&#6BF18DRefresh'
+      LORE:
+      - '&7Reload the punishment list'
+  SEARCH-SIGN:
+    INPUT-LINE: 0
+    LINES:
+    - ''
+    - '^^^^^^^^^^^^^^'
+    - 'Player Name'
+    - ''
+  PUNISHMENT-ITEM:
+    MATERIALS:
+      BAN: IRON_BARS
+      MUTE: PAPER
+      WARN: YELLOW_DYE
+      KICK: LEATHER_BOOTS
+      BLACKLIST: BARRIER
+    DISPLAY-NAME: '{status_color}{player} &8- &f{type}'
+    LORE:
+    - '&7Reason: &f{reason}'
+    - '&7Issued by: &f{issuer}'
+    - '&7Date: &f{issued_at}'
+    - '&7Expires: &f{expires_at}'
+    - '&7Status: {status_color}{status}'
+    - '&7ID: &f#{id}'
+    - ''
+    - '&aLeft-click to view full history'
+    - '&cShift-right-click to delete this record'
+  LOADING-BUTTON:
+    MATERIAL: CLOCK
+    DISPLAY-NAME: '&eLoading Punishments'
+    LORE:
+    - '&7Reading the punishment table.'
+  EMPTY-BUTTON:
+    MATERIAL: BARRIER
+    DISPLAY-NAME: '&cNo Punishments Found'
+    LORE:
+    - '&7No punishments match the current filters.'
 STATS-WIPE-MENU:
   TITLE: '&8Stats Wipe'
   SIZE: 27

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -616,7 +616,7 @@ PUNISHMENTS:
   NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
     records.'
   # The text or value for Usage. Available options: Any valid string text
-  USAGE: '&cUsage: /punishments <player>'
+  USAGE: '&cUsage: /punishments [player]'
   # The text or value for Usage Ban. Available options: Any valid string text
   USAGE-BAN: '&cUsage: /ban <player> [reason]'
   # The text or value for Usage Tempban. Available options: Any valid string text

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -410,8 +410,8 @@ commands:
     permission: ultimatedonutsmp.command.profileviewer
     permission-message: "&cYou do not have permission to use /profileviewer."
   punishments:
-    description: View a player's punishment history
-    usage: /punishments <player>
+    description: Browse every punishment on the server, or one player's history
+    usage: /punishments [player]
     aliases:
     - phistory
     permission: ultimatedonutsmp.command.punishments

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PunishmentListQueryTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PunishmentListQueryTest.java
@@ -1,0 +1,216 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PunishmentFilterState;
+import com.bx.ultimateDonutSmp.models.PunishmentQuery;
+import com.bx.ultimateDonutSmp.models.PunishmentRecord;
+import com.bx.ultimateDonutSmp.models.PunishmentScope;
+import com.bx.ultimateDonutSmp.models.PunishmentSortOrder;
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PunishmentListQueryTest {
+
+    private static final long HOUR = 3_600_000L;
+
+    private Connection connection;
+    private DatabaseManager dbManager;
+    private long now;
+
+    private UUID rodney;
+    private UUID rodneyAlt;
+    private UUID mara;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        try (Statement st = connection.createStatement()) {
+            st.execute("CREATE TABLE IF NOT EXISTS punishments (" +
+                    "  id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "  target_uuid TEXT NOT NULL," +
+                    "  target_name_snapshot TEXT," +
+                    "  type TEXT NOT NULL," +
+                    "  reason TEXT NOT NULL," +
+                    "  issuer_uuid TEXT," +
+                    "  issuer_name_snapshot TEXT," +
+                    "  issued_at INTEGER NOT NULL," +
+                    "  expires_at INTEGER," +
+                    "  removed_by_uuid TEXT," +
+                    "  removed_by_name_snapshot TEXT," +
+                    "  removed_at INTEGER," +
+                    "  removal_reason TEXT," +
+                    "  source_server TEXT DEFAULT 'local'," +
+                    "  scope TEXT DEFAULT 'SERVER'" +
+                    ")");
+        }
+
+        dbManager = new DatabaseManager(null);
+        Field connectionField = DatabaseManager.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(dbManager, connection);
+
+        now = System.currentTimeMillis();
+        rodney = UUID.randomUUID();
+        rodneyAlt = UUID.randomUUID();
+        mara = UUID.randomUUID();
+
+        // Oldest first so the ids ascend with issued_at.
+        insert(mara, "Mara_", PunishmentType.WARN, now - 4 * HOUR, null, false);
+        insert(rodneyAlt, "Rodney_Alt", PunishmentType.MUTE, now - 3 * HOUR, now + HOUR, false);
+        insert(rodney, "Cuteboyrodney", PunishmentType.BAN, now - 2 * HOUR, now - HOUR, false);
+        insert(rodney, "Cuteboyrodney", PunishmentType.BAN, now - HOUR, null, true);
+        insert(mara, "Mara_", PunishmentType.BAN, now - 30 * 60_000L, null, false);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    private void insert(UUID target, String name, PunishmentType type, long issuedAt, Long expiresAt, boolean removed) {
+        dbManager.createPunishmentRecord(new PunishmentRecord(
+                0L,
+                target,
+                name,
+                type,
+                "Testing",
+                null,
+                "console",
+                issuedAt,
+                expiresAt,
+                null,
+                "",
+                null,
+                "",
+                "local",
+                PunishmentScope.SERVER
+        ));
+
+        if (removed) {
+            List<PunishmentRecord> all = dbManager.loadAllPunishments(
+                    PunishmentQuery.defaultQuery(), null, 100, 0, now);
+            dbManager.markPunishmentRemoved(all.get(0).getId(), null, "console", issuedAt, "appealed");
+        }
+    }
+
+    private List<String> names(List<PunishmentRecord> records) {
+        return records.stream().map(PunishmentRecord::getTargetNameSnapshot).toList();
+    }
+
+    @Test
+    void listsEveryPlayerNewestFirst() {
+        List<PunishmentRecord> records = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), null, 45, 0, now);
+
+        assertEquals(5, records.size());
+        assertEquals(5, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), null, now));
+        assertEquals(
+                List.of("Mara_", "Cuteboyrodney", "Cuteboyrodney", "Rodney_Alt", "Mara_"),
+                names(records)
+        );
+    }
+
+    @Test
+    void oldestSortOrderReversesTheList() {
+        List<PunishmentRecord> records = dbManager.loadAllPunishments(
+                new PunishmentQuery(null, PunishmentFilterState.ALL, PunishmentSortOrder.OLDEST), null, 45, 0, now);
+
+        assertEquals(
+                List.of("Mara_", "Rodney_Alt", "Cuteboyrodney", "Cuteboyrodney", "Mara_"),
+                names(records)
+        );
+    }
+
+    @Test
+    void typeFilterNarrowsTheList() {
+        PunishmentQuery bansOnly = new PunishmentQuery(PunishmentType.BAN, PunishmentFilterState.ALL, null);
+
+        assertEquals(3, dbManager.countAllPunishments(bansOnly, null, now));
+        assertTrue(dbManager.loadAllPunishments(bansOnly, null, 45, 0, now).stream()
+                .allMatch(record -> record.getType() == PunishmentType.BAN));
+    }
+
+    @Test
+    void activeFilterDropsExpiredAndRemovedRecords() {
+        PunishmentQuery active = new PunishmentQuery(null, PunishmentFilterState.ACTIVE, null);
+        List<PunishmentRecord> records = dbManager.loadAllPunishments(active, null, 45, 0, now);
+
+        // The expired ban and the removed ban both drop out; the temporary mute is still running.
+        assertEquals(List.of("Mara_", "Rodney_Alt", "Mara_"), names(records));
+        assertEquals(3, dbManager.countAllPunishments(active, null, now));
+    }
+
+    @Test
+    void searchMatchesPartialNamesIgnoringCase() {
+        List<PunishmentRecord> records = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), "rodney", 45, 0, now);
+
+        assertEquals(3, records.size());
+        assertEquals(3, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "rodney", now));
+        assertTrue(records.stream().allMatch(record ->
+                record.getTargetNameSnapshot().toLowerCase().contains("rodney")));
+    }
+
+    @Test
+    void searchMatchesAnExactUuid() {
+        List<PunishmentRecord> records = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), mara.toString(), 45, 0, now);
+
+        assertEquals(2, records.size());
+        assertTrue(records.stream().allMatch(record -> mara.equals(record.getTargetUuid())));
+    }
+
+    @Test
+    void searchTreatsLikeWildcardsAsLiteralText() {
+        // "%" and "_" would otherwise match everything / any single character.
+        assertEquals(0, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "%", now));
+        assertEquals(0, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "Rodney%Alt", now));
+        assertEquals(0, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "Mara!", now));
+
+        // A real underscore still matches the player actually called "Mara_".
+        assertEquals(2, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "Mara_", now));
+        assertEquals(0, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "MaraX", now));
+    }
+
+    @Test
+    void searchCombinesWithFilters() {
+        PunishmentQuery activeBans = new PunishmentQuery(PunishmentType.BAN, PunishmentFilterState.ACTIVE, null);
+
+        assertEquals(1, dbManager.countAllPunishments(activeBans, "mara", now));
+        assertEquals(0, dbManager.countAllPunishments(activeBans, "rodney", now));
+    }
+
+    @Test
+    void paginationWalksTheListWithoutRepeatingRecords() {
+        List<PunishmentRecord> firstPage = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), null, 2, 0, now);
+        List<PunishmentRecord> secondPage = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), null, 2, 2, now);
+        List<PunishmentRecord> lastPage = dbManager.loadAllPunishments(
+                PunishmentQuery.defaultQuery(), null, 2, 4, now);
+
+        assertEquals(2, firstPage.size());
+        assertEquals(2, secondPage.size());
+        assertEquals(1, lastPage.size());
+        assertTrue(firstPage.stream().noneMatch(first ->
+                secondPage.stream().anyMatch(second -> second.getId() == first.getId())));
+    }
+
+    @Test
+    void blankSearchIsTreatedAsNoSearch() {
+        assertEquals(5, dbManager.countAllPunishments(PunishmentQuery.defaultQuery(), "   ", now));
+    }
+}


### PR DESCRIPTION
Closes #133

Adds a server-wide punishment browser so staff can see every ban, mute, warn, kick and blacklist in one place instead of having to know which player to look up first.

## What was already there

Most of what the issue asks for already ships. `/punishments <player>` opens a paginated history GUI with state and type filters, and the `punishments` table already stores the target, reason, issuer, issue date, expiry (null means permanent) and removal details. What was missing was the entry point: every query was keyed by `target_uuid`, and `countPunishmentHistory` / `loadPunishmentHistory` return 0 and an empty list when no target is given. So this adds the global view and a search rather than a new punishment system.

## The list

`/punishments` with no arguments now opens `PunishmentsListMenu` instead of printing usage. Records are newest first and each row shows the punished player, type, reason, issuer, date, expiry and status. The bottom row carries the state filter, type filter, a sort toggle, search and refresh. Left-clicking a row opens that player's existing history menu; shift-right-click deletes the record and still requires `ultimatedonutsmp.staff.punishments.delete`.

Search reuses the sign input that Auction House, Bounties and Friends already use. It matches any part of the stored name, case-insensitively, so `rod` finds `Cuteboyrodney`, and a full UUID matches exactly. `%` and `_` are escaped before they reach the `LIKE`, otherwise a staff member typing `Mara_` would have matched `MaraX` too.

## Not blocking the server thread

This is the part worth reviewing. `BaseMenu.open` calls `build` synchronously, so the history menu queries the database on the main thread. That is fine when the query is one indexed target, but a global list ordered by date is a different shape of read, and on a server with a long history it would stall the tick.

`PunishmentsListMenu` therefore never queries in `build`. It paints a loading placeholder, opens, then fetches through `PunishmentManager.getAllAsync` on the existing database executor and repaints when the page arrives, skipping the repaint if the viewer has since closed or navigated away. Filter, sort, page and search changes all go through the same path. On SQLite that executor is single threaded and shared with the async writes, so a page can queue behind pending saves; that is still much better than holding the tick.

`idx_punishments_issued` on `issued_at DESC` is new. The three existing indexes are all prefixed with `target_uuid`, so an unfiltered list sorted by date would otherwise be a full scan plus a filesort.

## Notes

Paging is clamped server-side: if filters or a deletion shrink the result set under someone sitting on page 9, the offset snaps back to the last real page boundary rather than paging off the end.

`PunishmentItemRenderer` is extracted from `PunishmentHistoryMenu` and now backs both menus, so the two views cannot drift apart on date format, status colours or the expired-record wording. The history menu behaviour is unchanged.

New `PUNISHMENTS-LIST-MENU` section in `menus.yml`, translated across all 8 bundled languages. `PUNISHMENTS.USAGE` was reworded to `[player]` in every language, since the merge step only fills in absent keys and would have left the old text in place. Covered by `PunishmentListQueryTest` (10 cases: ordering, both filters, search matching, wildcard escaping, pagination); full suite is 197 green.
