### PR TITLE
fix(staffmode): make custom item commands run on folia (#145)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
@@ -250,8 +250,13 @@ public final class SpigotScheduler {
     }
 
     /**
-     * Runs a command as the given player. Carries the same Folia threading rules as
-     * {@link #dispatchConsoleCommand(String)}.
+     * Runs a command as the given player.
+     *
+     * <p>Folia splits the world into regions and only lets a player be touched from the region that
+     * currently owns them, so a player command cannot go to the global region scheduler the way a
+     * console command does. The global region owns no players, so a dispatch handed to it fails a
+     * thread check instead of running. When the caller already holds the player's region the command
+     * runs straight away, otherwise it goes to the player's own entity scheduler.</p>
      *
      * @return the dispatch result when the command ran inline, or {@code true} when it was scheduled
      */
@@ -261,11 +266,13 @@ public final class SpigotScheduler {
         }
 
         String resolved = command;
-        if (!isFolia() && Bukkit.isPrimaryThread()) {
+        PlayerCommandRoute route = playerCommandRoute(
+                isFolia(), Bukkit.isPrimaryThread(), isOwnedByCurrentRegion(player));
+        if (route == PlayerCommandRoute.INLINE) {
             return player.performCommand(resolved);
         }
 
-        runGlobal(() -> {
+        Runnable dispatch = () -> {
             if (!player.isOnline()) {
                 return;
             }
@@ -275,8 +282,37 @@ public final class SpigotScheduler {
                 plugin.getLogger().log(Level.WARNING, "Failed to dispatch command '" + resolved
                         + "' as " + player.getName(), exception);
             }
-        });
+        };
+
+        if (route == PlayerCommandRoute.ENTITY_SCHEDULER) {
+            runEntity(player, dispatch);
+        } else {
+            runGlobal(dispatch);
+        }
         return true;
+    }
+
+    /** Where the dispatch of a player command has to happen. */
+    enum PlayerCommandRoute {
+        /** Run it on the calling thread, which already owns the player. */
+        INLINE,
+        /** Hand it to the player's own region through their entity scheduler. */
+        ENTITY_SCHEDULER,
+        /** Hand it to the main thread, which on Paper owns every player. */
+        GLOBAL_SCHEDULER
+    }
+
+    /**
+     * Picks the dispatch route for a player command. Paper has one main thread that owns every
+     * player, so being on it is enough. On Folia the calling thread also has to own the player,
+     * and when it does not the work belongs on that player's entity scheduler rather than on the
+     * global region.
+     */
+    static PlayerCommandRoute playerCommandRoute(boolean folia, boolean tickThread, boolean ownsPlayer) {
+        if (!folia) {
+            return tickThread ? PlayerCommandRoute.INLINE : PlayerCommandRoute.GLOBAL_SCHEDULER;
+        }
+        return tickThread && ownsPlayer ? PlayerCommandRoute.INLINE : PlayerCommandRoute.ENTITY_SCHEDULER;
     }
 
     private static long ticksToMillis(long ticks) {

--- a/src/test/java/com/bx/ultimateDonutSmp/staff/StaffCustomItemTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/staff/StaffCustomItemTest.java
@@ -214,6 +214,37 @@ class StaffCustomItemTest {
         assertEquals(StaffCustomItem.ExecuteAs.PLAYER, enabled.get(0).executeAs());
     }
 
+    @Test
+    void aRenamedEnabledEntryOnAFreeSlotLoads() throws Exception {
+        // The shape reported in #145: the bundled example renamed, armed, and moved to a free slot.
+        List<String> warnings = new ArrayList<>();
+        List<StaffCustomItem> items = parse("""
+                CUSTOM-ITEMS:
+                  SUS:
+                    ENABLED: true
+                    SLOT: 6
+                    MATERIAL: TNT
+                    NAME: '&cS&cU&cS'
+                    LORE:
+                    - '&7Click to open /sus'
+                    EXECUTE-AS: PLAYER
+                    PERMISSION: ''
+                    REQUIRE-TARGET: false
+                    COMMANDS:
+                    - 'sus'
+                """, warnings);
+
+        assertEquals(1, items.size(), () -> "the entry was rejected: " + warnings);
+        StaffCustomItem item = items.get(0);
+        assertEquals("SUS", item.id());
+        assertEquals(6, item.slot());
+        assertEquals(Material.TNT, item.material());
+        assertEquals(StaffCustomItem.ExecuteAs.PLAYER, item.executeAs());
+        assertFalse(item.hasPermission(), "an empty PERMISSION must not gate the item");
+        assertEquals(List.of("sus"), item.commands());
+        assertTrue(warnings.isEmpty(), () -> "unexpected warnings: " + warnings);
+    }
+
     private static List<StaffCustomItem> parse(String yaml, List<String> warnings) throws Exception {
         YamlConfiguration config = new YamlConfiguration();
         config.loadFromString(yaml);

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/SpigotSchedulerCommandRouteTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/SpigotSchedulerCommandRouteTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static com.bx.ultimateDonutSmp.utils.SpigotScheduler.PlayerCommandRoute;
+import static com.bx.ultimateDonutSmp.utils.SpigotScheduler.playerCommandRoute;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpigotSchedulerCommandRouteTest {
+
+    @Test
+    void paperRunsInlineOnTheMainThread() {
+        assertEquals(PlayerCommandRoute.INLINE, playerCommandRoute(false, true, true));
+    }
+
+    @Test
+    void paperHandsAnAsyncCallerToTheMainThread() {
+        assertEquals(PlayerCommandRoute.GLOBAL_SCHEDULER, playerCommandRoute(false, false, false));
+    }
+
+    @Test
+    void foliaRunsInlineWhenTheCallerAlreadyOwnsThePlayer() {
+        // A staff member clicking their own hotbar item is handled on the region that owns them.
+        assertEquals(PlayerCommandRoute.INLINE, playerCommandRoute(true, true, true));
+    }
+
+    @Test
+    void foliaNeverSendsAPlayerCommandToTheGlobalRegion() {
+        // The global region owns no players, so a dispatch there fails a thread check and the
+        // command silently never runs.
+        assertEquals(PlayerCommandRoute.ENTITY_SCHEDULER, playerCommandRoute(true, true, false));
+        assertEquals(PlayerCommandRoute.ENTITY_SCHEDULER, playerCommandRoute(true, false, false));
+        assertEquals(PlayerCommandRoute.ENTITY_SCHEDULER, playerCommandRoute(true, false, true));
+    }
+}


### PR DESCRIPTION
Closes #145

Staff mode custom items never ran their commands on Folia. The item showed up in the hotbar and the click registered fine, but anything set to `EXECUTE-AS: PLAYER` quietly did nothing, so an entry like the reporter's `SUS` block looked completely dead in game.

## What was wrong

`SpigotScheduler.dispatchPlayerCommand` sent every dispatch to the global region scheduler once it detected Folia. That is the right home for a console command, but not for a player one. Folia cuts the world into regions, and a player may only be touched from the region that currently owns them. The global region owns no players at all, so the dispatch failed a thread check instead of running the command. Paper has a single main thread that owns everyone, which is why this only ever showed up on Folia.

The annoying part is that the click already arrives on the right thread. `PlayerInteractEvent` fires on the region holding the staff member, so the old code took a command that was already in the right place and sent it somewhere it could not run.

## The fix

Routing now depends on whether the calling thread actually owns the player. When it does, which covers the normal case of a staff member clicking their own hotbar item, the command runs straight away and the real dispatch result comes back. When it does not, the command goes to that player's own entity scheduler instead of the global region. Paper keeps the behaviour it already had: inline on the main thread, main thread scheduler from anywhere else.

The decision itself sits in a small static `playerCommandRoute` helper so it can be tested without a running server, the same way the first-join spawn delay was handled.

## Notes

The console path is untouched. `EXECUTE-AS: CONSOLE` items were already fine, since the global region scheduler is where Folia wants arbitrary console dispatch to happen.

`PlayerSettingsMenu` shares the same helper for its `COMMAND` entries, so menu buttons that run a command as the player pick up the fix too.

No config or language keys change, and no docs needed updating: `docs/wiki/Config-staff-mode.yml.md` already describes the behaviour this restores.

Coverage is four new cases for the routing helper, plus a regression test that runs the exact `CUSTOM-ITEMS` block from the issue through the parser to confirm the config was never the problem. Suite is at 205 tests, all green.
