### PR TITLE
fix(rtp): warm the location cache without flooding chunk generation (#151)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -122,13 +122,24 @@ SETTINGS:
 ## Section: `SETTINGS.LOCATION-CACHE`
 
 Finding a safe spot is the slow part of `/rtp`, and on a large overworld it can keep a player waiting
-for the best part of a minute. This cache does that work in the background while people are playing,
-so the command usually has a verified location waiting for it and teleports straight away.
+for the best part of a minute. This cache does that work in the background, so the command
+usually has a verified location waiting for it and teleports straight away.
 
-The cache is filled by the same search `/rtp` runs, one world at a time, and only while at least one
-player is online. Each entry is re-checked against the current world and radius before it is handed
-out, and a search only starts when a world is short of ready locations. When the cache is empty the
-command falls back to searching live, exactly as before.
+Filling starts with the server and keeps going whether or not anyone is online, which is the point:
+the first player to join should not be the one who pays for the search. What it will not do is fill
+in a hurry. Exactly one background search runs at a time across the whole server, it takes the
+worlds in turn, it waits a few seconds between searches, and it uses fewer parallel checks than a
+search a player is waiting on. A search that has not finished within thirty seconds is stopped
+outright rather than left running beside its replacement.
+
+That pace matters most when `GENERATE-CHUNKS` is on, because then every search is generating fresh
+terrain and the warm-up is doing real work rather than reading chunks that already exist. On a world
+that has never been walked, expect the cache to take a few minutes to fill rather than seconds. That
+is the intended trade: the generation happens while nobody is waiting instead of while somebody is.
+
+Each entry is re-checked against the current world and radius before it is handed out, and a search
+only starts when a world is short of ready locations. When the cache is empty the command falls back
+to searching live, exactly as before.
 
 ### 1. Commented Setup Code Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -97,6 +97,9 @@ public class RTPManager {
     private static final int DEFAULT_LOCATION_CACHE_SIZE = 3;
     private static final int MAX_LOCATION_CACHE_SIZE = 16;
     private static final int DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS = 600;
+    private static final int PRE_CACHE_PARALLEL_ATTEMPTS = 4;
+    private static final long PRE_CACHE_SEARCH_TIMEOUT_MILLIS = 30_000L;
+    private static final long PRE_CACHE_SEARCH_COOLDOWN_MILLIS = 5_000L;
 
     private static final class SearchProgress {
         private final String worldName;
@@ -151,7 +154,11 @@ public class RTPManager {
     private final Map<UUID, CompletableFuture<Location>> activeDirectSearches = new ConcurrentHashMap<>();
     private final Map<UUID, SearchProgress> activeSearches = new ConcurrentHashMap<>();
     private final Map<String, java.util.Queue<CachedLocation>> locationPreCache = new ConcurrentHashMap<>();
-    private final Set<String> preCacheInFlight = ConcurrentHashMap.newKeySet();
+    private final java.util.concurrent.atomic.AtomicReference<CompletableFuture<Location>> preCacheSearch =
+            new java.util.concurrent.atomic.AtomicReference<>();
+    private final AtomicInteger preCacheRotation = new AtomicInteger();
+    private volatile long preCacheSearchDeadlineMillis;
+    private volatile long nextPreCacheSearchAtMillis;
     private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
     private List<RTPDestination> menuDestinations = List.of();
@@ -166,7 +173,8 @@ public class RTPManager {
         clearQueue();
         lastRtpUseByPlayer.clear();
         locationPreCache.clear();
-        preCacheInFlight.clear();
+        cancelPreCacheSearch();
+        nextPreCacheSearchAtMillis = 0L;
         configuredDestinations = loadConfiguredDestinations();
         menuDestinations = buildMenuDestinations(configuredDestinations);
         refillPreCacheAllWorlds();
@@ -333,9 +341,8 @@ public class RTPManager {
         if (!isPreCacheReady() || getPreCacheSize() <= 0) {
             return;
         }
-        if (Bukkit.getOnlinePlayers().isEmpty()) {
-            return;
-        }
+
+        expireOverduePreCacheSearch();
 
         Set<String> worldNames = new LinkedHashSet<>();
         for (RTPDestination destination : configuredDestinations) {
@@ -343,18 +350,28 @@ public class RTPManager {
                 worldNames.add(destination.worldName());
             }
         }
-        for (String worldName : worldNames) {
-            refillPreCache(worldName);
+        if (worldNames.isEmpty()) {
+            return;
+        }
+
+        // Rotate where the sweep starts so a world that always finds a spot cannot starve the rest.
+        List<String> ordered = new ArrayList<>(worldNames);
+        int start = Math.floorMod(preCacheRotation.getAndIncrement(), ordered.size());
+        for (int offset = 0; offset < ordered.size(); offset++) {
+            if (refillPreCache(ordered.get((start + offset) % ordered.size()))) {
+                return;
+            }
         }
     }
 
-    public void refillPreCache(String worldName) {
+    /** @return whether a background search was actually started for this world. */
+    public boolean refillPreCache(String worldName) {
         if (!isPreCacheReady() || worldName == null || worldName.isBlank()) {
-            return;
+            return false;
         }
         int cacheSize = getPreCacheSize();
         if (cacheSize <= 0) {
-            return;
+            return false;
         }
 
         String worldKey = normalizeWorldKey(worldName);
@@ -362,22 +379,44 @@ public class RTPManager {
                 .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
         cached.removeIf(entry -> !isCachedLocationUsable(entry));
         if (cached.size() >= cacheSize) {
-            return;
+            return false;
         }
 
         if (isDeniedWorld(worldName) || isConfiguredDestinationDisabled(worldName)) {
-            return;
+            return false;
         }
         SearchSettings settings = getWorldSearchSettings(worldName);
-        if (settings == null || getLoadedWorld(worldName) == null) {
-            return;
-        }
-        if (!preCacheInFlight.add(worldKey)) {
-            return;
+        if (settings == null || getLoadedWorld(worldName) == null || !isSearchRequestValid(settings)) {
+            return false;
         }
 
-        findSafeLocationAsync(settings).whenComplete((location, throwable) -> {
-            preCacheInFlight.remove(worldKey);
+        return startPreCacheSearch(worldKey, settings);
+    }
+
+    /**
+     * Starts the one background search this server is allowed to have running.
+     *
+     * <p>The ceiling is deliberately low. A search may generate terrain, and on a world that has
+     * never been walked that is the expensive part, so the warm-up takes one world at a time with a
+     * pause between searches rather than filling every world at once.</p>
+     *
+     * @return whether the search was started
+     */
+    private boolean startPreCacheSearch(String worldKey, SearchSettings settings) {
+        expireOverduePreCacheSearch();
+        if (System.currentTimeMillis() < nextPreCacheSearchAtMillis) {
+            return false;
+        }
+
+        CompletableFuture<Location> future = new CompletableFuture<>();
+        if (!preCacheSearch.compareAndSet(null, future)) {
+            return false;
+        }
+        preCacheSearchDeadlineMillis = System.currentTimeMillis() + PRE_CACHE_SEARCH_TIMEOUT_MILLIS;
+
+        future.whenComplete((location, throwable) -> {
+            preCacheSearch.compareAndSet(future, null);
+            nextPreCacheSearchAtMillis = System.currentTimeMillis() + PRE_CACHE_SEARCH_COOLDOWN_MILLIS;
             if (throwable != null || location == null) {
                 return;
             }
@@ -387,6 +426,46 @@ public class RTPManager {
                 target.add(new CachedLocation(location, System.currentTimeMillis()));
             }
         });
+
+        try {
+            startDirectSearch(settings, future, getPreCacheParallelAttempts());
+        } catch (RuntimeException exception) {
+            future.complete(null);
+            throw exception;
+        }
+        return true;
+    }
+
+    /**
+     * Ends a background search that has outstayed its deadline.
+     *
+     * <p>Completing the future is what stops it. Every chain checks the future before its next step,
+     * so this winds the search down for real. Merely dropping the record of it would leave it
+     * generating chunks alongside the replacement that took its place, and each round of that makes
+     * the next search slower and more likely to overrun in turn.</p>
+     */
+    private void expireOverduePreCacheSearch() {
+        CompletableFuture<Location> running = preCacheSearch.get();
+        if (running == null || System.currentTimeMillis() < preCacheSearchDeadlineMillis) {
+            return;
+        }
+        running.complete(null);
+    }
+
+    private void cancelPreCacheSearch() {
+        CompletableFuture<Location> running = preCacheSearch.getAndSet(null);
+        if (running != null) {
+            running.complete(null);
+        }
+    }
+
+    /**
+     * Background searches run on fewer parallel chains than a player-facing one. Nobody is waiting
+     * on the result, so the warm-up has no business claiming the chunk throughput a waiting player
+     * gets.
+     */
+    private int getPreCacheParallelAttempts() {
+        return Math.max(1, Math.min(PRE_CACHE_PARALLEL_ATTEMPTS, getSearchAttemptsPerTick()));
     }
 
     private boolean isPreCacheReady() {
@@ -806,8 +885,12 @@ public class RTPManager {
     }
 
     private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
+        startDirectSearch(settings, future, getSearchAttemptsPerTick());
+    }
+
+    private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future, int parallelAttempts) {
         DirectSearchState state = new DirectSearchState(settings);
-        int chains = Math.max(1, Math.min(getSearchAttemptsPerTick(), settings.maxChunkSamples()));
+        int chains = Math.max(1, Math.min(parallelAttempts, settings.maxChunkSamples()));
         state.activeChains.set(chains);
         for (int chain = 0; chain < chains; chain++) {
             scheduleDirectSearchStep(state, future, settings.attemptIntervalTicks());

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -1,12 +1,14 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.SpigotScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,9 +22,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -33,11 +39,24 @@ class RTPManagerTest {
     private Server originalServer;
     private Server mockServer;
     private List<World> mockWorlds;
+    private AtomicInteger scheduledTasks;
 
     @BeforeEach
     void setUp() throws Exception {
         originalServer = Bukkit.getServer();
         mockWorlds = new ArrayList<>();
+        scheduledTasks = new AtomicInteger();
+
+        Object mockScheduler = Proxy.newProxyInstance(
+                BukkitScheduler.class.getClassLoader(),
+                new Class<?>[]{BukkitScheduler.class},
+                (proxy, method, args) -> {
+                    if (method.getName().startsWith("runTask")) {
+                        scheduledTasks.incrementAndGet();
+                    }
+                    return null;
+                }
+        );
 
         mockServer = (Server) Proxy.newProxyInstance(
                 Server.class.getClassLoader(),
@@ -57,6 +76,12 @@ class RTPManagerTest {
                     }
                     if (method.getName().equals("getWorldContainer")) {
                         return new java.io.File(".");
+                    }
+                    if (method.getName().equals("getOnlinePlayers")) {
+                        return List.of();
+                    }
+                    if (method.getName().equals("getScheduler")) {
+                        return mockScheduler;
                     }
                     if (method.getName().equals("getLogger")) {
                         return java.util.logging.Logger.getLogger("Minecraft");
@@ -340,6 +365,108 @@ class RTPManagerTest {
             assertTrue(probed[1] >= 339 * 16 && probed[1] < 339 * 16 + 16,
                     "probe read z " + probed[1] + ", which is outside chunk 339");
         }
+    }
+
+    /** Gives the mock plugin the two collaborators the background warm-up needs to run. */
+    private void attachSchedulerAndFeatures(UltimateDonutSmp plugin) throws Exception {
+        Field featureField = UltimateDonutSmp.class.getDeclaredField("featureManager");
+        featureField.setAccessible(true);
+        featureField.set(plugin, new FeatureManager(plugin));
+
+        Field schedulerField = UltimateDonutSmp.class.getDeclaredField("SpigotScheduler");
+        schedulerField.setAccessible(true);
+        schedulerField.set(plugin, new SpigotScheduler(plugin));
+    }
+
+    private YamlConfiguration preCacheRtpConfig() {
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        rtpConfig.set("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", 25);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", true);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 5);
+        rtpConfig.set("WORLD-SETTINGS.world_nether.MIN-RADIUS", 500);
+        rtpConfig.set("WORLD-SETTINGS.world_nether.MAX-RADIUS", 5000);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.SLOT", 11);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.WORLD", "world");
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.ENABLED", true);
+        rtpConfig.set("RTP-MENU.BUTTONS.NETHER.SLOT", 13);
+        rtpConfig.set("RTP-MENU.BUTTONS.NETHER.WORLD", "world_nether");
+        rtpConfig.set("RTP-MENU.BUTTONS.NETHER.ENABLED", true);
+        return rtpConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AtomicReference<CompletableFuture<Location>> preCacheSearch(RTPManager rtpManager) throws Exception {
+        Field field = RTPManager.class.getDeclaredField("preCacheSearch");
+        field.setAccessible(true);
+        return (AtomicReference<CompletableFuture<Location>>) field.get(rtpManager);
+    }
+
+    private void setLongField(RTPManager rtpManager, String name, long value) throws Exception {
+        Field field = RTPManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.setLong(rtpManager, value);
+    }
+
+    private RTPManager preCacheManager() throws Exception {
+        createMockWorld("world", World.Environment.NORMAL);
+        createMockWorld("world_nether", World.Environment.NETHER);
+        UltimateDonutSmp plugin = createMockPlugin(preCacheRtpConfig());
+        attachSchedulerAndFeatures(plugin);
+        return new RTPManager(plugin);
+    }
+
+    @Test
+    void testPreCacheWarmsUpWhileTheServerIsEmpty() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+
+        assertEquals(0, Bukkit.getOnlinePlayers().size());
+        assertNotNull(preCacheSearch(rtpManager).get(), "warm-up should not wait for a player to join");
+        assertTrue(scheduledTasks.get() > 0);
+    }
+
+    @Test
+    void testOnlyOneBackgroundSearchRunsAcrossTheWholeServer() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+
+        CompletableFuture<Location> first = preCacheSearch(rtpManager).get();
+        int afterFirst = scheduledTasks.get();
+
+        setLongField(rtpManager, "nextPreCacheSearchAtMillis", 0L);
+        rtpManager.refillPreCacheAllWorlds();
+        rtpManager.refillPreCacheAllWorlds();
+
+        assertSame(first, preCacheSearch(rtpManager).get(), "a second search must not start alongside the first");
+        assertEquals(afterFirst, scheduledTasks.get(), "no extra search chains should have been scheduled");
+        assertFalse(rtpManager.refillPreCache("world"));
+    }
+
+    @Test
+    void testOverdueBackgroundSearchIsStoppedRatherThanForgotten() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+
+        CompletableFuture<Location> overdue = preCacheSearch(rtpManager).get();
+        assertNotNull(overdue);
+        assertFalse(overdue.isDone());
+
+        setLongField(rtpManager, "preCacheSearchDeadlineMillis", 0L);
+        rtpManager.refillPreCacheAllWorlds();
+
+        assertTrue(overdue.isDone(), "the deadline must complete the search so its chains wind down");
+        assertNull(preCacheSearch(rtpManager).get());
+    }
+
+    @Test
+    void testCooldownHoldsTheNextSearchBack() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+
+        setLongField(rtpManager, "preCacheSearchDeadlineMillis", 0L);
+        rtpManager.refillPreCacheAllWorlds();
+        int afterExpiry = scheduledTasks.get();
+
+        rtpManager.refillPreCacheAllWorlds();
+
+        assertNull(preCacheSearch(rtpManager).get(), "the cooldown should keep the slot empty");
+        assertEquals(afterExpiry, scheduledTasks.get());
     }
 
     @Test


### PR DESCRIPTION
Closes #151. Second attempt, after #152 was reverted by #155 for burning 10 GB of RAM on the
reporter's server.

The original complaint still stands. The location cache only filled while somebody was online, so a
server that had been up for ten minutes still made the first player sit through a full search. That
gate is gone again. What is different this time is the ceiling on what the warm-up may do.

## Why the first attempt blew up

Two searches per world, 4 chains each, 3 worlds, all generating terrain around the clock. Worse, the
30 second deadline only dropped a search from the in-flight list. Nothing cancelled it, so an
overrunning search kept generating chunks while its replacement started up beside it, and each extra
search made the next one slower and likelier to overrun in turn.

## The ceiling

One background search at a time for the whole server, not one per world. The sweep takes the
configured worlds in turn from a rotating offset, so a world that always finds a spot quickly cannot
starve the others, and there is a 5 second pause after each search before the next may start.
Background searches run on 4 parallel chains against whatever `SEARCH-ATTEMPTS-PER-TICK` gives a
player who is actually waiting.

Worst case is 4 concurrent chunk generations against 24 before, and it cannot compound, because
there is one slot and it is claimed with a compare-and-set.

The deadline now completes the search's future. Every chain checks that future before its next step,
so completing it winds the search down for real rather than leaving it running anonymously. The old
version dropped the bookkeeping and left the work, which is precisely how it got into a spiral.

## Why background generation is still allowed

The obvious safe answer was to forbid the warm-up from generating chunks at all, and I had leaned
that way until the reporter answered a question about their setup. Their RTP ring is ungenerated and
they cannot pregenerate it, because Chunky takes their VPS down at 8 or 9 percent every time. On a
server like that, refusing to generate in the background does not avoid the cost. It just hands the
cost back to whoever runs `/rtp`. Generating slowly while nobody waits beats generating in a hurry
while somebody does.

With `SIZE: 5` across three worlds, expect a few minutes to fill on an ungenerated world rather than
seconds. The wiki page says so plainly now, including which setting decides whether the warm-up is
cheap or not.

## Notes

- No new config keys. `PRE_CACHE_PARALLEL_ATTEMPTS`, `PRE_CACHE_SEARCH_TIMEOUT_MILLIS` and
  `PRE_CACHE_SEARCH_COOLDOWN_MILLIS` are internal. Background parallelism is still clamped to
  `SEARCH-ATTEMPTS-PER-TICK`, so lowering that for a weak box lowers this along with it.
- `refillPreCache` returns a boolean now, so the sweep can tell whether it used up the one slot.
- Four new tests: warm-up starting with nobody online, a second search being refused while one is
  running, an overdue search being completed instead of forgotten, and the cooldown holding the next
  one back. The third is the exact regression that forced #155.
- Suite is at 222.
