### PR TITLE
fix(scoreboard): stop long lines cutting an emoji in half (#193)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -395,8 +395,9 @@ public class ScoreboardManager {
         }
 
         int split = findSafeSplit(text, 64);
+        int end = findSafeSplit(text, split + 64);
         team.setPrefix(ColorUtils.toComponent(text.substring(0, split)));
-        team.setSuffix(ColorUtils.toComponent(text.substring(split, Math.min(text.length(), split + 64))));
+        team.setSuffix(ColorUtils.toComponent(text.substring(split, end)));
     }
 
     private void hidePlayerSpigot(Player player) {
@@ -713,6 +714,8 @@ public class ScoreboardManager {
     private int findSafeSplit(String text, int max) {
         if (max >= text.length()) return text.length();
         int split = max;
+        // A surrogate pair has to stay in one half, or the client draws two broken glyphs.
+        if (split > 0 && Character.isHighSurrogate(text.charAt(split - 1))) split--;
         if (split > 0 && text.charAt(split - 1) == '\u00A7') split--;
         return split;
     }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardLineSplitTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardLineSplitTest.java
@@ -1,0 +1,111 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.scoreboard.Team;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScoreboardLineSplitTest {
+
+    // The dagger the default scoreboard ships with. Outside the BMP, so Java holds it as a surrogate pair.
+    private static final String DAGGER = Character.toString(0x1F5E1);
+
+    private ScoreboardManager manager() throws Exception {
+        // The real constructor needs a live server; the line splitting only reads its arguments.
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> managerConstructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(ScoreboardManager.class, objectConstructor);
+        return (ScoreboardManager) managerConstructor.newInstance();
+    }
+
+    private int findSafeSplit(String text, int max) throws Exception {
+        Method findSafeSplit = ScoreboardManager.class.getDeclaredMethod("findSafeSplit", String.class, int.class);
+        findSafeSplit.setAccessible(true);
+        return (int) findSafeSplit.invoke(manager(), text, max);
+    }
+
+    private String[] halvesOf(String text) throws Exception {
+        String[] halves = new String[2];
+        Team team = (Team) Proxy.newProxyInstance(
+                Team.class.getClassLoader(),
+                new Class<?>[]{Team.class},
+                (proxy, method, args) -> {
+                    if ("setPrefix".equals(method.getName())) halves[0] = (String) args[0];
+                    if ("setSuffix".equals(method.getName())) halves[1] = (String) args[0];
+                    return null;
+                });
+
+        Method applyLineSpigot = ScoreboardManager.class.getDeclaredMethod("applyLineSpigot", Team.class, String.class);
+        applyLineSpigot.setAccessible(true);
+        applyLineSpigot.invoke(manager(), team, text);
+        return halves;
+    }
+
+    private boolean hasUnpairedSurrogate(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char current = text.charAt(i);
+            if (Character.isHighSurrogate(current)) {
+                if (i + 1 >= text.length() || !Character.isLowSurrogate(text.charAt(i + 1))) return true;
+            } else if (Character.isLowSurrogate(current)) {
+                if (i == 0 || !Character.isHighSurrogate(text.charAt(i - 1))) return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    void keepsAnEmojiWholeWhenItStraddlesTheSplit() throws Exception {
+        // The dagger starts at index 63, so cutting at 64 would land between its two halves.
+        String line = "a".repeat(63) + DAGGER + "b".repeat(20);
+        assertEquals(63, findSafeSplit(line, 64));
+
+        String[] halves = halvesOf(line);
+        assertFalse(hasUnpairedSurrogate(halves[0]));
+        assertFalse(hasUnpairedSurrogate(halves[1]));
+        assertTrue(halves[1].startsWith(DAGGER));
+        assertEquals(line, halves[0] + halves[1]);
+    }
+
+    @Test
+    void keepsAnEmojiWholeAtTheEndOfTheSuffix() throws Exception {
+        // Nothing straddles the first cut, so the dagger lands on the second one instead.
+        String line = "a".repeat(127) + DAGGER + "b".repeat(20);
+        assertEquals(64, findSafeSplit(line, 64));
+
+        String[] halves = halvesOf(line);
+        assertFalse(hasUnpairedSurrogate(halves[0]));
+        assertFalse(hasUnpairedSurrogate(halves[1]));
+    }
+
+    @Test
+    void stillKeepsAColourCodeWithItsSectionSign() throws Exception {
+        String line = "a".repeat(63) + "\u00A7c" + "b".repeat(20);
+        assertEquals(63, findSafeSplit(line, 64));
+    }
+
+    @Test
+    void backsOffPastASectionSignSittingRightBeforeTheEmoji() throws Exception {
+        String line = "a".repeat(62) + "\u00A7" + DAGGER + "b".repeat(20);
+        assertEquals(62, findSafeSplit(line, 64));
+    }
+
+    @Test
+    void cutsAtTheLimitWhenNothingStraddlesIt() throws Exception {
+        assertEquals(64, findSafeSplit("a".repeat(100), 64));
+    }
+
+    @Test
+    void leavesALineShorterThanTheLimitAlone() throws Exception {
+        String[] halves = halvesOf("a".repeat(64));
+        assertEquals("a".repeat(64), halves[0]);
+        assertEquals("", halves[1]);
+    }
+}


### PR DESCRIPTION
Closes #193

A scoreboard line longer than 64 characters gets split into a team prefix and a suffix. Both cuts were made at a fixed character index, so either one could land between the two halves of an emoji and leave a lone surrogate on each side, which the client draws as replacement boxes. The dagger and axe in the default `scoreboard.yml` are both reachable this way once placeholder values push their line past the limit.

## The split point

`findSafeSplit` already stepped back when the cut would separate a section sign from its color code. It now steps back off a high surrogate first, then runs the section sign check. Order matters here: a section sign sitting immediately before an emoji needs both steps, and only doing the surrogate one first lets the second check see it.

## The end of the suffix

The suffix was cut a second time by `Math.min(text.length(), split + 64)` with no boundary check at all, so a line past 128 characters could break an emoji there instead. That offset now goes through `findSafeSplit` too, which also removes the need for the `Math.min`, since the helper already returns the string length when the limit runs past the end.

Only the Spigot team path splits lines like this. The Folia renderer sends each line as one component, so it was never affected.

## Notes

New `ScoreboardLineSplitTest`, six cases, built on the same `ReflectionFactory` approach `ScoreboardTeamLineTest` uses to get a `ScoreboardManager` without a live server. Two of them drive the real `applyLineSpigot` through a `Proxy` `Team` that records the prefix and suffix, so they assert on actual output instead of on arithmetic copied into the test.

Three of the six fail on the old code: the split landing mid emoji, the suffix ending on an unpaired surrogate, and the section sign case needing a double step back. The other three cover the existing section sign rule, a clean cut at the limit and a short line staying whole. Those pass either way, which is what shows nothing outside the defect moved. Suite is 312 tests, all green.
