### PR TITLE
feat(rtp): drop players at a random location when they respawn (#169)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -365,6 +365,91 @@ The search attempt budget, chunk sample budget, and chunk generation behaviour a
 
 ---
 
+## Section: `RESPAWN-RTP`
+
+Sends players back out into the world at a random location after they die, instead of leaving them standing on spawn with everyone else.
+The location search reuses the RTP engine but bypasses RTP cooldowns, playtime requirements, and the RTP queue, so dying never leaves a player stuck behind a cooldown.
+It does require the `RTP` feature itself to be enabled - with RTP off, respawns behave exactly as they did before.
+
+The teleport only starts once the player has already landed on their normal respawn location, so a search that finds nothing simply leaves them at spawn.
+Players who keep their bed or respawn anchor under `SETTINGS.RESPAWN-ON-BED` are left where they are, and so are players respawning into a duel, an FFA arena, or an ender pearl death drop.
+
+### 1. Commented Setup Code Example
+
+```yaml
+RESPAWN-RTP:
+  # Determines whether Respawn Rtp is enabled or disabled. Available options: true, false
+  ENABLED: false
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to respawn...'
+  # The text or value for Success Message, sent once the player has been dropped. Supports
+  # {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid string text
+  SUCCESS-MESSAGE: '&aYou respawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. The
+  # player is left on the normal respawn location. Set to '' to disable. Available options:
+  # Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random respawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop dead players in. Leave empty to use the world they died in.
+    # Available options: Any valid string text
+    NAME: ''
+    # Determines whether the boundaries from World Settings in rtp.yml are reused for that
+    # world. The Center X, Center Z, Min Radius, and Max Radius below are only read when
+    # this is false, or when the world has no entry in rtp.yml. Available options: true,
+    # false
+    USE-RTP-BOUNDS: true
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RESPAWN-RTP.ENABLED` | `bool` | `true`, `false` | `false` | Master toggle for the random teleport after death. Needs `RTP.ENABLED` in `rtp.yml` to be `true` as well. |
+| `RESPAWN-RTP.SEARCHING-MESSAGE` | `str` | Any string text | `'&7Finding you a safe place to respawn...'` | Sent as soon as the search starts, so the player knows why they are standing on spawn for a moment. Set to `''` to stay silent. |
+| `RESPAWN-RTP.SUCCESS-MESSAGE` | `str` | Any string text | `'&aYou respawned at &fX:{x} Y:{y} Z:{z}&a.'` | Sent after the teleport succeeds. Supports `{world}`, `{x}`, `{y}`, `{z}`. Set to `''` to stay silent. |
+| `RESPAWN-RTP.FAILED-MESSAGE` | `str` | Any string text | `'&cCould not find a random respawn location for you.'` | Sent when no safe location was found or the teleport failed. The player keeps the normal respawn location. Set to `''` to stay silent. |
+| `RESPAWN-RTP.WORLD.NAME` | `str` | Any string text | `''` | World to search in. Leave empty to use whichever world the player died in. `world`, `nether`, and `end` resolve to the loaded overworld/nether/end. A world listed in `DENIED-WORLDS` is skipped entirely. |
+| `RESPAWN-RTP.WORLD.USE-RTP-BOUNDS` | `bool` | `true`, `false` | `true` | Reuses `WORLD-SETTINGS.<world>` from `rtp.yml`, so `/rtp` and a death drop land in the same area. A world with no entry of its own inherits the entry matching its environment. Set to `false` to use the four values below instead. |
+| `RESPAWN-RTP.WORLD.CENTER-X` | `int` | Any valid integer number | `0` | X coordinate the search radius is measured from. Only read when `USE-RTP-BOUNDS` is `false` or the world has no `rtp.yml` entry. |
+| `RESPAWN-RTP.WORLD.CENTER-Z` | `int` | Any valid integer number | `0` | Z coordinate the search radius is measured from. Same condition as `CENTER-X`. |
+| `RESPAWN-RTP.WORLD.MIN-RADIUS` | `int` | Any valid integer number | `500` | Closest a respawning player can land to the center. Raise it to push people away from spawn after they die. |
+| `RESPAWN-RTP.WORLD.MAX-RADIUS` | `int` | Any valid integer number | `5000` | Furthest a respawning player can land from the center. Keep it inside your pregenerated area, otherwise the search has to fall back to chunk generation. |
+
+### 3. Practical Setup Example
+
+Scatter everyone who dies somewhere in the overworld between 1000 and 8000 blocks from spawn, ignoring the `/rtp` boundaries:
+
+```yaml
+RESPAWN-RTP:
+  ENABLED: true
+  SEARCHING-MESSAGE: '&7Sending you back out...'
+  SUCCESS-MESSAGE: '&aYou woke up at &fX:{x} Z:{z}&a.'
+  FAILED-MESSAGE: ''
+  WORLD:
+    NAME: 'world'
+    USE-RTP-BOUNDS: false
+    CENTER-X: 0
+    CENTER-Z: 0
+    MIN-RADIUS: 1000
+    MAX-RADIUS: 8000
+```
+
+Leave `USE-RTP-BOUNDS` at `true` and `NAME` empty instead if you want a death in the nether to drop the player back in the nether, inside the same radius `/rtp` already uses there.
+
+The search attempt budget, chunk sample budget, and chunk generation behaviour are shared with `/rtp` and stay in [`rtp.yml`](Config-rtp.yml).
+
+---
+
 ## Section: `FEATURES_SETTINGS`
 
 ### 1. Commented Setup Code Example

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -897,6 +897,66 @@ FIRST-JOIN-RTP:
 
 ---
 
+## Section: `RESPAWN-RTP` - Random Drop After A Player Dies
+
+Sends players back out into the world at a random location after they die, instead of leaving them standing on spawn with everyone else.
+The search reuses the RTP engine but skips RTP cooldowns, playtime requirements, and the RTP queue.
+It still needs the `RTP` feature enabled - with RTP off, respawns behave exactly as they did before.
+
+The teleport only starts once the player has landed on their normal respawn location, so a search that finds nothing leaves them at spawn.
+Bed and respawn anchor spawns kept by `SETTINGS.RESPAWN-ON-BED` are left alone, as are duel, FFA, and ender pearl death respawns.
+
+### Fully Commented Setup Code Example
+```yaml
+RESPAWN-RTP:
+  # Determines whether Respawn Rtp is enabled or disabled. Available options: true, false
+  ENABLED: false
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to respawn...'
+  # The text or value for Success Message, sent once the player has been dropped. Supports
+  # {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid string text
+  SUCCESS-MESSAGE: '&aYou respawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. The
+  # player is left on the normal respawn location. Set to '' to disable. Available options:
+  # Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random respawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop dead players in. Leave empty to use the world they died in.
+    # Available options: Any valid string text
+    NAME: ''
+    # Determines whether the boundaries from World Settings in rtp.yml are reused for that
+    # world. The Center X, Center Z, Min Radius, and Max Radius below are only read when
+    # this is false, or when the world has no entry in rtp.yml. Available options: true,
+    # false
+    USE-RTP-BOUNDS: true
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
+```
+
+### Key Options
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function |
+| :--- | :--- | :--- | :--- | :--- |
+| `RESPAWN-RTP.ENABLED` | `bool` | true, false | `False` | Master toggle for the random teleport after death. Needs `RTP.ENABLED` in `rtp.yml` too. |
+| `RESPAWN-RTP.SEARCHING-MESSAGE` | `str` | Any string text | `&7Finding you a safe place to respawn...` | Sent when the search starts. Set to `''` to stay silent. |
+| `RESPAWN-RTP.SUCCESS-MESSAGE` | `str` | Any string text | `&aYou respawned at &fX:{x} Y:{y} Z:{z}&a.` | Sent after the teleport lands. Supports `{world}`, `{x}`, `{y}`, `{z}`. |
+| `RESPAWN-RTP.FAILED-MESSAGE` | `str` | Any string text | `&cCould not find a random respawn location for you.` | Sent when nothing safe was found. The player keeps the normal respawn location. |
+| `RESPAWN-RTP.WORLD.NAME` | `str` | Any string text | `''` | World to search in. Empty uses the world the player died in. A world in `DENIED-WORLDS` is skipped. |
+| `RESPAWN-RTP.WORLD.USE-RTP-BOUNDS` | `bool` | true, false | `True` | Reuses `WORLD-SETTINGS.<world>` from `rtp.yml` so `/rtp` and a death drop share one area. |
+| `RESPAWN-RTP.WORLD.CENTER-X` | `int` | Any valid integer | `0` | X the radius is measured from. Read only when `USE-RTP-BOUNDS` is `false` or the world has no `rtp.yml` entry. |
+| `RESPAWN-RTP.WORLD.CENTER-Z` | `int` | Any valid integer | `0` | Z the radius is measured from. Same condition as `CENTER-X`. |
+| `RESPAWN-RTP.WORLD.MIN-RADIUS` | `int` | Any valid integer | `500` | Closest a respawning player can land to the center. |
+| `RESPAWN-RTP.WORLD.MAX-RADIUS` | `int` | Any valid integer | `5000` | Furthest a respawning player can land from the center. Keep inside pregenerated terrain. |
+
+---
+
 ## Section: `SHARDS` - Virtual Shards & Anti-AFK Movement Checks
 
 ### Fully Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -87,6 +87,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private RTPManager rtpManager;
     private RTPZoneManager rtpZoneManager;
     private FirstJoinSpawnManager firstJoinSpawnManager;
+    private RespawnRtpManager respawnRtpManager;
     private PortalManager portalManager;
     private AmethystToolsManager amethystToolsManager;
     private EnderChestManager enderChestManager;
@@ -259,6 +260,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         rtpManager = new RTPManager(this);
         rtpZoneManager = new RTPZoneManager(this);
         firstJoinSpawnManager = new FirstJoinSpawnManager(this);
+        respawnRtpManager = new RespawnRtpManager(this);
         portalManager = new PortalManager(this);
         portalManager.loadAll();
         initializeLuckPermsTablistRefreshBridge();
@@ -1041,6 +1043,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         shardManager.reloadSettings();
         rtpZoneManager.reloadSettings();
         firstJoinSpawnManager.reloadSettings();
+        respawnRtpManager.reloadSettings();
         enderChestManager.reload();
         if (offenseManager != null) {
             offenseManager.reload();
@@ -1321,6 +1324,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public FirstJoinSpawnManager getFirstJoinSpawnManager() {
         return firstJoinSpawnManager;
+    }
+
+    public RespawnRtpManager getRespawnRtpManager() {
+        return respawnRtpManager;
     }
 
     public PortalManager getPortalManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerRespawnListener.java
@@ -31,6 +31,8 @@ public class PlayerRespawnListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
+        String deathWorldName = player.getWorld() == null ? null : player.getWorld().getName();
+        boolean respawnRtpAllowed = false;
 
         boolean duelRespawnHandled = plugin.getDuelManager() != null
                 && plugin.getDuelManager().consumeRespawn(player, event);
@@ -66,7 +68,8 @@ public class PlayerRespawnListener implements Listener {
             }
 
             boolean respawnOnBed = plugin.getConfigManager().getConfig().getBoolean("SETTINGS.RESPAWN-ON-BED", false);
-            if (!respawnOnBed || !isRespawningAtBedOrAnchor(event, player)) {
+            respawnRtpAllowed = !respawnOnBed || !isRespawningAtBedOrAnchor(event, player);
+            if (respawnRtpAllowed) {
                 Location respawnLocation = plugin.getSpawnManager().resolveCommandDestination(SpawnManager.AreaType.SPAWN);
                 if (respawnLocation == null) {
                     respawnLocation = plugin.getSpawnManager().getSpawnLocation();
@@ -90,6 +93,7 @@ public class PlayerRespawnListener implements Listener {
                                     if (!isStaffMode) {
                                         scheduleChainmailKit(plugin, player, 0L);
                                     }
+                                    startRespawnRtp(player, deathWorldName);
                                 }
                             });
                         });
@@ -99,12 +103,16 @@ public class PlayerRespawnListener implements Listener {
             }
         }
 
+        boolean respawnRtpOnFallback = respawnRtpAllowed;
         plugin.getStaffModeManager().handleRespawn(player);
         plugin.getSpigotScheduler().runGlobalLater(() -> {
             if (player.isOnline()) {
                 plugin.getSpigotScheduler().runEntity(player, () -> {
                     if (player.isOnline()) {
                         NightVisionUtils.restoreIfEnabled(plugin, player);
+                        if (respawnRtpOnFallback) {
+                            startRespawnRtp(player, deathWorldName);
+                        }
                     }
                 });
             }
@@ -116,6 +124,13 @@ public class PlayerRespawnListener implements Listener {
             }
             scheduleChainmailKit(plugin, player, 2L);
         }
+    }
+
+    private void startRespawnRtp(Player player, String deathWorldName) {
+        if (plugin.getRespawnRtpManager() == null) {
+            return;
+        }
+        plugin.getRespawnRtpManager().handleRespawn(player, deathWorldName);
     }
 
     private boolean shouldSnapToRespawnLocation(Location current, Location expected) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -764,6 +764,44 @@ public class RTPManager {
         );
     }
 
+    public SearchSettings getRespawnSearchSettings(String deathWorldName) {
+        String configuredWorld = plugin.getConfigManager().getConfig().getString("RESPAWN-RTP.WORLD.NAME", "");
+        String worldName = normalizeConfiguredWorldName(
+                configuredWorld == null || configuredWorld.isBlank() ? deathWorldName : configuredWorld
+        );
+        if (worldName == null || worldName.isBlank() || isDeniedWorld(worldName) || !isWorldAvailable(worldName)) {
+            return null;
+        }
+
+        boolean useRtpBounds = plugin.getConfigManager().getConfig()
+                .getBoolean("RESPAWN-RTP.WORLD.USE-RTP-BOUNDS", true);
+        if (useRtpBounds) {
+            SearchSettings rtpBounds = getWorldSearchSettings(worldName);
+            if (rtpBounds != null) {
+                return rtpBounds;
+            }
+        }
+
+        int minRadius = plugin.getConfigManager().getConfig().getInt("RESPAWN-RTP.WORLD.MIN-RADIUS", 500);
+        int maxRadius = plugin.getConfigManager().getConfig().getInt("RESPAWN-RTP.WORLD.MAX-RADIUS", 5000);
+        int centerX = plugin.getConfigManager().getConfig().getInt("RESPAWN-RTP.WORLD.CENTER-X", 0);
+        int centerZ = plugin.getConfigManager().getConfig().getInt("RESPAWN-RTP.WORLD.CENTER-Z", 0);
+        int maxAttempts = plugin.getConfigManager().getRtp().getInt("SETTINGS.MAX-ATTEMPTS", DEFAULT_MAX_ATTEMPTS);
+        int maxChunkSamples = plugin.getConfigManager().getRtp().getInt("SETTINGS.MAX-CHUNK-SAMPLES", DEFAULT_MAX_CHUNK_SAMPLES);
+        int attemptIntervalTicks = plugin.getConfigManager().getRtp().getInt("SETTINGS.ATTEMPT-INTERVAL-TICKS", DEFAULT_ATTEMPT_INTERVAL_TICKS);
+
+        return new SearchSettings(
+                worldName,
+                minRadius,
+                Math.max(minRadius, maxRadius),
+                centerX,
+                centerZ,
+                normalizeSearchLimit(maxAttempts),
+                normalizeChunkSampleLimit(maxChunkSamples),
+                normalizeAttemptInterval(attemptIntervalTicks)
+        );
+    }
+
     public String describeWorld(String worldName) {
         for (RTPDestination destination : configuredDestinations) {
             if (destination.worldName().equalsIgnoreCase(worldName)) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RespawnRtpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RespawnRtpManager.java
@@ -1,0 +1,121 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Sends players back out into the world at a random location after they die, instead of
+ * leaving them standing on spawn. The search reuses the RTP engine directly, so a respawn
+ * is never blocked by RTP cooldowns, playtime requirements, or the RTP queue.
+ *
+ * <p>The teleport is started only once the player has already landed on the normal respawn
+ * location, so a failed or slow search simply leaves them at spawn.
+ */
+public class RespawnRtpManager {
+
+    private final UltimateDonutSmp plugin;
+    private final Set<UUID> pendingTeleports = ConcurrentHashMap.newKeySet();
+
+    private boolean enabled;
+    private String searchingMessage;
+    private String successMessage;
+    private String failedMessage;
+
+    public RespawnRtpManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        reloadSettings();
+    }
+
+    public void reloadSettings() {
+        enabled = plugin.getConfigManager().getConfig().getBoolean("RESPAWN-RTP.ENABLED", false);
+        searchingMessage = plugin.getConfigManager().getConfig().getString("RESPAWN-RTP.SEARCHING-MESSAGE", "");
+        successMessage = plugin.getConfigManager().getConfig().getString("RESPAWN-RTP.SUCCESS-MESSAGE", "");
+        failedMessage = plugin.getConfigManager().getConfig().getString("RESPAWN-RTP.FAILED-MESSAGE", "");
+        pendingTeleports.clear();
+    }
+
+    public boolean isEnabled() {
+        return enabled
+                && plugin.getRtpManager() != null
+                && plugin.getRtpManager().isEnabled();
+    }
+
+    /**
+     * Handles a player who has just respawned after dying.
+     *
+     * @param player          the player that respawned
+     * @param deathWorldName  the world the player died in, used when no world is configured
+     * @return true when the random teleport search was started
+     */
+    public boolean handleRespawn(Player player, String deathWorldName) {
+        if (player == null || !isEnabled()) {
+            return false;
+        }
+
+        UUID uuid = player.getUniqueId();
+        if (!pendingTeleports.add(uuid)) {
+            return true;
+        }
+
+        RTPManager.SearchSettings settings = plugin.getRtpManager().getRespawnSearchSettings(deathWorldName);
+        if (settings == null) {
+            pendingTeleports.remove(uuid);
+            return false;
+        }
+
+        sendMessage(player, searchingMessage, null);
+        plugin.getRtpManager().findSafeLocationAsync(settings).whenComplete((destination, throwable) -> {
+            pendingTeleports.remove(uuid);
+            plugin.getSpigotScheduler().runEntity(player, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (throwable != null || destination == null) {
+                    sendMessage(player, failedMessage, null);
+                    return;
+                }
+                plugin.getSpigotScheduler().teleport(player, destination).thenAccept(success ->
+                        plugin.getSpigotScheduler().runEntity(player, () -> {
+                            if (!player.isOnline()) {
+                                return;
+                            }
+                            if (!Boolean.TRUE.equals(success)) {
+                                sendMessage(player, failedMessage, null);
+                                return;
+                            }
+                            SoundUtils.play(player, plugin.getConfigManager().getSound("TELEPORT.SUCCESS"));
+                            sendMessage(player, successMessage, destination);
+                        }));
+            });
+        });
+        return true;
+    }
+
+    private void sendMessage(Player player, String message, Location location) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        player.sendMessage(ColorUtils.toComponent(applyPlaceholders(message, location)));
+    }
+
+    static String applyPlaceholders(String message, Location location) {
+        if (message == null || message.isBlank()) {
+            return "";
+        }
+        if (location == null) {
+            return message;
+        }
+        return message
+                .replace("{world}", location.getWorld() == null ? "" : location.getWorld().getName())
+                .replace("{x}", String.valueOf(location.getBlockX()))
+                .replace("{y}", String.valueOf(location.getBlockY()))
+                .replace("{z}", String.valueOf(location.getBlockZ()));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -720,6 +720,42 @@ FIRST-JOIN-RTP:
     MIN-RADIUS: 500
     # The numerical value for Max Radius. Available options: Any valid integer
     MAX-RADIUS: 5000
+# Configuration section for Respawn Rtp. Sends players back out into the world at a random
+# location after they die, instead of leaving them standing on spawn. The search ignores RTP
+# cooldowns, playtime requirements, and the RTP queue, but it does require the RTP feature
+# itself to be enabled. Players who keep their bed or anchor respawn under Settings Respawn
+# On Bed are left alone.
+RESPAWN-RTP:
+  # Determines whether Respawn Rtp is enabled or disabled. Available options: true, false
+  ENABLED: false
+  # The text or value for Searching Message, sent while the safe location is being looked
+  # up. Set to '' to disable. Available options: Any valid string text
+  SEARCHING-MESSAGE: '&7Finding you a safe place to respawn...'
+  # The text or value for Success Message, sent once the player has been dropped. Supports
+  # {world}, {x}, {y}, {z}. Set to '' to disable. Available options: Any valid string text
+  SUCCESS-MESSAGE: '&aYou respawned at &fX:{x} Y:{y} Z:{z}&a.'
+  # The text or value for Failed Message, sent when no safe location could be found. The
+  # player is left on the normal respawn location. Set to '' to disable. Available options:
+  # Any valid string text
+  FAILED-MESSAGE: '&cCould not find a random respawn location for you.'
+  # Configuration section for World.
+  WORLD:
+    # The world to drop dead players in. Leave empty to use the world they died in.
+    # Available options: Any valid string text
+    NAME: ''
+    # Determines whether the boundaries from World Settings in rtp.yml are reused for that
+    # world. The Center X, Center Z, Min Radius, and Max Radius below are only read when
+    # this is false, or when the world has no entry in rtp.yml. Available options: true,
+    # false
+    USE-RTP-BOUNDS: true
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 5000
 # Configuration section for Teleport Cooldown.
 TELEPORT-COOLDOWN:
   # The numerical value for Home. Available options: Any valid integer

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RespawnRtpManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RespawnRtpManagerTest.java
@@ -1,0 +1,265 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sun.reflect.ReflectionFactory;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RespawnRtpManagerTest {
+
+    private Server originalServer;
+    private List<World> mockWorlds;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalServer = Bukkit.getServer();
+        mockWorlds = new ArrayList<>();
+
+        Server mockServer = (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getWorlds")) {
+                        return mockWorlds;
+                    }
+                    if (method.getName().equals("getWorld")) {
+                        String name = (String) args[0];
+                        for (World world : mockWorlds) {
+                            if (world.getName().equalsIgnoreCase(name)) {
+                                return world;
+                            }
+                        }
+                        return null;
+                    }
+                    if (method.getName().equals("getWorldContainer")) {
+                        return new File(".");
+                    }
+                    if (method.getName().equals("getOnlinePlayers")) {
+                        return List.of();
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("Minecraft");
+                    }
+                    return null;
+                }
+        );
+
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, mockServer);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, originalServer);
+    }
+
+    private void createMockWorld(String name) {
+        World mockWorld = (World) Proxy.newProxyInstance(
+                World.class.getClassLoader(),
+                new Class<?>[]{World.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getName")) {
+                        return name;
+                    }
+                    if (method.getName().equals("getEnvironment")) {
+                        return World.Environment.NORMAL;
+                    }
+                    return null;
+                }
+        );
+        mockWorlds.add(mockWorld);
+    }
+
+    private UltimateDonutSmp createMockPlugin(YamlConfiguration config, YamlConfiguration rtpConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+        Constructor<?> newConstructor =
+                reflectionFactory.newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) newConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        Field rtpField = ConfigManager.class.getDeclaredField("rtp");
+        rtpField.setAccessible(true);
+        rtpField.set(configManager, rtpConfig);
+
+        Field configField = ConfigManager.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(configManager, config);
+
+        Field cmField = UltimateDonutSmp.class.getDeclaredField("configManager");
+        cmField.setAccessible(true);
+        cmField.set(plugin, configManager);
+
+        return plugin;
+    }
+
+    private YamlConfiguration rtpConfigWithOverworldBounds() {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("WORLD-SETTINGS.world.MIN-RADIUS", 750);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 4000);
+        rtpConfig.set("WORLD-SETTINGS.world.CENTER-X", 100);
+        rtpConfig.set("WORLD-SETTINGS.world.CENTER-Z", -200);
+        return rtpConfig;
+    }
+
+    @Test
+    void bundledConfigShipsRespawnRtpDisabledByDefault() {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new File("src/main/resources/config.yml"));
+        assertTrue(config.contains("RESPAWN-RTP.ENABLED"));
+        assertFalse(config.getBoolean("RESPAWN-RTP.ENABLED"));
+        assertEquals("", config.getString("RESPAWN-RTP.WORLD.NAME"));
+        assertTrue(config.getBoolean("RESPAWN-RTP.WORLD.USE-RTP-BOUNDS"));
+        assertEquals(500, config.getInt("RESPAWN-RTP.WORLD.MIN-RADIUS"));
+        assertEquals(5000, config.getInt("RESPAWN-RTP.WORLD.MAX-RADIUS"));
+    }
+
+    @Test
+    void emptyWorldNameFallsBackToTheWorldThePlayerDiedIn() throws Exception {
+        createMockWorld("world");
+        UltimateDonutSmp plugin = createMockPlugin(new YamlConfiguration(), rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("world");
+
+        assertNotNull(settings);
+        assertEquals("world", settings.worldName());
+    }
+
+    @Test
+    void rtpBoundsAreReusedForTheDeathWorldByDefault() throws Exception {
+        createMockWorld("world");
+        UltimateDonutSmp plugin = createMockPlugin(new YamlConfiguration(), rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("world");
+
+        assertNotNull(settings);
+        assertEquals(750, settings.minRadius());
+        assertEquals(4000, settings.maxRadius());
+        assertEquals(100, settings.centerX());
+        assertEquals(-200, settings.centerZ());
+    }
+
+    @Test
+    void ownBoundsWinWhenRtpBoundsAreTurnedOff() throws Exception {
+        createMockWorld("world");
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("RESPAWN-RTP.WORLD.USE-RTP-BOUNDS", false);
+        config.set("RESPAWN-RTP.WORLD.MIN-RADIUS", 1500);
+        config.set("RESPAWN-RTP.WORLD.MAX-RADIUS", 9000);
+        config.set("RESPAWN-RTP.WORLD.CENTER-X", 64);
+        config.set("RESPAWN-RTP.WORLD.CENTER-Z", 32);
+        UltimateDonutSmp plugin = createMockPlugin(config, rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("world");
+
+        assertNotNull(settings);
+        assertEquals(1500, settings.minRadius());
+        assertEquals(9000, settings.maxRadius());
+        assertEquals(64, settings.centerX());
+        assertEquals(32, settings.centerZ());
+    }
+
+    @Test
+    void aCustomOverworldInheritsTheOverworldRtpBounds() throws Exception {
+        createMockWorld("resource");
+        UltimateDonutSmp plugin = createMockPlugin(new YamlConfiguration(), rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("resource");
+
+        assertNotNull(settings);
+        assertEquals("resource", settings.worldName());
+        assertEquals(750, settings.minRadius());
+        assertEquals(4000, settings.maxRadius());
+    }
+
+    @Test
+    void ownBoundsAreUsedWhenRtpHasNoWorldSettingsAtAll() throws Exception {
+        createMockWorld("resource");
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("RESPAWN-RTP.WORLD.MIN-RADIUS", 200);
+        config.set("RESPAWN-RTP.WORLD.MAX-RADIUS", 800);
+        UltimateDonutSmp plugin = createMockPlugin(config, new YamlConfiguration());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("resource");
+
+        assertNotNull(settings);
+        assertEquals("resource", settings.worldName());
+        assertEquals(200, settings.minRadius());
+        assertEquals(800, settings.maxRadius());
+    }
+
+    @Test
+    void aConfiguredWorldOverridesTheDeathWorld() throws Exception {
+        createMockWorld("world");
+        createMockWorld("resource");
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("RESPAWN-RTP.WORLD.NAME", "resource");
+        UltimateDonutSmp plugin = createMockPlugin(config, rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings("world");
+
+        assertNotNull(settings);
+        assertEquals("resource", settings.worldName());
+    }
+
+    @Test
+    void deniedAndMissingWorldsAreRefused() throws Exception {
+        createMockWorld("world");
+        createMockWorld("afk");
+        YamlConfiguration rtpConfig = rtpConfigWithOverworldBounds();
+        rtpConfig.set("DENIED-WORLDS", List.of("afk"));
+        UltimateDonutSmp plugin = createMockPlugin(new YamlConfiguration(), rtpConfig);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        assertNull(rtpManager.getRespawnSearchSettings("afk"));
+        assertNull(rtpManager.getRespawnSearchSettings("nowhere"));
+    }
+
+    @Test
+    void anUnknownDeathWorldFallsBackToTheOverworld() throws Exception {
+        createMockWorld("world");
+        UltimateDonutSmp plugin = createMockPlugin(new YamlConfiguration(), rtpConfigWithOverworldBounds());
+
+        RTPManager.SearchSettings settings = new RTPManager(plugin).getRespawnSearchSettings(null);
+
+        assertNotNull(settings);
+        assertEquals("world", settings.worldName());
+    }
+
+    @Test
+    void placeholdersUseBlockCoordinatesOfTheDestination() {
+        Location destination = new Location(null, 128.9, 71.0, -64.2);
+        assertEquals(
+                "respawned at X:128 Y:71 Z:-65 in ",
+                RespawnRtpManager.applyPlaceholders("respawned at X:{x} Y:{y} Z:{z} in {world}", destination)
+        );
+    }
+
+    @Test
+    void placeholdersAreLeftUntouchedWithoutADestination() {
+        assertEquals("still searching {x}", RespawnRtpManager.applyPlaceholders("still searching {x}", null));
+        assertEquals("", RespawnRtpManager.applyPlaceholders("", null));
+        assertEquals("", RespawnRtpManager.applyPlaceholders(null, null));
+    }
+}


### PR DESCRIPTION
Closes #169

Players who die all pile up on the same spawn point right now. This adds a `RESPAWN-RTP` block to `config.yml` that sends them back out to a random spot instead, reusing the RTP engine and, by default, the same per-world boundaries `/rtp` already uses.

## How it hooks in

The teleport starts only after the player has already landed on their normal respawn location. The respawn location has to be set synchronously while the search takes several ticks, so doing it the other way round would drop players somewhere broken every time a search ran long or came back empty. This way a failed search just leaves them standing at spawn, and the existing fallback chain keeps working untouched.

Respawns another system already owns are left alone: duels, FFA, ender pearl death drops, and bed or anchor spawns kept by `SETTINGS.RESPAWN-ON-BED`.

## Boundaries

`WORLD.USE-RTP-BOUNDS` defaults to `true`, which reads `WORLD-SETTINGS.<world>` straight out of `rtp.yml`. That covers the part of the request about integrating with the existing RTP boundaries and worlds, so a death in the nether lands inside the same radius `/rtp` uses there and there is no second set of numbers to keep in sync. Set it to `false` and the block's own `CENTER-X`, `CENTER-Z`, `MIN-RADIUS`, and `MAX-RADIUS` are read instead, which covers the x/z min/max shape from the issue.

`WORLD.NAME` is empty by default, meaning the world the player died in. A world listed in `DENIED-WORLDS`, or one that is not loaded, is refused and the player keeps the normal respawn.

## Notes

The `force-ground-spawn` idea from the issue is already how the RTP engine works. It only ever accepts a safe ground location, so there is nothing to toggle. I also dropped the separate `ON-DEATH` key from the suggested config, since a respawn RTP only ever fires on a death respawn and a second toggle inside the same block would just be another thing to get wrong.

Everything lives in one self-contained `config.yml` block, so this does not touch the language files. `RESPAWN-RTP.ENABLED` ships `false`, and the feature also needs RTP itself enabled in `rtp.yml`, so nothing changes for existing servers until someone opts in.

Eleven tests in `RespawnRtpManagerTest` cover the bundled defaults, the world fallback, both boundary sources, denied and unloaded worlds, and the message placeholders. Full suite is 255 tests, all green.

`docs/wiki/Config-config.yml.md` and `docs/wiki/Configuration-Reference.md` document the new section.
