### PR TITLE
feat(homes): set the home limit per rank with permissions (#146)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -130,6 +130,37 @@ the per-world value for everyone.
 
 ---
 
+## Home Limit Permissions
+
+These nodes are not registered in `plugin.yml` and are read straight off the player, so they work with
+LuckPerms or any other permission plugin. Assign them per rank.
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.homes.<1-100>` | `false` | How many homes the player may save. `ultimatedonutsmp.homes.10` allows ten homes. |
+| `ultimatedonutsmp.homes.page.<1-100>` | `false` | The same limit expressed in menu pages, five homes each. `ultimatedonutsmp.homes.page.3` allows fifteen homes. |
+
+When a player holds more than one node the **highest** value wins, so a player with both `.homes.5`
+and `.homes.20` gets 20 homes, and mixing the two styles is fine — `.homes.page.2` and `.homes.12`
+together give 12. A player with no home node falls back to `SETTINGS.HOME-DEFAULT` in `config.yml`,
+which ships as 2.
+
+The limit applies everywhere a home is created, so `/sethome`, the `/homes` menu and the Bedrock form
+all stop at the same number, and the menu paginates to fit whatever the player is entitled to.
+
+Wildcards do not grant a limit. `ultimatedonutsmp.*` leaves the player on `HOME-DEFAULT`, the same way
+it does for `ultimatedonutsmp.enderchest.rows.<1-6>`, so a staff wildcard cannot quietly hand every
+player 100 homes.
+
+Named rank nodes can be mapped to a home count instead of using numeric nodes. See
+`SETTINGS.HOME-PERMISSIONS.PERMISSIONS` in [Config-config.yml](Config-config.yml) — the shipped
+defaults map `ultimatedonutsmp.homes.vip`, `.vip+` and `.vip++` to 5, 10 and 15 homes.
+
+Set `SETTINGS.HOME-PERMISSIONS.ENABLED: false` in `config.yml` to ignore every home permission and
+give everyone `HOME-DEFAULT`.
+
+---
+
 ## Ender Chest Size Permissions
 
 These nodes are not registered in `plugin.yml` and are read straight off the player, so they work with
@@ -146,7 +177,7 @@ value above 6 is treated as 6. A player with no row node falls back to `ENDER-CH
 as a rank perk.
 
 Wildcards do not grant a tier. `ultimatedonutsmp.*` leaves the player on the default size, the same way
-it does for `ultimatedonutsmp.homes.<amount>`, so a staff wildcard cannot quietly resize everyone.
+it does for `ultimatedonutsmp.homes.<1-100>`, so a staff wildcard cannot quietly resize everyone.
 
 Named rank nodes can be mapped to a row count instead of using numeric nodes. See
 `ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS` in [Config-ender-chest.yml](Config-ender-chest.yml) — the

--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -158,8 +158,24 @@ SETTINGS:
   - MATERIAL: COOKED_BEEF
     # The numerical value for Amount. Available options: Any valid integer
     AMOUNT: 16
-  # The numerical value for Home Default. Available options: Any valid integer
+  # Homes every player gets when no HOME-PERMISSIONS entry applies to them
+  # Raise the HOME-PERMISSIONS entries below to hand out extra homes as a rank perk
+  # Available options: Any valid integer
   HOME-DEFAULT: 2
+  # Per-rank home limits resolved from permissions
+  HOME-PERMISSIONS:
+    # Enable or disable permission based home limits
+    ENABLED: true
+    # Explicit mapping from permission node to home limit
+    # Players can also be given ultimatedonutsmp.homes.<1-100> directly, for example
+    # ultimatedonutsmp.homes.10 for ten homes, or ultimatedonutsmp.homes.page.<1-100> to
+    # hand out whole pages of five at a time
+    # The highest value the player has wins
+    # Players without any of these permissions keep HOME-DEFAULT above
+    PERMISSIONS:
+      "ultimatedonutsmp.homes.vip++": 15
+      "ultimatedonutsmp.homes.vip+": 10
+      "ultimatedonutsmp.homes.vip": 5
   # The numerical value for Shards Per Kill. Available options: Any valid integer
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text
@@ -213,6 +229,8 @@ SETTINGS:
 | `SETTINGS.CHAINMAIL-ON-RESPAWN` | `bool` | `true`, `false` | `true` | Equips players with starter chainmail armor & stone sword upon death respawn. |
 | `SETTINGS.CHAINMAIL-RESPAWN-ITEMS` | `list` | List of configured items/strings | `[{'MATERIAL': 'STONE_SWORD', 'AMOUNT': 1}, {'MATERIAL': 'CHAINMAIL_HELMET', 'NAME': '&eChainmail Helmet', 'AMOUNT': 1}, {'MATERIAL': 'CHAINMAIL_CHESTPLATE', 'NAME': '&eChainmail Chestplate', 'AMOUNT': 1}...]` | Configures the technical `CHAINMAIL-RESPAWN-ITEMS` parameter for `SETTINGS.CHAINMAIL-RESPAWN-ITEMS` in `config.yml`. |
 | `SETTINGS.HOME-DEFAULT` | `int` | Any valid integer number | `'2'` | Default maximum `/sethome` limit for non-donor players. |
+| `SETTINGS.HOME-PERMISSIONS.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for permission based home limits. Set to `false` to ignore every home permission and give everyone `HOME-DEFAULT`. |
+| `SETTINGS.HOME-PERMISSIONS.PERMISSIONS` | `section` | Permission node to home count | `{'ultimatedonutsmp.homes.vip++': 15, 'ultimatedonutsmp.homes.vip+': 10, 'ultimatedonutsmp.homes.vip': 5}` | Named rank nodes mapped to a home limit, for servers that prefer `ultimatedonutsmp.homes.vip` over the numbered nodes. The highest value a player holds wins. See [Commands-and-Permissions](Commands-and-Permissions). |
 | `SETTINGS.SHARDS-PER-KILL` | `int` | Any valid integer number | `'1'` | Configures the technical `SHARDS-PER-KILL` parameter for `SETTINGS.SHARDS-PER-KILL` in `config.yml`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE` | `str` | Any string text | `'&#A303F9+{shards} Shard'` | Configures the technical `SHARDS-KILL-MESSAGE` parameter for `SETTINGS.SHARDS-KILL-MESSAGE` in `config.yml`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` | `str` | Any string text | `'&#A303F9+{shards} Shards &7(&ax{multiplier}&7)'` | Action bar shown instead of `SHARDS-KILL-MESSAGE` while a shard booster multiplies the kill reward. Supports `{multiplier}`. |

--- a/docs/wiki/Config-ender-chest.yml.md
+++ b/docs/wiki/Config-ender-chest.yml.md
@@ -184,7 +184,7 @@ without a separate config entry per rank.
 4. If the player holds none of these nodes, `DEFAULT-ROWS` applies.
 
 Wildcards do not grant a tier. `ultimatedonutsmp.*` leaves the player on `DEFAULT-ROWS`, the same way it
-does for `ultimatedonutsmp.homes.<amount>`, so a staff wildcard cannot quietly resize everyone.
+does for `ultimatedonutsmp.homes.<1-100>`, so a staff wildcard cannot quietly resize everyone.
 
 The size is evaluated every time the chest is opened, so a rank change applies on the next open.
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -488,8 +488,24 @@ SETTINGS:
   - MATERIAL: COOKED_BEEF
     # The numerical value for Amount. Available options: Any valid integer
     AMOUNT: 16
-  # The numerical value for Home Default. Available options: Any valid integer
+  # Homes every player gets when no HOME-PERMISSIONS entry applies to them
+  # Raise the HOME-PERMISSIONS entries below to hand out extra homes as a rank perk
+  # Available options: Any valid integer
   HOME-DEFAULT: 2
+  # Per-rank home limits resolved from permissions
+  HOME-PERMISSIONS:
+    # Enable or disable permission based home limits
+    ENABLED: true
+    # Explicit mapping from permission node to home limit
+    # Players can also be given ultimatedonutsmp.homes.<1-100> directly, for example
+    # ultimatedonutsmp.homes.10 for ten homes, or ultimatedonutsmp.homes.page.<1-100> to
+    # hand out whole pages of five at a time
+    # The highest value the player has wins
+    # Players without any of these permissions keep HOME-DEFAULT above
+    PERMISSIONS:
+      "ultimatedonutsmp.homes.vip++": 15
+      "ultimatedonutsmp.homes.vip+": 10
+      "ultimatedonutsmp.homes.vip": 5
   # The numerical value for Shards Per Kill. Available options: Any valid integer
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text
@@ -542,6 +558,8 @@ SETTINGS:
 | `SETTINGS.CHAINMAIL-ON-RESPAWN` | `bool` | `true`, `false` | `True` | If `true`, equips players with starter chainmail armor & stone sword upon death respawn. |
 | `SETTINGS.CHAINMAIL-RESPAWN-ITEMS` | `list` | Configured values | `[{'MATERIAL': 'STONE_SWORD', 'AMOUNT'...` | Configures `CHAINMAIL-RESPAWN-ITEMS` for `SETTINGS`. |
 | `SETTINGS.HOME-DEFAULT` | `int` | Any positive integer | `2` | Default maximum `/sethome` limit for non-donor players. |
+| `SETTINGS.HOME-PERMISSIONS.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for permission based home limits. Set to `false` to ignore every home permission and give everyone `HOME-DEFAULT`. |
+| `SETTINGS.HOME-PERMISSIONS.PERMISSIONS` | `section` | Permission node to home count | `{'ultimatedonutsmp.homes.vip++': 15, 'ultimatedonutsmp.homes.vip+': 10, 'ultimatedonutsmp.homes.vip': 5}` | Named rank nodes mapped to a home limit, for servers that prefer `ultimatedonutsmp.homes.vip` over the numbered nodes. The highest value a player holds wins. See [Commands-and-Permissions](Commands-and-Permissions). |
 | `SETTINGS.SHARDS-PER-KILL` | `int` | Any valid integer | `1` | Configures `SHARDS-PER-KILL` for `SETTINGS`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE` | `str` | Any string text | `&#A303F9+{shards} Shard` | Configures `SHARDS-KILL-MESSAGE` for `SETTINGS`. |
 | `SETTINGS.SHARDS-KILL-MESSAGE-BOOSTED` | `str` | Any string text | `&#A303F9+{shards} Shards &7(&ax{multiplier}&7)` | Action bar shown instead of `SHARDS-KILL-MESSAGE` while a shard booster multiplies the kill reward. Supports `{multiplier}`. |

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1859,6 +1859,13 @@ public class ConfigManager {
             return true;
         }
 
+        // Home limit permission entries are keyed by a server's own ranks for the same reason,
+        // so the bundled vip examples must not come back once admins delete or replace them.
+        if ("config.yml".equals(resourceName)
+                && path.startsWith("SETTINGS.HOME-PERMISSIONS.PERMISSIONS.")) {
+            return true;
+        }
+
         // Network server entries can be expanded per deployment.
         if ("network.yml".equals(resourceName)
                 && path.startsWith("NETWORK-STATUS.SERVERS.")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HomeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HomeManager.java
@@ -8,6 +8,8 @@ import com.bx.ultimateDonutSmp.menus.HomeMenu;
 import com.bx.ultimateDonutSmp.models.Home;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import java.util.*;
@@ -16,6 +18,8 @@ public class HomeManager {
 
     private static final int HOMES_PER_PAGE = 5;
     private static final int MAX_PERMISSION_VALUE = 100;
+    private static final String HOMES_PERMISSION_PREFIX = "ultimatedonutsmp.homes.";
+    private static final String HOME_PAGES_PERMISSION_PREFIX = "ultimatedonutsmp.homes.page.";
 
     private final UltimateDonutSmp plugin;
     /** UUID → list of homes */
@@ -59,16 +63,58 @@ public class HomeManager {
         return getHomes(uuid).size();
     }
 
-    public int getMaxHomes(Player player) {
-        int defaultHomes = Math.max(1, plugin.getConfigManager().getConfig().getInt("SETTINGS.HOME-DEFAULT", 5));
-        int homesByAmountPermission = PermissionUtils.resolveHighestExactNumberedPermission(
-                player, "ultimatedonutsmp.homes.", MAX_PERMISSION_VALUE);
-        int pagesByPermission = PermissionUtils.resolveHighestExactNumberedPermission(
-                player, "ultimatedonutsmp.homes.page.", MAX_PERMISSION_VALUE);
-        int homesByPagePermission = pagesByPermission * HOMES_PER_PAGE;
-        int permissionHomes = Math.max(homesByAmountPermission, homesByPagePermission);
+    private FileConfiguration getConfig() {
+        return plugin != null && plugin.getConfigManager() != null
+                ? plugin.getConfigManager().getConfig()
+                : null;
+    }
 
-        return permissionHomes > 0 ? permissionHomes : defaultHomes;
+    public boolean isHomePermissionsEnabled() {
+        FileConfiguration config = getConfig();
+        return config == null || config.getBoolean("SETTINGS.HOME-PERMISSIONS.ENABLED", true);
+    }
+
+    public int getDefaultHomes() {
+        FileConfiguration config = getConfig();
+        return Math.max(1, config == null ? 5 : config.getInt("SETTINGS.HOME-DEFAULT", 5));
+    }
+
+    /**
+     * Highest home count the player is entitled to by permission, or 0 when no home permission applies.
+     */
+    public int getPermissionHomes(Player player) {
+        if (player == null || !isHomePermissionsEnabled()) {
+            return 0;
+        }
+
+        int resolved = PermissionUtils.resolveHighestExactNumberedPermission(
+                player, HOMES_PERMISSION_PREFIX, MAX_PERMISSION_VALUE);
+        int pagesByPermission = PermissionUtils.resolveHighestExactNumberedPermission(
+                player, HOME_PAGES_PERMISSION_PREFIX, MAX_PERMISSION_VALUE);
+        resolved = Math.max(resolved, pagesByPermission * HOMES_PER_PAGE);
+
+        FileConfiguration config = getConfig();
+        ConfigurationSection section = config == null
+                ? null
+                : config.getConfigurationSection("SETTINGS.HOME-PERMISSIONS.PERMISSIONS");
+        if (section != null) {
+            for (Map.Entry<String, Object> entry : section.getValues(true).entrySet()) {
+                if (!(entry.getValue() instanceof Number number)) {
+                    continue;
+                }
+                if (!PermissionUtils.hasExact(player, entry.getKey())) {
+                    continue;
+                }
+                resolved = Math.max(resolved, number.intValue());
+            }
+        }
+
+        return Math.max(0, resolved);
+    }
+
+    public int getMaxHomes(Player player) {
+        int permissionHomes = getPermissionHomes(player);
+        return permissionHomes > 0 ? permissionHomes : getDefaultHomes();
     }
 
     public int getMaxHomePages(Player player) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -68,8 +68,24 @@ SETTINGS:
   - MATERIAL: COOKED_BEEF
     # The numerical value for Amount. Available options: Any valid integer
     AMOUNT: 16
-  # The numerical value for Home Default. Available options: Any valid integer
+  # Homes every player gets when no HOME-PERMISSIONS entry applies to them
+  # Raise the HOME-PERMISSIONS entries below to hand out extra homes as a rank perk
+  # Available options: Any valid integer
   HOME-DEFAULT: 2
+  # Per-rank home limits resolved from permissions
+  HOME-PERMISSIONS:
+    # Enable or disable permission based home limits
+    ENABLED: true
+    # Explicit mapping from permission node to home limit
+    # Players can also be given ultimatedonutsmp.homes.<1-100> directly, for example
+    # ultimatedonutsmp.homes.10 for ten homes, or ultimatedonutsmp.homes.page.<1-100> to
+    # hand out whole pages of five at a time
+    # The highest value the player has wins
+    # Players without any of these permissions keep HOME-DEFAULT above
+    PERMISSIONS:
+      "ultimatedonutsmp.homes.vip++": 15
+      "ultimatedonutsmp.homes.vip+": 10
+      "ultimatedonutsmp.homes.vip": 5
   # The numerical value for Shards Per Kill. Available options: Any valid integer
   SHARDS-PER-KILL: 1
   # The text or value for Shards Kill Message. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/HomePermissionTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/HomePermissionTest.java
@@ -1,0 +1,204 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HomePermissionTest {
+
+    private HomeManager createManager(YamlConfiguration mainConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+
+        Constructor<?> pluginConstructor = reflectionFactory
+                .newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) pluginConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        Field configField = ConfigManager.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(configManager, mainConfig);
+
+        Field configManagerField = UltimateDonutSmp.class.getDeclaredField("configManager");
+        configManagerField.setAccessible(true);
+        configManagerField.set(plugin, configManager);
+
+        return new HomeManager(plugin);
+    }
+
+    private Player createMockPlayer(Set<String> permissions) {
+        final Player[] playerHolder = new Player[1];
+        Player playerProxy = (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return UUID.randomUUID();
+                    }
+                    if (method.getName().equals("hasPermission")) {
+                        return permissions.contains(((String) args[0]).toLowerCase(Locale.ROOT));
+                    }
+                    if (method.getName().equals("getEffectivePermissions")) {
+                        Set<PermissionAttachmentInfo> effective = new HashSet<>();
+                        for (String permission : permissions) {
+                            effective.add(new PermissionAttachmentInfo(playerHolder[0], permission, null, true));
+                        }
+                        return effective;
+                    }
+                    if (method.getName().equals("isOnline")) {
+                        return true;
+                    }
+                    return null;
+                }
+        );
+        playerHolder[0] = playerProxy;
+        return playerProxy;
+    }
+
+    private YamlConfiguration baseConfig() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("SETTINGS.HOME-DEFAULT", 2);
+        config.set("SETTINGS.HOME-PERMISSIONS.ENABLED", true);
+        config.set("SETTINGS.HOME-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.homes.vip++", 15);
+        config.set("SETTINGS.HOME-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.homes.vip+", 10);
+        config.set("SETTINGS.HOME-PERMISSIONS.PERMISSIONS.ultimatedonutsmp.homes.vip", 5);
+        return config;
+    }
+
+    @Test
+    void defaultHomesUsedWithoutPermissions() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player regular = createMockPlayer(Set.of());
+
+        assertEquals(0, manager.getPermissionHomes(regular));
+        assertEquals(2, manager.getMaxHomes(regular));
+    }
+
+    @Test
+    void homesResolvedFromConfiguredPermissionMap() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+
+        assertEquals(5, manager.getMaxHomes(
+                createMockPlayer(Set.of("ultimatedonutsmp.homes.vip"))));
+        assertEquals(10, manager.getMaxHomes(
+                createMockPlayer(Set.of("ultimatedonutsmp.homes.vip+"))));
+        assertEquals(15, manager.getMaxHomes(
+                createMockPlayer(Set.of("ultimatedonutsmp.homes.vip++"))));
+    }
+
+    @Test
+    void homesResolvedFromNumberedPermission() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player numbered = createMockPlayer(Set.of("ultimatedonutsmp.homes.7"));
+
+        assertEquals(7, manager.getMaxHomes(numbered));
+    }
+
+    @Test
+    void pagePermissionGrantsFiveHomesEach() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player paged = createMockPlayer(Set.of("ultimatedonutsmp.homes.page.3"));
+
+        assertEquals(15, manager.getMaxHomes(paged));
+        assertEquals(3, manager.getMaxHomePages(paged));
+    }
+
+    @Test
+    void highestValueWinsAcrossStackedPermissions() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player stacked = createMockPlayer(Set.of(
+                "ultimatedonutsmp.homes.3",
+                "ultimatedonutsmp.homes.vip",
+                "ultimatedonutsmp.homes.page.2"
+        ));
+
+        assertEquals(10, manager.getMaxHomes(stacked));
+    }
+
+    @Test
+    void permissionHomesCanSitBelowTheDefault() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player limited = createMockPlayer(Set.of("ultimatedonutsmp.homes.1"));
+
+        assertEquals(1, manager.getMaxHomes(limited));
+    }
+
+    @Test
+    void malformedNumberedPermissionIsIgnored() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player malformed = createMockPlayer(Set.of(
+                "ultimatedonutsmp.homes.abc",
+                "ultimatedonutsmp.homes.-2",
+                "ultimatedonutsmp.homes."
+        ));
+
+        assertEquals(2, manager.getMaxHomes(malformed));
+    }
+
+    @Test
+    void wildcardDoesNotGrantAHomeTier() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+        Player wildcard = createMockPlayer(Set.of("ultimatedonutsmp.*"));
+
+        assertEquals(2, manager.getMaxHomes(wildcard));
+    }
+
+    @Test
+    void disabledHomePermissionsFallBackToTheDefault() throws Exception {
+        YamlConfiguration config = baseConfig();
+        config.set("SETTINGS.HOME-PERMISSIONS.ENABLED", false);
+        HomeManager manager = createManager(config);
+        Player vip = createMockPlayer(Set.of(
+                "ultimatedonutsmp.homes.vip++",
+                "ultimatedonutsmp.homes.20"
+        ));
+
+        assertFalse(manager.isHomePermissionsEnabled());
+        assertEquals(2, manager.getMaxHomes(vip));
+    }
+
+    @Test
+    void nullPlayerFallsBackToTheDefault() throws Exception {
+        HomeManager manager = createManager(baseConfig());
+
+        assertEquals(0, manager.getPermissionHomes(null));
+        assertEquals(2, manager.getMaxHomes(null));
+    }
+
+    @Test
+    void defaultHomesNeverDropBelowOne() throws Exception {
+        YamlConfiguration config = baseConfig();
+        config.set("SETTINGS.HOME-DEFAULT", 0);
+        HomeManager manager = createManager(config);
+
+        assertEquals(1, manager.getMaxHomes(createMockPlayer(Set.of())));
+    }
+
+    @Test
+    void bundledConfigShipsTheHomePermissionSection() throws Exception {
+        YamlConfiguration bundled = new YamlConfiguration();
+        bundled.load(new File("src/main/resources/config.yml"));
+
+        assertTrue(bundled.getBoolean("SETTINGS.HOME-PERMISSIONS.ENABLED"));
+        assertTrue(bundled.isConfigurationSection("SETTINGS.HOME-PERMISSIONS.PERMISSIONS"));
+        assertEquals(2, bundled.getInt("SETTINGS.HOME-DEFAULT"));
+    }
+}


### PR DESCRIPTION
Closes #146

Home limits could already be set by permission. `ultimatedonutsmp.homes.<n>` has been read by the plugin for a while, but nothing in the docs said so, and the nodes only came in numbered form. This brings homes in line with how RTP cooldowns and Ender Chest sizes already work: named rank nodes in the config, a switch to turn the whole thing off, and docs that actually mention any of it.

## What was already there

`ultimatedonutsmp.homes.<1-100>` and `ultimatedonutsmp.homes.page.<1-100>` were already resolved in `HomeManager.getMaxHomes`, highest value winning, falling back to `SETTINGS.HOME-DEFAULT`. That behaviour is unchanged. The request was mostly a discoverability problem.

## Named rank nodes

`SETTINGS.HOME-PERMISSIONS.PERMISSIONS` maps a permission node to a home count, so a server running `ultimatedonutsmp.homes.vip` doesn't have to translate its ranks into numbers first. The shipped defaults are vip, vip+ and vip++ at 5, 10 and 15, matching the shape of `ENDER-CHEST.ROW-PERMISSIONS.PERMISSIONS`. The highest value across every source wins, so numbered nodes, page nodes and named nodes can be mixed freely.

`SETTINGS.HOME-PERMISSIONS.ENABLED: false` ignores every home permission and puts everyone back on `HOME-DEFAULT`.

Entries under that section go into `ConfigManager.isUserManagedBundledPath` alongside the RTP and Ender Chest equivalents, so the bundled vip examples don't come back after an admin deletes or renames them.

## Notes

- Resolution stays exact-match, so `ultimatedonutsmp.*` still grants nothing. A staff wildcard can't quietly hand every player 100 homes.
- `getMaxHomes` now tolerates a null player and a missing config rather than dereferencing straight through, which is also what lets the new tests run without a live server.
- The whole block lives in `config.yml`, so there are no new language keys and the 8 language files are untouched.
- New `HomePermissionTest` covers the default, numbered nodes, page nodes, the named map, stacking, wildcards, the disabled switch and the bundled config. 12 tests, suite now 236 green.
- Wiki: a Home Limit Permissions section in `Commands-and-Permissions`, plus the new keys in `Config-config.yml` and `Configuration-Reference`.
