### PR TITLE
fix(rtp): stop the background cache searching nonstop (#151)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -122,17 +122,13 @@ SETTINGS:
 ## Section: `SETTINGS.LOCATION-CACHE`
 
 Finding a safe spot is the slow part of `/rtp`, and on a large overworld it can keep a player waiting
-for the best part of a minute. This cache does that work in the background, so the command usually
-has a verified location waiting for it and teleports straight away.
+for the best part of a minute. This cache does that work in the background while people are playing,
+so the command usually has a verified location waiting for it and teleports straight away.
 
-Filling starts as soon as the server does and keeps going whether or not anyone is online, which is
-the point: the first player to join should not be the one who pays for the search. Each world runs up
-to two background searches at a time until it holds `SIZE` locations, and those searches check fewer
-candidates side by side than a player-facing one so the warm-up never competes with someone who is
-actually waiting. Every entry is re-checked against the current world and radius before it is handed
-out, and a background search that never reports back is given up on after thirty seconds so a world
-cannot be left without ready locations. When the cache is empty the command falls back to searching
-live, exactly as before.
+The cache is filled by the same search `/rtp` runs, one world at a time, and only while at least one
+player is online. Each entry is re-checked against the current world and radius before it is handed
+out, and a search only starts when a world is short of ready locations. When the cache is empty the
+command falls back to searching live, exactly as before.
 
 ### 1. Commented Setup Code Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -97,9 +97,6 @@ public class RTPManager {
     private static final int DEFAULT_LOCATION_CACHE_SIZE = 3;
     private static final int MAX_LOCATION_CACHE_SIZE = 16;
     private static final int DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS = 600;
-    private static final int PRE_CACHE_PARALLEL_ATTEMPTS = 4;
-    private static final int MAX_PRE_CACHE_SEARCHES_PER_WORLD = 2;
-    private static final long PRE_CACHE_SEARCH_TIMEOUT_MILLIS = 30_000L;
 
     private static final class SearchProgress {
         private final String worldName;
@@ -154,7 +151,7 @@ public class RTPManager {
     private final Map<UUID, CompletableFuture<Location>> activeDirectSearches = new ConcurrentHashMap<>();
     private final Map<UUID, SearchProgress> activeSearches = new ConcurrentHashMap<>();
     private final Map<String, java.util.Queue<CachedLocation>> locationPreCache = new ConcurrentHashMap<>();
-    private final Map<String, java.util.Queue<Long>> preCacheInFlight = new ConcurrentHashMap<>();
+    private final Set<String> preCacheInFlight = ConcurrentHashMap.newKeySet();
     private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
     private List<RTPDestination> menuDestinations = List.of();
@@ -336,6 +333,9 @@ public class RTPManager {
         if (!isPreCacheReady() || getPreCacheSize() <= 0) {
             return;
         }
+        if (Bukkit.getOnlinePlayers().isEmpty()) {
+            return;
+        }
 
         Set<String> worldNames = new LinkedHashSet<>();
         for (RTPDestination destination : configuredDestinations) {
@@ -361,14 +361,7 @@ public class RTPManager {
         java.util.Queue<CachedLocation> cached = locationPreCache
                 .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
         cached.removeIf(entry -> !isCachedLocationUsable(entry));
-
-        int searches = preCacheSearchesToStart(
-                cacheSize,
-                cached.size(),
-                countPreCacheSearchesInFlight(worldKey),
-                MAX_PRE_CACHE_SEARCHES_PER_WORLD
-        );
-        if (searches <= 0) {
+        if (cached.size() >= cacheSize) {
             return;
         }
 
@@ -379,82 +372,21 @@ public class RTPManager {
         if (settings == null || getLoadedWorld(worldName) == null) {
             return;
         }
-
-        for (int started = 0; started < searches; started++) {
-            startPreCacheSearch(worldKey, settings);
+        if (!preCacheInFlight.add(worldKey)) {
+            return;
         }
-    }
 
-    /**
-     * How many background searches a world should start right now, so the cache walks up to its
-     * configured size instead of gaining at most one location per refill, while never running more
-     * than {@code maxConcurrentSearches} of them at a time.
-     */
-    static int preCacheSearchesToStart(
-            int cacheSize,
-            int cachedLocations,
-            int searchesInFlight,
-            int maxConcurrentSearches
-    ) {
-        int missing = cacheSize - cachedLocations - searchesInFlight;
-        int free = maxConcurrentSearches - searchesInFlight;
-        return Math.max(0, Math.min(missing, free));
-    }
-
-    private void startPreCacheSearch(String worldKey, SearchSettings settings) {
-        long startedAt = System.currentTimeMillis();
-        preCacheInFlight
-                .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>())
-                .add(startedAt);
-
-        try {
-            findSafeLocationAsync(settings, getPreCacheParallelAttempts()).whenComplete((location, throwable) -> {
-                releasePreCacheSearch(worldKey, startedAt);
-                if (throwable != null || location == null) {
-                    return;
-                }
-                java.util.Queue<CachedLocation> target = locationPreCache
-                        .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
-                if (target.size() < getPreCacheSize()) {
-                    target.add(new CachedLocation(location, System.currentTimeMillis()));
-                }
-            });
-        } catch (RuntimeException exception) {
-            releasePreCacheSearch(worldKey, startedAt);
-            throw exception;
-        }
-    }
-
-    /**
-     * Counts the background searches still running for a world, dropping any that outlived
-     * {@link #PRE_CACHE_SEARCH_TIMEOUT_MILLIS}. A search whose callback never arrives - a scheduled
-     * step the server dropped, say - would otherwise hold its slot for the rest of the uptime and
-     * leave that world without a single cached location.
-     */
-    private int countPreCacheSearchesInFlight(String worldKey) {
-        java.util.Queue<Long> running = preCacheInFlight.get(worldKey);
-        if (running == null) {
-            return 0;
-        }
-        long cutoff = System.currentTimeMillis() - PRE_CACHE_SEARCH_TIMEOUT_MILLIS;
-        running.removeIf(startedAt -> startedAt == null || startedAt < cutoff);
-        return running.size();
-    }
-
-    private void releasePreCacheSearch(String worldKey, long startedAt) {
-        java.util.Queue<Long> running = preCacheInFlight.get(worldKey);
-        if (running != null) {
-            running.remove(startedAt);
-        }
-    }
-
-    /**
-     * Background searches run on fewer parallel chains than a player-facing one. Nobody is waiting
-     * on the result, so the warm-up has no reason to claim the chunk throughput a waiting player
-     * gets.
-     */
-    private int getPreCacheParallelAttempts() {
-        return Math.max(1, Math.min(PRE_CACHE_PARALLEL_ATTEMPTS, getSearchAttemptsPerTick()));
+        findSafeLocationAsync(settings).whenComplete((location, throwable) -> {
+            preCacheInFlight.remove(worldKey);
+            if (throwable != null || location == null) {
+                return;
+            }
+            java.util.Queue<CachedLocation> target = locationPreCache
+                    .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
+            if (target.size() < getPreCacheSize()) {
+                target.add(new CachedLocation(location, System.currentTimeMillis()));
+            }
+        });
     }
 
     private boolean isPreCacheReady() {
@@ -858,15 +790,11 @@ public class RTPManager {
     }
 
     public CompletableFuture<Location> findSafeLocationAsync(SearchSettings settings) {
-        return findSafeLocationAsync(settings, getSearchAttemptsPerTick());
-    }
-
-    private CompletableFuture<Location> findSafeLocationAsync(SearchSettings settings, int parallelAttempts) {
         if (!isSearchRequestValid(settings)) {
             return CompletableFuture.completedFuture(null);
         }
         CompletableFuture<Location> future = new CompletableFuture<>();
-        startDirectSearch(settings, future, parallelAttempts);
+        startDirectSearch(settings, future);
         return future;
     }
 
@@ -878,12 +806,8 @@ public class RTPManager {
     }
 
     private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
-        startDirectSearch(settings, future, getSearchAttemptsPerTick());
-    }
-
-    private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future, int parallelAttempts) {
         DirectSearchState state = new DirectSearchState(settings);
-        int chains = Math.max(1, Math.min(parallelAttempts, settings.maxChunkSamples()));
+        int chains = Math.max(1, Math.min(getSearchAttemptsPerTick(), settings.maxChunkSamples()));
         state.activeChains.set(chains);
         for (int chain = 0; chain < chains; chain++) {
             scheduleDirectSearchStep(state, future, settings.attemptIntervalTicks());

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -1,13 +1,11 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
-import com.bx.ultimateDonutSmp.utils.SpigotScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,36 +20,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RTPManagerTest {
 
     private Server originalServer;
     private Server mockServer;
     private List<World> mockWorlds;
-    private AtomicInteger scheduledTasks;
 
     @BeforeEach
     void setUp() throws Exception {
         originalServer = Bukkit.getServer();
         mockWorlds = new ArrayList<>();
-        scheduledTasks = new AtomicInteger();
-
-        Object mockScheduler = Proxy.newProxyInstance(
-                BukkitScheduler.class.getClassLoader(),
-                new Class<?>[]{BukkitScheduler.class},
-                (proxy, method, args) -> {
-                    if (method.getName().startsWith("runTask")) {
-                        scheduledTasks.incrementAndGet();
-                    }
-                    return null;
-                }
-        );
 
         mockServer = (Server) Proxy.newProxyInstance(
                 Server.class.getClassLoader(),
@@ -71,12 +54,6 @@ class RTPManagerTest {
                     }
                     if (method.getName().equals("getWorldContainer")) {
                         return new java.io.File(".");
-                    }
-                    if (method.getName().equals("getOnlinePlayers")) {
-                        return List.of();
-                    }
-                    if (method.getName().equals("getScheduler")) {
-                        return mockScheduler;
                     }
                     if (method.getName().equals("getLogger")) {
                         return java.util.logging.Logger.getLogger("Minecraft");
@@ -264,108 +241,6 @@ class RTPManagerTest {
         seedLocationCache(rtpManager, "world", new Location(world, 1000.5, 70.0, 1000.5), System.currentTimeMillis());
 
         assertNull(pollCachedLocation(rtpManager, "world"));
-    }
-
-    /** Gives the mock plugin the two collaborators the background pre-cache needs to run. */
-    private void attachSchedulerAndFeatures(UltimateDonutSmp plugin) throws Exception {
-        Field featureField = UltimateDonutSmp.class.getDeclaredField("featureManager");
-        featureField.setAccessible(true);
-        featureField.set(plugin, new FeatureManager(plugin));
-
-        Field schedulerField = UltimateDonutSmp.class.getDeclaredField("SpigotScheduler");
-        schedulerField.setAccessible(true);
-        schedulerField.set(plugin, new SpigotScheduler(plugin));
-    }
-
-    private YamlConfiguration preCacheRtpConfig() {
-        YamlConfiguration rtpConfig = overworldRtpConfig();
-        rtpConfig.set("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", 25);
-        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", true);
-        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 5);
-        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.SLOT", 11);
-        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.WORLD", "world");
-        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.ENABLED", true);
-        return rtpConfig;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Queue<Long>> preCacheInFlight(RTPManager rtpManager) throws Exception {
-        Field field = RTPManager.class.getDeclaredField("preCacheInFlight");
-        field.setAccessible(true);
-        return (Map<String, Queue<Long>>) field.get(rtpManager);
-    }
-
-    private Queue<Long> searchesInFlight(RTPManager rtpManager, String worldKey) throws Exception {
-        Queue<Long> running = preCacheInFlight(rtpManager).get(worldKey);
-        return running == null ? new ConcurrentLinkedQueue<>() : running;
-    }
-
-    private void seedSearchesInFlight(RTPManager rtpManager, String worldKey, long... startedAt) throws Exception {
-        Queue<Long> running = new ConcurrentLinkedQueue<>();
-        for (long value : startedAt) {
-            running.add(value);
-        }
-        preCacheInFlight(rtpManager).put(worldKey, running);
-    }
-
-    @Test
-    void testPreCacheSearchesToStartFillsTheCacheWithinTheConcurrencyLimit() {
-        assertEquals(2, RTPManager.preCacheSearchesToStart(5, 0, 0, 2));
-        assertEquals(1, RTPManager.preCacheSearchesToStart(5, 0, 1, 2));
-        assertEquals(0, RTPManager.preCacheSearchesToStart(5, 0, 2, 2));
-        assertEquals(1, RTPManager.preCacheSearchesToStart(2, 1, 0, 2));
-        assertEquals(0, RTPManager.preCacheSearchesToStart(2, 2, 0, 2));
-        assertEquals(0, RTPManager.preCacheSearchesToStart(0, 0, 0, 2));
-    }
-
-    @Test
-    void testPreCacheWarmsUpWhileTheServerIsEmpty() throws Exception {
-        createMockWorld("world", World.Environment.NORMAL);
-        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
-        attachSchedulerAndFeatures(plugin);
-
-        RTPManager rtpManager = new RTPManager(plugin);
-
-        assertEquals(0, Bukkit.getOnlinePlayers().size());
-        assertEquals(2, searchesInFlight(rtpManager, "world").size());
-        assertTrue(scheduledTasks.get() > 0);
-
-        rtpManager.refillPreCacheAllWorlds();
-        assertEquals(2, searchesInFlight(rtpManager, "world").size());
-    }
-
-    @Test
-    void testPreCacheReleasesSearchesThatNeverFinished() throws Exception {
-        createMockWorld("world", World.Environment.NORMAL);
-        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
-        attachSchedulerAndFeatures(plugin);
-        RTPManager rtpManager = new RTPManager(plugin);
-
-        long stale = System.currentTimeMillis() - 120_000L;
-        seedSearchesInFlight(rtpManager, "world", stale, stale);
-
-        rtpManager.refillPreCacheAllWorlds();
-
-        Queue<Long> running = searchesInFlight(rtpManager, "world");
-        assertEquals(2, running.size());
-        for (long startedAt : running) {
-            assertTrue(startedAt > stale, "a stale search should have been replaced by a fresh one");
-        }
-    }
-
-    @Test
-    void testPreCacheLeavesRunningSearchesAlone() throws Exception {
-        createMockWorld("world", World.Environment.NORMAL);
-        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
-        attachSchedulerAndFeatures(plugin);
-        RTPManager rtpManager = new RTPManager(plugin);
-
-        long now = System.currentTimeMillis();
-        seedSearchesInFlight(rtpManager, "world", now, now);
-
-        rtpManager.refillPreCacheAllWorlds();
-
-        assertEquals(List.of(now, now), new ArrayList<>(searchesInFlight(rtpManager, "world")));
     }
 
     @Test


### PR DESCRIPTION
Reverts #152. Re #151, which stays open.

The reporter on #151 came back 16 minutes after that merge with their server sitting at 10 GB of RAM.
That is my change doing it, so it goes back out and the cache gets rebuilt properly on its own PR.

## What went wrong

The base cost came from removing the gate that kept background searching off an empty server. That
reporter runs `GENERATE-CHUNKS: true` with radii of 15000, 8000 and 5000, so after #152 their box was
generating fresh terrain around the clock across three worlds instead of only while somebody was
online. At 2 searches per world and 4 chains each, that is 24 chunk generations running continuously.

What turned it into a blowup is `countPreCacheSearchesInFlight`. It drops a search from the in-flight
queue once it passes the 30 second deadline, but nothing holds a handle to cancel the search itself,
so the forgotten one carries on generating chunks until its attempt budget runs out while a
replacement starts up beside it. More overlap makes chunk generation slower, which pushes more
searches past the deadline, which adds more overlap. It feeds itself.

Their `SIZE: 10` meant 30 successful searches before the cache could settle, and the End at a minimum
radius of 1000 probably never fills at all, so those searches would have run forever.

## What this restores

Everything from #152 goes back: the online-player gate, one search per world, the single in-flight
flag with no deadline, and the wiki page that described that behaviour. The cache only fills while
someone is online again, which is the original complaint on #151 and why that issue stays open.

## Notes

- The reporter has already been told to set `LOCATION-CACHE.ENABLED: false` and put `SIZE` back to 5,
  so this costs them nothing.
- Nothing else had landed on `RTPManager.java` since #152, so this is a clean revert rather than a
  hand-written undo.
- The four tests from #152 go with it. Suite is green at 215.
- Whatever replaces this needs the deadline to actually cancel a search rather than forget it, and a
  far lower ceiling on how many background searches can run at once. Whether background searching
  should be allowed to generate chunks at all is still open.
