### PR TITLE
refactor(spawners): remove the storage filter check that can never match

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -912,33 +912,6 @@ public class SpawnerManager {
                 + ColorUtils.strip(getTypeDisplayName(instance.getMobTypeKey())) + "&a.", (int) breakAmount, fullyDestroyed);
     }
 
-    public List<SpawnerLootEntry> getSortedLootEntries(SpawnerInstance instance) {
-        if (instance == null) {
-            return List.of();
-        }
-
-        List<SpawnerLootEntry> entries = new ArrayList<>();
-        for (SpawnerLootEntry entry : instance.getStoredLootEntries()) {
-            if (entry != null && entry.getAmount() > 0L) {
-                entries.add(entry);
-            }
-        }
-
-        entries.sort((a, b) -> {
-            int cmp = Long.compare(b.getAmount(), a.getAmount());
-            if (cmp != 0) {
-                return cmp;
-            }
-            boolean aDisabled = instance.isLootDisabled(a.getKey());
-            boolean bDisabled = instance.isLootDisabled(b.getKey());
-            if (aDisabled != bDisabled) {
-                return aDisabled ? 1 : -1;
-            }
-            return a.getMaterial().name().compareTo(b.getMaterial().name());
-        });
-        return entries;
-    }
-
     public ActionResult collectLootEntry(Player player, SpawnerInstance instance, String lootKey, boolean collectAll) {
         if (player == null || instance == null) {
             return fail("&cspawner not found.");
@@ -976,9 +949,6 @@ public class SpawnerManager {
 
         long totalMoved = 0L;
         for (SpawnerLootEntry entry : new ArrayList<>(instance.getStoredLootEntries())) {
-            if (instance.isLootDisabled(entry.getKey())) {
-                continue;
-            }
             long moved = moveMaterialToInventory(player.getInventory(), entry.getMaterial(), entry.getAmount());
             if (moved <= 0L) {
                 continue;
@@ -1042,7 +1012,7 @@ public class SpawnerManager {
         boolean foundCategory = false;
 
         for (SpawnerLootEntry entry : new ArrayList<>(instance.getStoredLootEntries())) {
-            if (instance.isLootDisabled(entry.getKey()) || entry.getAmount() <= 0) {
+            if (entry.getAmount() <= 0) {
                 continue;
             }
             ItemStack single = new ItemStack(entry.getMaterial(), 1);
@@ -1094,9 +1064,6 @@ public class SpawnerManager {
         List<DatabaseManager.SellHistoryRecord> historyRecords = new ArrayList<>();
 
         for (SpawnerLootEntry entry : new ArrayList<>(instance.getStoredLootEntries())) {
-            if (instance.isLootDisabled(entry.getKey())) {
-                continue;
-            }
             ItemStack single = new ItemStack(entry.getMaterial(), 1);
             WorthResult worthResult = plugin.getWorthManager().resolveWorth(single);
             if (!worthResult.sellable()) {
@@ -1427,9 +1394,6 @@ public class SpawnerManager {
 
         List<SpawnerLootEntry> entries = new ArrayList<>(instance.getStoredLootEntries());
         for (SpawnerLootEntry entry : entries) {
-            if (instance.isLootDisabled(entry.getKey())) {
-                continue;
-            }
             long storedAmount = entry.getAmount();
             if (storedAmount <= 0L) {
                 continue;

--- a/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerLootFilterKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerLootFilterKeyTest.java
@@ -1,0 +1,64 @@
+package com.bx.ultimateDonutSmp.models;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpawnerLootFilterKeyTest {
+
+    @Test
+    void filteringAMaterialNeverMatchesTheSlotKeyStoredLootIsKeyedBy() {
+        SpawnerInstance instance = spawner();
+        instance.setStoredLootEntries(List.of(new SpawnerLootEntry("SLOT_0", Material.ROTTEN_FLESH, 64)));
+        instance.setLootDisabled(Material.ROTTEN_FLESH.name(), true);
+
+        SpawnerLootEntry stored = instance.getSlotLoot(0);
+        assertTrue(instance.isLootDisabled(stored.getMaterial().name()));
+        assertFalse(instance.isLootDisabled(stored.getKey()));
+    }
+
+    @Test
+    void filteringADropDefinitionKeyNeverMatchesTheSlotKeyEither() {
+        SpawnerInstance instance = spawner();
+        instance.setStoredLootEntries(List.of(new SpawnerLootEntry("SLOT_7", Material.BONE, 32)));
+        instance.setLootDisabled("BONE_DROP", true);
+
+        assertTrue(instance.isLootDisabled("BONE_DROP"));
+        assertFalse(instance.isLootDisabled("SLOT_7"));
+    }
+
+    @Test
+    void disablingAndReEnablingOnlyEverTouchesTheKeyItWasGiven() {
+        SpawnerInstance instance = spawner();
+
+        instance.setLootDisabled(Material.ARROW.name(), true);
+        assertTrue(instance.isLootDisabled("arrow"));
+        assertTrue(instance.isLootDisabled(Material.ARROW.name()));
+
+        instance.setLootDisabled(Material.ARROW.name(), false);
+        assertFalse(instance.isLootDisabled(Material.ARROW.name()));
+    }
+
+    private static SpawnerInstance spawner() {
+        return new SpawnerInstance(
+                1L,
+                "world",
+                0,
+                64,
+                0,
+                UUID.randomUUID(),
+                "BeestoXd",
+                "ZOMBIE",
+                1L,
+                SpawnerInstance.AccessMode.OWNER_ONLY,
+                0L,
+                0L,
+                0L
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #178. While fixing the drop button I found the same filter check sitting in four other places, and in none of them can it ever match.

Stored loot is keyed by slot index (`SLOT_0`, `SLOT_7`, and so on), but the disabled set only ever holds material names and drop definition keys. `SpawnerStorageMenu` writes `slotItem.getType().name()`, `SpawnerFilterMenu` writes `drop.key()` plus `drop.material().name()`. Comparing `SLOT_7` against that set always comes back false, so the guard skipped nothing and every caller behaved as if it were not there.

## Why it broke

The check was correct when it was written. Before a6615d57 storage was keyed by `drop.key()`, which is exactly what the disabled set holds. That commit moved storage to persistent slot keys without migrating the existing rows, and the guard has been silently inert ever since.

## Why removing it rather than repairing it

The filter is about what goes into storage, not what comes out. Every string the player sees says so: the status reads `Enabled (Storing)` or `Disabled (Not Storing)`, and the two bulk buttons are `Enable storing all drops` and `Disable storing all drops`. The guard in `processSpawnerGeneration` checks `isLootDisabled(drop.key())` against a real drop key, so it works, and it already delivers that promise: disable a material and none of it accumulates.

Repairing the other four by material name would have bought something the filter never advertised. Disabling a material would also strand whatever had already piled up, putting it out of reach of Collect All and Sell All. Servers have run without that since late July and nobody has asked for it.

## What changed

The guard is gone from `collectAllLoot`, `sellAllLoot`, `calculateLootSellPreview`, and the hopper extraction loop. `getSortedLootEntries` held a fifth copy and turned out to have no callers at all, orphaned when the storage GUI moved to slot-based rendering, so the whole method went with it.

The generation guard is untouched.

## Notes

One small behaviour change, on servers old enough to still hold pre-a6615d57 rows in `spawner_loot`. Those rows are keyed by drop key, so the guard does match them, and today they are skipped by collect, sell, and hoppers while being invisible in the storage GUI. They will now be collected and sold like everything else, which is what the slot-keyed rows sitting next to them already do.

`SpawnerLootFilterKeyTest` adds three tests pinning the invariant that made the check dead, so nobody reintroduces slot-key filtering by accident. Suite is at 276 tests, all passing.
