### PR TITLE
fix(rtp): stop the search log reporting more attempts than allowed (#151)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -1301,8 +1301,10 @@ public class RTPManager {
         boolean generateChunks = plugin.getConfigManager().getRtp().getBoolean(GENERATE_CHUNKS_SETTING, false);
         warn("rtp search failed in world '" + progress.worldName
                 + "' radius " + progress.settings.minRadius() + "-" + progress.settings.maxRadius()
-                + ", attempts " + progress.attemptsUsed + "/" + progress.settings.maxAttempts()
-                + ", samples " + progress.chunkSamplesUsed + "/" + progress.settings.maxChunkSamples()
+                + ", attempts " + displaySearchCount(progress.attemptsUsed, progress.settings.maxAttempts())
+                + "/" + progress.settings.maxAttempts()
+                + ", samples " + displaySearchCount(progress.chunkSamplesUsed, progress.settings.maxChunkSamples())
+                + "/" + progress.settings.maxChunkSamples()
                 + ", generatechunks=" + generateChunks
                 + ", generatefallback=" + isGenerateFallbackEnabled()
                 + ", fallbackgeneratedsamples=" + progress.generateFallbackSamplesUsed
@@ -1315,9 +1317,11 @@ public class RTPManager {
             return;
         }
 
-        String attempts = String.valueOf(progress.attemptsUsed);
+        String attempts = String.valueOf(
+                displaySearchCount(progress.attemptsUsed, progress.settings.maxAttempts()));
         String maxAttempts = formatSearchLimit(progress.settings.maxAttempts());
-        String samples = String.valueOf(progress.chunkSamplesUsed);
+        String samples = String.valueOf(
+                displaySearchCount(progress.chunkSamplesUsed, progress.settings.maxChunkSamples()));
         String maxSamples = formatSearchLimit(progress.settings.maxChunkSamples());
         String maxAttemptsMessage = plugin.getConfigManager().getRtp()
                 .getString("MESSAGES.MAX-ATTEMPTS", "&cᴄᴏᴜʟᴅ ɴᴏᴛ ꜰɪɴᴅ ᴀ ѕᴀꜰᴇ ʟᴏᴄᴀᴛɪᴏɴ ᴀꜰᴛᴇʀ %attempts% ᴀᴛᴛᴇᴍᴘᴛѕ.")
@@ -1347,8 +1351,10 @@ public class RTPManager {
         boolean generateChunks = plugin.getConfigManager().getRtp().getBoolean(GENERATE_CHUNKS_SETTING, false);
         warn("rtp search failed in world '" + settings.worldName()
                 + "' radius " + settings.minRadius() + "-" + settings.maxRadius()
-                + ", attempts " + attemptsUsed + "/" + settings.maxAttempts()
-                + ", samples " + chunkSamplesUsed + "/" + settings.maxChunkSamples()
+                + ", attempts " + displaySearchCount(attemptsUsed, settings.maxAttempts())
+                + "/" + settings.maxAttempts()
+                + ", samples " + displaySearchCount(chunkSamplesUsed, settings.maxChunkSamples())
+                + "/" + settings.maxChunkSamples()
                 + ", generatechunks=" + generateChunks
                 + ", generatefallback=" + isGenerateFallbackEnabled()
                 + ", fallbackgeneratedsamples=" + generateFallbackSamplesUsed
@@ -1431,9 +1437,11 @@ public class RTPManager {
         actionBar = stripSearchCounter(actionBar)
                 .replace("{world}", describeWorld(progress.worldName))
                 .replace("{elapsed}", formatElapsedSeconds(progress.elapsedTicks))
-                .replace("{attempts}", String.valueOf(progress.attemptsUsed))
+                .replace("{attempts}", String.valueOf(
+                        displaySearchCount(progress.attemptsUsed, progress.settings.maxAttempts())))
                 .replace("{max_attempts}", formatSearchLimit(progress.settings.maxAttempts()))
-                .replace("{samples}", String.valueOf(progress.chunkSamplesUsed))
+                .replace("{samples}", String.valueOf(
+                        displaySearchCount(progress.chunkSamplesUsed, progress.settings.maxChunkSamples())))
                 .replace("{max_samples}", formatSearchLimit(progress.settings.maxChunkSamples()));
 
         sendPersistentActionBar(player, actionBar, progress.elapsedTicks);
@@ -2233,6 +2241,21 @@ public class RTPManager {
 
     private String formatSearchLimit(int limit) {
         return String.valueOf(Math.max(0, limit));
+    }
+
+    /**
+     * Caps a search counter at its own limit for display.
+     *
+     * <p>Checks run several at a time and the budget is tested before they report back, so the last
+     * few can land after the limit has already been reached. The raw tally is honest about how much
+     * work happened, but "attempts 72/64" in a log just reads as a broken counter to whoever runs
+     * the server, so what gets shown stops at the ceiling they configured.</p>
+     */
+    static int displaySearchCount(int used, int limit) {
+        if (limit <= 0) {
+            return Math.max(0, used);
+        }
+        return Math.max(0, Math.min(used, limit));
     }
 
     private String stripSearchCounter(String text) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -470,6 +470,23 @@ class RTPManagerTest {
     }
 
     @Test
+    void testSearchCountNeverDisplaysMoreThanTheConfiguredLimit() {
+        // The reporter on #151 saw "attempts 72/64" after several parallel checks landed past the cap.
+        assertEquals(64, RTPManager.displaySearchCount(72, 64));
+        assertEquals(64, RTPManager.displaySearchCount(64, 64));
+        assertEquals(63, RTPManager.displaySearchCount(63, 64));
+        assertEquals(0, RTPManager.displaySearchCount(0, 64));
+    }
+
+    @Test
+    void testSearchCountLeavesUnlimitedAndNegativeAlone() {
+        assertEquals(72, RTPManager.displaySearchCount(72, 0));
+        assertEquals(72, RTPManager.displaySearchCount(72, -1));
+        assertEquals(0, RTPManager.displaySearchCount(-5, 64));
+        assertEquals(0, RTPManager.displaySearchCount(-5, 0));
+    }
+
+    @Test
     void testGetLoadedNormalWorldNameWithDeniedNormalWorld() throws Exception {
         createMockWorld("world", World.Environment.NORMAL); // denied world
         createMockWorld("smp", World.Environment.NORMAL); // normal world


### PR DESCRIPTION
Re #151. Cosmetic, and the last loose end from that thread.

The reporter's log had this in it:

```
rtp search failed in world 'world' radius 8000-15000, attempts 72/64, samples 104/128, ...
```

72 attempts against a `MAX-ATTEMPTS` of 64. Nothing was actually broken. The budget gets checked
before a batch of checks goes out, and each one bumps the counter when its chunk comes back, so with
several running at once the last few land after the ceiling has already been reached. The search
still stops where it should. The number just looks wrong, and to somebody reading their own server
log, a counter that sails past its own maximum reads like a bug worth reporting. Which is what
happened.

## What changed

A `displaySearchCount` helper caps a counter at its limit, and every place those counters get shown
goes through it now: the failure log on both search paths, the `%attempts%` and `%samples%`
placeholders in the `MAX-ATTEMPTS` message a player sees, and the live search action bar, which could
drift past the cap the same way while a search was still running.

Only the display changes. The counters keep their real values, so a search stops at exactly the point
it did before.

I went with clamping rather than reserving an attempt slot up front. Reserving would have counted
checks that never read a block, and that would make searches on ungenerated worlds give up far
earlier than they do today, which is a real behaviour change dressed up as a cosmetic fix.

## Notes

- `normalizeSearchLimit` and `normalizeChunkSampleLimit` already guarantee a positive limit, so there
  is always a real ceiling to clamp against. The helper still treats a non-positive limit as "no
  ceiling" in case that ever changes.
- Two tests, one of them the reporter's exact 72 against 64.
- Suite is at 224.
