### PR TITLE
fix(rtp): read loaded chunks from the region that owns them (#151)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -866,17 +866,25 @@ public class RTPManager {
         boolean generateFallback = shouldUseGenerateFallback(chunkSamplesUsed, state.generateFallbackSamplesUsed.get());
         if (!generateFallback && shouldUseLoadedChunkFallback(chunkSamplesUsed)) {
             plugin.getSpigotScheduler().runRegion(world, settings.centerX() >> 4, settings.centerZ() >> 4, () -> {
-                Location found = null;
-                try {
-                    LocationAttempt attempt = tryLoadedChunkLocationAttempt(settings);
-                    if (attempt.countedAttempt()) {
+                int[] loadedChunk = nextLoadedChunkSample(world);
+                if (loadedChunk == null) {
+                    continueDirectSearch(state, future, null);
+                    return;
+                }
+                plugin.getSpigotScheduler().runRegion(world, loadedChunk[0], loadedChunk[1], () -> {
+                    Location found = null;
+                    try {
+                        LocationAttempt attempt =
+                                tryLoadedChunkLocationAttempt(settings, loadedChunk[0], loadedChunk[1]);
+                        if (attempt.countedAttempt()) {
+                            state.attemptsUsed.incrementAndGet();
+                        }
+                        found = attempt.location();
+                    } catch (RuntimeException exception) {
                         state.attemptsUsed.incrementAndGet();
                     }
-                    found = attempt.location();
-                } catch (RuntimeException exception) {
-                    state.attemptsUsed.incrementAndGet();
-                }
-                continueDirectSearch(state, future, found);
+                    continueDirectSearch(state, future, found);
+                });
             });
             return;
         }
@@ -1102,12 +1110,20 @@ public class RTPManager {
             progress.chunkSamplesUsed++;
             progress.activeAttemptsInFlight++;
             plugin.getSpigotScheduler().runRegion(world, progress.settings.centerX() >> 4, progress.settings.centerZ() >> 4, () -> {
-                try {
-                    LocationAttempt attempt = tryLoadedChunkLocationAttempt(progress.settings);
-                    completeAsyncLocationAttempt(playerId, progress, attempt, null);
-                } catch (RuntimeException exception) {
-                    completeAsyncLocationAttempt(playerId, progress, null, exception);
+                int[] loadedChunk = nextLoadedChunkSample(world);
+                if (loadedChunk == null) {
+                    completeAsyncLocationAttempt(playerId, progress, new LocationAttempt(null, false), null);
+                    return;
                 }
+                plugin.getSpigotScheduler().runRegion(world, loadedChunk[0], loadedChunk[1], () -> {
+                    try {
+                        LocationAttempt attempt =
+                                tryLoadedChunkLocationAttempt(progress.settings, loadedChunk[0], loadedChunk[1]);
+                        completeAsyncLocationAttempt(playerId, progress, attempt, null);
+                    } catch (RuntimeException exception) {
+                        completeAsyncLocationAttempt(playerId, progress, null, exception);
+                    }
+                });
             });
             return;
         }
@@ -1587,7 +1603,34 @@ public class RTPManager {
         return Math.max(1, plugin.getConfigManager().getRtp().getInt(PRELOAD_MAX_TICKS_SETTING, 40));
     }
 
-    private LocationAttempt tryLoadedChunkLocationAttempt(SearchSettings settings) {
+    /**
+     * Picks one of the world's loaded chunks at random, or {@code null} when it has none. Only the
+     * chunk coordinates are read here, never a block, so the caller can hop to the region that owns
+     * that chunk before touching it.
+     */
+    int[] nextLoadedChunkSample(World world) {
+        if (world == null) {
+            return null;
+        }
+
+        Chunk[] loadedChunks = world.getLoadedChunks();
+        if (loadedChunks.length == 0) {
+            return null;
+        }
+
+        Chunk chunk = loadedChunks[ThreadLocalRandom.current().nextInt(loadedChunks.length)];
+        return new int[] {chunk.getX(), chunk.getZ()};
+    }
+
+    /**
+     * Probes a single column inside one already-loaded chunk.
+     *
+     * <p>Folia splits a world into regions and only lets a thread read the chunks its own region
+     * owns, so this has to run on the region that owns {@code chunkX, chunkZ} and must not wander
+     * outside it. Reading a spread of loaded chunks from one region thread trips Folia's tick
+     * thread check and finds nothing.</p>
+     */
+    private LocationAttempt tryLoadedChunkLocationAttempt(SearchSettings settings, int chunkX, int chunkZ) {
         if (settings == null || settings.worldName() == null || settings.worldName().isBlank()) {
             return new LocationAttempt(null, false);
         }
@@ -1597,29 +1640,12 @@ public class RTPManager {
             return new LocationAttempt(null, false);
         }
 
-        Chunk[] loadedChunks = world.getLoadedChunks();
-        if (loadedChunks.length == 0) {
-            return new LocationAttempt(null, false);
-        }
+        int x = (chunkX << 4) + ThreadLocalRandom.current().nextInt(16);
+        int z = (chunkZ << 4) + ThreadLocalRandom.current().nextInt(16);
 
-        int start = ThreadLocalRandom.current().nextInt(loadedChunks.length);
-        int checked = 0;
-        int maxChecks = Math.min(loadedChunks.length, 32);
-        for (int offset = 0; offset < loadedChunks.length && checked < maxChecks; offset++) {
-            Chunk chunk = loadedChunks[(start + offset) % loadedChunks.length];
-            int baseX = chunk.getX() << 4;
-            int baseZ = chunk.getZ() << 4;
-            int x = baseX + ThreadLocalRandom.current().nextInt(16);
-            int z = baseZ + ThreadLocalRandom.current().nextInt(16);
-            checked++;
-
-            Location found = resolveSafeLocation(world, x, z);
-            if (found == null) {
-                continue;
-            }
-            if (isWithinRadius(settings, found, true)) {
-                return new LocationAttempt(found, true);
-            }
+        Location found = resolveSafeLocation(world, x, z);
+        if (found != null && isWithinRadius(settings, found, true)) {
+            return new LocationAttempt(found, true);
         }
 
         return new LocationAttempt(null, true);

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
@@ -22,8 +23,10 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RTPManagerTest {
 
@@ -241,6 +244,102 @@ class RTPManagerTest {
         seedLocationCache(rtpManager, "world", new Location(world, 1000.5, 70.0, 1000.5), System.currentTimeMillis());
 
         assertNull(pollCachedLocation(rtpManager, "world"));
+    }
+
+    private Chunk createMockChunk(World world, int x, int z) {
+        return (Chunk) Proxy.newProxyInstance(
+                Chunk.class.getClassLoader(),
+                new Class<?>[]{Chunk.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getX" -> x;
+                    case "getZ" -> z;
+                    case "getWorld" -> world;
+                    default -> null;
+                }
+        );
+    }
+
+    /**
+     * A world that reports the given loaded chunks and records every column the search probes, so a
+     * test can prove the probe never reads outside the chunk it was handed. The recorded height sits
+     * below the minimum so the probe stops before it reaches any block.
+     */
+    private World createProbeMockWorld(String name, List<int[]> loadedChunkCoords, List<int[]> probes) {
+        List<Chunk> chunks = new ArrayList<>();
+        World mockWorld = (World) Proxy.newProxyInstance(
+                World.class.getClassLoader(),
+                new Class<?>[]{World.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getName":
+                            return name;
+                        case "getEnvironment":
+                            return World.Environment.NORMAL;
+                        case "getLoadedChunks":
+                            return chunks.toArray(new Chunk[0]);
+                        case "getMinHeight":
+                            return 0;
+                        case "getHighestBlockYAt":
+                            if (args != null && args.length == 2 && args[0] instanceof Integer x
+                                    && args[1] instanceof Integer z) {
+                                probes.add(new int[]{x, z});
+                            }
+                            return -1;
+                        default:
+                            return null;
+                    }
+                }
+        );
+        for (int[] coords : loadedChunkCoords) {
+            chunks.add(createMockChunk(mockWorld, coords[0], coords[1]));
+        }
+        mockWorlds.add(mockWorld);
+        return mockWorld;
+    }
+
+    @Test
+    void testNextLoadedChunkSampleReturnsNullWhenNothingIsLoaded() throws Exception {
+        World world = createProbeMockWorld("world", List.of(), new ArrayList<>());
+        RTPManager rtpManager = new RTPManager(createMockPlugin(overworldRtpConfig()));
+
+        assertNull(rtpManager.nextLoadedChunkSample(world));
+    }
+
+    @Test
+    void testNextLoadedChunkSampleReportsTheChunkCoordinates() throws Exception {
+        World world = createProbeMockWorld("world", List.of(new int[]{666, 339}), new ArrayList<>());
+        RTPManager rtpManager = new RTPManager(createMockPlugin(overworldRtpConfig()));
+
+        int[] sample = rtpManager.nextLoadedChunkSample(world);
+
+        assertNotNull(sample);
+        assertEquals(666, sample[0]);
+        assertEquals(339, sample[1]);
+    }
+
+    @Test
+    void testLoadedChunkProbeNeverLeavesTheChunkItWasGiven() throws Exception {
+        List<int[]> probes = new ArrayList<>();
+        // A second loaded chunk sitting in a different region. The probe must never touch it.
+        createProbeMockWorld("world", List.of(new int[]{666, 339}, new int[]{10, 10}), probes);
+        RTPManager rtpManager = new RTPManager(createMockPlugin(overworldRtpConfig()));
+
+        Method probe = RTPManager.class.getDeclaredMethod(
+                "tryLoadedChunkLocationAttempt", RTPManager.SearchSettings.class, int.class, int.class);
+        probe.setAccessible(true);
+        RTPManager.SearchSettings settings = rtpManager.getWorldSearchSettings("world");
+
+        for (int run = 0; run < 200; run++) {
+            probe.invoke(rtpManager, settings, 666, 339);
+        }
+
+        assertEquals(200, probes.size());
+        for (int[] probed : probes) {
+            assertTrue(probed[0] >= 666 * 16 && probed[0] < 666 * 16 + 16,
+                    "probe read x " + probed[0] + ", which is outside chunk 666");
+            assertTrue(probed[1] >= 339 * 16 && probed[1] < 339 * 16 + 16,
+                    "probe read z " + probed[1] + ", which is outside chunk 339");
+        }
     }
 
     @Test


### PR DESCRIPTION
Re #151, which stays open. This is a separate bug that surfaced in that thread.

A reporter on Folia 26.1.2 posted 44 identical stack traces logged inside two seconds:

```
Thread failed main thread check: Cannot retrieve chunk asynchronously,
  region={center=[0, 0], world=minecraft:overworld}, chunk_pos=[666, 339]
    CraftWorld.getHighestBlockYAt
      RTPManager.resolveSafeLocation
        RTPManager.tryLoadedChunkLocationAttempt
          RTPManager.runDirectSearchStep
```

## The bug

Both loaded-chunk fallback call sites scheduled their work on the region that owns the center chunk,
`centerX >> 4, centerZ >> 4`, which on a default setup is chunk 0,0. The method they called then
walked `world.getLoadedChunks()` and read `getHighestBlockYAt` in whatever came back. The log above
caught it reading chunk 666,339, about 10600 blocks from the region it was running on.

Folia only lets a thread read the chunks its own region owns, so every one of those reads failed its
tick thread check. Paper never showed this, because `runRegion` there falls through to `runGlobal`
and the main thread owns the whole world.

The console filling up is the visible half. The half that matters is that the loaded-chunk fallback
has never once worked on Folia. It fails every read and finds nothing, which is part of why searches
on that reporter's server burned their entire attempt budget before giving up.

## The fix

Choosing a chunk and reading a chunk are now two separate steps. `nextLoadedChunkSample` picks one
loaded chunk at random and returns nothing but its coordinates, touching no blocks at all. The caller
then hops to the region that owns that chunk and probes a single column inside it. Reads cannot cross
a region boundary anymore because the code has no way left to express one.

An individual attempt is weaker than it was, since the old version scanned up to 32 loaded chunks and
this one probes a single column. That costs nothing real: those 32 reads were all failing on Folia
anyway, and a search makes plenty of attempts.

`beginAsyncLocationAttempt` on the player `/rtp` path had the same defect and got the same treatment,
so this is not a location cache problem.

## Notes

- Came in with #143 and has been live on `main` the whole time since, including after the #152
  revert.
- It only bites once a search passes `LOADED-CHUNK-FALLBACK-AFTER-SAMPLES`, which defaults to 32,
  with `FALLBACK-TO-LOADED-CHUNKS` left at its default of `true`.
- Three new tests. The one worth having gives the world two loaded chunks in different regions and
  probes 200 times, asserting nothing ever reads outside the chunk it was handed. The old code fails
  that, since it wandered into the other chunk about half the time.
- Suite is at 218.
