### PR TITLE
fix(rtp): stop the location cache warming up a world it cannot search (#175)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -55,8 +55,9 @@ SETTINGS:
   GENERATE-FALLBACK-AFTER-SAMPLES: 8
   # Maximum fallback chunks allowed to generate during one RTP search
   MAX-GENERATE-FALLBACK-SAMPLES: 32
-  # Allow loading already-generated chunks from disk if chunk generation is disabled
-  LOAD-GENERATED-CHUNKS: false
+  # Allow loading already-generated chunks from disk if chunk generation is disabled.
+  # Turning this off with GENERATE-CHUNKS off as well leaves the search no way to reach a chunk
+  LOAD-GENERATED-CHUNKS: true
   # If random samples cannot be prepared, try already-loaded chunks as a fallback
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
@@ -86,7 +87,7 @@ SETTINGS:
 | `SETTINGS.GENERATE-FALLBACK-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `GENERATE-FALLBACK-CHUNKS` parameter for `SETTINGS.GENERATE-FALLBACK-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'8'` | Configures the technical `GENERATE-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
 | `SETTINGS.MAX-GENERATE-FALLBACK-SAMPLES` | `int` | Any valid integer number | `'32'` | Configures the technical `MAX-GENERATE-FALLBACK-SAMPLES` parameter for `SETTINGS.MAX-GENERATE-FALLBACK-SAMPLES` in `rtp.yml`. |
-| `SETTINGS.LOAD-GENERATED-CHUNKS` | `bool` | `true`, `false` | `false` | Configures the technical `LOAD-GENERATED-CHUNKS` parameter for `SETTINGS.LOAD-GENERATED-CHUNKS` in `rtp.yml`. |
+| `SETTINGS.LOAD-GENERATED-CHUNKS` | `bool` | `true`, `false` | `true` | Whether a search may read terrain that already exists on disk. This is what makes a pregenerated RTP world work while `GENERATE-CHUNKS` stays off. Turning both off leaves the search nothing to read and nothing to make, so every sample comes back empty and the background cache stands down and says so in the console. |
 | `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `FALLBACK-TO-LOADED-CHUNKS` parameter for `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'32'` | Configures the technical `LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
 | `SETTINGS.LOCATION-CACHE` | `section` | See `SETTINGS.LOCATION-CACHE` below | See example | Keeps safe locations ready in the background so `/rtp` can teleport without running a search first. |
@@ -145,6 +146,14 @@ spare. If you want a cache on a brand new world and your server can take it, thi
 Each entry is re-checked against the current world and radius before it is handed out, and a search
 only starts when a world is short of ready locations. When the cache is empty the command falls back
 to searching live, exactly as before.
+
+A world with no generated terrain inside its RTP radius has nothing for the warm-up to find, and
+retrying cannot change that. So a world that comes back empty is warned about once and then waited
+on for longer and longer, up to ten minutes, rather than being searched again every few seconds. The
+wait belongs to that world alone, so a world that is fine keeps its normal pace, and the first
+location a backed-off world produces puts it straight back to normal too. If `LOAD-GENERATED-CHUNKS`
+and `LOCATION-CACHE.GENERATE-CHUNKS` are both off there is no way to reach a chunk at all, and the
+warm-up says which one to turn on instead of searching.
 
 ### 1. Commented Setup Code Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -101,6 +101,8 @@ public class RTPManager {
     private static final int PRE_CACHE_PARALLEL_ATTEMPTS = 4;
     private static final long PRE_CACHE_SEARCH_TIMEOUT_MILLIS = 30_000L;
     private static final long PRE_CACHE_SEARCH_COOLDOWN_MILLIS = 5_000L;
+    private static final long PRE_CACHE_BACKOFF_START_MILLIS = 30_000L;
+    private static final long PRE_CACHE_BACKOFF_MAX_MILLIS = 600_000L;
 
     private static final class SearchProgress {
         private final String worldName;
@@ -129,14 +131,17 @@ public class RTPManager {
         private final SearchSettings settings;
         /** Whether this particular search may generate terrain, regardless of what the config allows. */
         private final boolean allowChunkGeneration;
+        /** Whether this search is the background warm-up rather than one somebody is waiting on. */
+        private final boolean backgroundWarmUp;
         private final AtomicInteger attemptsUsed = new AtomicInteger();
         private final AtomicInteger chunkSamplesUsed = new AtomicInteger();
         private final AtomicInteger generateFallbackSamplesUsed = new AtomicInteger();
         private final AtomicInteger activeChains = new AtomicInteger();
 
-        private DirectSearchState(SearchSettings settings, boolean allowChunkGeneration) {
+        private DirectSearchState(SearchSettings settings, boolean allowChunkGeneration, boolean backgroundWarmUp) {
             this.settings = settings;
             this.allowChunkGeneration = allowChunkGeneration;
+            this.backgroundWarmUp = backgroundWarmUp;
         }
     }
 
@@ -161,8 +166,11 @@ public class RTPManager {
     private final java.util.concurrent.atomic.AtomicReference<CompletableFuture<Location>> preCacheSearch =
             new java.util.concurrent.atomic.AtomicReference<>();
     private final AtomicInteger preCacheRotation = new AtomicInteger();
+    private final Map<String, Integer> preCacheFailureStreak = new ConcurrentHashMap<>();
+    private final Map<String, Long> preCacheRetryAtMillis = new ConcurrentHashMap<>();
     private volatile long preCacheSearchDeadlineMillis;
     private volatile long nextPreCacheSearchAtMillis;
+    private volatile boolean warnedPreCacheCannotPrepareChunks;
     private final List<RTPQueueEntry> waitingQueue = java.util.Collections.synchronizedList(new ArrayList<>());
     private List<RTPDestination> configuredDestinations = List.of();
     private List<RTPDestination> menuDestinations = List.of();
@@ -179,6 +187,9 @@ public class RTPManager {
         locationPreCache.clear();
         cancelPreCacheSearch();
         nextPreCacheSearchAtMillis = 0L;
+        preCacheFailureStreak.clear();
+        preCacheRetryAtMillis.clear();
+        warnedPreCacheCannotPrepareChunks = false;
         configuredDestinations = loadConfiguredDestinations();
         menuDestinations = buildMenuDestinations(configuredDestinations);
         refillPreCacheAllWorlds();
@@ -389,12 +400,77 @@ public class RTPManager {
         if (isDeniedWorld(worldName) || isConfiguredDestinationDisabled(worldName)) {
             return false;
         }
+        if (!canPrepareChunks(isPreCacheChunkGenerationEnabled())) {
+            warnPreCacheCannotPrepareChunksOnce();
+            return false;
+        }
+        if (System.currentTimeMillis() < preCacheRetryAtMillis.getOrDefault(worldKey, 0L)) {
+            return false;
+        }
         SearchSettings settings = getWorldSearchSettings(worldName);
         if (settings == null || getLoadedWorld(worldName) == null || !isSearchRequestValid(settings)) {
             return false;
         }
 
         return startPreCacheSearch(worldKey, settings);
+    }
+
+    /**
+     * Whether a search under the current config can get hold of a chunk at all.
+     *
+     * <p>A sample is only ever prepared by generating the chunk or by reading one that is already
+     * generated. Forbid both and every random sample returns nothing without so much as touching the
+     * world, so the search burns its whole budget and fails on a world that is perfectly fine. The
+     * background warm-up is the one that suffers for it, because it is not allowed to generate and
+     * so depends entirely on {@code LOAD-GENERATED-CHUNKS} being on.</p>
+     */
+    private boolean canPrepareChunks(boolean allowChunkGeneration) {
+        FileConfiguration rtp = plugin.getConfigManager().getRtp();
+        if (rtp.getBoolean(LOAD_GENERATED_CHUNKS_SETTING, true)) {
+            return true;
+        }
+        return allowChunkGeneration
+                && (rtp.getBoolean(GENERATE_CHUNKS_SETTING, false)
+                || rtp.getBoolean(GENERATE_FALLBACK_CHUNKS_SETTING, true));
+    }
+
+    private void warnPreCacheCannotPrepareChunksOnce() {
+        if (warnedPreCacheCannotPrepareChunks) {
+            return;
+        }
+        warnedPreCacheCannotPrepareChunks = true;
+        warn("the rtp location cache is off because nothing lets it reach a chunk. Turn on"
+                + " SETTINGS.LOAD-GENERATED-CHUNKS to read pregenerated terrain, or"
+                + " SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS to let the warm-up generate its own.");
+    }
+
+    /**
+     * Slows a world's warm-up down after it comes back empty-handed.
+     *
+     * <p>A world nobody has explored has no terrain to offer, and no amount of retrying changes
+     * that. Without a backoff the sweep starts another doomed search every few seconds and buries
+     * the console in warnings for a server that is behaving exactly as configured. Each failure
+     * doubles the wait for that world alone, so a world that is fine keeps its normal cadence, and
+     * one success puts the failing world straight back to it.</p>
+     */
+    private void backOffPreCacheWorld(String worldKey) {
+        int streak = preCacheFailureStreak.merge(worldKey, 1, Integer::sum);
+        long wait = Math.min(
+                PRE_CACHE_BACKOFF_MAX_MILLIS,
+                PRE_CACHE_BACKOFF_START_MILLIS << Math.min(streak - 1, 20)
+        );
+        preCacheRetryAtMillis.put(worldKey, System.currentTimeMillis() + wait);
+        if (streak == 1) {
+            warn("no safe rtp location was found in '" + worldKey + "' while warming the cache up."
+                    + " That world most likely has no generated terrain inside its rtp radius yet."
+                    + " Pregenerate it, or turn on SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS to have the"
+                    + " warm-up build its own. Retrying quietly from here on.");
+        }
+    }
+
+    private void clearPreCacheBackoff(String worldKey) {
+        preCacheFailureStreak.remove(worldKey);
+        preCacheRetryAtMillis.remove(worldKey);
     }
 
     /**
@@ -420,10 +496,15 @@ public class RTPManager {
 
         future.whenComplete((location, throwable) -> {
             preCacheSearch.compareAndSet(future, null);
-            nextPreCacheSearchAtMillis = System.currentTimeMillis() + PRE_CACHE_SEARCH_COOLDOWN_MILLIS;
-            if (throwable != null || location == null) {
+            if (throwable instanceof java.util.concurrent.CancellationException) {
                 return;
             }
+            nextPreCacheSearchAtMillis = System.currentTimeMillis() + PRE_CACHE_SEARCH_COOLDOWN_MILLIS;
+            if (throwable != null || location == null) {
+                backOffPreCacheWorld(worldKey);
+                return;
+            }
+            clearPreCacheBackoff(worldKey);
             java.util.Queue<CachedLocation> target = locationPreCache
                     .computeIfAbsent(worldKey, ignored -> new ConcurrentLinkedQueue<>());
             if (target.size() < getPreCacheSize()) {
@@ -436,7 +517,8 @@ public class RTPManager {
                     settings,
                     future,
                     getPreCacheParallelAttempts(),
-                    isPreCacheChunkGenerationEnabled()
+                    isPreCacheChunkGenerationEnabled(),
+                    true
             );
         } catch (RuntimeException exception) {
             future.complete(null);
@@ -461,10 +543,15 @@ public class RTPManager {
         running.complete(null);
     }
 
+    /**
+     * Drops the running warm-up on reload. Cancelling rather than completing it keeps the search
+     * from being counted as a world that had nothing to offer, which it never got the chance to
+     * decide either way.
+     */
     private void cancelPreCacheSearch() {
         CompletableFuture<Location> running = preCacheSearch.getAndSet(null);
         if (running != null) {
-            running.complete(null);
+            running.cancel(false);
         }
     }
 
@@ -962,16 +1049,17 @@ public class RTPManager {
     }
 
     private void startDirectSearch(SearchSettings settings, CompletableFuture<Location> future) {
-        startDirectSearch(settings, future, getSearchAttemptsPerTick(), true);
+        startDirectSearch(settings, future, getSearchAttemptsPerTick(), true, false);
     }
 
     private void startDirectSearch(
             SearchSettings settings,
             CompletableFuture<Location> future,
             int parallelAttempts,
-            boolean allowChunkGeneration
+            boolean allowChunkGeneration,
+            boolean backgroundWarmUp
     ) {
-        DirectSearchState state = new DirectSearchState(settings, allowChunkGeneration);
+        DirectSearchState state = new DirectSearchState(settings, allowChunkGeneration, backgroundWarmUp);
         int chains = Math.max(1, Math.min(parallelAttempts, settings.maxChunkSamples()));
         state.activeChains.set(chains);
         for (int chain = 0; chain < chains; chain++) {
@@ -998,14 +1086,17 @@ public class RTPManager {
         if (state.activeChains.decrementAndGet() > 0) {
             return;
         }
-        if (future.complete(null)) {
-            logSearchFailure(
-                    state.settings,
-                    state.attemptsUsed.get(),
-                    state.chunkSamplesUsed.get(),
-                    state.generateFallbackSamplesUsed.get()
-            );
+        if (!future.complete(null) || state.backgroundWarmUp) {
+            // The warm-up reports through its own backoff instead, so a world with nothing to offer
+            // costs one warning rather than one every few seconds for as long as the server runs.
+            return;
         }
+        logSearchFailure(
+                state.settings,
+                state.attemptsUsed.get(),
+                state.chunkSamplesUsed.get(),
+                state.generateFallbackSamplesUsed.get()
+        );
     }
 
     private void runDirectSearchStep(DirectSearchState state, CompletableFuture<Location> future) {

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -25,8 +25,9 @@ SETTINGS:
   GENERATE-FALLBACK-AFTER-SAMPLES: 8
   # Maximum fallback chunks allowed to generate during one RTP search
   MAX-GENERATE-FALLBACK-SAMPLES: 32
-  # Allow loading already-generated chunks from disk if chunk generation is disabled
-  LOAD-GENERATED-CHUNKS: false
+  # Allow loading already-generated chunks from disk if chunk generation is disabled.
+  # Turning this off with GENERATE-CHUNKS off as well leaves the search no way to reach a chunk
+  LOAD-GENERATED-CHUNKS: true
   # If random samples cannot be prepared, try already-loaded chunks as a fallback
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.reflect.ReflectionFactory;
 
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -40,6 +41,7 @@ class RTPManagerTest {
     private Server mockServer;
     private List<World> mockWorlds;
     private AtomicInteger scheduledTasks;
+    private UltimateDonutSmp lastMockPlugin;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -76,6 +78,9 @@ class RTPManagerTest {
                     }
                     if (method.getName().equals("getWorldContainer")) {
                         return new java.io.File(".");
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("RTPManagerTest");
                     }
                     if (method.getName().equals("getOnlinePlayers")) {
                         return List.of();
@@ -139,7 +144,52 @@ class RTPManagerTest {
         cmField.setAccessible(true);
         cmField.set(plugin, configManager);
 
+        attachLogger(plugin);
+        lastMockPlugin = plugin;
         return plugin;
+    }
+
+    /** Collects everything the plugin warns about from this point on. */
+    private List<String> captureWarnings() {
+        List<String> warnings = new ArrayList<>();
+        lastMockPlugin.getLogger().addHandler(new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord record) {
+                if (record.getLevel().intValue() >= java.util.logging.Level.WARNING.intValue()) {
+                    warnings.add(record.getMessage());
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        return warnings;
+    }
+
+    /**
+     * A plugin built without running its constructor has no logger, so anything that warns blows up
+     * with a NullPointerException instead of reaching the assertion the test is actually about.
+     */
+    private void attachLogger(UltimateDonutSmp plugin) throws Exception {
+        Class<?> javaPlugin = org.bukkit.plugin.java.JavaPlugin.class;
+
+        Field serverField = javaPlugin.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(plugin, mockServer);
+
+        Field descriptionField = javaPlugin.getDeclaredField("description");
+        descriptionField.setAccessible(true);
+        descriptionField.set(plugin, new org.bukkit.plugin.PluginDescriptionFile(
+                "UltimateDonutSmp", "test", UltimateDonutSmp.class.getName()));
+
+        Field loggerField = javaPlugin.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(plugin, new org.bukkit.plugin.PluginLogger(plugin));
     }
 
     @Test
@@ -520,6 +570,113 @@ class RTPManagerTest {
         optedIn.set("SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS", true);
         RTPManager turnedOn = new RTPManager(createMockPlugin(optedIn));
         assertTrue(turnedOn.isPreCacheChunkGenerationEnabled());
+    }
+
+    @Test
+    void testWarmUpStandsDownWhenNothingLetsItReachAChunk() throws Exception {
+        // #175: with generating off and reading generated chunks off too, every sample returns
+        // before it touches the world, so the warm-up burns 128 samples and warns, every few
+        // seconds, forever.
+        createMockWorld("world", World.Environment.NORMAL);
+        createMockWorld("world_nether", World.Environment.NETHER);
+
+        YamlConfiguration rtpConfig = preCacheRtpConfig();
+        rtpConfig.set("SETTINGS.GENERATE-CHUNKS", false);
+        rtpConfig.set("SETTINGS.GENERATE-FALLBACK-CHUNKS", false);
+        rtpConfig.set("SETTINGS.LOAD-GENERATED-CHUNKS", false);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.GENERATE-CHUNKS", false);
+
+        UltimateDonutSmp plugin = createMockPlugin(rtpConfig);
+        attachSchedulerAndFeatures(plugin);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        assertNull(preCacheSearch(rtpManager).get(),
+                "a search with no way to reach a chunk should never be started");
+        assertFalse(rtpManager.refillPreCache("world"));
+        assertEquals(0, scheduledTasks.get(), "no search chains should have been scheduled at all");
+    }
+
+    @Test
+    void testWarmUpBacksOffTheWorldThatCameBackEmpty() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+
+        CompletableFuture<Location> first = preCacheSearch(rtpManager).get();
+        assertNotNull(first);
+        first.complete(null);
+
+        setLongField(rtpManager, "nextPreCacheSearchAtMillis", 0L);
+
+        assertFalse(rtpManager.refillPreCache("world"),
+                "a world that just came back empty should not be searched again straight away");
+        assertTrue(rtpManager.refillPreCache("world_nether"),
+                "the backoff belongs to the world that failed, not to the whole sweep");
+    }
+
+    @Test
+    void testAWarmUpThatFindsSomewhereKeepsItsNormalCadence() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+        World world = Bukkit.getWorld("world");
+
+        CompletableFuture<Location> first = preCacheSearch(rtpManager).get();
+        assertNotNull(first);
+        first.complete(new Location(world, 1000.5, 70.0, 1000.5));
+
+        setLongField(rtpManager, "nextPreCacheSearchAtMillis", 0L);
+
+        assertTrue(rtpManager.refillPreCache("world"),
+                "a world that just produced a location should not be held back");
+    }
+
+    @Test
+    void testAWorldWithNothingToOfferIsWarnedAboutOnceRatherThanEverySweep() throws Exception {
+        // The console spam from #175: a doomed warm-up restarted every few seconds, warning each time.
+        createMockWorld("world", World.Environment.NORMAL);
+
+        YamlConfiguration rtpConfig = overworldRtpConfig();
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.ENABLED", true);
+        rtpConfig.set("SETTINGS.LOCATION-CACHE.SIZE", 5);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.SLOT", 11);
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.WORLD", "world");
+        rtpConfig.set("RTP-MENU.BUTTONS.OVERWORLD.ENABLED", true);
+
+        UltimateDonutSmp plugin = createMockPlugin(rtpConfig);
+        attachSchedulerAndFeatures(plugin);
+        RTPManager rtpManager = new RTPManager(plugin);
+
+        List<String> warnings = captureWarnings();
+        preCacheSearch(rtpManager).get().complete(null);
+
+        for (int sweep = 0; sweep < 5; sweep++) {
+            setLongField(rtpManager, "nextPreCacheSearchAtMillis", 0L);
+            rtpManager.refillPreCacheAllWorlds();
+        }
+
+        assertNull(preCacheSearch(rtpManager).get(), "the backed-off world should be left alone");
+        assertEquals(1, warnings.size(), "one warning, not one per sweep: " + warnings);
+    }
+
+    @Test
+    void testReloadingDoesNotWarnAboutTheWarmUpItInterrupted() throws Exception {
+        RTPManager rtpManager = preCacheManager();
+        assertNotNull(preCacheSearch(rtpManager).get());
+
+        List<String> warnings = captureWarnings();
+        rtpManager.reload();
+
+        assertTrue(warnings.isEmpty(),
+                "a reload cuts the search short, it does not prove the world had nothing: " + warnings);
+    }
+
+    @Test
+    void testShippedConfigLeavesTheSearchAWayToReachAChunk() {
+        YamlConfiguration shipped = YamlConfiguration.loadConfiguration(new File("src/main/resources/rtp.yml"));
+
+        assertTrue(
+                shipped.getBoolean("SETTINGS.LOAD-GENERATED-CHUNKS")
+                        || shipped.getBoolean("SETTINGS.GENERATE-CHUNKS"),
+                "the bundled rtp.yml must not forbid both loading and generating, or no search can"
+                        + " prepare a single chunk"
+        );
     }
 
     @Test


### PR DESCRIPTION
Closes #175

The screenshot on the issue is not `/rtp` failing for a player. It is the background location cache warming up, and the counters give it away: `attempts 0/64` next to `samples 128/128` means the search looked at 128 candidate spots and never once got as far as reading a block. Every sample returned before it touched the world, the search ran out of budget, warned, and the sweep started another one five seconds later against the next world in the rotation. That is the seven second cadence across three worlds in the log, and it does not stop.

## Why every sample came back empty

A sample can only be prepared two ways: generate the chunk, or read one that already exists. The bundled `rtp.yml` shipped `GENERATE-CHUNKS: false` and `LOAD-GENERATED-CHUNKS: false`, and the warm-up has not been allowed to generate since #151, so `runDirectSearchStep` hit its early return on every single sample. That combination cannot find a location on any world, however healthy the world is.

`LOAD-GENERATED-CHUNKS: false` is the part that should never have been there. The Java default is `true`, the comment above it says it exists to read pregenerated terrain when generation is off, and the setting directly above it tells you to keep `GENERATE-CHUNKS` off for pregenerated worlds. Together they are meant to say "don't build terrain, read what's there". Shipping `false` said "don't build terrain and don't read it either", which leaves a pregenerated RTP world impossible to search. It was `true` until the wholesale config rewrite in e1497372 flipped it.

## What changed

`rtp.yml` gets `LOAD-GENERATED-CHUNKS: true` back, with a comment about what turning both off costs you.

The warm-up now stands down rather than running a search it has no way to win. If nothing lets it reach a chunk it says once which setting to turn on and stops there, instead of burning 128 samples per world every five seconds.

A world that comes back empty is backed off on its own, starting at thirty seconds and doubling up to a ten minute ceiling. Somewhere with no terrain inside its RTP radius has nothing to offer and retrying will not change that, so it gets one warning and then goes quiet. The wait belongs to that world alone, so a healthy world keeps its normal pace, and the first location a backed-off world produces clears its backoff outright.

Warm-up failures no longer share the player-facing failure log. Somebody who ran `/rtp` and got nothing still gets a warning with the full counters. A background task that found nothing does not need one twelve times a minute.

## Notes

A reload cancels the running warm-up rather than completing it, so a search that got interrupted is not mistaken for a world with nothing in it.

`/rtp` itself is unchanged. The player-facing search was always allowed its limited fallback generation, which is why the command kept working while the console filled up. Existing installs keep their own `rtp.yml`, so a server already carrying `LOAD-GENERATED-CHUNKS: false` has to set it to `true` by hand. The new console message names the setting.

`RTPManagerTest` gains six tests and four of them fail without this change: the doomed config never starting a search at all, the per-world backoff and the fact that it does not spread to the other worlds, one warning instead of one per sweep, and a guard so the bundled `rtp.yml` cannot ship both switches off again. The other two cover a warm-up that finds somewhere keeping its normal cadence, and a reload staying quiet about the search it cut short. The harness needed a real plugin logger before any of that would run, since anything that warned used to NPE on the mock. Full suite is 266 green.

`docs/wiki/Config-rtp.yml.md` is updated for the new default and the backoff behaviour.
