### PR TITLE
fix(staffmode): pin the staff tools without locking the rest of the inventory (#187)

### DIFF
--- a/docs/wiki/Config-staff-mode.yml.md
+++ b/docs/wiki/Config-staff-mode.yml.md
@@ -91,7 +91,7 @@ STAFF-MODE:
 | `STAFF-MODE.AUTO-VANISH-ON-ENABLE` | `bool` | `true`, `false` | `false` | Configures the technical `AUTO-VANISH-ON-ENABLE` parameter for `STAFF-MODE.AUTO-VANISH-ON-ENABLE` in `staff-mode.yml`. |
 | `STAFF-MODE.PERSIST-ON-QUIT` | `bool` | `true`, `false` | `true` | Configures the technical `PERSIST-ON-QUIT` parameter for `STAFF-MODE.PERSIST-ON-QUIT` in `staff-mode.yml`. |
 | `STAFF-MODE.PERSIST-ON-RESTART` | `bool` | `true`, `false` | `true` | Configures the technical `PERSIST-ON-RESTART` parameter for `STAFF-MODE.PERSIST-ON-RESTART` in `staff-mode.yml`. |
-| `STAFF-MODE.LOCK-TOOLS` | `bool` | `true`, `false` | `true` | Configures the technical `LOCK-TOOLS` parameter for `STAFF-MODE.LOCK-TOOLS` in `staff-mode.yml`. |
+| `STAFF-MODE.LOCK-TOOLS` | `bool` | `true`, `false` | `true` | Keeps the Staff Mode hotbar items pinned to the moderator while Staff Mode is active. They cannot be dropped, swapped into the off hand, dragged around, or moved into a chest. Anything else the moderator is carrying stays free to move and drop. Set to `false` to leave the tools loose. |
 | `STAFF-MODE.RESTORE-INVENTORY-ON-DISABLE` | `bool` | `true`, `false` | `true` | Configures the technical `RESTORE-INVENTORY-ON-DISABLE` parameter for `STAFF-MODE.RESTORE-INVENTORY-ON-DISABLE` in `staff-mode.yml`. |
 | `STAFF-MODE.VANISH-ACTIONBAR.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `STAFF-MODE` system. Set to `true` to enable, `false` to disable. |
 | `STAFF-MODE.VANISH-ACTIONBAR.INTERVAL-TICKS` | `int` | Any valid integer number | `'40'` | Configures the technical `INTERVAL-TICKS` parameter for `STAFF-MODE.VANISH-ACTIONBAR.INTERVAL-TICKS` in `staff-mode.yml`. |

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -10,6 +10,7 @@ UltimateDonutSMP provides a comprehensive suite of staff moderation tools, anti-
 Toggles Staff Mode for authorized moderators:
 - Gives custom hotbar items: Fast-Fly, Vanish toggle, Freeze tool, Random Teleport, Player Inspector, and Counter.
 - Separates staff inventory from normal player survival inventory.
+- Pins those hotbar items to the moderator so they cannot be dropped or handed to anyone (`LOCK-TOOLS` in `staff-mode.yml`). Other items stay droppable.
 - Permission: `ultimatedonutsmp.admin.staffmode`
 
 ### 2. Vanish (`/vanish` or `/v`)

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.listeners;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.FreezeManager;
+import com.bx.ultimateDonutSmp.managers.StaffModeManager;
 import com.bx.ultimateDonutSmp.staff.StaffToolType;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.entity.Entity;
@@ -12,7 +13,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
-import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
@@ -48,26 +49,7 @@ public class StaffModeListener implements Listener {
             return;
         }
 
-        ItemStack currentItem = event.getCurrentItem();
-        ItemStack cursorItem = event.getCursor();
-        boolean clickOwnInventory = event.getClickedInventory() != null
-                && event.getClickedInventory().equals(player.getInventory());
-        boolean movingBetweenInventories = event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
-                || event.getClick().isKeyboardClick()
-                || event.getAction() == InventoryAction.COLLECT_TO_CURSOR;
-        boolean isDropAction = event.getAction() == InventoryAction.DROP_ALL_CURSOR
-                || event.getAction() == InventoryAction.DROP_ONE_CURSOR
-                || event.getAction() == InventoryAction.DROP_ALL_SLOT
-                || event.getAction() == InventoryAction.DROP_ONE_SLOT;
-        boolean isOutsideClick = event.getSlotType() == org.bukkit.event.inventory.InventoryType.SlotType.OUTSIDE
-                || event.getClickedInventory() == null;
-
-        if (!clickOwnInventory
-                && !movingBetweenInventories
-                && !isDropAction
-                && !isOutsideClick
-                && !plugin.getStaffModeManager().isStaffTool(currentItem)
-                && !plugin.getStaffModeManager().isStaffTool(cursorItem)) {
+        if (!touchesStaffTool(player, event)) {
             return;
         }
 
@@ -85,6 +67,10 @@ public class StaffModeListener implements Listener {
             return;
         }
 
+        if (!touchesStaffTool(event)) {
+            return;
+        }
+
         event.setCancelled(true);
         event.setResult(org.bukkit.event.Event.Result.DENY);
     }
@@ -94,6 +80,9 @@ public class StaffModeListener implements Listener {
         Player player = event.getPlayer();
         if (!plugin.getStaffModeManager().isInStaffMode(player.getUniqueId())
                 || !plugin.getStaffModeManager().shouldLockTools()) {
+            return;
+        }
+        if (!plugin.getStaffModeManager().isStaffTool(event.getItemDrop().getItemStack())) {
             return;
         }
 
@@ -111,6 +100,10 @@ public class StaffModeListener implements Listener {
         Player player = event.getPlayer();
         if (!plugin.getStaffModeManager().isInStaffMode(player.getUniqueId())
                 || !plugin.getStaffModeManager().shouldLockTools()) {
+            return;
+        }
+        if (!plugin.getStaffModeManager().isStaffTool(event.getMainHandItem())
+                && !plugin.getStaffModeManager().isStaffTool(event.getOffHandItem())) {
             return;
         }
 
@@ -306,6 +299,37 @@ public class StaffModeListener implements Listener {
         if (result != null) {
             staff.sendMessage(ColorUtils.toComponent(freezeManager.buildToggleMessage(result)));
         }
+    }
+
+    private boolean touchesStaffTool(Player player, InventoryClickEvent event) {
+        StaffModeManager manager = plugin.getStaffModeManager();
+        if (manager.isStaffTool(event.getCurrentItem()) || manager.isStaffTool(event.getCursor())) {
+            return true;
+        }
+
+        if (event.getClick() == ClickType.SWAP_OFFHAND) {
+            return manager.isStaffTool(player.getInventory().getItemInOffHand());
+        }
+
+        int hotbarButton = event.getHotbarButton();
+        if (hotbarButton < 0 || hotbarButton > 8) {
+            return false;
+        }
+        return manager.isStaffTool(player.getInventory().getItem(hotbarButton));
+    }
+
+    private boolean touchesStaffTool(InventoryDragEvent event) {
+        StaffModeManager manager = plugin.getStaffModeManager();
+        if (manager.isStaffTool(event.getOldCursor())) {
+            return true;
+        }
+
+        for (int rawSlot : event.getRawSlots()) {
+            if (manager.isStaffTool(event.getView().getItem(rawSlot))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isOnInteractCooldown(Player player) {

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
@@ -3,12 +3,26 @@ package com.bx.ultimateDonutSmp.listeners;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.StaffModeManager;
 import com.bx.ultimateDonutSmp.staff.StaffToolType;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.reflect.ReflectionFactory;
@@ -16,20 +30,32 @@ import sun.reflect.ReflectionFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StaffModeListenerTest {
 
+    private static final Material STAFF_TOOL = Material.NETHER_STAR;
+    private static final Material NORMAL_ITEM = Material.STONE;
+
     private UUID playerUuid;
     private AtomicInteger vanishToggleCount;
+    private AtomicInteger toolLockedMessageCount;
+    private TestStaffModeManager staffModeManager;
     private StaffModeListener listener;
+    private Server originalServer;
 
     public static class TestStaffModeManager extends StaffModeManager {
         private AtomicInteger toggleCount;
+        private AtomicInteger lockedMessageCount;
+        private Material staffToolMaterial;
 
         public TestStaffModeManager() {
             super(null);
@@ -41,7 +67,25 @@ class StaffModeListenerTest {
         }
 
         @Override
+        public boolean shouldLockTools() {
+            return true;
+        }
+
+        @Override
+        public void sendToolLockedMessage(Player player) {
+            if (lockedMessageCount != null) {
+                lockedMessageCount.incrementAndGet();
+            }
+        }
+
+        @Override
         public StaffToolType resolveTool(ItemStack item) {
+            if (staffToolMaterial == null) {
+                return StaffToolType.VANISH;
+            }
+            if (item == null || item.getType() != staffToolMaterial) {
+                return null;
+            }
             return StaffToolType.VANISH;
         }
 
@@ -63,6 +107,9 @@ class StaffModeListenerTest {
     void setUp() throws Exception {
         playerUuid = UUID.randomUUID();
         vanishToggleCount = new AtomicInteger(0);
+        toolLockedMessageCount = new AtomicInteger(0);
+        originalServer = Bukkit.getServer();
+        installMockServer();
 
         Constructor<Object> objectConstructor = Object.class.getConstructor();
         ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
@@ -77,15 +124,20 @@ class StaffModeListenerTest {
         );
         TestStaffModeManager mockStaffModeManager = (TestStaffModeManager) smmConstructor.newInstance();
 
-        Field countField = TestStaffModeManager.class.getDeclaredField("toggleCount");
-        countField.setAccessible(true);
-        countField.set(mockStaffModeManager, vanishToggleCount);
+        setManagerField(mockStaffModeManager, "toggleCount", vanishToggleCount);
+        setManagerField(mockStaffModeManager, "lockedMessageCount", toolLockedMessageCount);
 
         Field smmField = UltimateDonutSmp.class.getDeclaredField("staffModeManager");
         smmField.setAccessible(true);
         smmField.set(mockPlugin, mockStaffModeManager);
 
+        staffModeManager = mockStaffModeManager;
         listener = new StaffModeListener(mockPlugin);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        setBukkitServer(originalServer);
     }
 
     @Test
@@ -143,5 +195,246 @@ class StaffModeListenerTest {
         listener.onInteract(event3);
         assertTrue(event3.isCancelled(), "Third event should be cancelled");
         assertEquals(2, vanishToggleCount.get(), "Click after cooldown expires should trigger vanish toggle again");
+    }
+
+    @Test
+    void dropIsCancelledForStaffToolsOnly() throws Exception {
+        onlyStaffToolsAreTools();
+        Player player = mockPlayer(mockPlayerInventory(Map.of(), null));
+
+        PlayerDropItemEvent toolDrop = new PlayerDropItemEvent(player, mockItemEntity(new ItemStack(STAFF_TOOL)));
+        listener.onDrop(toolDrop);
+        assertTrue(toolDrop.isCancelled(), "Dropping a staff tool should be blocked");
+        assertEquals(1, toolLockedMessageCount.get(), "Blocking a staff tool drop should explain why");
+
+        PlayerDropItemEvent normalDrop = new PlayerDropItemEvent(player, mockItemEntity(new ItemStack(NORMAL_ITEM)));
+        listener.onDrop(normalDrop);
+        assertFalse(normalDrop.isCancelled(), "Dropping a normal item should still be allowed");
+        assertEquals(1, toolLockedMessageCount.get(), "An allowed drop should not send the locked message");
+    }
+
+    @Test
+    void offhandSwapIsCancelledOnlyWhenAStaffToolIsInvolved() throws Exception {
+        onlyStaffToolsAreTools();
+        Player player = mockPlayer(mockPlayerInventory(Map.of(), null));
+
+        PlayerSwapHandItemsEvent toolInMainHand = new PlayerSwapHandItemsEvent(
+                player, new ItemStack(NORMAL_ITEM), new ItemStack(STAFF_TOOL));
+        listener.onSwap(toolInMainHand);
+        assertTrue(toolInMainHand.isCancelled(), "Swapping a staff tool into the off hand should be blocked");
+
+        PlayerSwapHandItemsEvent toolInOffHand = new PlayerSwapHandItemsEvent(
+                player, new ItemStack(STAFF_TOOL), new ItemStack(NORMAL_ITEM));
+        listener.onSwap(toolInOffHand);
+        assertTrue(toolInOffHand.isCancelled(), "Swapping a staff tool out of the off hand should be blocked");
+
+        PlayerSwapHandItemsEvent normalSwap = new PlayerSwapHandItemsEvent(
+                player, new ItemStack(NORMAL_ITEM), new ItemStack(NORMAL_ITEM));
+        listener.onSwap(normalSwap);
+        assertFalse(normalSwap.isCancelled(), "Swapping two normal items should still be allowed");
+    }
+
+    @Test
+    void inventoryClickIsCancelledOnlyWhenAStaffToolIsInvolved() throws Exception {
+        onlyStaffToolsAreTools();
+        Player player = mockPlayer(mockPlayerInventory(Map.of(), null));
+
+        InventoryClickEvent toolClick = mockClick(
+                player, Map.of(9, new ItemStack(STAFF_TOOL)), null, 9, ClickType.LEFT,
+                InventoryAction.PICKUP_ALL, -1);
+        listener.onInventoryClick(toolClick);
+        assertTrue(toolClick.isCancelled(), "Picking a staff tool up in the inventory should be blocked");
+
+        InventoryClickEvent normalClick = mockClick(
+                player, Map.of(9, new ItemStack(NORMAL_ITEM)), null, 9, ClickType.LEFT,
+                InventoryAction.PICKUP_ALL, -1);
+        listener.onInventoryClick(normalClick);
+        assertFalse(normalClick.isCancelled(), "Moving a normal item around the inventory should be allowed");
+
+        InventoryClickEvent cursorClick = mockClick(
+                player, Map.of(9, new ItemStack(NORMAL_ITEM)), new ItemStack(STAFF_TOOL), 9, ClickType.LEFT,
+                InventoryAction.PLACE_ALL, -1);
+        listener.onInventoryClick(cursorClick);
+        assertTrue(cursorClick.isCancelled(), "Placing a staff tool held on the cursor should be blocked");
+    }
+
+    @Test
+    void hotbarAndOffhandSwapClicksSeeTheToolTheyWouldMove() throws Exception {
+        onlyStaffToolsAreTools();
+        PlayerInventory inventory = mockPlayerInventory(Map.of(3, new ItemStack(STAFF_TOOL)), new ItemStack(STAFF_TOOL));
+        Player player = mockPlayer(inventory);
+
+        InventoryClickEvent hotbarSwap = mockClick(
+                player, Map.of(9, new ItemStack(NORMAL_ITEM)), null, 9, ClickType.NUMBER_KEY,
+                InventoryAction.HOTBAR_SWAP, 3);
+        listener.onInventoryClick(hotbarSwap);
+        assertTrue(hotbarSwap.isCancelled(), "A number key that would move a staff tool should be blocked");
+
+        InventoryClickEvent emptyHotbarSwap = mockClick(
+                player, Map.of(9, new ItemStack(NORMAL_ITEM)), null, 9, ClickType.NUMBER_KEY,
+                InventoryAction.HOTBAR_SWAP, 5);
+        listener.onInventoryClick(emptyHotbarSwap);
+        assertFalse(emptyHotbarSwap.isCancelled(), "A number key aimed at a normal slot should be allowed");
+
+        InventoryClickEvent offhandSwap = mockClick(
+                player, Map.of(9, new ItemStack(NORMAL_ITEM)), null, 9, ClickType.SWAP_OFFHAND,
+                InventoryAction.HOTBAR_SWAP, -1);
+        listener.onInventoryClick(offhandSwap);
+        assertTrue(offhandSwap.isCancelled(), "An off hand swap holding a staff tool should be blocked");
+    }
+
+    @Test
+    void dragIsCancelledOnlyWhenItTouchesAStaffTool() throws Exception {
+        onlyStaffToolsAreTools();
+        Player player = mockPlayer(mockPlayerInventory(Map.of(), null));
+
+        InventoryDragEvent toolDrag = new InventoryDragEvent(
+                mockView(player, Map.of(), null),
+                null,
+                new ItemStack(STAFF_TOOL),
+                false,
+                Map.of(9, new ItemStack(STAFF_TOOL))
+        );
+        listener.onInventoryDrag(toolDrag);
+        assertTrue(toolDrag.isCancelled(), "Dragging a staff tool should be blocked");
+
+        InventoryDragEvent overToolDrag = new InventoryDragEvent(
+                mockView(player, Map.of(9, new ItemStack(STAFF_TOOL)), null),
+                null,
+                new ItemStack(NORMAL_ITEM),
+                false,
+                Map.of(9, new ItemStack(NORMAL_ITEM))
+        );
+        listener.onInventoryDrag(overToolDrag);
+        assertTrue(overToolDrag.isCancelled(), "Dragging onto a slot that holds a staff tool should be blocked");
+
+        InventoryDragEvent normalDrag = new InventoryDragEvent(
+                mockView(player, Map.of(), null),
+                null,
+                new ItemStack(NORMAL_ITEM),
+                false,
+                Map.of(9, new ItemStack(NORMAL_ITEM))
+        );
+        listener.onInventoryDrag(normalDrag);
+        assertFalse(normalDrag.isCancelled(), "Dragging normal items around should be allowed");
+    }
+
+    private void onlyStaffToolsAreTools() throws Exception {
+        setManagerField(staffModeManager, "staffToolMaterial", STAFF_TOOL);
+    }
+
+    private void setManagerField(TestStaffModeManager manager, String name, Object value) throws Exception {
+        Field field = TestStaffModeManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(manager, value);
+    }
+
+    private void installMockServer() throws Exception {
+        Object scheduler = Proxy.newProxyInstance(
+                BukkitScheduler.class.getClassLoader(),
+                new Class<?>[]{BukkitScheduler.class},
+                (proxy, method, args) -> null
+        );
+        Server server = (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getScheduler")) {
+                        return scheduler;
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("StaffModeListenerTest");
+                    }
+                    return null;
+                }
+        );
+        setBukkitServer(server);
+    }
+
+    private void setBukkitServer(Server server) throws Exception {
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, server);
+    }
+
+    private Player mockPlayer(PlayerInventory inventory) {
+        return (Player) Proxy.newProxyInstance(
+                StaffModeListenerTest.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getUniqueId")) {
+                        return playerUuid;
+                    }
+                    if (method.getName().equals("getInventory")) {
+                        return inventory;
+                    }
+                    return null;
+                }
+        );
+    }
+
+    private PlayerInventory mockPlayerInventory(Map<Integer, ItemStack> slots, ItemStack offhand) {
+        Map<Integer, ItemStack> contents = new HashMap<>(slots);
+        return (PlayerInventory) Proxy.newProxyInstance(
+                StaffModeListenerTest.class.getClassLoader(),
+                new Class<?>[]{PlayerInventory.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getItem") && args != null && args.length == 1
+                            && args[0] instanceof Integer slot) {
+                        return contents.get(slot);
+                    }
+                    if (method.getName().equals("getItemInOffHand")) {
+                        return offhand;
+                    }
+                    return null;
+                }
+        );
+    }
+
+    private Item mockItemEntity(ItemStack stack) {
+        return (Item) Proxy.newProxyInstance(
+                StaffModeListenerTest.class.getClassLoader(),
+                new Class<?>[]{Item.class},
+                (proxy, method, args) -> method.getName().equals("getItemStack") ? stack : null
+        );
+    }
+
+    private InventoryView mockView(Player player, Map<Integer, ItemStack> rawSlots, ItemStack cursor) {
+        Map<Integer, ItemStack> contents = new HashMap<>(rawSlots);
+        return (InventoryView) Proxy.newProxyInstance(
+                StaffModeListenerTest.class.getClassLoader(),
+                new Class<?>[]{InventoryView.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getPlayer":
+                            return player;
+                        case "getCursor":
+                            return cursor;
+                        case "getItem":
+                            return contents.get((Integer) args[0]);
+                        case "convertSlot":
+                            return args[0];
+                        default:
+                            return method.getReturnType() == int.class ? 0 : null;
+                    }
+                }
+        );
+    }
+
+    private InventoryClickEvent mockClick(Player player,
+                                          Map<Integer, ItemStack> rawSlots,
+                                          ItemStack cursor,
+                                          int rawSlot,
+                                          ClickType click,
+                                          InventoryAction action,
+                                          int hotbarButton) {
+        return new InventoryClickEvent(
+                mockView(player, rawSlots, cursor),
+                InventoryType.SlotType.CONTAINER,
+                rawSlot,
+                click,
+                action,
+                hotbarButton
+        );
     }
 }


### PR DESCRIPTION
Closes #187

Staff Mode hands the moderator a hotbar of tools, and `LOCK-TOOLS` was meant to keep those tools with them. It did not work that way. With the setting on, every drop, drag, hotbar swap and item pickup was cancelled outright, so the moderator could not move anything at all. With it off nothing was checked at all, and the tools themselves could be thrown on the floor for anyone to pick up. The setting is named after the tools and the lock message says "your staff tools are locked", so this narrows the lock down to the items it was always describing.

## What the handlers check now

The inventory handlers in `StaffModeListener` look at the item being moved before they cancel anything. The drop handler reads the dropped stack, the off hand swap reads both hands, and the click and drag handlers read the clicked slot along with whatever is sitting on the cursor. A moderator can throw away a stone block again and still cannot throw away the Random TP tool.

## Two routes that never looked at the item

Pressing a number key over a chest slot moves whatever sits in that hotbar slot, but the item under the cursor is the chest item rather than the tool. The click handler now resolves the hotbar button back to the inventory slot and checks there. The off hand swap key does the same thing from inside an inventory screen, so that click type reads the off hand. Drags are covered by walking the drag's raw slots, which also catches dragging a stack onto a slot that already holds a tool.

## Notes

Picking items up off the ground stays blocked while Staff Mode is active, and that is on purpose. Leaving Staff Mode writes the saved inventory snapshot back over whatever the moderator is holding, so anything collected during the session is destroyed on the way out. Blocking the pickup is what stops a moderator quietly deleting a player's dropped items.

`LOCK-TOOLS` keeps its meaning as an opt out and still defaults to `true`. Anyone who switched it off to get their own inventory back can switch it on again without losing the ability to drop things.

No new config or language keys. The wiki row for `LOCK-TOOLS` was boilerplate that only repeated the key name, so it now says what the setting actually does, and the Staff Mode section of the security guide mentions it too. `StaffModeListenerTest` gains five cases covering drops, off hand swaps, inventory clicks, the number key and off hand routes, and drags. Each one asserts that the tool is blocked and that a plain item is not. Full suite runs 293 tests, all passing.
