### PR TITLE
fix(mobspawn): keep trial chamber spawners out of the toggle (#167)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -218,6 +218,11 @@ SETTINGS:
   DISABLE-MOB-SPAWN-LIMIT-SECONDS: -1
   # The numerical value for Disable Phantom Spawn Limit Seconds. Set to -1 for no limit. Available options: Any valid integer
   DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS: 3600
+  # Determines whether the per player mob spawn toggle also stops trial spawners in trial
+  # chambers. Leave it false so the chamber still has to be fought. A trial spawner ejects
+  # its rewards once the mobs it released are gone, so blocking those spawns hands out the
+  # loot for free. Available options: true, false
+  MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS: false
 # Configuration section for Features.
 ```
 
@@ -247,6 +252,7 @@ SETTINGS:
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer number | `'40'` | Configures the technical `PHANTOM-SPAWN-RADIUS` parameter for `SETTINGS.PHANTOM-SPAWN-RADIUS` in `config.yml`. |
 | `SETTINGS.DISABLE-MOB-SPAWN-LIMIT-SECONDS` | `int` | Any valid integer number | `'-1'` | Configures the technical `DISABLE-MOB-SPAWN-LIMIT-SECONDS` parameter for `SETTINGS.DISABLE-MOB-SPAWN-LIMIT-SECONDS` in `config.yml`. |
 | `SETTINGS.DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS` | `int` | Any valid integer number | `'3600'` | Configures the technical `DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS` parameter for `SETTINGS.DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS` in `config.yml`. |
+| `SETTINGS.MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS` | `bool` | `true`, `false` | `false` | Whether the `/settings` mob spawn toggle reaches trial spawners in trial chambers. A trial spawner ejects its rewards as soon as the mobs it released are gone, so cancelling those spawns pays out the chamber without a fight. Set it to `true` only if you would rather have the quiet room than the loot. |
 
 ### 3. Practical Setup Example
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -548,6 +548,11 @@ SETTINGS:
   DISABLE-MOB-SPAWN-LIMIT-SECONDS: -1
   # The numerical value for Disable Phantom Spawn Limit Seconds. Set to -1 for no limit. Available options: Any valid integer
   DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS: 3600
+  # Determines whether the per player mob spawn toggle also stops trial spawners in trial
+  # chambers. Leave it false so the chamber still has to be fought. A trial spawner ejects
+  # its rewards once the mobs it released are gone, so blocking those spawns hands out the
+  # loot for free. Available options: true, false
+  MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS: false
 # Configuration section for Features.
 ```
 
@@ -576,6 +581,7 @@ SETTINGS:
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer | `40` | Configures `PHANTOM-SPAWN-RADIUS` for `SETTINGS`. |
 | `SETTINGS.DISABLE-MOB-SPAWN-LIMIT-SECONDS` | `int` | Any valid integer | `-1` | Configures `DISABLE-MOB-SPAWN-LIMIT-SECONDS` for `SETTINGS`. |
 | `SETTINGS.DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS` | `int` | Any valid integer | `3600` | Configures `DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS` for `SETTINGS`. |
+| `SETTINGS.MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS` | `bool` | true, false | `False` | Whether the `/settings` mob spawn toggle reaches trial spawners in trial chambers. A trial spawner ejects its rewards as soon as the mobs it released are gone, so cancelling those spawns pays out the chamber without a fight. Set it to `true` only if you would rather have the quiet room than the loot. |
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/MobSpawnListener.java
@@ -20,6 +20,9 @@ import java.util.function.Function;
  * toggle governs the spawn cycle only: mobs that are already alive stay alive when a player turns it
  * off, and turning it back on lets the next natural spawn attempt through immediately. Nothing here
  * removes entities, so there is no sweep of the loaded world at any point.
+ *
+ * <p>Which spawn reasons are in scope is decided by
+ * {@link MobSpawnPolicy#isPreventableSpawnReason(CreatureSpawnEvent.SpawnReason, boolean)}.
  */
 public class MobSpawnListener implements Listener {
 
@@ -29,6 +32,7 @@ public class MobSpawnListener implements Listener {
     private volatile FileConfiguration cachedConfig;
     private volatile double mobSpawnRadius = 50.0D;
     private volatile double phantomSpawnRadius = 40.0D;
+    private volatile boolean trialSpawnersBlocked = false;
 
     public MobSpawnListener(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -41,9 +45,9 @@ public class MobSpawnListener implements Listener {
 
         if (MobSpawnPolicy.hasCustomName(entity)) return;
 
-        if (!isPreventableSpawnReason(event.getSpawnReason())) return;
-
         refreshSettingsIfNeeded();
+
+        if (!MobSpawnPolicy.isPreventableSpawnReason(event.getSpawnReason(), trialSpawnersBlocked)) return;
 
         if (event.getEntityType() == EntityType.PHANTOM) {
             if (shouldCancelPhantomSpawn(entity.getLocation())) {
@@ -62,7 +66,7 @@ public class MobSpawnListener implements Listener {
     }
 
     /**
-     * Re-reads the radii only when {@link com.bx.ultimateDonutSmp.managers.ConfigManager} swapped in a
+     * Re-reads the cached settings only when {@link com.bx.ultimateDonutSmp.managers.ConfigManager} swapped in a
      * new {@link FileConfiguration}, so the hot path costs a reference compare instead of a YAML path
      * lookup per spawn attempt.
      */
@@ -73,6 +77,7 @@ public class MobSpawnListener implements Listener {
         }
         mobSpawnRadius = Math.max(0.0D, current.getDouble("SETTINGS.MOB-SPAWN-RADIUS", 50));
         phantomSpawnRadius = Math.max(0.0D, current.getDouble("SETTINGS.PHANTOM-SPAWN-RADIUS", 40));
+        trialSpawnersBlocked = current.getBoolean("SETTINGS.MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS", false);
         cachedConfig = current;
     }
 
@@ -98,13 +103,5 @@ public class MobSpawnListener implements Listener {
                 mobSpawnRadius,
                 dataProvider
         );
-    }
-
-    private boolean isPreventableSpawnReason(CreatureSpawnEvent.SpawnReason reason) {
-        if (reason == null) return false;
-        return switch (reason) {
-            case CUSTOM, SPAWNER_EGG, BUILD_WITHER, BREEDING -> false;
-            default -> true;
-        };
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicy.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 
 import java.util.Collection;
 import java.util.function.Function;
@@ -35,6 +36,31 @@ public final class MobSpawnPolicy {
         return switch (type) {
             case WITHER, ENDER_DRAGON, ELDER_GUARDIAN, WARDEN -> true;
             default -> false;
+        };
+    }
+
+    /**
+     * Whether the toggle is allowed to cancel a spawn that came from {@code reason}.
+     *
+     * <p>Trial spawners sit outside the toggle by default. A trial spawner counts the mobs it
+     * released and starts ejecting its rewards once none of them are left alive, so cancelling the
+     * spawn does not just keep the room quiet — it hands the player the loot without the fight.
+     * Servers that would rather keep the quiet room can set
+     * {@code SETTINGS.MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS} to true and take that trade.
+     */
+    public static boolean isPreventableSpawnReason(
+            CreatureSpawnEvent.SpawnReason reason,
+            boolean trialSpawnersBlocked
+    ) {
+        if (reason == null) {
+            return false;
+        }
+        if (reason == CreatureSpawnEvent.SpawnReason.TRIAL_SPAWNER) {
+            return trialSpawnersBlocked;
+        }
+        return switch (reason) {
+            case CUSTOM, SPAWNER_EGG, BUILD_WITHER, BREEDING -> false;
+            default -> true;
         };
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -128,6 +128,11 @@ SETTINGS:
   DISABLE-MOB-SPAWN-LIMIT-SECONDS: -1
   # The numerical value for Disable Phantom Spawn Limit Seconds. Set to -1 for no limit. Available options: Any valid integer
   DISABLE-PHANTOM-SPAWN-LIMIT-SECONDS: 3600
+  # Determines whether the per player mob spawn toggle also stops trial spawners in trial
+  # chambers. Leave it false so the chamber still has to be fought. A trial spawner ejects
+  # its rewards once the mobs it released are gone, so blocking those spawns hands out the
+  # loot for free. Available options: true, false
+  MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS: false
 # Configuration section for Features.
 FEATURES_SETTINGS:
   # Action when executing a command linked to a disabled feature.

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/MobSpawnPolicyTest.java
@@ -4,6 +4,7 @@ import com.bx.ultimateDonutSmp.models.PlayerData;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
@@ -31,6 +32,43 @@ class MobSpawnPolicyTest {
         assertFalse(MobSpawnPolicy.isBoss(EntityType.HOGLIN));
         assertFalse(MobSpawnPolicy.isBoss(EntityType.SPIDER));
         assertFalse(MobSpawnPolicy.isBoss(EntityType.CAVE_SPIDER));
+    }
+
+    @Test
+    void trialSpawnersAreLeftAloneByDefault() {
+        // Cancelling a trial spawner spawn empties the mob list it waits on, so the spawner rolls
+        // straight to ejecting its rewards and the chamber pays out without a fight.
+        assertFalse(MobSpawnPolicy.isPreventableSpawnReason(
+                CreatureSpawnEvent.SpawnReason.TRIAL_SPAWNER, false));
+    }
+
+    @Test
+    void trialSpawnersComeBackUnderTheToggleWhenTheServerAsksForIt() {
+        assertTrue(MobSpawnPolicy.isPreventableSpawnReason(
+                CreatureSpawnEvent.SpawnReason.TRIAL_SPAWNER, true));
+    }
+
+    @Test
+    void theTrialSpawnerSwitchLeavesEveryOtherSpawnReasonAlone() {
+        for (boolean trialSpawnersBlocked : new boolean[]{false, true}) {
+            assertFalse(MobSpawnPolicy.isPreventableSpawnReason(null, trialSpawnersBlocked));
+
+            assertFalse(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.CUSTOM, trialSpawnersBlocked));
+            assertFalse(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.SPAWNER_EGG, trialSpawnersBlocked));
+            assertFalse(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.BUILD_WITHER, trialSpawnersBlocked));
+            assertFalse(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.BREEDING, trialSpawnersBlocked));
+
+            assertTrue(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.NATURAL, trialSpawnersBlocked));
+            assertTrue(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.SPAWNER, trialSpawnersBlocked));
+            assertTrue(MobSpawnPolicy.isPreventableSpawnReason(
+                    CreatureSpawnEvent.SpawnReason.CHUNK_GEN, trialSpawnersBlocked));
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #167

Turning mob spawning off in `/settings` was also switching off the trial spawners inside trial chambers, and that costs more than a quiet room. A trial spawner watches the mobs it released and starts ejecting its rewards once none of them are left alive, so cancelling those spawns hands the player the chamber's loot without a fight. M3wzs hit it by walking into a chamber with the toggle off and activating a spawner.

## The cause

`MobSpawnListener` worked out which spawns were in scope with a private `isPreventableSpawnReason`. It exempted `CUSTOM`, `SPAWNER_EGG`, `BUILD_WITHER` and `BREEDING`, then let everything else fall through to `default -> true`. `TRIAL_SPAWNER` landed in that default and got cancelled along with the ambient spawn cycle.

The check now sits in `MobSpawnPolicy` beside `isBoss` and `isHostileMob`, where the toggle's other leave-this-alone rules already live and where it can be tested without a running server.

## The config switch

A switch was asked for on the issue, so `SETTINGS.MOB-SPAWN-TOGGLE-BLOCKS-TRIAL-SPAWNERS` is there for it. It defaults to `false`, which means a chamber has to be fought out of the box. Owners who preferred the old behaviour and would rather have the quiet room than the loot can set it to `true`. It is an ordinary `SETTINGS` key, so existing configs pick it up on the next start.

## Notes

Bosses were already outside the toggle for much the same reason, so this exemption is explained next to theirs. The spawn radius and the phantom path are untouched, and a test walks both switch positions to confirm no other spawn reason moved. `MobSpawnPolicyTest` goes from 9 tests to 12, with the suite at 244 green.
