### PR TITLE
fix(spawn): run the first join spawn teleport after the join finishes (#144)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -188,6 +188,10 @@ SETTINGS:
   # join the server. Ignored while First Join Rtp Enabled is true. Available options:
   # true, false
   TELEPORT-SPAWN-ON-FIRST-JOIN: true
+  # The numerical value for First Join Spawn Delay Ticks, how long to wait after a new
+  # player joins before sending them to spawn. Raise it when another plugin moves players
+  # around on join. Available options: Any valid integer
+  FIRST-JOIN-SPAWN-DELAY-TICKS: 20
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -219,6 +223,7 @@ SETTINGS:
 | `SETTINGS.SPAWN-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `SPAWN-MENU` parameter for `SETTINGS.SPAWN-MENU` in `config.yml`. |
 | `SETTINGS.AFK-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `AFK-MENU` parameter for `SETTINGS.AFK-MENU` in `config.yml`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | `true`, `false` | `true` | Teleports a player to the spawn location the first time they join. Does nothing until `/setspawn` has been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
+| `SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS` | `int` | Any valid integer number | `20` | How long the plugin waits after the join before running that teleport. Values below `1` are treated as `1` and anything above `1200` is capped there. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Any decimal number | `'1.0'` | Configures the technical `WORTH-DEFAULT-VALUE` parameter for `SETTINGS.WORTH-DEFAULT-VALUE` in `config.yml`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer number | `'50'` | Configures the technical `MOB-SPAWN-RADIUS` parameter for `SETTINGS.MOB-SPAWN-RADIUS` in `config.yml`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer number | `'40'` | Configures the technical `PHANTOM-SPAWN-RADIUS` parameter for `SETTINGS.PHANTOM-SPAWN-RADIUS` in `config.yml`. |

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -518,6 +518,10 @@ SETTINGS:
   # join the server. Ignored while First Join Rtp Enabled is true. Available options:
   # true, false
   TELEPORT-SPAWN-ON-FIRST-JOIN: true
+  # The numerical value for First Join Spawn Delay Ticks, how long to wait after a new
+  # player joins before sending them to spawn. Raise it when another plugin moves players
+  # around on join. Available options: Any valid integer
+  FIRST-JOIN-SPAWN-DELAY-TICKS: 20
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -548,6 +552,7 @@ SETTINGS:
 | `SETTINGS.SPAWN-MENU` | `bool` | true, false | `True` | Configures `SPAWN-MENU` for `SETTINGS`. |
 | `SETTINGS.AFK-MENU` | `bool` | true, false | `True` | Configures `AFK-MENU` for `SETTINGS`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | true, false | `True` | Teleports a player to spawn on their first join. Needs `/setspawn` to have been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
+| `SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS` | `int` | Any valid integer | `20` | How long the plugin waits after the join before running that teleport. Values below `1` become `1`, anything above `1200` is capped there. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Configured values | `1.0` | Configures `WORTH-DEFAULT-VALUE` for `SETTINGS`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer | `50` | Configures `MOB-SPAWN-RADIUS` for `SETTINGS`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer | `40` | Configures `PHANTOM-SPAWN-RADIUS` for `SETTINGS`. |

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -25,6 +25,10 @@ import java.util.UUID;
 
 public class PlayerJoinQuitListener implements Listener {
 
+    static final long DEFAULT_FIRST_JOIN_SPAWN_DELAY_TICKS = 20L;
+    static final long MAX_FIRST_JOIN_SPAWN_DELAY_TICKS = 1200L;
+    private static final long FIRST_JOIN_SPAWN_RETRY_DELAY_TICKS = 20L;
+
     private final UltimateDonutSmp plugin;
 
     public PlayerJoinQuitListener(UltimateDonutSmp plugin) {
@@ -213,11 +217,8 @@ public class PlayerJoinQuitListener implements Listener {
             boolean randomSpawnStarted = plugin.getFirstJoinSpawnManager() != null
                     && plugin.getFirstJoinSpawnManager().handleFirstJoin(player);
             boolean spawnOnFirstJoin = plugin.getConfigManager().getConfig().getBoolean("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN", true);
-            if (!randomSpawnStarted && spawnOnFirstJoin && plugin.getSpawnManager().hasSpawn()) {
-                Location spawn = plugin.getSpawnManager().getSpawnLocation();
-                if (spawn != null) {
-                    plugin.getSpigotScheduler().teleport(player, spawn);
-                }
+            if (!randomSpawnStarted && spawnOnFirstJoin) {
+                scheduleFirstJoinSpawnTeleport(player);
             }
         }
         if (plugin.getOrdersManager() != null) {
@@ -258,6 +259,48 @@ public class PlayerJoinQuitListener implements Listener {
                 }
             });
         }
+    }
+
+    /**
+     * Sends a brand new player to the spawn location. The teleport waits for the player's
+     * own scheduler instead of running inside the join event, because the server is still
+     * placing the player in the world while that event runs and a teleport issued there is
+     * dropped rather than applied.
+     */
+    private void scheduleFirstJoinSpawnTeleport(Player player) {
+        long delay = firstJoinSpawnDelayTicks(plugin.getConfigManager().getConfig()
+                .getLong("SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS", DEFAULT_FIRST_JOIN_SPAWN_DELAY_TICKS));
+        plugin.getSpigotScheduler().runEntityLater(player, () -> firstJoinSpawnTeleport(player, true), delay);
+    }
+
+    private void firstJoinSpawnTeleport(Player player, boolean retryOnFailure) {
+        if (!player.isOnline()) {
+            return;
+        }
+
+        String name = player.getName();
+        Location spawn = plugin.getSpawnManager() == null ? null : plugin.getSpawnManager().getSpawnLocation();
+        if (spawn == null) {
+            plugin.getLogger().warning("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN is on but there is no spawn to send "
+                    + name + " to. Run /setspawn, or check that the world named in LOCATIONS.SPAWN-LOCATION is loaded.");
+            return;
+        }
+
+        plugin.getSpigotScheduler().teleport(player, spawn).thenAccept(success -> {
+            if (Boolean.TRUE.equals(success)) {
+                return;
+            }
+            if (retryOnFailure) {
+                plugin.getSpigotScheduler().runEntityLater(player, () -> firstJoinSpawnTeleport(player, false),
+                        FIRST_JOIN_SPAWN_RETRY_DELAY_TICKS);
+                return;
+            }
+            plugin.getLogger().warning("Could not send " + name + " to the spawn location on first join.");
+        });
+    }
+
+    static long firstJoinSpawnDelayTicks(long configured) {
+        return Math.max(1L, Math.min(MAX_FIRST_JOIN_SPAWN_DELAY_TICKS, configured));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -98,6 +98,10 @@ SETTINGS:
   # join the server. Ignored while First Join Rtp Enabled is true. Available options:
   # true, false
   TELEPORT-SPAWN-ON-FIRST-JOIN: true
+  # The numerical value for First Join Spawn Delay Ticks, how long to wait after a new
+  # player joins before sending them to spawn. Raise it when another plugin moves players
+  # around on join. Available options: Any valid integer
+  FIRST-JOIN-SPAWN-DELAY-TICKS: 20
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/FirstJoinSpawnTeleportTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/FirstJoinSpawnTeleportTest.java
@@ -1,0 +1,39 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FirstJoinSpawnTeleportTest {
+
+    @Test
+    void bundledConfigShipsTheFirstJoinSpawnDelay() {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new File("src/main/resources/config.yml"));
+        assertTrue(config.contains("SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS"));
+        assertEquals(
+                PlayerJoinQuitListener.DEFAULT_FIRST_JOIN_SPAWN_DELAY_TICKS,
+                config.getLong("SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS")
+        );
+    }
+
+    @Test
+    void theTeleportNeverRunsInsideTheJoinEvent() {
+        assertEquals(1L, PlayerJoinQuitListener.firstJoinSpawnDelayTicks(0L));
+        assertEquals(1L, PlayerJoinQuitListener.firstJoinSpawnDelayTicks(-40L));
+        assertEquals(1L, PlayerJoinQuitListener.firstJoinSpawnDelayTicks(1L));
+    }
+
+    @Test
+    void aConfiguredDelayIsKeptUpToTheCap() {
+        assertEquals(20L, PlayerJoinQuitListener.firstJoinSpawnDelayTicks(20L));
+        assertEquals(100L, PlayerJoinQuitListener.firstJoinSpawnDelayTicks(100L));
+        assertEquals(
+                PlayerJoinQuitListener.MAX_FIRST_JOIN_SPAWN_DELAY_TICKS,
+                PlayerJoinQuitListener.firstJoinSpawnDelayTicks(999_999L)
+        );
+    }
+}


### PR DESCRIPTION
Closes #144

`SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` fired the teleport from inside `PlayerJoinEvent`, in the same tick the server is still placing the player in the world. A teleport issued there gets thrown away, so new players stayed on the vanilla world spawn no matter what the setting said. Every other place in this listener that moves a player on join already waits a tick on the player's own scheduler before teleporting; the first join spawn teleport was the one that didn't.

## Deferring the teleport

The teleport now goes through `runEntityLater` on the player's scheduler instead of running inline. On Folia that also puts the call on the thread that owns the player, which is why the maintenance restore path in this same file was moved onto that scheduler back in 70452441.

The spawn location is resolved inside the deferred task rather than before it. That helps servers where a world manager loads the spawn world after this plugin enables, since the world is there by the time the task runs.

## Failures are no longer silent

`SpigotScheduler.teleport` returns a future and nothing was reading it, so a refused teleport produced no retry and nothing in console. It now retries once a second later and warns if that attempt fails too.

A second warning covers the case where the setting is on but there is nowhere to send anyone, either because `/setspawn` was never run or because the world named in `LOCATIONS.SPAWN-LOCATION` is not loaded. That used to be a silent no-op, which is a rough thing to debug from the outside.

## Notes

New config key `SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS`, default 20, clamped to 1..1200. Twenty ticks is invisible to someone who is still downloading chunks on their first join, and it leaves room for other join plugins to finish what they are doing. Owners whose setup needs longer can raise it.

No language files touched, since both new messages are console warnings rather than player facing text. Both wiki config pages document the new key. Suite is 200 tests with three new ones, all green.
