### PR TITLE
fix(spawn): stop setup commands rewriting a configured shard region (#150)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
@@ -509,11 +509,13 @@ public class SpawnManager {
             return SetupLocationResult.failure("ɴᴏ ꜰʀᴇᴇ " + getLocationLabel(type) + " ᴍᴇɴᴜ ѕʟᴏᴛ ɪѕ ᴀᴠᴀɪʟᴀʙʟᴇ.");
         }
 
+        String previousSetupLocation = config.getString(configPath, "");
+
         config.set(configPath, serialized);
         config.set(getMenuTogglePath(type), true);
         menus.set(target.path() + "." + MENU_LOCATION_KEY, serialized);
         menus.set(target.path() + "." + LEGACY_MENU_LOCATION_KEY, null);
-        configureSetupShardRegion(config, menus, target, location, serialized, type);
+        configureSetupShardRegion(config, menus, target, location, serialized, type, previousSetupLocation);
 
         try {
             if (!plugin.getConfigManager().saveConfig()) {
@@ -546,9 +548,16 @@ public class SpawnManager {
             SetupAreaTarget target,
             Location location,
             String serialized,
-            AreaType type
+            AreaType type,
+            String previousSetupLocation
     ) {
         if (location == null || location.getWorld() == null || serialized == null || serialized.isBlank()) {
+            return;
+        }
+
+        String regionLocationPath = SETUP_SHARD_REGION_PATH + "."
+                + (type == AreaType.SPAWN ? MENU_LOCATION_KEY : "AFK-LOCATION");
+        if (!setupOwnsShardRegion(config.getString(regionLocationPath), previousSetupLocation)) {
             return;
         }
 
@@ -558,9 +567,9 @@ public class SpawnManager {
         }
 
         config.set(SETUP_SHARD_REGION_PATH + ".ENABLED", true);
-        config.set(SETUP_SHARD_REGION_PATH + ".WORLD", location.getWorld().getName());
 
         if (type == AreaType.SPAWN) {
+            config.set(SETUP_SHARD_REGION_PATH + ".WORLD", location.getWorld().getName());
             config.set(SETUP_SHARD_REGION_PATH + ".BOUND", true);
             config.set(SETUP_SHARD_REGION_PATH + ".CUBOID", cuboidName);
             config.set(SETUP_SHARD_REGION_PATH + "." + MENU_LOCATION_KEY, serialized);
@@ -571,6 +580,22 @@ public class SpawnManager {
             config.set(SETUP_SHARD_REGION_PATH + ".AFK-CUBOID", cuboidName);
             config.set(SETUP_SHARD_REGION_PATH + ".AFK-LOCATION", serialized);
         }
+    }
+
+    /**
+     * The spawn shard region is only there to give a fresh server something usable, so /setspawn and
+     * /setafk may fill it in while it still holds whatever the last setup run wrote. Once a server
+     * owner has pointed the region somewhere of their own it belongs to them, and saving a new spawn
+     * or AFK point leaves the whole region untouched.
+     */
+    static boolean setupOwnsShardRegion(String regionLocation, String previousSetupLocation) {
+        String current = regionLocation == null ? "" : regionLocation.trim();
+        if (current.isEmpty()) {
+            return true;
+        }
+
+        String previous = previousSetupLocation == null ? "" : previousSetupLocation.trim();
+        return current.equalsIgnoreCase(previous);
     }
 
     private SetupAreaTarget findNextSetupAreaTarget(AreaType type) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/SetupShardRegionOwnershipTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/SetupShardRegionOwnershipTest.java
@@ -1,0 +1,37 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetupShardRegionOwnershipTest {
+
+    private static final String SPAWN_BUILD = "worlds_spawn1,13.0,-3.0,-31.0,45.0,-5.0";
+    private static final String WORLD_ORIGIN = "worlds_spawn1,0.5,0.0,0.5,90.0,0.0";
+
+    @Test
+    void aRegionWithNoLocationYetIsBootstrapped() {
+        assertTrue(SpawnManager.setupOwnsShardRegion(null, ""));
+        assertTrue(SpawnManager.setupOwnsShardRegion("", ""));
+        assertTrue(SpawnManager.setupOwnsShardRegion("   ", SPAWN_BUILD));
+    }
+
+    @Test
+    void aRegionStillFollowingSetupMovesWithTheNewLocation() {
+        assertTrue(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, SPAWN_BUILD));
+        assertTrue(SpawnManager.setupOwnsShardRegion("  " + SPAWN_BUILD + "  ", SPAWN_BUILD));
+        assertTrue(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD.toUpperCase(), SPAWN_BUILD));
+    }
+
+    @Test
+    void aRegionTheOwnerMovedIsLeftAlone() {
+        assertFalse(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, WORLD_ORIGIN));
+    }
+
+    @Test
+    void aRegionConfiguredBeforeAnySetupRunIsLeftAlone() {
+        assertFalse(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, ""));
+        assertFalse(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, null));
+    }
+}


### PR DESCRIPTION
Closes #150

Saving a spawn or AFK point used to reach into `SHARDS.CUBOIDS.REGIONS.spawn` and overwrite it. That is harmless on a fresh server, where the region is empty and the setup commands are the only thing that will ever fill it in. On a server that already has its shard zone configured it means `/setspawn` quietly drags the reward region along to wherever the admin happened to be standing. That is what happened in #150: the reporter ran `/setspawn`, their shard zone moved off their spawn build to 0 0 0, and players started earning shards in the wrong place.

## Only bootstrap a region that still follows setup

`configureSetupShardRegion` now returns early unless the region's stored location is empty, or still equal to the spawn/AFK location this setup run is replacing. An empty region is a fresh install and gets filled in exactly as before. A region that still matches the previous setup value is one nobody has moved, so it keeps travelling with `/setspawn`. Anything else was pointed somewhere deliberately and is left completely alone now, `ENABLED` and `BOUND` and `CUBOID` included.

The check compares the raw serialized strings instead of parsed `Location` objects. `LocationUtils.parse` returns null when the world named in the value is not loaded, so a region pointing into an unloaded world would look empty and get overwritten anyway. Both sides of the comparison come from the same `LocationUtils.serialize` call, which makes the string match exact.

`setSetupLocation` reads the old value before it writes the new one and hands it down, because by the time the shard helper runs the config key already holds the new location.

## Setting the AFK point no longer moves the spawn region's world

`WORLD` was written on both paths, so `/setafk` rewrote the spawn shard region's world with whatever world the AFK point sits in. It is now written only on the spawn path, alongside the other spawn keys.

## Notes

`RADIUS` was already protected this way on its own; the guard simply moved up a level so it covers the rest of the region too, and existing radius behaviour is unchanged. No config or language keys were added, so there is nothing to translate.

`SetupShardRegionOwnershipTest` covers the four cases: an empty region, a region still following setup, a region the owner moved (using the values from #150), and a region configured before setup was ever run. Suite is green at 215 tests.
