### PR TITLE
perf(rtp): find safe locations before players ask for them (#143)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -61,6 +61,14 @@ SETTINGS:
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
   LOADED-CHUNK-FALLBACK-AFTER-SAMPLES: 32
+  # Safe locations found ahead of time in the background so RTP can teleport without searching
+  LOCATION-CACHE:
+    # Enable or disable the background safe location cache
+    ENABLED: true
+    # How many ready locations are kept per RTP world. 0 disables the cache
+    SIZE: 3
+    # Seconds a cached location stays usable before it is thrown away. 0 keeps it until the next reload
+    MAX-AGE-SECONDS: 600
 
 # User feedback and status messages
 ```
@@ -73,7 +81,7 @@ SETTINGS:
 | `SETTINGS.MAX-ATTEMPTS` | `int` | Any valid integer number | `'64'` | Configures the technical `MAX-ATTEMPTS` parameter for `SETTINGS.MAX-ATTEMPTS` in `rtp.yml`. |
 | `SETTINGS.MAX-CHUNK-SAMPLES` | `int` | Any valid integer number | `'128'` | Configures the technical `MAX-CHUNK-SAMPLES` parameter for `SETTINGS.MAX-CHUNK-SAMPLES` in `rtp.yml`. |
 | `SETTINGS.ATTEMPT-INTERVAL-TICKS` | `int` | Any valid integer number | `'1'` | Configures the technical `ATTEMPT-INTERVAL-TICKS` parameter for `SETTINGS.ATTEMPT-INTERVAL-TICKS` in `rtp.yml`. |
-| `SETTINGS.SEARCH-ATTEMPTS-PER-TICK` | `int` | Any valid integer number | `'4'` | Configures the technical `SEARCH-ATTEMPTS-PER-TICK` parameter for `SETTINGS.SEARCH-ATTEMPTS-PER-TICK` in `rtp.yml`. |
+| `SETTINGS.SEARCH-ATTEMPTS-PER-TICK` | `int` | Any valid integer number | `'4'` | How many candidate locations are checked side by side instead of one after another. Higher values find a spot sooner at the cost of more chunk work per search. |
 | `SETTINGS.GENERATE-CHUNKS` | `bool` | `true`, `false` | `false` | Configures the technical `GENERATE-CHUNKS` parameter for `SETTINGS.GENERATE-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.GENERATE-FALLBACK-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `GENERATE-FALLBACK-CHUNKS` parameter for `SETTINGS.GENERATE-FALLBACK-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'8'` | Configures the technical `GENERATE-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
@@ -81,6 +89,7 @@ SETTINGS:
 | `SETTINGS.LOAD-GENERATED-CHUNKS` | `bool` | `true`, `false` | `false` | Configures the technical `LOAD-GENERATED-CHUNKS` parameter for `SETTINGS.LOAD-GENERATED-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `FALLBACK-TO-LOADED-CHUNKS` parameter for `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'32'` | Configures the technical `LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
+| `SETTINGS.LOCATION-CACHE` | `section` | See `SETTINGS.LOCATION-CACHE` below | See example | Keeps safe locations ready in the background so `/rtp` can teleport without running a search first. |
 
 ### 3. Practical Setup Example
 
@@ -106,6 +115,60 @@ SETTINGS:
   MAX-GENERATE-FALLBACK-SAMPLES: 32
   # Allow loading already-generated chunks from disk if chunk generation is disabled
   LOAD-GEN
+```
+
+---
+
+## Section: `SETTINGS.LOCATION-CACHE`
+
+Finding a safe spot is the slow part of `/rtp`, and on a large overworld it can keep a player waiting
+for the best part of a minute. This cache does that work in the background while people are playing,
+so the command usually has a verified location waiting for it and teleports straight away.
+
+The cache is filled by the same search `/rtp` runs, one world at a time, and only while at least one
+player is online. Each entry is re-checked against the current world and radius before it is handed
+out, and a search only starts when a world is short of ready locations. When the cache is empty the
+command falls back to searching live, exactly as before.
+
+### 1. Commented Setup Code Example
+
+```yaml
+  # Safe locations found ahead of time in the background so RTP can teleport without searching
+  LOCATION-CACHE:
+    # Enable or disable the background safe location cache
+    ENABLED: true
+    # How many ready locations are kept per RTP world. 0 disables the cache
+    SIZE: 3
+    # Seconds a cached location stays usable before it is thrown away. 0 keeps it until the next reload
+    MAX-AGE-SECONDS: 600
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SETTINGS.LOCATION-CACHE.ENABLED` | `bool` | `true`, `false` | `true` | Master toggle. When `false` every `/rtp` searches for a location the moment the player runs it. |
+| `SETTINGS.LOCATION-CACHE.SIZE` | `int` | `0` to `16` | `'3'` | Ready locations kept per RTP world. Raise it on a busy server so back to back teleports stay instant, lower it to spend less time searching in the background. `0` turns the cache off. |
+| `SETTINGS.LOCATION-CACHE.MAX-AGE-SECONDS` | `int` | Any valid integer number | `'600'` | How long a cached location may sit unused before it is discarded and searched again. `0` keeps entries until the next reload. |
+
+### 3. Practical Setup Example
+
+Keep more spots ready on a busy server and refresh them more often:
+
+```yaml
+SETTINGS:
+  LOCATION-CACHE:
+    ENABLED: true
+    SIZE: 8
+    MAX-AGE-SECONDS: 300
+```
+
+Turn the cache off entirely and go back to searching on demand:
+
+```yaml
+SETTINGS:
+  LOCATION-CACHE:
+    ENABLED: false
 ```
 
 ---

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -277,6 +277,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ShardTask.start(this); // passive "everywhere" shards (per minute)
         ShardCuboidTask.start(this); // spawn cuboid countdown + reward (per second)
         RTPZoneTask.start(this);
+        RTPCacheTask.start(this);
         ClearLagTask.start(this);
         KeyAllTask.start(this);
         AutoSaveTask.start(this);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -90,6 +91,12 @@ public class RTPManager {
     private static final String COOLDOWN_PERMISSION_PREFIX = "ultimatedonutsmp.rtp.cooldown.";
     private static final int DEFAULT_GENERATE_FALLBACK_AFTER_SAMPLES = 32;
     private static final int DEFAULT_MAX_GENERATE_FALLBACK_SAMPLES = 32;
+    private static final String LOCATION_CACHE_ENABLED_SETTING = "SETTINGS.LOCATION-CACHE.ENABLED";
+    private static final String LOCATION_CACHE_SIZE_SETTING = "SETTINGS.LOCATION-CACHE.SIZE";
+    private static final String LOCATION_CACHE_MAX_AGE_SETTING = "SETTINGS.LOCATION-CACHE.MAX-AGE-SECONDS";
+    private static final int DEFAULT_LOCATION_CACHE_SIZE = 3;
+    private static final int MAX_LOCATION_CACHE_SIZE = 16;
+    private static final int DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS = 600;
 
     private static final class SearchProgress {
         private final String worldName;
@@ -111,6 +118,21 @@ public class RTPManager {
     private record LocationAttempt(Location location, boolean countedAttempt) {
     }
 
+    private record CachedLocation(Location location, long cachedAtMillis) {
+    }
+
+    private static final class DirectSearchState {
+        private final SearchSettings settings;
+        private final AtomicInteger attemptsUsed = new AtomicInteger();
+        private final AtomicInteger chunkSamplesUsed = new AtomicInteger();
+        private final AtomicInteger generateFallbackSamplesUsed = new AtomicInteger();
+        private final AtomicInteger activeChains = new AtomicInteger();
+
+        private DirectSearchState(SearchSettings settings) {
+            this.settings = settings;
+        }
+    }
+
     public record RTPQueueEntry(
             UUID playerId,
             String worldName,
@@ -128,7 +150,7 @@ public class RTPManager {
     private final Map<UUID, BukkitTask> activeResultTasks = new ConcurrentHashMap<>();
     private final Map<UUID, CompletableFuture<Location>> activeDirectSearches = new ConcurrentHashMap<>();
     private final Map<UUID, SearchProgress> activeSearches = new ConcurrentHashMap<>();
-    private final Map<String, java.util.Queue<Location>> locationPreCache = new ConcurrentHashMap<>();
+    private final Map<String, java.util.Queue<CachedLocation>> locationPreCache = new ConcurrentHashMap<>();
     private final Set<String> preCacheInFlight = ConcurrentHashMap.newKeySet();
     private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
@@ -286,11 +308,18 @@ public class RTPManager {
     }
 
     public boolean isPreCacheEnabled() {
-        return false;
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return false;
+        }
+        return plugin.getConfigManager().getRtp().getBoolean(LOCATION_CACHE_ENABLED_SETTING, true);
     }
 
     public int getPreCacheSize() {
-        return 0;
+        if (!isPreCacheEnabled()) {
+            return 0;
+        }
+        int size = plugin.getConfigManager().getRtp().getInt(LOCATION_CACHE_SIZE_SETTING, DEFAULT_LOCATION_CACHE_SIZE);
+        return Math.min(MAX_LOCATION_CACHE_SIZE, Math.max(0, size));
     }
 
     public int getSearchAttemptsPerTick() {
@@ -301,19 +330,118 @@ public class RTPManager {
     }
 
     public void refillPreCacheAllWorlds() {
-        // Disabled background pre-caching loop to avoid disk region scanning
+        if (!isPreCacheReady() || getPreCacheSize() <= 0) {
+            return;
+        }
+        if (Bukkit.getOnlinePlayers().isEmpty()) {
+            return;
+        }
+
+        Set<String> worldNames = new LinkedHashSet<>();
+        for (RTPDestination destination : configuredDestinations) {
+            if (destination.enabled()) {
+                worldNames.add(destination.worldName());
+            }
+        }
+        for (String worldName : worldNames) {
+            refillPreCache(worldName);
+        }
     }
 
     public void refillPreCache(String worldName) {
-        // Disabled background pre-caching loop to avoid disk region scanning
+        if (!isPreCacheReady() || worldName == null || worldName.isBlank()) {
+            return;
+        }
+        int cacheSize = getPreCacheSize();
+        if (cacheSize <= 0) {
+            return;
+        }
+
+        String worldKey = normalizeWorldKey(worldName);
+        java.util.Queue<CachedLocation> cached = locationPreCache
+                .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
+        cached.removeIf(entry -> !isCachedLocationUsable(entry));
+        if (cached.size() >= cacheSize) {
+            return;
+        }
+
+        if (isDeniedWorld(worldName) || isConfiguredDestinationDisabled(worldName)) {
+            return;
+        }
+        SearchSettings settings = getWorldSearchSettings(worldName);
+        if (settings == null || getLoadedWorld(worldName) == null) {
+            return;
+        }
+        if (!preCacheInFlight.add(worldKey)) {
+            return;
+        }
+
+        findSafeLocationAsync(settings).whenComplete((location, throwable) -> {
+            preCacheInFlight.remove(worldKey);
+            if (throwable != null || location == null) {
+                return;
+            }
+            java.util.Queue<CachedLocation> target = locationPreCache
+                    .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
+            if (target.size() < getPreCacheSize()) {
+                target.add(new CachedLocation(location, System.currentTimeMillis()));
+            }
+        });
+    }
+
+    private boolean isPreCacheReady() {
+        return plugin != null
+                && plugin.getConfigManager() != null
+                && plugin.getConfigManager().getRtp() != null
+                && plugin.getFeatureManager() != null
+                && plugin.getSpigotScheduler() != null;
     }
 
     private Location pollPreCachedLocation(String worldName) {
+        if (worldName == null || worldName.isBlank() || getPreCacheSize() <= 0) {
+            return null;
+        }
+        java.util.Queue<CachedLocation> cached = locationPreCache.get(normalizeWorldKey(worldName));
+        if (cached == null) {
+            return null;
+        }
+
+        CachedLocation entry;
+        while ((entry = cached.poll()) != null) {
+            if (isCachedLocationUsable(entry)) {
+                return entry.location().clone();
+            }
+        }
         return null;
     }
 
+    private boolean isCachedLocationUsable(CachedLocation entry) {
+        if (entry == null) {
+            return false;
+        }
+        long maxAgeMillis = getPreCacheMaxAgeMillis();
+        if (maxAgeMillis > 0L && System.currentTimeMillis() - entry.cachedAtMillis() > maxAgeMillis) {
+            return false;
+        }
+        return isPreCachedLocationValid(entry.location());
+    }
+
+    private long getPreCacheMaxAgeMillis() {
+        int seconds = plugin.getConfigManager().getRtp()
+                .getInt(LOCATION_CACHE_MAX_AGE_SETTING, DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS);
+        return seconds <= 0 ? 0L : seconds * 1000L;
+    }
+
     private boolean isPreCachedLocationValid(Location loc) {
-        return false;
+        if (loc == null || loc.getWorld() == null) {
+            return false;
+        }
+        World world = getLoadedWorld(loc.getWorld().getName());
+        if (world != loc.getWorld()) {
+            return false;
+        }
+        SearchSettings settings = getWorldSearchSettings(world.getName());
+        return settings == null || isWithinRadius(settings, loc, true);
     }
 
     public boolean isEnabled() {
@@ -657,7 +785,7 @@ public class RTPManager {
             return CompletableFuture.completedFuture(null);
         }
         future.whenComplete((location, throwable) -> activeDirectSearches.remove(playerId, future));
-        scheduleFindSafeLocationAsyncHelper(settings, 0, 0, 0, future, settings.attemptIntervalTicks());
+        startDirectSearch(settings, future);
         return future;
     }
 
@@ -666,7 +794,7 @@ public class RTPManager {
             return CompletableFuture.completedFuture(null);
         }
         CompletableFuture<Location> future = new CompletableFuture<>();
-        scheduleFindSafeLocationAsyncHelper(settings, 0, 0, 0, future, settings.attemptIntervalTicks());
+        startDirectSearch(settings, future);
         return future;
     }
 
@@ -677,189 +805,130 @@ public class RTPManager {
         return settings != null && settings.worldName() != null && !settings.worldName().isBlank();
     }
 
-    private void scheduleFindSafeLocationAsyncHelper(
-            SearchSettings settings,
-            int attemptsUsed,
-            int chunkSamplesUsed,
-            int generateFallbackSamplesUsed,
+    private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
+        DirectSearchState state = new DirectSearchState(settings);
+        int chains = Math.max(1, Math.min(getSearchAttemptsPerTick(), settings.maxChunkSamples()));
+        state.activeChains.set(chains);
+        for (int chain = 0; chain < chains; chain++) {
+            scheduleDirectSearchStep(state, future, settings.attemptIntervalTicks());
+        }
+    }
+
+    private void scheduleDirectSearchStep(
+            DirectSearchState state,
             CompletableFuture<Location> future,
             long delayTicks
     ) {
         if (future.isDone()) {
+            finishDirectSearchChain(state, future);
             return;
         }
         plugin.getSpigotScheduler().runGlobalLater(
-                () -> findSafeLocationAsyncHelper(
-                        settings,
-                        attemptsUsed,
-                        chunkSamplesUsed,
-                        generateFallbackSamplesUsed,
-                        future
-                ),
+                () -> runDirectSearchStep(state, future),
                 Math.max(0L, delayTicks)
         );
     }
 
-    private void retryFindSafeLocationAsyncHelper(
-            SearchSettings settings,
-            int attemptsUsed,
-            int chunkSamplesUsed,
-            int generateFallbackSamplesUsed,
-            CompletableFuture<Location> future
-    ) {
-        scheduleFindSafeLocationAsyncHelper(
-                settings,
-                attemptsUsed,
-                chunkSamplesUsed,
-                generateFallbackSamplesUsed,
-                future,
-                settings.attemptIntervalTicks()
-        );
+    private void finishDirectSearchChain(DirectSearchState state, CompletableFuture<Location> future) {
+        if (state.activeChains.decrementAndGet() > 0) {
+            return;
+        }
+        if (future.complete(null)) {
+            logSearchFailure(
+                    state.settings,
+                    state.attemptsUsed.get(),
+                    state.chunkSamplesUsed.get(),
+                    state.generateFallbackSamplesUsed.get()
+            );
+        }
     }
 
-    private void findSafeLocationAsyncHelper(
-            SearchSettings settings,
-            int attemptsUsed,
-            int chunkSamplesUsed,
-            int generateFallbackSamplesUsed,
-            CompletableFuture<Location> future
-    ) {
+    private void runDirectSearchStep(DirectSearchState state, CompletableFuture<Location> future) {
         if (future.isDone()) {
+            finishDirectSearchChain(state, future);
             return;
         }
-        if (!hasAttemptBudget(attemptsUsed, settings)
-                || !hasChunkSampleBudget(chunkSamplesUsed, settings)) {
-            completeDirectSearchFailure(settings, attemptsUsed, chunkSamplesUsed, generateFallbackSamplesUsed, future);
+
+        SearchSettings settings = state.settings;
+        if (!hasAttemptBudget(state.attemptsUsed.get(), settings)
+                || !hasChunkSampleBudget(state.chunkSamplesUsed.get(), settings)) {
+            finishDirectSearchChain(state, future);
             return;
         }
-        int nextChunkSamplesUsed = chunkSamplesUsed + 1;
-        boolean generateFallback = shouldUseGenerateFallback(chunkSamplesUsed, generateFallbackSamplesUsed);
-        boolean useLoadedFallback = !generateFallback && shouldUseLoadedChunkFallback(chunkSamplesUsed);
-        if (useLoadedFallback) {
-            World world = resolveWorld(settings.worldName());
-            if (world == null) {
-                completeDirectSearchFailure(settings, attemptsUsed, nextChunkSamplesUsed, generateFallbackSamplesUsed, future);
-                return;
-            }
+
+        World world = resolveWorld(settings.worldName());
+        if (world == null) {
+            finishDirectSearchChain(state, future);
+            return;
+        }
+
+        int chunkSamplesUsed = state.chunkSamplesUsed.getAndIncrement();
+        boolean generateFallback = shouldUseGenerateFallback(chunkSamplesUsed, state.generateFallbackSamplesUsed.get());
+        if (!generateFallback && shouldUseLoadedChunkFallback(chunkSamplesUsed)) {
             plugin.getSpigotScheduler().runRegion(world, settings.centerX() >> 4, settings.centerZ() >> 4, () -> {
+                Location found = null;
                 try {
                     LocationAttempt attempt = tryLoadedChunkLocationAttempt(settings);
-                    int nextAttemptsUsed = attemptsUsed + (attempt.countedAttempt() ? 1 : 0);
-                    if (attempt.location() != null) {
-                        future.complete(attempt.location());
-                    } else {
-                        retryFindSafeLocationAsyncHelper(
-                                settings,
-                                nextAttemptsUsed,
-                                nextChunkSamplesUsed,
-                                generateFallbackSamplesUsed,
-                                future
-                        );
+                    if (attempt.countedAttempt()) {
+                        state.attemptsUsed.incrementAndGet();
                     }
+                    found = attempt.location();
                 } catch (RuntimeException exception) {
-                    retryFindSafeLocationAsyncHelper(
-                            settings,
-                            attemptsUsed + 1,
-                            nextChunkSamplesUsed,
-                            generateFallbackSamplesUsed,
-                            future
-                    );
+                    state.attemptsUsed.incrementAndGet();
                 }
+                continueDirectSearch(state, future, found);
             });
-        } else {
-            World world = resolveWorld(settings.worldName());
-            if (world == null) {
-                completeDirectSearchFailure(settings, attemptsUsed, nextChunkSamplesUsed, generateFallbackSamplesUsed, future);
-                return;
-            }
-            int minRadius = Math.max(0, settings.minRadius());
-            int maxRadius = Math.max(minRadius, settings.maxRadius());
-            double angle = ThreadLocalRandom.current().nextDouble(0, 2 * Math.PI);
-            double distance = minRadius;
-            if (maxRadius > minRadius) {
-                distance += ThreadLocalRandom.current().nextDouble(0, maxRadius - minRadius);
-            }
-            int x = settings.centerX() + (int) Math.round(Math.cos(angle) * distance);
-            int z = settings.centerZ() + (int) Math.round(Math.sin(angle) * distance);
-            int chunkX = x >> 4;
-            int chunkZ = z >> 4;
-            boolean generateChunks = plugin.getConfigManager().getRtp().getBoolean(GENERATE_CHUNKS_SETTING, false);
-            boolean generateForSample = generateChunks || generateFallback;
-            int nextGenerateFallbackSamplesUsed = generateFallback
-                    ? generateFallbackSamplesUsed + 1
-                    : generateFallbackSamplesUsed;
-            if (!generateForSample && !plugin.getConfigManager().getRtp().getBoolean(LOAD_GENERATED_CHUNKS_SETTING, true)) {
-                retryFindSafeLocationAsyncHelper(
-                        settings,
-                        attemptsUsed,
-                        nextChunkSamplesUsed,
-                        nextGenerateFallbackSamplesUsed,
-                        future
-                );
-                return;
-            }
-            getChunkAtAsync(world, chunkX, chunkZ, generateForSample).thenAccept(chunk -> {
+            return;
+        }
+
+        if (generateFallback) {
+            state.generateFallbackSamplesUsed.incrementAndGet();
+        }
+
+        FileConfiguration rtp = plugin.getConfigManager().getRtp();
+        boolean generateForSample = rtp.getBoolean(GENERATE_CHUNKS_SETTING, false) || generateFallback;
+        if (!generateForSample && !rtp.getBoolean(LOAD_GENERATED_CHUNKS_SETTING, true)) {
+            continueDirectSearch(state, future, null);
+            return;
+        }
+
+        int[] sample = nextRandomSample(settings);
+        int x = sample[0];
+        int z = sample[1];
+        int chunkX = x >> 4;
+        int chunkZ = z >> 4;
+
+        getChunkAtAsync(world, chunkX, chunkZ, generateForSample).thenAccept(chunk ->
                 plugin.getSpigotScheduler().runRegion(world, chunkX, chunkZ, () -> {
+                    Location found = null;
                     try {
-                        if (chunk == null) {
-                            retryFindSafeLocationAsyncHelper(
-                                    settings,
-                                    attemptsUsed,
-                                    nextChunkSamplesUsed,
-                                    nextGenerateFallbackSamplesUsed,
-                                    future
-                            );
-                            return;
-                        }
-                        Location found = resolveSafeLocationInChunk(world, settings, x, z, chunkX, chunkZ);
-                        int nextAttemptsUsed = attemptsUsed + 1;
-                        if (found != null) {
-                            future.complete(found);
-                        } else {
-                            retryFindSafeLocationAsyncHelper(
-                                    settings,
-                                    nextAttemptsUsed,
-                                    nextChunkSamplesUsed,
-                                    nextGenerateFallbackSamplesUsed,
-                                    future
-                            );
+                        if (chunk != null) {
+                            found = resolveSafeLocationInChunk(world, settings, x, z, chunkX, chunkZ);
+                            state.attemptsUsed.incrementAndGet();
                         }
                     } catch (RuntimeException exception) {
-                        retryFindSafeLocationAsyncHelper(
-                                settings,
-                                attemptsUsed + 1,
-                                nextChunkSamplesUsed,
-                                nextGenerateFallbackSamplesUsed,
-                                future
-                        );
+                        state.attemptsUsed.incrementAndGet();
                     }
-                });
-            }).exceptionally(throwable -> {
-                plugin.getSpigotScheduler().runRegion(world, chunkX, chunkZ, () -> {
-                    int nextAttemptsUsed = generateForSample ? attemptsUsed + 1 : attemptsUsed;
-                    retryFindSafeLocationAsyncHelper(
-                            settings,
-                            nextAttemptsUsed,
-                            nextChunkSamplesUsed,
-                            nextGenerateFallbackSamplesUsed,
-                            future
-                    );
-                });
-                return null;
+                    continueDirectSearch(state, future, found);
+                })
+        ).exceptionally(throwable -> {
+            plugin.getSpigotScheduler().runRegion(world, chunkX, chunkZ, () -> {
+                if (generateForSample) {
+                    state.attemptsUsed.incrementAndGet();
+                }
+                continueDirectSearch(state, future, null);
             });
-        }
+            return null;
+        });
     }
 
-    private void completeDirectSearchFailure(
-            SearchSettings settings,
-            int attemptsUsed,
-            int chunkSamplesUsed,
-            int generateFallbackSamplesUsed,
-            CompletableFuture<Location> future
-    ) {
-        if (future.complete(null)) {
-            logSearchFailure(settings, attemptsUsed, chunkSamplesUsed, generateFallbackSamplesUsed);
+    private void continueDirectSearch(DirectSearchState state, CompletableFuture<Location> future, Location found) {
+        if (found != null) {
+            future.complete(found);
+            finishDirectSearchChain(state, future);
+            return;
         }
+        scheduleDirectSearchStep(state, future, state.settings.attemptIntervalTicks());
     }
 
     private boolean queueTeleport(Player player, String worldName) {
@@ -1016,7 +1085,7 @@ public class RTPManager {
             return;
         }
 
-        int maxConcurrent = 4;
+        int maxConcurrent = Math.max(1, getSearchAttemptsPerTick());
         while (progress.activeAttemptsInFlight < maxConcurrent && hasSearchBudget(progress)) {
             beginAsyncLocationAttempt(playerId, progress);
         }
@@ -1042,15 +1111,9 @@ public class RTPManager {
             });
             return;
         }
-        int minRadius = Math.max(0, progress.settings.minRadius());
-        int maxRadius = Math.max(minRadius, progress.settings.maxRadius());
-        double angle = ThreadLocalRandom.current().nextDouble(0, 2 * Math.PI);
-        double distance = minRadius;
-        if (maxRadius > minRadius) {
-            distance += ThreadLocalRandom.current().nextDouble(0, maxRadius - minRadius);
-        }
-        int x = progress.settings.centerX() + (int) Math.round(Math.cos(angle) * distance);
-        int z = progress.settings.centerZ() + (int) Math.round(Math.sin(angle) * distance);
+        int[] sample = nextRandomSample(progress.settings);
+        int x = sample[0];
+        int z = sample[1];
         int chunkX = x >> 4;
         int chunkZ = z >> 4;
         progress.chunkSamplesUsed++;
@@ -1311,6 +1374,13 @@ public class RTPManager {
             return new LocationAttempt(null, false);
         }
 
+        int[] sample = nextRandomSample(settings);
+        int x = sample[0];
+        int z = sample[1];
+        return tryResolveSafeLocation(world, x, z, x >> 4, z >> 4);
+    }
+
+    private int[] nextRandomSample(SearchSettings settings) {
         int minRadius = Math.max(0, settings.minRadius());
         int maxRadius = Math.max(minRadius, settings.maxRadius());
 
@@ -1320,9 +1390,10 @@ public class RTPManager {
             distance += ThreadLocalRandom.current().nextDouble(0, maxRadius - minRadius);
         }
 
-        int x = settings.centerX() + (int) Math.round(Math.cos(angle) * distance);
-        int z = settings.centerZ() + (int) Math.round(Math.sin(angle) * distance);
-        return tryResolveSafeLocation(world, x, z, x >> 4, z >> 4);
+        return new int[] {
+                settings.centerX() + (int) Math.round(Math.cos(angle) * distance),
+                settings.centerZ() + (int) Math.round(Math.sin(angle) * distance)
+        };
     }
 
     private LocationAttempt tryResolveSafeLocation(

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/RTPCacheTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/RTPCacheTask.java
@@ -1,0 +1,24 @@
+package com.bx.ultimateDonutSmp.tasks;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+
+public class RTPCacheTask implements Runnable {
+
+    private final UltimateDonutSmp plugin;
+
+    public RTPCacheTask(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void run() {
+        if (plugin.getRtpManager() == null || !plugin.getRtpManager().isEnabled()) {
+            return;
+        }
+        plugin.getRtpManager().refillPreCacheAllWorlds();
+    }
+
+    public static void start(UltimateDonutSmp plugin) {
+        plugin.getSpigotScheduler().runGlobalTimer(new RTPCacheTask(plugin), 100L, 20L);
+    }
+}

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -31,6 +31,14 @@ SETTINGS:
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
   LOADED-CHUNK-FALLBACK-AFTER-SAMPLES: 32
+  # Safe locations found ahead of time in the background so RTP can teleport without searching
+  LOCATION-CACHE:
+    # Enable or disable the background safe location cache
+    ENABLED: true
+    # How many ready locations are kept per RTP world. 0 disables the cache
+    SIZE: 3
+    # Seconds a cached location stays usable before it is thrown away. 0 keeps it until the next reload
+    MAX-AGE-SECONDS: 600
   # Priority queue settings for RTP requests
   PRIORITY-QUEUE:
     # Enable or disable the RTP permission priority queue system

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -16,9 +17,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class RTPManagerTest {
 
@@ -128,6 +133,114 @@ class RTPManagerTest {
 
         String normalWorld = (String) getLoadedNormalWorldName.invoke(rtpManager);
         assertEquals("survival", normalWorld);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void seedLocationCache(RTPManager rtpManager, String worldName, Location location, long cachedAtMillis)
+            throws Exception {
+        Class<?> cachedLocationClass = Class.forName("com.bx.ultimateDonutSmp.managers.RTPManager$CachedLocation");
+        Constructor<?> cachedLocationConstructor = cachedLocationClass.getDeclaredConstructor(Location.class, long.class);
+        cachedLocationConstructor.setAccessible(true);
+        Object entry = cachedLocationConstructor.newInstance(location, cachedAtMillis);
+
+        Field cacheField = RTPManager.class.getDeclaredField("locationPreCache");
+        cacheField.setAccessible(true);
+        Map<String, Queue<Object>> cache = (Map<String, Queue<Object>>) cacheField.get(rtpManager);
+        Queue<Object> queue = new ConcurrentLinkedQueue<>();
+        queue.add(entry);
+        cache.put(worldName.toLowerCase(java.util.Locale.ROOT), queue);
+    }
+
+    private Location pollCachedLocation(RTPManager rtpManager, String worldName) throws Exception {
+        Method pollPreCachedLocation = RTPManager.class.getDeclaredMethod("pollPreCachedLocation", String.class);
+        pollPreCachedLocation.setAccessible(true);
+        return (Location) pollPreCachedLocation.invoke(rtpManager, worldName);
+    }
+
+    private YamlConfiguration overworldRtpConfig() {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("WORLD-SETTINGS.world.MIN-RADIUS", 500);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+        return rtpConfig;
+    }
+
+    @Test
+    void testSearchAttemptsPerTickReadsConfiguredValue() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+        assertEquals(1, rtpManager.getSearchAttemptsPerTick());
+
+        rtpConfig.set("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", 8);
+        assertEquals(8, rtpManager.getSearchAttemptsPerTick());
+
+        rtpConfig.set("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", 0);
+        assertEquals(1, rtpManager.getSearchAttemptsPerTick());
+    }
+
+    @Test
+    void testPreCacheSizeIsClampedAndRespectsToggle() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+        assertEquals(3, rtpManager.getPreCacheSize());
+
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 64);
+        assertEquals(16, rtpManager.getPreCacheSize());
+
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", -4);
+        assertEquals(0, rtpManager.getPreCacheSize());
+
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 5);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", false);
+        assertEquals(0, rtpManager.getPreCacheSize());
+    }
+
+    @Test
+    void testPollPreCachedLocationReturnsUsableEntry() throws Exception {
+        World world = createMockWorld("world", World.Environment.NORMAL);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(overworldRtpConfig()));
+
+        Location cached = new Location(world, 1000.5, 70.0, 1000.5);
+        seedLocationCache(rtpManager, "world", cached, System.currentTimeMillis());
+
+        Location polled = pollCachedLocation(rtpManager, "world");
+        assertEquals(cached, polled);
+        assertSame(world, polled.getWorld());
+        assertNull(pollCachedLocation(rtpManager, "world"));
+    }
+
+    @Test
+    void testPollPreCachedLocationDropsEntryOutsideRadius() throws Exception {
+        World world = createMockWorld("world", World.Environment.NORMAL);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(overworldRtpConfig()));
+
+        seedLocationCache(rtpManager, "world", new Location(world, 100.5, 70.0, 100.5), System.currentTimeMillis());
+
+        assertNull(pollCachedLocation(rtpManager, "world"));
+    }
+
+    @Test
+    void testPollPreCachedLocationDropsExpiredEntry() throws Exception {
+        World world = createMockWorld("world", World.Environment.NORMAL);
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.MAX-AGE-SECONDS", 60);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+
+        Location cached = new Location(world, 1000.5, 70.0, 1000.5);
+        seedLocationCache(rtpManager, "world", cached, System.currentTimeMillis() - 120_000L);
+
+        assertNull(pollCachedLocation(rtpManager, "world"));
+    }
+
+    @Test
+    void testPollPreCachedLocationIgnoresCacheWhenDisabled() throws Exception {
+        World world = createMockWorld("world", World.Environment.NORMAL);
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", false);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+
+        seedLocationCache(rtpManager, "world", new Location(world, 1000.5, 70.0, 1000.5), System.currentTimeMillis());
+
+        assertNull(pollCachedLocation(rtpManager, "world"));
     }
 
     @Test


### PR DESCRIPTION
Closes #143

Finding a safe spot is the slow part of `/rtp`. On a 5000 block overworld it was leaving people watching the search bar for 30 to 50 seconds. The search itself is fine, it just never ran until somebody was already waiting on it. Now it runs in the background, so most of the time the command has a verified location ready and teleports straight away.

## Background location cache

The manager already had the plumbing for this, but `refillPreCache`, `pollPreCachedLocation` and friends were all stubbed out to return nothing, because the old version scanned region files off disk. This version fills the cache with the normal async search, so no disk scanning is involved.

A new task tops each RTP world up once a second, and only while somebody is online. It only starts a search when a world is short of ready locations, so a full cache does nothing but the check. When a player takes an entry, that world immediately goes looking for a replacement. If the cache is empty, `/rtp` searches live exactly like it did before.

Entries get re-checked before they are handed out. The world still has to be loaded and the location still has to sit inside the configured radius, and anything older than `MAX-AGE-SECONDS` is thrown away rather than used.

## SEARCH-ATTEMPTS-PER-TICK now does something

`rtp.yml` has shipped this key for a while and the wiki documents it, but `tickSearch` had `4` hardcoded and `getSearchAttemptsPerTick()` was never called, so nobody could actually change it. It is wired up now, so a server that wants the live search to try harder can raise the number.

## The background and first join searches run in parallel too

`findSafeLocationAsync` walked one chunk sample at a time, one per `ATTEMPT-INTERVAL-TICKS`. That is the path the first join spawn and the RTP zone use as well. It now runs `SEARCH-ATTEMPTS-PER-TICK` chains side by side over a shared sample and attempt budget, so the same limits apply, they are just spent several at a time. That is also what lets the cache refill fast enough to keep up.

## Notes

Three new keys under `SETTINGS.LOCATION-CACHE` in `rtp.yml`: `ENABLED` (true), `SIZE` (3, clamped to 16) and `MAX-AGE-SECONDS` (600). They are toggles and numbers rather than player facing text, so no language files were touched. Existing configs pick the block up through the usual bundled config merge.

Setting `SIZE: 0` or `ENABLED: false` puts the plugin back on the old search-on-demand path.

The random ring sample was copy pasted in three places, so it moved into one `nextRandomSample` helper. Behaviour there is unchanged.

`docs/wiki/Config-rtp.yml.md` gains a section for the new block, and the `SEARCH-ATTEMPTS-PER-TICK` row now says what the key does instead of repeating its own name.

Five new tests in `RTPManagerTest` cover the cache size clamp, the enabled toggle, and the poll path returning a usable entry while rejecting one that is expired, outside the radius, or cached with the feature turned off. Full suite is 211 tests, all green.
