### PR TITLE
fix(amethyst): stop the tools doing nothing in creative mode (#174)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
@@ -54,6 +54,20 @@ public class AmethystToolsListener implements Listener {
         this.manager = plugin.getAmethystToolsManager();
     }
 
+    /**
+     * Inventory upkeep - splitting stacks, stamping identity, clearing expired tools - stays off in
+     * creative, where the client owns the inventory and correcting it only causes desync. What the
+     * tool itself does is not gated on the game mode.
+     */
+    static boolean shouldManageInventory(GameMode gameMode) {
+        return gameMode != GameMode.CREATIVE;
+    }
+
+    /** Breaking a block in creative drops nothing in vanilla, so neither does an amethyst tool. */
+    static boolean shouldDropAoeLoot(GameMode gameMode) {
+        return gameMode != GameMode.CREATIVE;
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockDamage(BlockDamageEvent event) {
         Player player = event.getPlayer();
@@ -70,20 +84,24 @@ public class AmethystToolsListener implements Listener {
         }
 
         Player player = event.getPlayer();
-        if (player.getGameMode() == GameMode.CREATIVE) {
-            return;
-        }
         ItemStack item = player.getInventory().getItemInMainHand();
         if (!manager.isAmethystTool(item)) {
             return;
         }
 
+        boolean manageInventory = shouldManageInventory(player.getGameMode());
+
         if (item.getAmount() > 1) {
+            if (!manageInventory) {
+                return;
+            }
             manager.sanitizeHeldItem(player, false);
             return;
         }
 
-        manager.ensureIdentity(item, player.getUniqueId(), false);
+        if (manageInventory) {
+            manager.ensureIdentity(item, player.getUniqueId(), false);
+        }
         AmethystToolType type = manager.getToolType(item);
         if (type != AmethystToolType.DRILL && type != AmethystToolType.SHOVEL && type != AmethystToolType.CHOPPER) {
             return;
@@ -136,8 +154,7 @@ public class AmethystToolsListener implements Listener {
                     continue;
                 }
 
-                block.breakNaturally(item);
-                player.sendBlockChange(block.getLocation(), Material.AIR.createBlockData());
+                breakAoeBlock(player, block, item);
                 if (particlesSpawned < 4) {
                     manager.spawnAmethystParticles(block.getLocation());
                     particlesSpawned++;
@@ -187,8 +204,7 @@ public class AmethystToolsListener implements Listener {
                     continue;
                 }
 
-                block.breakNaturally(item);
-                player.sendBlockChange(block.getLocation(), Material.AIR.createBlockData());
+                breakAoeBlock(player, block, item);
                 if (particlesSpawned < 4) {
                     manager.spawnAmethystParticles(block.getLocation());
                     particlesSpawned++;
@@ -238,8 +254,7 @@ public class AmethystToolsListener implements Listener {
                     continue;
                 }
 
-                log.breakNaturally(item);
-                player.sendBlockChange(log.getLocation(), Material.AIR.createBlockData());
+                breakAoeBlock(player, log, item);
                 if (particlesSpawned < 5) {
                     manager.spawnAmethystParticles(log.getLocation());
                     particlesSpawned++;
@@ -264,9 +279,6 @@ public class AmethystToolsListener implements Listener {
         }
 
         Player player = event.getPlayer();
-        if (player.getGameMode() == GameMode.CREATIVE) {
-            return;
-        }
         ItemStack item = player.getInventory().getItemInMainHand();
         if (!manager.isAmethystTool(item)) {
             return;
@@ -277,13 +289,20 @@ public class AmethystToolsListener implements Listener {
             return;
         }
 
+        boolean manageInventory = shouldManageInventory(player.getGameMode());
+
         if (item.getAmount() > 1) {
+            if (!manageInventory) {
+                return;
+            }
             manager.sanitizeHeldItem(player, false);
             event.setCancelled(true);
             return;
         }
 
-        manager.ensureIdentity(item, player.getUniqueId(), false);
+        if (manageInventory) {
+            manager.ensureIdentity(item, player.getUniqueId(), false);
+        }
         AmethystToolType type = manager.getToolType(item);
         if (type == null) {
             event.setCancelled(true);
@@ -418,15 +437,14 @@ public class AmethystToolsListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerConsume(PlayerItemConsumeEvent event) {
         Player player = event.getPlayer();
-        if (player.getGameMode() == GameMode.CREATIVE) {
-            return;
-        }
         ItemStack item = event.getItem();
         if (!manager.isAmethystTool(item)) {
             return;
         }
 
-        manager.ensureIdentity(item, player.getUniqueId(), false);
+        if (shouldManageInventory(player.getGameMode())) {
+            manager.ensureIdentity(item, player.getUniqueId(), false);
+        }
         AmethystToolType type = manager.getToolType(item);
         if (type != AmethystToolType.SHARD_BOOSTER) {
             return;
@@ -459,28 +477,6 @@ public class AmethystToolsListener implements Listener {
 
         if (currentIsAmethystTool && cursorIsAmethystTool) {
             event.setCancelled(true);
-            if (player.getGameMode() == GameMode.CREATIVE) {
-                Inventory clickedInventory = event.getClickedInventory();
-                int clickedSlot = event.getSlot();
-                ItemStack currentSnapshot = current.clone();
-                ItemStack cursorSnapshot = cursor.clone();
-
-                manager.suppressVisualSync(player.getUniqueId());
-                plugin.getSpigotScheduler().runEntity(player, () -> {
-                    if (!player.isOnline()) {
-                        return;
-                    }
-
-                    manager.suppressVisualSync(player.getUniqueId());
-                    if (clickedInventory != null
-                            && clickedSlot >= 0
-                            && clickedSlot < clickedInventory.getSize()) {
-                        clickedInventory.setItem(clickedSlot, currentSnapshot.clone());
-                    }
-                    player.setItemOnCursor(cursorSnapshot.clone());
-                    player.updateInventory();
-                });
-            }
             return;
         }
 
@@ -696,6 +692,15 @@ public class AmethystToolsListener implements Listener {
     private boolean shouldSendBreakMessages(Player player) {
         PlayerData data = plugin.getPlayerDataManager().get(player);
         return data == null || data.isAmethystBreakMessagesEnabled();
+    }
+
+    private void breakAoeBlock(Player player, Block block, ItemStack item) {
+        if (shouldDropAoeLoot(player.getGameMode())) {
+            block.breakNaturally(item);
+        } else {
+            block.setType(Material.AIR);
+        }
+        player.sendBlockChange(block.getLocation(), Material.AIR.createBlockData());
     }
 
     private List<Block> getAoeBlocks(Block origin, Player player, int radius) {

--- a/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListenerTest.java
@@ -1,0 +1,25 @@
+package com.bx.ultimateDonutSmp.amethyst;
+
+import org.bukkit.GameMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AmethystToolsListenerTest {
+
+    @Test
+    void inventoryUpkeepStaysOffInCreative() {
+        assertFalse(AmethystToolsListener.shouldManageInventory(GameMode.CREATIVE));
+        assertTrue(AmethystToolsListener.shouldManageInventory(GameMode.SURVIVAL));
+        assertTrue(AmethystToolsListener.shouldManageInventory(GameMode.ADVENTURE));
+        assertTrue(AmethystToolsListener.shouldManageInventory(GameMode.SPECTATOR));
+    }
+
+    @Test
+    void areaBreaksDropLootOutsideCreativeOnly() {
+        assertFalse(AmethystToolsListener.shouldDropAoeLoot(GameMode.CREATIVE));
+        assertTrue(AmethystToolsListener.shouldDropAoeLoot(GameMode.SURVIVAL));
+        assertTrue(AmethystToolsListener.shouldDropAoeLoot(GameMode.ADVENTURE));
+    }
+}


### PR DESCRIPTION
Closes #174

Every amethyst tool did nothing at all for anyone in creative mode, which is how most people try them for the first time: `/amethysttool give <player> drill`, switch to the drill, mine some stone, and watch one block break like it was an ordinary pickaxe. Nothing in chat and nothing in console, so there was no reason to think the plugin had even seen the swing.

## Where it came from

`9b86a9f` ("bypass inventory and tool event handlers in creative mode") pasted `if (player.getGameMode() == GameMode.CREATIVE) return;` into all eight handlers in `AmethystToolsListener`. For the inventory handlers that is the right call. The creative inventory is client-authoritative, and the plugin's stack splitting and expiry cleanup only fight it and cause desync.

The problem is that the same early return also went onto `onBlockBreak`, `onPlayerInteract` and `onPlayerConsume`, which are not inventory upkeep. Those three are where the tools actually do their work, so drill, shovel, chopper, sell axe, bucket and shard booster all stopped responding along with them. The giveaway is still sitting in `onInventoryClick`, where an entire creative branch ended up behind the new early return and could never run again.

## What changed

The one blanket check is now split into the two decisions it was conflating, both written as small static predicates so they can be tested:

- `shouldManageInventory(gameMode)` still returns false in creative, but it now guards only the inventory upkeep, meaning stack splitting and identity stamping on a held tool. The inventory handlers themselves (click, drag, drop, pickup) keep their creative bypass exactly as it was.
- `shouldDropAoeLoot(gameMode)` is new. The three mining tools now break their extra blocks through a single `breakAoeBlock` helper, which calls `breakNaturally` in survival and clears the block without drops in creative. That matches what vanilla does when you break a block in creative.

What a tool does is no longer decided by the game mode. Ownership binding, the excluded-worlds list, permissions and the expiry check all still run the way they did before, in every mode.

## Notes

The sell axe and the shard booster now work in creative too. That was a deliberate choice: `/sell` has never had a creative gate either, so blocking them here would have meant inventing a rule the plugin does not apply anywhere else.

The unreachable creative branch in `onInventoryClick` is gone.

Nothing was added to the config or the language files, so there is nothing to translate and no wiki page to update. Two tests cover the new predicates across survival, creative, adventure and spectator. The suite is at 262 and green. The handler wiring itself is not covered, because this repo has no Bukkit test harness.
