### PR TITLE
fix(spawners): drop only the loot on the open storage page (#176)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -998,7 +998,7 @@ public class SpawnerManager {
         return ok("&acollected &f" + NumberUtils.format(totalMoved) + "&a items from this spawner.");
     }
 
-    public ActionResult dropAllLoot(Player player, SpawnerInstance instance) {
+    public ActionResult dropPageLoot(Player player, SpawnerInstance instance, int page) {
         if (player == null || instance == null) {
             return fail("&cspawner not found.");
         }
@@ -1008,10 +1008,7 @@ public class SpawnerManager {
 
         Location dropLocation = getSpawnerCenter(instance).add(0, 0.5D, 0);
         long dropped = 0L;
-        for (SpawnerLootEntry entry : new ArrayList<>(instance.getStoredLootEntries())) {
-            if (instance.isLootDisabled(entry.getKey())) {
-                continue;
-            }
+        for (SpawnerLootEntry entry : instance.getPageLootEntries(page, storageItemsPerPage)) {
             long droppedForEntry = dropMaterial(player, dropLocation, entry.getMaterial(), entry.getAmount());
             if (droppedForEntry > 0L) {
                 instance.removeStoredLoot(entry.getKey(), droppedForEntry);
@@ -1020,13 +1017,13 @@ public class SpawnerManager {
         }
 
         if (dropped <= 0L) {
-            return fail("&cthere is no enabled loot stored in that spawner.");
+            return fail("&cthere is no loot stored on this page.");
         }
 
         instance.setUpdatedAt(System.currentTimeMillis());
         saveLoot(instance);
         playDropLootSound(player);
-        return ok("&adropped &f" + NumberUtils.format(dropped) + "&a stored items on the ground.");
+        return ok("&adropped &f" + NumberUtils.format(dropped) + "&a stored items from this page on the ground.");
     }
 
     public record SpawnerSellPreview(double totalPayout, long totalSellableItems, double maxMultiplier) {}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
@@ -389,7 +389,7 @@ public class SpawnerStorageMenu extends BaseMenu {
             } else if (rawSlot == nextSlot) {
                 new SpawnerStorageMenu(plugin, spawnerId, page + 1).open(player);
             } else if (rawSlot == dropSlot) {
-                player.sendMessage(ColorUtils.toComponent(plugin.getSpawnerManager().dropAllLoot(player, instance).message()));
+                player.sendMessage(ColorUtils.toComponent(plugin.getSpawnerManager().dropPageLoot(player, instance, page).message()));
                 new SpawnerStorageMenu(plugin, spawnerId, page).open(player);
             } else if (rawSlot == sellSlot) {
                 plugin.getSpawnerManager().playSellConfirmOpenSound(player);

--- a/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
@@ -225,6 +225,22 @@ public class SpawnerInstance {
         storedLoot.remove("SLOT_" + slotIndex);
     }
 
+    public List<SpawnerLootEntry> getPageLootEntries(int page, int itemsPerPage) {
+        List<SpawnerLootEntry> entries = new ArrayList<>();
+        if (itemsPerPage <= 0) {
+            return entries;
+        }
+
+        int firstSlotIndex = (Math.max(1, page) - 1) * itemsPerPage;
+        for (int slotIndex = firstSlotIndex; slotIndex < firstSlotIndex + itemsPerPage; slotIndex++) {
+            SpawnerLootEntry entry = getSlotLoot(slotIndex);
+            if (entry != null && entry.getAmount() > 0L) {
+                entries.add(entry);
+            }
+        }
+        return entries;
+    }
+
     public void addAutoMobDrop(Material material, long amount, long capPerKey) {
         if (material == null || amount <= 0L) {
             return;

--- a/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerStoragePageTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerStoragePageTest.java
@@ -15,39 +15,37 @@ class SpawnerStoragePageTest {
 
     @Test
     void pageEntriesOnlyCoverTheSlotsShownOnThatPage() {
-        SpawnerInstance instance = spawner();
-        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
-        instance.setSlotLoot(44, Material.BONE, 32);
-        instance.setSlotLoot(45, Material.ARROW, 16);
-        instance.setSlotLoot(89, Material.STRING, 8);
-        instance.setSlotLoot(90, Material.GUNPOWDER, 4);
+        SpawnerInstance instance = spawnerWith(
+                slot(0, Material.ROTTEN_FLESH, 64),
+                slot(44, Material.BONE, 32),
+                slot(45, Material.ARROW, 16),
+                slot(89, Material.STRING, 8),
+                slot(90, Material.GUNPOWDER, 4)
+        );
 
-        List<SpawnerLootEntry> firstPage = instance.getPageLootEntries(1, ITEMS_PER_PAGE);
-        assertEquals(List.of("SLOT_0", "SLOT_44"), keys(firstPage));
-
-        List<SpawnerLootEntry> secondPage = instance.getPageLootEntries(2, ITEMS_PER_PAGE);
-        assertEquals(List.of("SLOT_45", "SLOT_89"), keys(secondPage));
-
-        List<SpawnerLootEntry> thirdPage = instance.getPageLootEntries(3, ITEMS_PER_PAGE);
-        assertEquals(List.of("SLOT_90"), keys(thirdPage));
+        assertEquals(List.of("SLOT_0", "SLOT_44"), keys(instance.getPageLootEntries(1, ITEMS_PER_PAGE)));
+        assertEquals(List.of("SLOT_45", "SLOT_89"), keys(instance.getPageLootEntries(2, ITEMS_PER_PAGE)));
+        assertEquals(List.of("SLOT_90"), keys(instance.getPageLootEntries(3, ITEMS_PER_PAGE)));
     }
 
     @Test
     void pageEntriesAreOrderedBySlotRatherThanInsertion() {
-        SpawnerInstance instance = spawner();
-        instance.setSlotLoot(30, Material.BONE, 12);
-        instance.setSlotLoot(2, Material.ARROW, 5);
-        instance.setSlotLoot(17, Material.STRING, 9);
+        SpawnerInstance instance = spawnerWith(
+                slot(30, Material.BONE, 12),
+                slot(2, Material.ARROW, 5),
+                slot(17, Material.STRING, 9)
+        );
 
         assertEquals(List.of("SLOT_2", "SLOT_17", "SLOT_30"), keys(instance.getPageLootEntries(1, ITEMS_PER_PAGE)));
     }
 
     @Test
     void droppingOnePageLeavesEveryOtherPageUntouched() {
-        SpawnerInstance instance = spawner();
-        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
-        instance.setSlotLoot(45, Material.ARROW, 16);
-        instance.setSlotLoot(90, Material.GUNPOWDER, 4);
+        SpawnerInstance instance = spawnerWith(
+                slot(0, Material.ROTTEN_FLESH, 64),
+                slot(45, Material.ARROW, 16),
+                slot(90, Material.GUNPOWDER, 4)
+        );
 
         for (SpawnerLootEntry entry : instance.getPageLootEntries(2, ITEMS_PER_PAGE)) {
             instance.removeStoredLoot(entry.getKey(), entry.getAmount());
@@ -61,8 +59,7 @@ class SpawnerStoragePageTest {
 
     @Test
     void emptyAndOutOfRangePagesYieldNothing() {
-        SpawnerInstance instance = spawner();
-        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
+        SpawnerInstance instance = spawnerWith(slot(0, Material.ROTTEN_FLESH, 64));
 
         assertTrue(instance.getPageLootEntries(2, ITEMS_PER_PAGE).isEmpty());
         assertTrue(instance.getPageLootEntries(500, ITEMS_PER_PAGE).isEmpty());
@@ -72,10 +69,11 @@ class SpawnerStoragePageTest {
 
     @Test
     void smallerPagesSplitTheSameStorageIntoMorePages() {
-        SpawnerInstance instance = spawner();
-        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
-        instance.setSlotLoot(9, Material.BONE, 32);
-        instance.setSlotLoot(18, Material.ARROW, 16);
+        SpawnerInstance instance = spawnerWith(
+                slot(0, Material.ROTTEN_FLESH, 64),
+                slot(9, Material.BONE, 32),
+                slot(18, Material.ARROW, 16)
+        );
 
         assertEquals(List.of("SLOT_0"), keys(instance.getPageLootEntries(1, 9)));
         assertEquals(List.of("SLOT_9"), keys(instance.getPageLootEntries(2, 9)));
@@ -86,8 +84,12 @@ class SpawnerStoragePageTest {
         return entries.stream().map(SpawnerLootEntry::getKey).toList();
     }
 
-    private static SpawnerInstance spawner() {
-        return new SpawnerInstance(
+    private static SpawnerLootEntry slot(int slotIndex, Material material, long amount) {
+        return new SpawnerLootEntry("SLOT_" + slotIndex, material, amount);
+    }
+
+    private static SpawnerInstance spawnerWith(SpawnerLootEntry... entries) {
+        SpawnerInstance instance = new SpawnerInstance(
                 1L,
                 "world",
                 0,
@@ -102,5 +104,7 @@ class SpawnerStoragePageTest {
                 0L,
                 0L
         );
+        instance.setStoredLootEntries(List.of(entries));
+        return instance;
     }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerStoragePageTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerStoragePageTest.java
@@ -1,0 +1,106 @@
+package com.bx.ultimateDonutSmp.models;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpawnerStoragePageTest {
+
+    private static final int ITEMS_PER_PAGE = 45;
+
+    @Test
+    void pageEntriesOnlyCoverTheSlotsShownOnThatPage() {
+        SpawnerInstance instance = spawner();
+        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
+        instance.setSlotLoot(44, Material.BONE, 32);
+        instance.setSlotLoot(45, Material.ARROW, 16);
+        instance.setSlotLoot(89, Material.STRING, 8);
+        instance.setSlotLoot(90, Material.GUNPOWDER, 4);
+
+        List<SpawnerLootEntry> firstPage = instance.getPageLootEntries(1, ITEMS_PER_PAGE);
+        assertEquals(List.of("SLOT_0", "SLOT_44"), keys(firstPage));
+
+        List<SpawnerLootEntry> secondPage = instance.getPageLootEntries(2, ITEMS_PER_PAGE);
+        assertEquals(List.of("SLOT_45", "SLOT_89"), keys(secondPage));
+
+        List<SpawnerLootEntry> thirdPage = instance.getPageLootEntries(3, ITEMS_PER_PAGE);
+        assertEquals(List.of("SLOT_90"), keys(thirdPage));
+    }
+
+    @Test
+    void pageEntriesAreOrderedBySlotRatherThanInsertion() {
+        SpawnerInstance instance = spawner();
+        instance.setSlotLoot(30, Material.BONE, 12);
+        instance.setSlotLoot(2, Material.ARROW, 5);
+        instance.setSlotLoot(17, Material.STRING, 9);
+
+        assertEquals(List.of("SLOT_2", "SLOT_17", "SLOT_30"), keys(instance.getPageLootEntries(1, ITEMS_PER_PAGE)));
+    }
+
+    @Test
+    void droppingOnePageLeavesEveryOtherPageUntouched() {
+        SpawnerInstance instance = spawner();
+        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
+        instance.setSlotLoot(45, Material.ARROW, 16);
+        instance.setSlotLoot(90, Material.GUNPOWDER, 4);
+
+        for (SpawnerLootEntry entry : instance.getPageLootEntries(2, ITEMS_PER_PAGE)) {
+            instance.removeStoredLoot(entry.getKey(), entry.getAmount());
+        }
+
+        assertTrue(instance.getPageLootEntries(2, ITEMS_PER_PAGE).isEmpty());
+        assertEquals(List.of("SLOT_0"), keys(instance.getPageLootEntries(1, ITEMS_PER_PAGE)));
+        assertEquals(List.of("SLOT_90"), keys(instance.getPageLootEntries(3, ITEMS_PER_PAGE)));
+        assertEquals(68L, instance.getTotalStoredItems());
+    }
+
+    @Test
+    void emptyAndOutOfRangePagesYieldNothing() {
+        SpawnerInstance instance = spawner();
+        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
+
+        assertTrue(instance.getPageLootEntries(2, ITEMS_PER_PAGE).isEmpty());
+        assertTrue(instance.getPageLootEntries(500, ITEMS_PER_PAGE).isEmpty());
+        assertTrue(instance.getPageLootEntries(1, 0).isEmpty());
+        assertEquals(List.of("SLOT_0"), keys(instance.getPageLootEntries(0, ITEMS_PER_PAGE)));
+    }
+
+    @Test
+    void smallerPagesSplitTheSameStorageIntoMorePages() {
+        SpawnerInstance instance = spawner();
+        instance.setSlotLoot(0, Material.ROTTEN_FLESH, 64);
+        instance.setSlotLoot(9, Material.BONE, 32);
+        instance.setSlotLoot(18, Material.ARROW, 16);
+
+        assertEquals(List.of("SLOT_0"), keys(instance.getPageLootEntries(1, 9)));
+        assertEquals(List.of("SLOT_9"), keys(instance.getPageLootEntries(2, 9)));
+        assertEquals(List.of("SLOT_18"), keys(instance.getPageLootEntries(3, 9)));
+    }
+
+    private static List<String> keys(List<SpawnerLootEntry> entries) {
+        return entries.stream().map(SpawnerLootEntry::getKey).toList();
+    }
+
+    private static SpawnerInstance spawner() {
+        return new SpawnerInstance(
+                1L,
+                "world",
+                0,
+                64,
+                0,
+                UUID.randomUUID(),
+                "BeestoXd",
+                "ZOMBIE",
+                1L,
+                SpawnerInstance.AccessMode.OWNER_ONLY,
+                0L,
+                0L,
+                0L
+        );
+    }
+}


### PR DESCRIPTION
Closes #176

The DROP LOOT button in the spawner storage GUI was emptying the whole spawner instead of the page in front of you. On a spawner sitting on a big backlog that means every stored stack hits the ground at once, which is where the lag and the disconnects come from. The button's own lore already said "Click to drop all loot on the page", so the lore was right and the code was the part that was wrong.

## What changed

`dropAllLoot` walked every stored entry regardless of which page it belonged to. It is now `dropPageLoot` and takes the page the player has open, so it only touches the slots that page actually shows. The storage menu passes its current page in.

## Page selection

Storage entries are keyed by slot index (`SLOT_0`, `SLOT_1`, and so on) and the GUI shows a fixed window of those per page. `SpawnerInstance.getPageLootEntries` returns the entries inside that window, ordered by slot so the drop follows what you see rather than insertion order. Pages below 1 clamp to the first page, and pages past the end come back empty.

## Notes

The filter check that used to sit in the drop loop compared the storage key (`SLOT_4`) against the disabled set, which only ever holds material names and drop definition keys. It never matched, so filtered items were being dropped anyway. Taking it out changes nothing that was actually happening. The same dead check still sits in the collect and sell paths and is worth a separate look.

Both messages are hardcoded in `SpawnerManager` rather than language keys, so no translation files were touched. Five new tests in `SpawnerStoragePageTest` cover the page window, slot ordering, dropping one page while the others stay put, and the out of range cases. Suite is at 267 tests, all passing.
