### PR TITLE
fix(rtp): fill the location cache on an empty server (#151)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -122,13 +122,17 @@ SETTINGS:
 ## Section: `SETTINGS.LOCATION-CACHE`
 
 Finding a safe spot is the slow part of `/rtp`, and on a large overworld it can keep a player waiting
-for the best part of a minute. This cache does that work in the background while people are playing,
-so the command usually has a verified location waiting for it and teleports straight away.
+for the best part of a minute. This cache does that work in the background, so the command usually
+has a verified location waiting for it and teleports straight away.
 
-The cache is filled by the same search `/rtp` runs, one world at a time, and only while at least one
-player is online. Each entry is re-checked against the current world and radius before it is handed
-out, and a search only starts when a world is short of ready locations. When the cache is empty the
-command falls back to searching live, exactly as before.
+Filling starts as soon as the server does and keeps going whether or not anyone is online, which is
+the point: the first player to join should not be the one who pays for the search. Each world runs up
+to two background searches at a time until it holds `SIZE` locations, and those searches check fewer
+candidates side by side than a player-facing one so the warm-up never competes with someone who is
+actually waiting. Every entry is re-checked against the current world and radius before it is handed
+out, and a background search that never reports back is given up on after thirty seconds so a world
+cannot be left without ready locations. When the cache is empty the command falls back to searching
+live, exactly as before.
 
 ### 1. Commented Setup Code Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -97,6 +97,9 @@ public class RTPManager {
     private static final int DEFAULT_LOCATION_CACHE_SIZE = 3;
     private static final int MAX_LOCATION_CACHE_SIZE = 16;
     private static final int DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS = 600;
+    private static final int PRE_CACHE_PARALLEL_ATTEMPTS = 4;
+    private static final int MAX_PRE_CACHE_SEARCHES_PER_WORLD = 2;
+    private static final long PRE_CACHE_SEARCH_TIMEOUT_MILLIS = 30_000L;
 
     private static final class SearchProgress {
         private final String worldName;
@@ -151,7 +154,7 @@ public class RTPManager {
     private final Map<UUID, CompletableFuture<Location>> activeDirectSearches = new ConcurrentHashMap<>();
     private final Map<UUID, SearchProgress> activeSearches = new ConcurrentHashMap<>();
     private final Map<String, java.util.Queue<CachedLocation>> locationPreCache = new ConcurrentHashMap<>();
-    private final Set<String> preCacheInFlight = ConcurrentHashMap.newKeySet();
+    private final Map<String, java.util.Queue<Long>> preCacheInFlight = new ConcurrentHashMap<>();
     private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
     private List<RTPDestination> menuDestinations = List.of();
@@ -333,9 +336,6 @@ public class RTPManager {
         if (!isPreCacheReady() || getPreCacheSize() <= 0) {
             return;
         }
-        if (Bukkit.getOnlinePlayers().isEmpty()) {
-            return;
-        }
 
         Set<String> worldNames = new LinkedHashSet<>();
         for (RTPDestination destination : configuredDestinations) {
@@ -361,7 +361,14 @@ public class RTPManager {
         java.util.Queue<CachedLocation> cached = locationPreCache
                 .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
         cached.removeIf(entry -> !isCachedLocationUsable(entry));
-        if (cached.size() >= cacheSize) {
+
+        int searches = preCacheSearchesToStart(
+                cacheSize,
+                cached.size(),
+                countPreCacheSearchesInFlight(worldKey),
+                MAX_PRE_CACHE_SEARCHES_PER_WORLD
+        );
+        if (searches <= 0) {
             return;
         }
 
@@ -372,21 +379,82 @@ public class RTPManager {
         if (settings == null || getLoadedWorld(worldName) == null) {
             return;
         }
-        if (!preCacheInFlight.add(worldKey)) {
-            return;
-        }
 
-        findSafeLocationAsync(settings).whenComplete((location, throwable) -> {
-            preCacheInFlight.remove(worldKey);
-            if (throwable != null || location == null) {
-                return;
-            }
-            java.util.Queue<CachedLocation> target = locationPreCache
-                    .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
-            if (target.size() < getPreCacheSize()) {
-                target.add(new CachedLocation(location, System.currentTimeMillis()));
-            }
-        });
+        for (int started = 0; started < searches; started++) {
+            startPreCacheSearch(worldKey, settings);
+        }
+    }
+
+    /**
+     * How many background searches a world should start right now, so the cache walks up to its
+     * configured size instead of gaining at most one location per refill, while never running more
+     * than {@code maxConcurrentSearches} of them at a time.
+     */
+    static int preCacheSearchesToStart(
+            int cacheSize,
+            int cachedLocations,
+            int searchesInFlight,
+            int maxConcurrentSearches
+    ) {
+        int missing = cacheSize - cachedLocations - searchesInFlight;
+        int free = maxConcurrentSearches - searchesInFlight;
+        return Math.max(0, Math.min(missing, free));
+    }
+
+    private void startPreCacheSearch(String worldKey, SearchSettings settings) {
+        long startedAt = System.currentTimeMillis();
+        preCacheInFlight
+                .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>())
+                .add(startedAt);
+
+        try {
+            findSafeLocationAsync(settings, getPreCacheParallelAttempts()).whenComplete((location, throwable) -> {
+                releasePreCacheSearch(worldKey, startedAt);
+                if (throwable != null || location == null) {
+                    return;
+                }
+                java.util.Queue<CachedLocation> target = locationPreCache
+                        .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
+                if (target.size() < getPreCacheSize()) {
+                    target.add(new CachedLocation(location, System.currentTimeMillis()));
+                }
+            });
+        } catch (RuntimeException exception) {
+            releasePreCacheSearch(worldKey, startedAt);
+            throw exception;
+        }
+    }
+
+    /**
+     * Counts the background searches still running for a world, dropping any that outlived
+     * {@link #PRE_CACHE_SEARCH_TIMEOUT_MILLIS}. A search whose callback never arrives - a scheduled
+     * step the server dropped, say - would otherwise hold its slot for the rest of the uptime and
+     * leave that world without a single cached location.
+     */
+    private int countPreCacheSearchesInFlight(String worldKey) {
+        java.util.Queue<Long> running = preCacheInFlight.get(worldKey);
+        if (running == null) {
+            return 0;
+        }
+        long cutoff = System.currentTimeMillis() - PRE_CACHE_SEARCH_TIMEOUT_MILLIS;
+        running.removeIf(startedAt -> startedAt == null || startedAt < cutoff);
+        return running.size();
+    }
+
+    private void releasePreCacheSearch(String worldKey, long startedAt) {
+        java.util.Queue<Long> running = preCacheInFlight.get(worldKey);
+        if (running != null) {
+            running.remove(startedAt);
+        }
+    }
+
+    /**
+     * Background searches run on fewer parallel chains than a player-facing one. Nobody is waiting
+     * on the result, so the warm-up has no reason to claim the chunk throughput a waiting player
+     * gets.
+     */
+    private int getPreCacheParallelAttempts() {
+        return Math.max(1, Math.min(PRE_CACHE_PARALLEL_ATTEMPTS, getSearchAttemptsPerTick()));
     }
 
     private boolean isPreCacheReady() {
@@ -790,11 +858,15 @@ public class RTPManager {
     }
 
     public CompletableFuture<Location> findSafeLocationAsync(SearchSettings settings) {
+        return findSafeLocationAsync(settings, getSearchAttemptsPerTick());
+    }
+
+    private CompletableFuture<Location> findSafeLocationAsync(SearchSettings settings, int parallelAttempts) {
         if (!isSearchRequestValid(settings)) {
             return CompletableFuture.completedFuture(null);
         }
         CompletableFuture<Location> future = new CompletableFuture<>();
-        startDirectSearch(settings, future);
+        startDirectSearch(settings, future, parallelAttempts);
         return future;
     }
 
@@ -806,8 +878,12 @@ public class RTPManager {
     }
 
     private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
+        startDirectSearch(settings, future, getSearchAttemptsPerTick());
+    }
+
+    private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future, int parallelAttempts) {
         DirectSearchState state = new DirectSearchState(settings);
-        int chains = Math.max(1, Math.min(getSearchAttemptsPerTick(), settings.maxChunkSamples()));
+        int chains = Math.max(1, Math.min(parallelAttempts, settings.maxChunkSamples()));
         state.activeChains.set(chains);
         for (int chain = 0; chain < chains; chain++) {
             scheduleDirectSearchStep(state, future, settings.attemptIntervalTicks());

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -1,11 +1,13 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.SpigotScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,21 +22,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RTPManagerTest {
 
     private Server originalServer;
     private Server mockServer;
     private List<World> mockWorlds;
+    private AtomicInteger scheduledTasks;
 
     @BeforeEach
     void setUp() throws Exception {
         originalServer = Bukkit.getServer();
         mockWorlds = new ArrayList<>();
+        scheduledTasks = new AtomicInteger();
+
+        Object mockScheduler = Proxy.newProxyInstance(
+                BukkitScheduler.class.getClassLoader(),
+                new Class<?>[]{BukkitScheduler.class},
+                (proxy, method, args) -> {
+                    if (method.getName().startsWith("runTask")) {
+                        scheduledTasks.incrementAndGet();
+                    }
+                    return null;
+                }
+        );
 
         mockServer = (Server) Proxy.newProxyInstance(
                 Server.class.getClassLoader(),
@@ -54,6 +71,12 @@ class RTPManagerTest {
                     }
                     if (method.getName().equals("getWorldContainer")) {
                         return new java.io.File(".");
+                    }
+                    if (method.getName().equals("getOnlinePlayers")) {
+                        return List.of();
+                    }
+                    if (method.getName().equals("getScheduler")) {
+                        return mockScheduler;
                     }
                     if (method.getName().equals("getLogger")) {
                         return java.util.logging.Logger.getLogger("Minecraft");
@@ -241,6 +264,108 @@ class RTPManagerTest {
         seedLocationCache(rtpManager, "world", new Location(world, 1000.5, 70.0, 1000.5), System.currentTimeMillis());
 
         assertNull(pollCachedLocation(rtpManager, "world"));
+    }
+
+    /** Gives the mock plugin the two collaborators the background pre-cache needs to run. */
+    private void attachSchedulerAndFeatures(UltimateDonutSmp plugin) throws Exception {
+        Field featureField = UltimateDonutSmp.class.getDeclaredField("featureManager");
+        featureField.setAccessible(true);
+        featureField.set(plugin, new FeatureManager(plugin));
+
+        Field schedulerField = UltimateDonutSmp.class.getDeclaredField("SpigotScheduler");
+        schedulerField.setAccessible(true);
+        schedulerField.set(plugin, new SpigotScheduler(plugin));
+    }
+
+    private YamlConfiguration preCacheRtpConfig() {
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        rtpConfig.set("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", 25);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", true);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 5);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.SLOT", 11);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.WORLD", "world");
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.ENABLED", true);
+        return rtpConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Queue<Long>> preCacheInFlight(RTPManager rtpManager) throws Exception {
+        Field field = RTPManager.class.getDeclaredField("preCacheInFlight");
+        field.setAccessible(true);
+        return (Map<String, Queue<Long>>) field.get(rtpManager);
+    }
+
+    private Queue<Long> searchesInFlight(RTPManager rtpManager, String worldKey) throws Exception {
+        Queue<Long> running = preCacheInFlight(rtpManager).get(worldKey);
+        return running == null ? new ConcurrentLinkedQueue<>() : running;
+    }
+
+    private void seedSearchesInFlight(RTPManager rtpManager, String worldKey, long... startedAt) throws Exception {
+        Queue<Long> running = new ConcurrentLinkedQueue<>();
+        for (long value : startedAt) {
+            running.add(value);
+        }
+        preCacheInFlight(rtpManager).put(worldKey, running);
+    }
+
+    @Test
+    void testPreCacheSearchesToStartFillsTheCacheWithinTheConcurrencyLimit() {
+        assertEquals(2, RTPManager.preCacheSearchesToStart(5, 0, 0, 2));
+        assertEquals(1, RTPManager.preCacheSearchesToStart(5, 0, 1, 2));
+        assertEquals(0, RTPManager.preCacheSearchesToStart(5, 0, 2, 2));
+        assertEquals(1, RTPManager.preCacheSearchesToStart(2, 1, 0, 2));
+        assertEquals(0, RTPManager.preCacheSearchesToStart(2, 2, 0, 2));
+        assertEquals(0, RTPManager.preCacheSearchesToStart(0, 0, 0, 2));
+    }
+
+    @Test
+    void testPreCacheWarmsUpWhileTheServerIsEmpty() throws Exception {
+        createMockWorld("world", World.Environment.NORMAL);
+        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
+        attachSchedulerAndFeatures(plugin);
+
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        assertEquals(0, Bukkit.getOnlinePlayers().size());
+        assertEquals(2, searchesInFlight(rtpManager, "world").size());
+        assertTrue(scheduledTasks.get() > 0);
+
+        rtpManager.refillPreCacheAllWorlds();
+        assertEquals(2, searchesInFlight(rtpManager, "world").size());
+    }
+
+    @Test
+    void testPreCacheReleasesSearchesThatNeverFinished() throws Exception {
+        createMockWorld("world", World.Environment.NORMAL);
+        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
+        attachSchedulerAndFeatures(plugin);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        long stale = System.currentTimeMillis() - 120_000L;
+        seedSearchesInFlight(rtpManager, "world", stale, stale);
+
+        rtpManager.refillPreCacheAllWorlds();
+
+        Queue<Long> running = searchesInFlight(rtpManager, "world");
+        assertEquals(2, running.size());
+        for (long startedAt : running) {
+            assertTrue(startedAt > stale, "a stale search should have been replaced by a fresh one");
+        }
+    }
+
+    @Test
+    void testPreCacheLeavesRunningSearchesAlone() throws Exception {
+        createMockWorld("world", World.Environment.NORMAL);
+        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
+        attachSchedulerAndFeatures(plugin);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        long now = System.currentTimeMillis();
+        seedSearchesInFlight(rtpManager, "world", now, now);
+
+        rtpManager.refillPreCacheAllWorlds();
+
+        assertEquals(List.of(now, now), new ArrayList<>(searchesInFlight(rtpManager, "world")));
     }
 
     @Test


### PR DESCRIPTION
Closes #151

The RTP location cache never had anything in it. A server could sit up for ten minutes and `/rtp`
would still run a full search, which is the opposite of what the cache is for. Three separate things
were stopping it.

## The cache refused to run on an empty server

`refillPreCacheAllWorlds` bailed out whenever nobody was online, which is backwards. The point of
finding locations ahead of time is that the first player to join should not be the one paying for the
search, and an idle server is the cheapest time to do that work. The gate is gone. Warm-up now starts
with the server and keeps going regardless of who is connected.

## It only ever gained one location per world

Each refill started a single search and stored a single result, so a `SIZE: 5` cache needed five
successful searches in a row before it was full. Someone who joined and ran `/rtp` a few seconds
later still missed. A world now starts as many searches as it is short of, capped at two at a time,
so it climbs to the configured size instead of trickling.

Those background searches run on fewer parallel chains than a player-facing one.
`SEARCH-ATTEMPTS-PER-TICK` is tuned for somebody staring at a progress bar; nothing is waiting on the
warm-up, so it has no business claiming the same chunk throughput. Even with two searches per world,
that works out to less background chunk work than the old code did with one.

## A dropped search wedged a world permanently

`preCacheInFlight` was a plain set of world names, added to before the search and removed in its
completion callback. If that callback never arrived, the world kept its slot for the rest of the
uptime and never pre-cached again. Not hypothetical on Folia: `SpigotScheduler` hands back a no-op
task when a region schedule fails, so the runnable never runs and the search chain is lost without an
exception anywhere. The set is now a queue of start timestamps per world, entries older than thirty
seconds get dropped, and a throw while starting a search releases its slot instead of leaking it.

## Notes

- No new config keys. `PRE_CACHE_PARALLEL_ATTEMPTS`, `MAX_PRE_CACHE_SEARCHES_PER_WORLD` and
  `PRE_CACHE_SEARCH_TIMEOUT_MILLIS` are internal constants. Background parallelism is clamped to
  `SEARCH-ATTEMPTS-PER-TICK`, so an admin who lowered that for a weak box still gets the lower value.
- `docs/wiki/Config-rtp.yml.md` claimed the cache filled "only while at least one player is online".
  That section has been rewritten.
- Four new tests in `RTPManagerTest`: the fill arithmetic on its own, warm-up starting with nobody
  online, a stale search being replaced, and a running search being left alone. Suite is at 215.
