### PR TITLE
fix(duels): stop random duel maps generating in the middle of an ocean (#184)

### DIFF
--- a/docs/wiki/Config-duels.yml.md
+++ b/docs/wiki/Config-duels.yml.md
@@ -392,6 +392,10 @@ MAP_SOURCES:
       MAX_SYNC_STEP_MS: 2000
       # Pause background chunk generation if a step exceeds MAX_SYNC_STEP_MS (true / false)
       PAUSE_ON_SLOW_STEP: true
+      # Maximum percentage of the arena allowed to be water before it is regenerated (100 = allow any)
+      MAX_WATER_PERCENT: 40
+      # How many times a too-watery arena is regenerated before it is used anyway
+      MAX_TERRAIN_ATTEMPTS: 5
 
 # Cross-server BungeeCord / Velocity Redis sync settings
 ```
@@ -425,6 +429,8 @@ MAP_SOURCES:
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PREPARE_INTERVAL_TICKS` | `int` | Any valid integer number | `'1'` | Configures the technical `PREPARE_INTERVAL_TICKS` parameter for `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PREPARE_INTERVAL_TICKS` in `duels.yml`. |
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_SYNC_STEP_MS` | `int` | Any valid integer number | `'2000'` | Configures the technical `MAX_SYNC_STEP_MS` parameter for `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_SYNC_STEP_MS` in `duels.yml`. |
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PAUSE_ON_SLOW_STEP` | `bool` | `true`, `false` | `true` | Configures the technical `PAUSE_ON_SLOW_STEP` parameter for `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PAUSE_ON_SLOW_STEP` in `duels.yml`. |
+| `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_WATER_PERCENT` | `int` | `0` - `100` | `'40'` | Share of the arena that is allowed to be water. A freshly generated arena above this share is thrown away and generated again on a new seed, which is what keeps duels off the middle of an ocean. Set it to `100` to accept whatever the terrain gives you. |
+| `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_TERRAIN_ATTEMPTS` | `int` | `1` - `20` | `'5'` | How many times a too-watery arena is regenerated before the last one is used regardless. Stops a narrow biome pool from generating chunks forever, and logs a warning when it happens. |
 
 ### 3. Practical Setup Example
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -267,6 +267,10 @@ MAP_SOURCES:
       MAX_SYNC_STEP_MS: 2000
       # Pause background chunk generation if a step exceeds MAX_SYNC_STEP_MS (true / false)
       PAUSE_ON_SLOW_STEP: true
+      # Maximum percentage of the arena allowed to be water before it is regenerated (100 = allow any)
+      MAX_WATER_PERCENT: 40
+      # How many times a too-watery arena is regenerated before it is used anyway
+      MAX_TERRAIN_ATTEMPTS: 5
 
 # Cross-server BungeeCord / Velocity Redis sync settings
 ```
@@ -299,6 +303,8 @@ MAP_SOURCES:
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PREPARE_INTERVAL_TICKS` | `int` | Any valid integer | `1` | Configures `PREPARE_INTERVAL_TICKS` for `MAP_SOURCES`. |
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_SYNC_STEP_MS` | `int` | Any valid integer | `2000` | Configures `MAX_SYNC_STEP_MS` for `MAP_SOURCES`. |
 | `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.PAUSE_ON_SLOW_STEP` | `bool` | true, false | `True` | Configures `PAUSE_ON_SLOW_STEP` for `MAP_SOURCES`. |
+| `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_WATER_PERCENT` | `int` | 0 - 100 | `40` | Share of a generated vanilla arena allowed to be water before it is regenerated on a new seed. |
+| `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.MAX_TERRAIN_ATTEMPTS` | `int` | 1 - 20 | `5` | How many regeneration attempts a too-watery arena gets before it is used anyway. |
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DuelWorldManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DuelWorldManager.java
@@ -60,6 +60,9 @@ public class DuelWorldManager {
     private static final String VANILLA_POOL_PATH = RANDOM_BIOMES_PATH + ".VANILLA_POOL";
     private static final String WORLDBORDER_PATH = "WORLDBORDER";
 
+    private static final int DEFAULT_MAX_WATER_PERCENT = 40;
+    private static final int DEFAULT_MAX_TERRAIN_ATTEMPTS = 5;
+
     private static final Set<String> DEFAULT_EXCLUDED_BIOMES = Set.of(
             "minecraft:the_end",
             "minecraft:end_highlands",
@@ -85,6 +88,7 @@ public class DuelWorldManager {
     private BukkitTask flatPoolTask;
     private long flatPoolTaskPeriodTicks = -1L;
     private VanillaPreparation activeVanillaPreparation;
+    private int vanillaTerrainAttempts;
     private BukkitTask vanillaPoolTask;
     private long vanillaPoolTaskPeriodTicks = -1L;
     private String lastInvalidTerrainModeWarning = "";
@@ -581,13 +585,13 @@ public class DuelWorldManager {
 
         Biome requestedBiome = requestedVanillaBiomes.pollFirst();
         if (requestedBiome != null) {
-            startVanillaPreparation(requestedBiome);
+            startVanillaPreparation(requestedBiome, true);
             stopVanillaPoolTaskIfIdle();
             return;
         }
 
         if (readyVanillaArenas.size() < getVanillaPoolSize()) {
-            startVanillaPreparation(resolveRandomPoolBiome());
+            startVanillaPreparation(resolveRandomPoolBiome(), false);
         }
         stopVanillaPoolTaskIfIdle();
     }
@@ -604,7 +608,7 @@ public class DuelWorldManager {
         }
     }
 
-    private void startVanillaPreparation(Biome biome) {
+    private void startVanillaPreparation(Biome biome, boolean requested) {
         if (biome == null) {
             return;
         }
@@ -628,7 +632,7 @@ public class DuelWorldManager {
 
         generatedWorldNames.add(world.getName());
         configureGeneratedWorld(world, false);
-        activeVanillaPreparation = new VanillaPreparation(world.getName(), biome, buildPreparationChunks());
+        activeVanillaPreparation = new VanillaPreparation(world.getName(), biome, buildPreparationChunks(), requested);
     }
 
     private void continueVanillaPreparation() {
@@ -749,7 +753,37 @@ public class DuelWorldManager {
         return asyncChunkLoadMethod;
     }
 
+    private boolean rejectTooWateryArena(VanillaPreparation preparation, World world) {
+        int maxWaterPercent = getVanillaMaxWaterPercent();
+        int waterPercent = measureArenaWaterPercent(world);
+        if (!isArenaTooWatery(waterPercent, maxWaterPercent)) {
+            vanillaTerrainAttempts = 0;
+            return false;
+        }
+
+        vanillaTerrainAttempts++;
+        if (vanillaTerrainAttempts >= getVanillaMaxTerrainAttempts()) {
+            plugin.getLogger().warning("Duel vanilla arena for " + prettifyBiomeKey(preparation.biomeKey())
+                    + " is " + waterPercent + "% water after " + vanillaTerrainAttempts
+                    + " attempts and is being used anyway. Raise MAX_WATER_PERCENT, widen the biome pool, "
+                    + "or switch TERRAIN_MODE to FLAT if this keeps happening.");
+            vanillaTerrainAttempts = 0;
+            return false;
+        }
+
+        activeVanillaPreparation = null;
+        if (preparation.requested()) {
+            requestedVanillaBiomes.addFirst(preparation.biome());
+        }
+        cleanupGeneratedWorld(world.getName());
+        return true;
+    }
+
     private void finishVanillaPreparation(VanillaPreparation preparation, World world) {
+        if (rejectTooWateryArena(preparation, world)) {
+            return;
+        }
+
         int radius = getArenaRadius();
         int spawnDistance = getSpawnDistance(radius);
         Location firstSpawn = findSafeSpawn(world, -spawnDistance, 0, null);
@@ -1138,6 +1172,22 @@ public class DuelWorldManager {
         return config().getBoolean(VANILLA_POOL_PATH + ".PAUSE_ON_SLOW_STEP", true);
     }
 
+    private int getVanillaMaxWaterPercent() {
+        return normalizeMaxWaterPercent(config().getInt(VANILLA_POOL_PATH + ".MAX_WATER_PERCENT", DEFAULT_MAX_WATER_PERCENT));
+    }
+
+    static int normalizeMaxWaterPercent(int configuredPercent) {
+        return Math.max(0, Math.min(100, configuredPercent));
+    }
+
+    private int getVanillaMaxTerrainAttempts() {
+        return normalizeMaxTerrainAttempts(config().getInt(VANILLA_POOL_PATH + ".MAX_TERRAIN_ATTEMPTS", DEFAULT_MAX_TERRAIN_ATTEMPTS));
+    }
+
+    static int normalizeMaxTerrainAttempts(int configuredAttempts) {
+        return Math.max(1, Math.min(20, configuredAttempts));
+    }
+
     private void configureGeneratedWorld(World world, boolean loadCenterChunk) {
         world.setPVP(true);
         world.setAutoSave(false);
@@ -1146,6 +1196,46 @@ public class DuelWorldManager {
         if (loadCenterChunk) {
             world.loadChunk(0, 0, true);
         }
+    }
+
+    private int measureArenaWaterPercent(World world) {
+        if (world == null) {
+            return 0;
+        }
+
+        int radius = getArenaRadius();
+        int step = arenaSampleStep(radius);
+        int samples = 0;
+        int water = 0;
+        for (int x = -radius; x <= radius; x += step) {
+            for (int z = -radius; z <= radius; z += step) {
+                samples++;
+                if (isWaterSurface(world, x, z)) {
+                    water++;
+                }
+            }
+        }
+        return waterPercent(water, samples);
+    }
+
+    static int arenaSampleStep(int arenaRadius) {
+        return Math.max(4, (arenaRadius * 2) / 32);
+    }
+
+    static int waterPercent(int waterSamples, int totalSamples) {
+        if (totalSamples <= 0) {
+            return 0;
+        }
+        return Math.round((waterSamples * 100F) / totalSamples);
+    }
+
+    static boolean isArenaTooWatery(int waterPercent, int maxWaterPercent) {
+        return waterPercent > maxWaterPercent;
+    }
+
+    private boolean isWaterSurface(World world, int x, int z) {
+        Block highest = world.getHighestBlockAt(x, z);
+        return highest != null && highest.getType().name().contains("WATER");
     }
 
     private Location findSafeSpawn(World world, int preferredX, int preferredZ, Location avoid) {
@@ -1366,16 +1456,22 @@ public class DuelWorldManager {
         private final Biome biome;
         private final String biomeKey;
         private final Deque<ChunkCoord> chunks;
+        private final boolean requested;
         private int pauseTicks;
         private boolean slowWarningSent;
         private boolean asyncChunkPending;
 
-        private VanillaPreparation(String worldName, Biome biome, Deque<ChunkCoord> chunks) {
+        private VanillaPreparation(String worldName, Biome biome, Deque<ChunkCoord> chunks, boolean requested) {
             this.worldName = worldName;
             this.biome = biome;
             NamespacedKey key = biome == null ? null : biome.getKey();
             this.biomeKey = key == null ? "" : key.toString().toLowerCase(Locale.ROOT);
             this.chunks = chunks == null ? new ArrayDeque<>() : chunks;
+            this.requested = requested;
+        }
+
+        private boolean requested() {
+            return requested;
         }
 
         private String worldName() {

--- a/src/main/resources/duels.yml
+++ b/src/main/resources/duels.yml
@@ -166,6 +166,10 @@ MAP_SOURCES:
       MAX_SYNC_STEP_MS: 2000
       # Pause background chunk generation if a step exceeds MAX_SYNC_STEP_MS (true / false)
       PAUSE_ON_SLOW_STEP: true
+      # Maximum percentage of the arena allowed to be water before it is regenerated (100 = allow any)
+      MAX_WATER_PERCENT: 40
+      # How many times a too-watery arena is regenerated before it is used anyway
+      MAX_TERRAIN_ATTEMPTS: 5
 
 # Cross-server BungeeCord / Velocity Redis sync settings
 CROSS_SERVER:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DuelWorldManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DuelWorldManagerTest.java
@@ -1,0 +1,70 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuelWorldManagerTest {
+
+    private static final String VANILLA_POOL = "MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL.";
+
+    private static YamlConfiguration bundledDuels() {
+        return YamlConfiguration.loadConfiguration(new File("src/main/resources/duels.yml"));
+    }
+
+    @Test
+    void bundledConfigDefinesWaterLimitDefaults() {
+        YamlConfiguration duels = bundledDuels();
+        assertEquals(40, duels.getInt(VANILLA_POOL + "MAX_WATER_PERCENT"));
+        assertEquals(5, duels.getInt(VANILLA_POOL + "MAX_TERRAIN_ATTEMPTS"));
+    }
+
+    @Test
+    void waterLimitIsClampedToAPercentage() {
+        assertEquals(0, DuelWorldManager.normalizeMaxWaterPercent(-20));
+        assertEquals(40, DuelWorldManager.normalizeMaxWaterPercent(40));
+        assertEquals(100, DuelWorldManager.normalizeMaxWaterPercent(250));
+    }
+
+    @Test
+    void terrainAttemptsAlwaysAllowAtLeastOneGeneration() {
+        assertEquals(1, DuelWorldManager.normalizeMaxTerrainAttempts(-3));
+        assertEquals(1, DuelWorldManager.normalizeMaxTerrainAttempts(0));
+        assertEquals(5, DuelWorldManager.normalizeMaxTerrainAttempts(5));
+        assertEquals(20, DuelWorldManager.normalizeMaxTerrainAttempts(500));
+    }
+
+    @Test
+    void waterPercentRoundsToTheNearestWholePercent() {
+        assertEquals(0, DuelWorldManager.waterPercent(0, 0));
+        assertEquals(0, DuelWorldManager.waterPercent(0, 625));
+        assertEquals(50, DuelWorldManager.waterPercent(312, 625));
+        assertEquals(100, DuelWorldManager.waterPercent(625, 625));
+    }
+
+    @Test
+    void oceanArenasAreRejectedWhileShallowPondsAreKept() {
+        assertTrue(DuelWorldManager.isArenaTooWatery(95, 40));
+        assertTrue(DuelWorldManager.isArenaTooWatery(41, 40));
+        assertFalse(DuelWorldManager.isArenaTooWatery(40, 40));
+        assertFalse(DuelWorldManager.isArenaTooWatery(12, 40));
+    }
+
+    @Test
+    void aFullyPermissiveLimitNeverRejectsAnArena() {
+        assertFalse(DuelWorldManager.isArenaTooWatery(100, 100));
+    }
+
+    @Test
+    void sampleStepGrowsWithTheArenaSoLargeArenasStayCheapToScan() {
+        assertEquals(4, DuelWorldManager.arenaSampleStep(16));
+        assertEquals(4, DuelWorldManager.arenaSampleStep(48));
+        assertEquals(8, DuelWorldManager.arenaSampleStep(128));
+        assertEquals(16, DuelWorldManager.arenaSampleStep(256));
+    }
+}


### PR DESCRIPTION
Closes #184

On `TERRAIN_MODE: VANILLA` a duel arena is a freshly seeded world with the chosen biome forced over it. The biome picks what the surface is made of. It does not decide how high the ground sits, so the terrain around 0,0 is whatever that seed happened to produce, and plenty of seeds put an ocean there. Nothing in the preparation step ever looked. The arena went out as generated, and when the spawn search could not find dry ground it paved a 5x5 stone brick platform over the water for each player. That is the "small platforms in the middle of an ocean" from the report, built by the plugin itself.

## Checking the terrain before the arena goes out

`finishVanillaPreparation` now measures the arena before it does anything else. It samples the play area on a grid, counts how many columns have water on top, and if that share is over `MAX_WATER_PERCENT` it deletes the world and lets the pool generate another. Each attempt is a new world on a new seed, so a retry gives you a different map instead of the same ocean twice.

Default is 40 percent. Ponds, rivers and a bit of coastline all survive that; only arenas that are mostly open water get thrown out.

## Not regenerating forever

`MAX_TERRAIN_ATTEMPTS` caps the retries at 5. One arena is roughly 49 chunks of generation, so an unlucky biome pool could otherwise sit there churning through seeds while somebody waits in queue. After the cap the last arena goes out regardless, and the console gets a warning with the water share it measured and what to change.

If a player picked a specific biome, the rejected attempt goes back on the front of the request queue. The retry stays on the biome they asked for rather than quietly dropping them into the random pool.

## Notes

The sampling step scales with `ARENA_RADIUS`, so a large arena costs no more to check than a small one. At the default radius of 48 it works out to a 25x25 grid, and those chunks are already force loaded by that point.

`FLAT` mode is untouched. It builds its own terrain and never places water, so none of this applied to it.

Two new keys under `MAP_SOURCES.RANDOM_BIOMES.VANILLA_POOL`, both merged into existing configs automatically: `MAX_WATER_PERCENT` (40) and `MAX_TERRAIN_ATTEMPTS` (5). Set `MAX_WATER_PERCENT` to 100 to turn the check off entirely. Both are in `Config-duels.yml.md` and `Configuration-Reference.md`.

New `DuelWorldManagerTest` covers the bundled defaults, the clamping on both keys, the percentage arithmetic, the accept/reject threshold and the sampling step. Suite is at 288, all green.
