### PR TITLE
feat(scoreboard): hide the team line until the player joins a team (#183)

### DIFF
--- a/docs/wiki/Config-scoreboard.yml.md
+++ b/docs/wiki/Config-scoreboard.yml.md
@@ -42,7 +42,7 @@ SCOREBOARD:
     - ''
     - '&7NA East &7(&#0069D6%economy_ping%ms&7)'
 
-  # Formatting template for the team display line
+  # Formatting template for the team display line, only shown while the player is in a team
   TEAM: '&#00A4FC🪓 &fTeam &#00A4FC%economy_team%     '
 
   # Formatting template for the active shard booster display line
@@ -62,7 +62,7 @@ SCOREBOARD:
 | `SCOREBOARD.ICON-COLUMN-WIDTH` | `int` | Any valid integer number | `'10'` | Configures the technical `ICON-COLUMN-WIDTH` parameter for `SCOREBOARD.ICON-COLUMN-WIDTH` in `scoreboard.yml`. |
 | `SCOREBOARD.TITLE` | `list` | List of configured items/strings | `['&#0069d6&lE&#0374da&lc&#067fdf&lo&#0a8be3&ln&#0d96e7&lo&#10a1ec&lm&#13acf0&ly&#17b8f4&lS&#1ac3f9&lM&#1dcefd&lP']` | Configures the technical `TITLE` parameter for `SCOREBOARD.TITLE` in `scoreboard.yml`. |
 | `SCOREBOARD.LINES` | `list` | List of configured items/strings | `[, &#00FC00&l$ &fMoney &#00FC00%economy_nicestMoney%     , &#A303F9★ &fShards &#A303F9%economy_shards%     ...]` | Configures the technical `LINES` parameter for `SCOREBOARD.LINES` in `scoreboard.yml`. |
-| `SCOREBOARD.TEAM` | `str` | Any string text | `'&#00A4FC🪓 &fTeam &#00A4FC%economy_t...'` | Configures the technical `TEAM` parameter for `SCOREBOARD.TEAM` in `scoreboard.yml`. |
+| `SCOREBOARD.TEAM` | `str` | Any string text | `'&#00A4FC🪓 &fTeam &#00A4FC%economy_t...'` | Formatting for the `{team}` entry listed in `SCOREBOARD.LINES`. The line only renders while the player is in a team, so anyone without one sees no Team line at all. To show it unconditionally, remove `{team}` from `LINES` and put the raw text containing `%economy_team%` there instead. |
 | `SCOREBOARD.SHARD-BOOSTER` | `str` | Any string text | `'&#A303F9⚡ &fBooster &#A303F9%econom...'` | Configures the technical `SHARD-BOOSTER` parameter for `SCOREBOARD.SHARD-BOOSTER` in `scoreboard.yml`. |
 | `SCOREBOARD.SHARD-CUBOID` | `str` | Any string text | `'&#A303F9⌛ &fShards &#A303F9%economy...'` | Configures the technical `SHARD-CUBOID` parameter for `SCOREBOARD.SHARD-CUBOID` in `scoreboard.yml`. |
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -449,6 +449,7 @@ public class ScoreboardManager {
         String teamLine = scoreboard.getString("SCOREBOARD.TEAM");
         String boosterLine = scoreboard.getString("SCOREBOARD.SHARD-BOOSTER");
         String shardCuboidLine = scoreboard.getString("SCOREBOARD.SHARD-CUBOID");
+        boolean inTeam = plugin.getTeamManager().isInTeam(player.getUniqueId());
         boolean hasBooster = plugin.getShardManager().hasBooster(player.getUniqueId());
         boolean showShardCuboid = plugin.getShardManager().shouldShowShardCuboidLine(player.getUniqueId());
 
@@ -458,6 +459,7 @@ public class ScoreboardManager {
                     teamLine,
                     boosterLine,
                     shardCuboidLine,
+                    inTeam,
                     hasBooster,
                     showShardCuboid
             );
@@ -475,6 +477,7 @@ public class ScoreboardManager {
             String teamLine,
             String boosterLine,
             String shardCuboidLine,
+            boolean inTeam,
             boolean hasBooster,
             boolean showShardCuboid
     ) {
@@ -484,7 +487,7 @@ public class ScoreboardManager {
 
         String trimmed = line.trim();
         if ("{team}".equalsIgnoreCase(trimmed)) {
-            return teamLine;
+            return inTeam ? teamLine : null;
         }
         if ("{shard_booster}".equalsIgnoreCase(trimmed)) {
             return hasBooster ? boosterLine : null;

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -34,7 +34,7 @@ SCOREBOARD:
     - ''
     - '&7NA East &7(&#0069D6%economy_ping%ms&7)'
 
-  # Formatting template for the team display line
+  # Formatting template for the team display line, only shown while the player is in a team
   TEAM: '&#00A4FC🪓 &fTeam &#00A4FC%economy_team%     '
 
   # Formatting template for the active shard booster display line

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardTeamLineTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardTeamLineTest.java
@@ -1,0 +1,72 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ScoreboardTeamLineTest {
+
+    private static final String TEAM_LINE = "&#00A4FC &fTeam &#00A4FC%economy_team%     ";
+    private static final String BOOSTER_LINE = "&fBooster &#A303F9%economy_booster_countdown%";
+    private static final String SHARD_CUBOID_LINE = "&fShards &#A303F9%economy_shard_cuboid_display%";
+
+    private String resolve(String line, boolean inTeam) throws Exception {
+        // The real constructor needs a live server; resolveConfiguredLine only reads its arguments.
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> managerConstructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(ScoreboardManager.class, objectConstructor);
+        ScoreboardManager manager = (ScoreboardManager) managerConstructor.newInstance();
+
+        Method resolveConfiguredLine = ScoreboardManager.class.getDeclaredMethod(
+                "resolveConfiguredLine",
+                String.class,
+                String.class,
+                String.class,
+                String.class,
+                boolean.class,
+                boolean.class,
+                boolean.class
+        );
+        resolveConfiguredLine.setAccessible(true);
+
+        return (String) resolveConfiguredLine.invoke(
+                manager,
+                line,
+                TEAM_LINE,
+                BOOSTER_LINE,
+                SHARD_CUBOID_LINE,
+                inTeam,
+                false,
+                false
+        );
+    }
+
+    @Test
+    void dropsTheTeamLineForPlayersWithoutATeam() throws Exception {
+        assertNull(resolve("{team}", false));
+    }
+
+    @Test
+    void showsTheTeamLineOnceThePlayerHasATeam() throws Exception {
+        assertEquals(TEAM_LINE, resolve("{team}", true));
+    }
+
+    @Test
+    void ignoresSurroundingWhitespaceAndCaseOnThePlaceholder() throws Exception {
+        assertNull(resolve("  {TEAM}  ", false));
+        assertEquals(TEAM_LINE, resolve("  {TEAM}  ", true));
+    }
+
+    @Test
+    void keepsARawTeamLineVisibleWithoutATeam() throws Exception {
+        // Servers that still want the line can drop {team} and inline the text themselves.
+        String raw = "&fTeam &#00A4FC%economy_team%";
+        assertEquals(raw, resolve(raw, false));
+    }
+}


### PR DESCRIPTION
Closes #183

The scoreboard printed a Team line for everyone, so players without a team just saw "Team none" sitting in a slot. That line now follows team membership: no team means no line, and it comes back on its own the moment someone creates or joins one.

## How the line is resolved

`{team}` in `SCOREBOARD.LINES` now behaves the way `{shard_booster}` and `{shard_cuboid}` already did. `resolveConfiguredLine` returns null for it when the player has no team, and the renderer drops a null line from the list rather than writing it out as blank, so nothing is left sitting where the line used to be.

The check reads membership straight from `TeamManager.isInTeam`, and the sidebar re-renders every couple of ticks, so leaving or disbanding a team clears the line again without any event wiring. Both render paths already cope with the list changing length: the Spigot path resets the leftover score slots and blanks its cached lines, and the Folia path re-sends when the size differs.

## Keeping the old behaviour

Anyone who wants the line up permanently can drop `{team}` from `SCOREBOARD.LINES` and put the raw text there instead. The renderer passes any line that is not a placeholder straight through, and `%economy_team%` still resolves for the player. The wiki page mentions this.

## Notes

This adds no config keys and touches no language files. The comment above `SCOREBOARD.TEAM` and the matching wiki row now say the line is conditional. `ScoreboardTeamLineTest` covers four cases: the hidden line, the visible line, whitespace and casing on the placeholder, and the raw text fallback. Full suite is 302 passing.
