### PR TITLE
fix(worth): stop bedrock players losing the enchantment table screen (#165)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
@@ -287,7 +287,8 @@ public class WorthPacketDisplay implements Listener {
         }
     }
 
-    // resend a tick later so worth reappears and matches whether the cursor is holding an item
+    // resend a tick later so worth reappears and matches whether the cursor is holding an item,
+    // except on the screens whose client-side state a resend would wipe
     private void scheduleCursorEval(Player player) {
         if (inPluginMenu.contains(player.getUniqueId())) {
             return;
@@ -311,7 +312,7 @@ public class WorthPacketDisplay implements Listener {
             } else {
                 suppressedMaterials.remove(uuid);
             }
-            if (openInventories.contains(uuid)) {
+            if (openInventories.contains(uuid) && plugin.getWorthManager().canResendOpenInventory(player)) {
                 player.updateInventory();
             }
         }, 1L);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
@@ -15,6 +15,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
@@ -328,7 +329,7 @@ public class WorthManager {
             player.setItemOnCursor(updatedCursor);
         }
 
-        if (player.isOnline() && (forceUpdate || shouldUpdateInventory(player))) {
+        if (player.isOnline() && shouldUpdateInventory(player, forceUpdate)) {
             player.updateInventory();
         }
     }
@@ -344,12 +345,16 @@ public class WorthManager {
 
         syncInventoryWorthDisplay(inventory, isWorthDisplayEnabled(player));
 
-        if (player.isOnline() && (forceUpdate || shouldUpdateInventory(player))) {
+        if (player.isOnline() && shouldUpdateInventory(player, forceUpdate)) {
             player.updateInventory();
         }
     }
 
     private boolean shouldUpdateInventory(Player player) {
+        return shouldUpdateInventory(player, false);
+    }
+
+    private boolean shouldUpdateInventory(Player player, boolean forceUpdate) {
         if (player == null || !player.isOnline()) {
             return false;
         }
@@ -359,9 +364,29 @@ public class WorthManager {
             return true;
         }
 
-        org.bukkit.event.inventory.InventoryType type = topInventory.getType();
+        InventoryType type = topInventory.getType();
+        if (holdsClientState(type)) {
+            return false;
+        }
+
+        if (forceUpdate) {
+            return true;
+        }
+
+        return type != InventoryType.CRAFTING && type != InventoryType.CREATIVE;
+    }
+
+    // Resending the whole window is safe on a chest, but these screens carry state the server never
+    // sent the client - the three enchantment offers, a half-typed anvil name, a picked recipe. A
+    // resync drops it. Java quietly redraws, Geyser does not, so a Bedrock player watches the
+    // enchantment offers vanish the moment the item lands in the slot. Kept as a switch rather than
+    // a constant set so nothing here touches the InventoryType registry before the server is up.
+    static boolean holdsClientState(InventoryType type) {
+        if (type == null) {
+            return false;
+        }
+
         switch (type) {
-            case CRAFTING:
             case WORKBENCH:
             case ANVIL:
             case SMITHING:
@@ -371,11 +396,15 @@ public class WorthManager {
             case LOOM:
             case ENCHANTING:
             case MERCHANT:
-            case CREATIVE:
-                return false;
-            default:
+            case BEACON:
                 return true;
+            default:
+                return false;
         }
+    }
+
+    public boolean canResendOpenInventory(Player player) {
+        return shouldUpdateInventory(player, true);
     }
 
     public ItemStack applyWorthDisplayForPlayer(Player player, ItemStack item) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
@@ -120,6 +120,80 @@ class WorthManagerTest {
         assertTrue(partialStack.isSimilar(fullStack));
     }
 
+    @Test
+    void screensThatHoldClientStateAreNotResynced() throws Exception {
+        setupMockServer();
+
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.ENCHANTING));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.ANVIL));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.GRINDSTONE));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.SMITHING));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.STONECUTTER));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.LOOM));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.CARTOGRAPHY));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.MERCHANT));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.BEACON));
+        assertTrue(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.WORKBENCH));
+
+        assertFalse(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.CHEST));
+        assertFalse(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.SHULKER_BOX));
+        assertFalse(WorthManager.holdsClientState(org.bukkit.event.inventory.InventoryType.CRAFTING));
+        assertFalse(WorthManager.holdsClientState(null));
+    }
+
+    @Test
+    void forcedRefreshLeavesAnOpenEnchantingTableAlone() throws Exception {
+        setupMockServer();
+        UltimateDonutSmp plugin = createMockPlugin(new org.bukkit.configuration.file.YamlConfiguration());
+        WorthManager worthManager = new WorthManager(plugin);
+
+        assertFalse(worthManager.canResendOpenInventory(
+                playerWithOpenView(org.bukkit.event.inventory.InventoryType.ENCHANTING)));
+        assertFalse(worthManager.canResendOpenInventory(
+                playerWithOpenView(org.bukkit.event.inventory.InventoryType.ANVIL)));
+
+        assertTrue(worthManager.canResendOpenInventory(
+                playerWithOpenView(org.bukkit.event.inventory.InventoryType.CHEST)));
+        assertTrue(worthManager.canResendOpenInventory(
+                playerWithOpenView(org.bukkit.event.inventory.InventoryType.CRAFTING)));
+    }
+
+    private org.bukkit.entity.Player playerWithOpenView(org.bukkit.event.inventory.InventoryType type) {
+        org.bukkit.inventory.Inventory topInventory = (org.bukkit.inventory.Inventory) java.lang.reflect.Proxy.newProxyInstance(
+                org.bukkit.inventory.Inventory.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.inventory.Inventory.class},
+                (proxy, method, args) -> method.getName().equals("getType") ? type : defaultValue(method));
+
+        org.bukkit.inventory.InventoryView view = (org.bukkit.inventory.InventoryView) java.lang.reflect.Proxy.newProxyInstance(
+                org.bukkit.inventory.InventoryView.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.inventory.InventoryView.class},
+                (proxy, method, args) -> method.getName().equals("getTopInventory") ? topInventory : defaultValue(method));
+
+        return (org.bukkit.entity.Player) java.lang.reflect.Proxy.newProxyInstance(
+                org.bukkit.entity.Player.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.entity.Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("isOnline")) {
+                        return true;
+                    }
+                    if (method.getName().equals("getOpenInventory")) {
+                        return view;
+                    }
+                    return defaultValue(method);
+                });
+    }
+
+    private static Object defaultValue(java.lang.reflect.Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        return null;
+    }
+
     private void setupMockServer() throws Exception {
         java.lang.reflect.Field serverField = org.bukkit.Bukkit.class.getDeclaredField("server");
         serverField.setAccessible(true);


### PR DESCRIPTION
Closes #165

Bedrock players could open an enchanting table but never get anything enchanted. Java players were fine. The cause was the worth display: one tick after every inventory click it resends the whole open window, and a window resend does not carry the three enchantment offers with it. A Java client just redraws and you never notice. Geyser has nothing left to rebuild the offers from, so on Bedrock the enchanting screen empties out the moment the item lands in the slot.

## The resend guard

`WorthManager` already kept a list of screens it would not resend, and the enchanting table was on it. Two things got past the list. `syncWorthDisplay` let a forced refresh skip the check outright, and `WorthPacketDisplay`, which is the path that runs in practice since ProtocolLib is required, called `updateInventory()` without ever consulting it.

The list now lives in `holdsClientState` and covers the enchanting table, anvil, grindstone, smithing table, stonecutter, loom, cartography table, villager trading, beacon and crafting table. Both callers go through it, and forcing a refresh no longer overrides it. Nothing else changes, including the forced refresh on a player's own inventory that the stacking logic relies on.

## Notes

The check is a switch and not a constant set, deliberately. `InventoryType` resolves against the server registry the first time its class loads, so holding those values in a static field would pull that into `WorthManager`'s class init and break every test in the file outside a running server.

No config or language keys. Two tests added to `WorthManagerTest`: one over the screen list, one asserting a forced refresh leaves an open enchanting table alone while still going through on a chest. Suite is 241 tests, all green.
