### PR TITLE
fix(spawners): keep the storage page you see and the page you click in sync

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerStorageMenu.java
@@ -132,6 +132,23 @@ public class SpawnerStorageMenu extends BaseMenu {
         return item;
     }
 
+    static int countStoredPages(SpawnerInstance instance, int itemsPerPage) {
+        if (instance == null || itemsPerPage <= 0) {
+            return 1;
+        }
+
+        int maxSlotIndex = 0;
+        for (SpawnerLootEntry entry : instance.getStoredLootEntries()) {
+            if (entry.getKey().startsWith("SLOT_")) {
+                try {
+                    int idx = Integer.parseInt(entry.getKey().substring(5));
+                    maxSlotIndex = Math.max(maxSlotIndex, idx);
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+        return Math.max(1, (int) Math.ceil((maxSlotIndex + 1) / (double) itemsPerPage));
+    }
+
     public static ItemStack stripStorageMeta(ItemStack item) {
         if (item == null || item.getType().isAir()) {
             return item;
@@ -158,22 +175,12 @@ public class SpawnerStorageMenu extends BaseMenu {
         }
 
         int itemsPerPage = plugin.getSpawnerManager().getStorageItemsPerPage();
-        int maxSlotIndex = 0;
-        for (SpawnerLootEntry entry : instance.getStoredLootEntries()) {
-            if (entry.getKey().startsWith("SLOT_")) {
-                try {
-                    int idx = Integer.parseInt(entry.getKey().substring(5));
-                    maxSlotIndex = Math.max(maxSlotIndex, idx);
-                } catch (NumberFormatException ignored) {}
-            }
-        }
-        int totalPages = Math.max(1, (int) Math.ceil((maxSlotIndex + 1) / (double) itemsPerPage));
-        int safePage = Math.min(page, totalPages);
+        int totalPages = countStoredPages(instance, itemsPerPage);
 
         inventory = Bukkit.createInventory(
                 this,
                 plugin.getSpawnerManager().getStorageSize(),
-                ColorUtils.toComponent(plugin.getSpawnerManager().getStorageTitle(instance, safePage, totalPages))
+                ColorUtils.toComponent(plugin.getSpawnerManager().getStorageTitle(instance, page, Math.max(totalPages, page)))
         );
 
         clear();
@@ -183,7 +190,7 @@ public class SpawnerStorageMenu extends BaseMenu {
         }
 
         int contentSlots = Math.min(itemsPerPage, inventory.getSize() - 9);
-        int pageOffset = (safePage - 1) * itemsPerPage;
+        int pageOffset = (page - 1) * itemsPerPage;
 
         for (int slot = 0; slot < contentSlots; slot++) {
             int slotIndex = pageOffset + slot;
@@ -227,7 +234,7 @@ public class SpawnerStorageMenu extends BaseMenu {
 
         // 3. Previous Page Button
         int prevSlot = config.getInt("SPAWNER-MENUS.STORAGE-MENU.PREVIOUS-PAGE-BUTTON.SLOT", lastRow + 4);
-        if (safePage > 1) {
+        if (page > 1) {
             String prevMatName = config.getString("SPAWNER-MENUS.STORAGE-MENU.PREVIOUS-PAGE-BUTTON.MATERIAL", "ARROW");
             Material prevMat = Material.matchMaterial(prevMatName);
             if (prevMat == null) prevMat = Material.ARROW;
@@ -235,10 +242,10 @@ public class SpawnerStorageMenu extends BaseMenu {
             List<String> rawPrevLore = config.getStringList("SPAWNER-MENUS.STORAGE-MENU.PREVIOUS-PAGE-BUTTON.LORE");
             List<String> prevLore = new ArrayList<>();
             if (rawPrevLore.isEmpty()) {
-                prevLore.add("&fClick to go back to page " + (safePage - 1));
+                prevLore.add("&fClick to go back to page " + (page - 1));
             } else {
                 for (String line : rawPrevLore) {
-                    prevLore.add(line.replace("{prev_page}", String.valueOf(safePage - 1)));
+                    prevLore.add(line.replace("{prev_page}", String.valueOf(page - 1)));
                 }
             }
             set(prevSlot, ItemUtils.createItem(prevMat, prevTitle, prevLore));
@@ -248,7 +255,7 @@ public class SpawnerStorageMenu extends BaseMenu {
 
         // 4. Next Page Button
         int nextSlot = config.getInt("SPAWNER-MENUS.STORAGE-MENU.NEXT-PAGE-BUTTON.SLOT", lastRow + 6);
-        if (safePage < totalPages) {
+        if (page <= totalPages) {
             String nextMatName = config.getString("SPAWNER-MENUS.STORAGE-MENU.NEXT-PAGE-BUTTON.MATERIAL", "ARROW");
             Material nextMat = Material.matchMaterial(nextMatName);
             if (nextMat == null) nextMat = Material.ARROW;
@@ -256,10 +263,10 @@ public class SpawnerStorageMenu extends BaseMenu {
             List<String> rawNextLore = config.getStringList("SPAWNER-MENUS.STORAGE-MENU.NEXT-PAGE-BUTTON.LORE");
             List<String> nextLore = new ArrayList<>();
             if (rawNextLore.isEmpty()) {
-                nextLore.add("&fClick to go to page " + (safePage + 1));
+                nextLore.add("&fClick to go to page " + (page + 1));
             } else {
                 for (String line : rawNextLore) {
-                    nextLore.add(line.replace("{next_page}", String.valueOf(safePage + 1)));
+                    nextLore.add(line.replace("{next_page}", String.valueOf(page + 1)));
                 }
             }
             set(nextSlot, ItemUtils.createItem(nextMat, nextTitle, nextLore));
@@ -386,7 +393,7 @@ public class SpawnerStorageMenu extends BaseMenu {
                 new SpawnerStorageMenu(plugin, spawnerId, page).open(player);
             } else if (rawSlot == prevSlot && page > 1) {
                 new SpawnerStorageMenu(plugin, spawnerId, page - 1).open(player);
-            } else if (rawSlot == nextSlot) {
+            } else if (rawSlot == nextSlot && page <= countStoredPages(instance, itemsPerPage)) {
                 new SpawnerStorageMenu(plugin, spawnerId, page + 1).open(player);
             } else if (rawSlot == dropSlot) {
                 player.sendMessage(ColorUtils.toComponent(plugin.getSpawnerManager().dropPageLoot(player, instance, page).message()));

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SpawnerStoragePageCountTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SpawnerStoragePageCountTest.java
@@ -1,0 +1,71 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.models.SpawnerInstance;
+import com.bx.ultimateDonutSmp.models.SpawnerLootEntry;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpawnerStoragePageCountTest {
+
+    private static final int ITEMS_PER_PAGE = 45;
+
+    @Test
+    void anEmptySpawnerStillHasOnePage() {
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(spawnerWith(), ITEMS_PER_PAGE));
+    }
+
+    @Test
+    void pageCountFollowsTheHighestOccupiedSlot() {
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(0)), ITEMS_PER_PAGE));
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(44)), ITEMS_PER_PAGE));
+        assertEquals(2, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(45)), ITEMS_PER_PAGE));
+        assertEquals(2, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(89)), ITEMS_PER_PAGE));
+        assertEquals(3, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(90)), ITEMS_PER_PAGE));
+    }
+
+    @Test
+    void gapsBelowTheHighestSlotStillCount() {
+        assertEquals(3, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(0), slot(90)), ITEMS_PER_PAGE));
+    }
+
+    @Test
+    void smallerPagesSplitTheSameStorageIntoMorePages() {
+        assertEquals(3, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(18)), 9));
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(8)), 9));
+    }
+
+    @Test
+    void missingInstanceOrPageSizeFallsBackToOnePage() {
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(null, ITEMS_PER_PAGE));
+        assertEquals(1, SpawnerStorageMenu.countStoredPages(spawnerWith(slot(90)), 0));
+    }
+
+    private static SpawnerLootEntry slot(int slotIndex) {
+        return new SpawnerLootEntry("SLOT_" + slotIndex, Material.ROTTEN_FLESH, 1);
+    }
+
+    private static SpawnerInstance spawnerWith(SpawnerLootEntry... entries) {
+        SpawnerInstance instance = new SpawnerInstance(
+                1L,
+                "world",
+                0,
+                64,
+                0,
+                UUID.randomUUID(),
+                "BeestoXd",
+                "ZOMBIE",
+                1L,
+                SpawnerInstance.AccessMode.OWNER_ONLY,
+                0L,
+                0L,
+                0L
+        );
+        instance.setStoredLootEntries(List.of(entries));
+        return instance;
+    }
+}


### PR DESCRIPTION
The spawner storage GUI kept two different opinions about which page was open. `build()` clamped with `Math.min(page, totalPages)` and painted that, while `handleClick()` and `refresh()` both worked from the raw `page` field. The Next button had no upper bound in the handler, so a player could walk past the last page and land somewhere the two disagreed.

## This is a duplication exploit, not just a display glitch

Worth reading before anything else in here.

On an over-scrolled page the top inventory shows the last real page's items, but the handler's `pageOffset` points at an empty slot range further out. Shift-clicking a stack in from your own inventory runs Step A, which reads the amount off the item on screen, adds to it, and writes the total to the slot the offset points at:

```
inSlot = topInventory.getItem(s)     // 30 rotten flesh, from the page actually on screen
add    = min(64 - 30, 10)            // player is inserting 10
instance.setSlotLoot(pageOffset + s, mat, 40)   // writes 40, to a slot that held nothing
```

The original 30 is still sitting in `SLOT_0`. The player handed over 10 and storage grew by 40. Repeat at will.

`refresh()` would clear the stale display within a second and close the window, except it deliberately skips while the player has clicked in the last 2 seconds. Someone clicking steadily never lets it run. Spawner loot sells through Sell All, so this reaches the economy.

## The fix

`build()` now renders the real `page` instead of a clamped one, so the three places that compute `pageOffset` all agree. Scrolling past the end shows a genuinely empty page rather than a lie about the previous one, and depositing into it writes where you are looking.

The Next button was already bounded in the rendering, `if (safePage < totalPages)` drew an arrow and otherwise a grey placeholder. Only the handler ignored that and advanced on any click in the slot, placeholder or not. Both sides now share one condition.

That condition allows exactly one page past the last occupied one, rather than stopping at `totalPages`. Stopping there would have taken away the only way to reach a fresh page and deposit by hand, since the shift-click path only fills empty slots on the page you are on. With a full page 1 you could never start a page 2. The empty page disappears again if you leave it empty.

## Page numbering

`{max_page}` is `Math.max(totalPages, page)`, so standing on that fresh page reads `2/2` rather than `2/1`. Once you put something on it the count catches up on its own.

## Notes

The page maths moved out of `build()` into `countStoredPages`, which the handler now shares. The drift between those two is what caused this, so having one copy is the point rather than a tidy-up.

`SpawnerStoragePageCountTest` covers it with five tests: empty storage, the boundary either side of a page edge, gaps below the highest occupied slot, smaller configured page sizes, and the null and zero fallbacks. Suite is at 281 tests, all passing.

Predates #178. That PR made the drop button page-scoped, which means it reads the same `page` field and inherits whatever the two sides agree on, so it is correct either way.
