### PR TITLE
docs(faq): correct what happens to players when they die (#150)

### DIFF
--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -235,9 +235,19 @@ MESSAGES:
 ### Question: Does `/uds setup setspawn` set where players respawn when they die?
 
 #### Clarification & Actual Purpose:
-- **No**. `/uds setup setspawn` (or `/setspawn`) does **NOT** set an individual player's death respawn point.
-- **Actual Purpose**: It is an administrator setup command used to set the **Global Server Spawn Hub Location** (e.g., Central Marketplace, Server Shop Hub, or Spawn Arena). This is the location where players are sent when executing `/spawn` or walking through Portal triggers (`/portal`).
-- **Player Death Respawn**: Player death respawn locations are governed by vanilla Minecraft **Beds**, **Respawn Anchors**, or player homes (`/sethome`).
+- **Yes, through the spawn hub**. `/uds setup setspawn` (or `/setspawn`) saves one location, the **Global Server Spawn Hub Location** (e.g., Central Marketplace, Server Shop Hub, or Spawn Arena). That is where players land when executing `/spawn` or walking through Portal triggers (`/portal`), and it is also where they land when they die.
+- **Player Death Respawn**: On death the plugin replaces the vanilla respawn point with that same spawn hub. There is no separate death location to configure, so moving spawn moves where your players come back.
+- **The one exception**: `SETTINGS.RESPAWN-ON-BED`. Turn it on and a player who has slept in a bed or charged a **Respawn Anchor** returns there instead. Everybody without one still goes to the spawn hub.
+- **Shipped default**: `RESPAWN-ON-BED` is `false` out of the box, so a fresh install sends every death to the spawn hub. Leave it on `false` to keep beds out of it entirely.
+
+```yaml
+SETTINGS:
+  # false: every death sends the player to the spawn hub
+  # true: beds and charged Respawn Anchors win, everyone else still goes to the spawn hub
+  RESPAWN-ON-BED: false
+```
+
+> If `/setspawn` has never been run there is no hub to send anybody to, and deaths fall back to vanilla behaviour. Run it once while standing where you want players to land.
 
 ---
 


### PR DESCRIPTION
Follow-up to #150. Deliberately no closing keyword, that issue is still waiting on the reporter.

FAQ section 12 told server owners the opposite of what the plugin does. It said death respawn is governed by vanilla beds, Respawn Anchors and player homes, and that `/setspawn` has nothing to do with it. `PlayerRespawnListener` actually replaces the vanilla respawn point on death and sends the player to the same spawn hub `/setspawn` saved. Beds and anchors only win when `SETTINGS.RESPAWN-ON-BED` is on and the player actually has one, and that setting ships as `false`, so on a default install every death goes to spawn. Homes were never part of it at all.

The reporter on #150 opened two separate issues believing death teleports were not a plugin feature. This page is part of why.

## What the section says now

The answer to "does `/setspawn` set where players respawn" flips from no to yes, with the spawn hub described as the one location that `/spawn`, portals and death all read. `RESPAWN-ON-BED` is written up as the single exception, its shipped default is called out, and a short YAML block spells out what each value means. The `/sethome` claim is gone.

There is also a note that deaths fall back to vanilla behaviour while `/setspawn` has never been run, which is the exact state that started #150.

## Notes

Docs only, no code, config keys or language keys touched. The wording now agrees with `Config-config.yml.md`, which already described `SETTINGS.RESPAWN-ON-BED` correctly as forcing all respawns to global Spawn when `false`. Suite is green at 219 tests. The page gets mirrored to the wiki after merge.
