### PR TITLE
fix(rtp): keep the cache warm-up off chunk generation by default (#151)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -132,10 +132,15 @@ worlds in turn, it waits a few seconds between searches, and it uses fewer paral
 search a player is waiting on. A search that has not finished within thirty seconds is stopped
 outright rather than left running beside its replacement.
 
-That pace matters most when `GENERATE-CHUNKS` is on, because then every search is generating fresh
-terrain and the warm-up is doing real work rather than reading chunks that already exist. On a world
-that has never been walked, expect the cache to take a few minutes to fill rather than seconds. That
-is the intended trade: the generation happens while nobody is waiting instead of while somebody is.
+By default the warm-up never generates terrain, even when `SETTINGS.GENERATE-CHUNKS` is on for
+players. It fills from chunks that already exist and skips anything that would have to be made. That
+is the safe setting and it is why the cache costs almost nothing on a pregenerated world.
+
+Turning `LOCATION-CACHE.GENERATE-CHUNKS` on lifts that restriction, and it is the one option here
+that can cost real memory. Generating for a player who asked is a short burst; generating in the
+background happens over and over on a world nobody has walked yet, and on a small box that adds up
+fast. Leave it off unless your RTP area is already generated or you know you have the memory to
+spare. If you want a cache on a brand new world and your server can take it, this is the switch.
 
 Each entry is re-checked against the current world and radius before it is handed out, and a search
 only starts when a world is short of ready locations. When the cache is empty the command falls back
@@ -152,6 +157,10 @@ to searching live, exactly as before.
     SIZE: 3
     # Seconds a cached location stays usable before it is thrown away. 0 keeps it until the next reload
     MAX-AGE-SECONDS: 600
+    # Let the background warm-up generate new terrain. Keep false unless your RTP area is pregenerated
+    # or the server has memory to spare, since generating in the background runs far more often than
+    # generating for one player who asked. Independent of SETTINGS.GENERATE-CHUNKS above
+    GENERATE-CHUNKS: false
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -161,6 +170,7 @@ to searching live, exactly as before.
 | `SETTINGS.LOCATION-CACHE.ENABLED` | `bool` | `true`, `false` | `true` | Master toggle. When `false` every `/rtp` searches for a location the moment the player runs it. |
 | `SETTINGS.LOCATION-CACHE.SIZE` | `int` | `0` to `16` | `'3'` | Ready locations kept per RTP world. Raise it on a busy server so back to back teleports stay instant, lower it to spend less time searching in the background. `0` turns the cache off. |
 | `SETTINGS.LOCATION-CACHE.MAX-AGE-SECONDS` | `int` | Any valid integer number | `'600'` | How long a cached location may sit unused before it is discarded and searched again. `0` keeps entries until the next reload. |
+| `SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS` | `bool` | `true`, `false` | `false` | Whether the background warm-up may generate terrain. Separate from `SETTINGS.GENERATE-CHUNKS`, which only covers searches a player asked for. Off means the cache fills from terrain that already exists and costs almost nothing. On means it can fill a world nobody has walked yet, at the price of generating chunks around the clock. |
 
 ### 3. Practical Setup Example
 
@@ -173,6 +183,20 @@ SETTINGS:
     SIZE: 8
     MAX-AGE-SECONDS: 300
 ```
+
+Fill the cache on a world that has never been generated, on a server with memory to spare:
+
+```yaml
+SETTINGS:
+  GENERATE-CHUNKS: true
+  LOCATION-CACHE:
+    ENABLED: true
+    SIZE: 3
+    GENERATE-CHUNKS: true
+```
+
+Watch your memory the first time you run that pairing. If it climbs and does not settle, put
+`LOCATION-CACHE.GENERATE-CHUNKS` back to `false` and pregenerate the area instead.
 
 Turn the cache off entirely and go back to searching on demand:
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -94,6 +94,7 @@ public class RTPManager {
     private static final String LOCATION_CACHE_ENABLED_SETTING = "SETTINGS.LOCATION-CACHE.ENABLED";
     private static final String LOCATION_CACHE_SIZE_SETTING = "SETTINGS.LOCATION-CACHE.SIZE";
     private static final String LOCATION_CACHE_MAX_AGE_SETTING = "SETTINGS.LOCATION-CACHE.MAX-AGE-SECONDS";
+    private static final String LOCATION_CACHE_GENERATE_CHUNKS_SETTING = "SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS";
     private static final int DEFAULT_LOCATION_CACHE_SIZE = 3;
     private static final int MAX_LOCATION_CACHE_SIZE = 16;
     private static final int DEFAULT_LOCATION_CACHE_MAX_AGE_SECONDS = 600;
@@ -126,13 +127,16 @@ public class RTPManager {
 
     private static final class DirectSearchState {
         private final SearchSettings settings;
+        /** Whether this particular search may generate terrain, regardless of what the config allows. */
+        private final boolean allowChunkGeneration;
         private final AtomicInteger attemptsUsed = new AtomicInteger();
         private final AtomicInteger chunkSamplesUsed = new AtomicInteger();
         private final AtomicInteger generateFallbackSamplesUsed = new AtomicInteger();
         private final AtomicInteger activeChains = new AtomicInteger();
 
-        private DirectSearchState(SearchSettings settings) {
+        private DirectSearchState(SearchSettings settings, boolean allowChunkGeneration) {
             this.settings = settings;
+            this.allowChunkGeneration = allowChunkGeneration;
         }
     }
 
@@ -428,7 +432,12 @@ public class RTPManager {
         });
 
         try {
-            startDirectSearch(settings, future, getPreCacheParallelAttempts());
+            startDirectSearch(
+                    settings,
+                    future,
+                    getPreCacheParallelAttempts(),
+                    isPreCacheChunkGenerationEnabled()
+            );
         } catch (RuntimeException exception) {
             future.complete(null);
             throw exception;
@@ -457,6 +466,36 @@ public class RTPManager {
         if (running != null) {
             running.complete(null);
         }
+    }
+
+    /**
+     * Whether one sample of a search may generate the chunk it lands on.
+     *
+     * <p>A search that is not allowed to generate never does, whatever the config says. That is what
+     * keeps the background warm-up off chunk generation on servers where {@code GENERATE-CHUNKS} is
+     * on for players.</p>
+     */
+    static boolean shouldGenerateForSample(
+            boolean allowChunkGeneration,
+            boolean generateChunksConfigured,
+            boolean generateFallback
+    ) {
+        return allowChunkGeneration && (generateChunksConfigured || generateFallback);
+    }
+
+    /**
+     * Whether the background warm-up may generate terrain.
+     *
+     * <p>Off by default, and deliberately separate from {@code SETTINGS.GENERATE-CHUNKS}. Generating
+     * on demand for a player who asked costs a burst; generating in the background costs it over and
+     * over on a world nobody has walked yet, which is enough to bury a small box. An admin with the
+     * headroom can turn it on and get a cache that fills on brand new terrain.</p>
+     */
+    public boolean isPreCacheChunkGenerationEnabled() {
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return false;
+        }
+        return plugin.getConfigManager().getRtp().getBoolean(LOCATION_CACHE_GENERATE_CHUNKS_SETTING, false);
     }
 
     /**
@@ -885,11 +924,16 @@ public class RTPManager {
     }
 
     private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
-        startDirectSearch(settings, future, getSearchAttemptsPerTick());
+        startDirectSearch(settings, future, getSearchAttemptsPerTick(), true);
     }
 
-    private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future, int parallelAttempts) {
-        DirectSearchState state = new DirectSearchState(settings);
+    private void startDirectSearch(
+            SearchSettings settings,
+            CompletableFuture<Location> future,
+            int parallelAttempts,
+            boolean allowChunkGeneration
+    ) {
+        DirectSearchState state = new DirectSearchState(settings, allowChunkGeneration);
         int chains = Math.max(1, Math.min(parallelAttempts, settings.maxChunkSamples()));
         state.activeChains.set(chains);
         for (int chain = 0; chain < chains; chain++) {
@@ -946,7 +990,8 @@ public class RTPManager {
         }
 
         int chunkSamplesUsed = state.chunkSamplesUsed.getAndIncrement();
-        boolean generateFallback = shouldUseGenerateFallback(chunkSamplesUsed, state.generateFallbackSamplesUsed.get());
+        boolean generateFallback = state.allowChunkGeneration
+                && shouldUseGenerateFallback(chunkSamplesUsed, state.generateFallbackSamplesUsed.get());
         if (!generateFallback && shouldUseLoadedChunkFallback(chunkSamplesUsed)) {
             plugin.getSpigotScheduler().runRegion(world, settings.centerX() >> 4, settings.centerZ() >> 4, () -> {
                 int[] loadedChunk = nextLoadedChunkSample(world);
@@ -977,7 +1022,11 @@ public class RTPManager {
         }
 
         FileConfiguration rtp = plugin.getConfigManager().getRtp();
-        boolean generateForSample = rtp.getBoolean(GENERATE_CHUNKS_SETTING, false) || generateFallback;
+        boolean generateForSample = shouldGenerateForSample(
+                state.allowChunkGeneration,
+                rtp.getBoolean(GENERATE_CHUNKS_SETTING, false),
+                generateFallback
+        );
         if (!generateForSample && !rtp.getBoolean(LOAD_GENERATED_CHUNKS_SETTING, true)) {
             continueDirectSearch(state, future, null);
             return;

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -39,6 +39,10 @@ SETTINGS:
     SIZE: 3
     # Seconds a cached location stays usable before it is thrown away. 0 keeps it until the next reload
     MAX-AGE-SECONDS: 600
+    # Let the background warm-up generate new terrain. Keep false unless your RTP area is pregenerated
+    # or the server has memory to spare, since generating in the background runs far more often than
+    # generating for one player who asked. Independent of SETTINGS.GENERATE-CHUNKS above
+    GENERATE-CHUNKS: false
   # Priority queue settings for RTP requests
   PRIORITY-QUEUE:
     # Enable or disable the RTP permission priority queue system

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -487,6 +487,42 @@ class RTPManagerTest {
     }
 
     @Test
+    void testBackgroundSearchNeverGeneratesWhenItIsNotAllowedTo() {
+        // The case from #151: GENERATE-CHUNKS on for players, warm-up still must not generate.
+        assertFalse(RTPManager.shouldGenerateForSample(false, true, true));
+        assertFalse(RTPManager.shouldGenerateForSample(false, true, false));
+        assertFalse(RTPManager.shouldGenerateForSample(false, false, true));
+    }
+
+    @Test
+    void testSearchAllowedToGenerateStillFollowsTheConfig() {
+        assertTrue(RTPManager.shouldGenerateForSample(true, true, false));
+        assertTrue(RTPManager.shouldGenerateForSample(true, false, true));
+        assertFalse(RTPManager.shouldGenerateForSample(true, false, false));
+    }
+
+    @Test
+    void testPreCacheChunkGenerationIsOffUnlessTurnedOn() throws Exception {
+        createMockWorld("world", World.Environment.NORMAL);
+
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        RTPManager offByDefault = new RTPManager(createMockPlugin(rtpConfig));
+        assertFalse(offByDefault.isPreCacheChunkGenerationEnabled(),
+                "an admin who changes nothing should not get background generating");
+
+        YamlConfiguration globalOnly = overworldRtpConfig();
+        globalOnly.set("SETTINGS.GENERATE-CHUNKS", true);
+        RTPManager globalDoesNotLeak = new RTPManager(createMockPlugin(globalOnly));
+        assertFalse(globalDoesNotLeak.isPreCacheChunkGenerationEnabled(),
+                "the player-facing setting must not switch the warm-up on");
+
+        YamlConfiguration optedIn = overworldRtpConfig();
+        optedIn.set("SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS", true);
+        RTPManager turnedOn = new RTPManager(createMockPlugin(optedIn));
+        assertTrue(turnedOn.isPreCacheChunkGenerationEnabled());
+    }
+
+    @Test
     void testGetLoadedNormalWorldNameWithDeniedNormalWorld() throws Exception {
         createMockWorld("world", World.Environment.NORMAL); // denied world
         createMockWorld("smp", World.Environment.NORMAL); // normal world


### PR DESCRIPTION
Closes #151.

The reporter ran the test that settles this. Cache on with `GENERATE-CHUNKS` off is fine. Cache off
with `GENERATE-CHUNKS` on is fine. Both together and their server sat at 7.16 GiB with no memory
limit to stop it climbing. In their words: "its the combination of generate chunks and location cache only one and it works fine".

So the pacing from #157 did its job. No spiral, no runaway. The underlying cost was just still too
high: one background search at a time on four chains is generating terrain around the clock on a
world nobody has walked, and a small box cannot carry that.

## The change

`SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS`, defaulting to `false`. The background warm-up decides for
itself whether it may generate now, instead of inheriting `SETTINGS.GENERATE-CHUNKS`. That setting
describes what a search does for a player standing there waiting on it, which is a different question
and never should have shared one answer with this.

Off, the warm-up fills from terrain that already exists and skips anything that would have to be
made. Cheap on a pregenerated world, useless on a brand new one, and that is the honest trade. On,
you get the old behaviour and a cache that can fill an ungenerated world if you have the memory for
it.

A search now carries an `allowChunkGeneration` flag rather than each sample rereading the config, so
a search that is not allowed to generate cannot manage it by any route. That covers the
generate-fallback path, which would otherwise have crept around the flag once a search ran long
enough.

## Why default off

An admin who changes nothing gets the safe behaviour. That was the objection to making this a setting
at all, and putting the safe value in the default answers it. The switch is there for people who know
they want it, rather than a trap for anyone who never reads this page.

## Notes

- Admin setting in `rtp.yml`, not player-facing text, so no language file work. The suite leaving
  `en_US.yml` alone confirms it.
- Named `GENERATE-CHUNKS` under `LOCATION-CACHE` so it reads as "does the cache generate chunks". The
  repeated leaf name could mislead, so the wiki spells out that it is independent of the top level
  one.
- Three new tests, one of them the exact shape of the reporter's problem: generating on for players,
  warm-up still refusing.
- Suite is at 239. Base was 236 once #159 landed.
