### PR TITLE
fix(worth): show item prices in the browser tooltips (#196)

### DIFF
--- a/docs/wiki/Config-worth.yml.md
+++ b/docs/wiki/Config-worth.yml.md
@@ -99,6 +99,17 @@ BROWSER:
   - BOOK
   - POTION
   - BLOCKS
+  # Configuration section for Item.
+  ITEM:
+    # The text or value for Name. Available options: Any valid string text
+    NAME: '&b{item}'
+    # Configuration section for Lore.
+    LORE:
+    - '&7Category: &f{category}'
+    - '&7Unit price: {unit_price_compact}'
+    - '&7Stack x{stack_size}: {stack_price_compact}'
+    - ''
+    - '&eClick to send the unit price in chat'
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -110,6 +121,8 @@ BROWSER:
 | `BROWSER.ITEMS-PER-PAGE` | `int` | Any valid integer number | `'45'` | Configures the technical `ITEMS-PER-PAGE` parameter for `BROWSER.ITEMS-PER-PAGE` in `worth.yml`. |
 | `BROWSER.DEFAULT-SORT` | `str` | Any string text | `'CATEGORY'` | Configures the technical `DEFAULT-SORT` parameter for `BROWSER.DEFAULT-SORT` in `worth.yml`. |
 | `BROWSER.CATEGORY-SORT` | `list` | List of configured items/strings | `[CROPS, ORES, MOBS...]` | Configures the technical `CATEGORY-SORT` parameter for `BROWSER.CATEGORY-SORT` in `worth.yml`. |
+| `BROWSER.ITEM.NAME` | `str` | Any string text | `'&b{item}'` | Display name of every item in the `/worth` browser. Supports `{item}` and `{category}`. |
+| `BROWSER.ITEM.LORE` | `list` | List of configured items/strings | `['&7Category: &f{category}', ...]` | Tooltip lines shown under each item in the `/worth` browser. Supports `{item}`, `{category}`, `{stack_size}`, and the price placeholders `{unit_price}`, `{unit_price_formatted}`, `{unit_price_compact}`, `{stack_price}`, `{stack_price_formatted}`, `{stack_price_compact}`. Leave it empty to show no tooltip at all. |
 
 ### 3. Practical Setup Example
 
@@ -132,6 +145,17 @@ BROWSER:
   - BOOK
   - POTION
   - BLOCKS
+  # Configuration section for Item.
+  ITEM:
+    # The text or value for Name. Available options: Any valid string text
+    NAME: '&b{item}'
+    # Configuration section for Lore.
+    LORE:
+    - '&7Category: &f{category}'
+    - '&7Unit price: {unit_price_compact}'
+    - '&7Stack x{stack_size}: {stack_price_compact}'
+    - ''
+    - '&eClick to send the unit price in chat'
 ```
 
 ---

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2163,6 +2163,14 @@ CONFIG:
       FORMAT: '&7Wert: &a$${price}'
     BROWSER:
       TITLE: '&8Artikelpreise'
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - '&7Kategorie: &f{category}'
+        - "&7Stückpreis: {unit_price_compact}"
+        - '&7Stapel x{stack_size}: {stack_price_compact}'
+        - ''
+        - "&eKlicke, um den Stückpreis in den Chat zu senden"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2306,8 +2306,8 @@ CONFIG:
         NAME: '&b{item}'
         LORE:
         - '&7Category: &f{category}'
-        - '&7Unit price: {unit_price_formatted}'
-        - '&7Stack x{stack_size}: {stack_price_formatted}'
+        - '&7Unit price: {unit_price_compact}'
+        - '&7Stack x{stack_size}: {stack_price_compact}'
         - ''
         - '&eClick to send the unit price in chat'
   SHOP:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2028,6 +2028,14 @@ CONFIG:
       FORMAT: '&7Valor: &a$${price}'
     BROWSER:
       TITLE: "&8Precios de los artículos"
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - "&7Categoría: &f{category}"
+        - '&7Precio unitario: {unit_price_compact}'
+        - '&7Pila x{stack_size}: {stack_price_compact}'
+        - ''
+        - "&eHaz clic para enviar el precio unitario al chat"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2028,6 +2028,14 @@ CONFIG:
       FORMAT: "&7Valeur : &a$${price}"
     BROWSER:
       TITLE: '&8Prix des articles'
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - "&7Catégorie : &f{category}"
+        - '&7Prix unitaire : {unit_price_compact}'
+        - '&7Pile x{stack_size} : {stack_price_compact}'
+        - ''
+        - "&eCliquez pour envoyer le prix unitaire dans le chat"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2163,6 +2163,14 @@ CONFIG:
       FORMAT: '&7Bernilai: &a$${price}'
     BROWSER:
       TITLE: '&8Harga barang'
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - '&7Kategori: &f{category}'
+        - '&7Harga satuan: {unit_price_compact}'
+        - '&7Tumpukan x{stack_size}: {stack_price_compact}'
+        - ''
+        - '&eKlik untuk mengirim harga satuan ke obrolan'
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2028,6 +2028,14 @@ CONFIG:
       FORMAT: '&7Valor: &a$${price}'
     BROWSER:
       TITLE: "&8Preços de itens"
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - '&7Categoria: &f{category}'
+        - "&7Preço unitário: {unit_price_compact}"
+        - '&7Pilha x{stack_size}: {stack_price_compact}'
+        - ''
+        - "&eClique para enviar o preço unitário no chat"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2025,6 +2025,14 @@ CONFIG:
       FORMAT: "&7Стоимость: &a$${price}"
     BROWSER:
       TITLE: "&8Цены на предметы"
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - "&7Категория: &f{category}"
+        - "&7Цена за штуку: {unit_price_compact}"
+        - "&7Стак x{stack_size}: {stack_price_compact}"
+        - ''
+        - "&eНажмите, чтобы отправить цену за штуку в чат"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2020,6 +2020,14 @@ CONFIG:
       FORMAT: "&7价值：&a$${price}"
     BROWSER:
       TITLE: "&8商品价格"
+      ITEM:
+        NAME: '&b{item}'
+        LORE:
+        - "&7类别：&f{category}"
+        - "&7单价：{unit_price_compact}"
+        - "&7一组 x{stack_size}：{stack_price_compact}"
+        - ''
+        - "&e点击将单价发送到聊天栏"
   HIDE:
     GUI:
       MAIN:

--- a/src/main/resources/worth.yml
+++ b/src/main/resources/worth.yml
@@ -31,6 +31,17 @@ BROWSER:
   - BOOK
   - POTION
   - BLOCKS
+  # Configuration section for Item.
+  ITEM:
+    # The text or value for Name. Available options: Any valid string text
+    NAME: '&b{item}'
+    # Configuration section for Lore.
+    LORE:
+    - '&7Category: &f{category}'
+    - '&7Unit price: {unit_price_compact}'
+    - '&7Stack x{stack_size}: {stack_price_compact}'
+    - ''
+    - '&eClick to send the unit price in chat'
 TYPE:
   # Configuration section for Crops.
   CROPS:

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/WorthMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/WorthMenuTest.java
@@ -1,15 +1,89 @@
 package com.bx.ultimateDonutSmp.menus;
 
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WorthMenuTest {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("[{][a-z_]+[}]");
+
+    // mirrors the substitutions WorthMenu#replaceItemPlaceholders performs
+    private static final Set<String> SUPPORTED_PLACEHOLDERS = Set.of(
+            "{item}",
+            "{category}",
+            "{unit_price}",
+            "{unit_price_formatted}",
+            "{unit_price_compact}",
+            "{stack_size}",
+            "{stack_price}",
+            "{stack_price_formatted}",
+            "{stack_price_compact}"
+    );
 
     @Test
     void calculatesConfiguredMaterialStackTotals() {
         assertEquals(640D, WorthMenu.calculateStackPrice(10D, 64));
         assertEquals(160D, WorthMenu.calculateStackPrice(10D, 16));
         assertEquals(10D, WorthMenu.calculateStackPrice(10D, 1));
+    }
+
+    @Test
+    void browserItemsShipNameAndPricedLore() throws Exception {
+        YamlConfiguration worth = loadWorth();
+
+        assertFalse(
+                worth.getString("BROWSER.ITEM.NAME", "").isBlank(),
+                "worth.yml must ship BROWSER.ITEM.NAME or browser items render without a name"
+        );
+
+        List<String> lore = worth.getStringList("BROWSER.ITEM.LORE");
+        assertFalse(
+                lore.isEmpty(),
+                "worth.yml must ship BROWSER.ITEM.LORE or browser items render with no price in their tooltip"
+        );
+        assertTrue(
+                lore.stream().anyMatch(line -> line.contains("{unit_price")),
+                "BROWSER.ITEM.LORE must show a unit price"
+        );
+        assertTrue(
+                lore.stream().anyMatch(line -> line.contains("{stack_price")),
+                "BROWSER.ITEM.LORE must show a stack price"
+        );
+    }
+
+    @Test
+    void browserItemTextOnlyUsesPlaceholdersTheMenuReplaces() throws Exception {
+        YamlConfiguration worth = loadWorth();
+
+        List<String> text = new ArrayList<>(worth.getStringList("BROWSER.ITEM.LORE"));
+        text.add(worth.getString("BROWSER.ITEM.NAME", ""));
+
+        for (String line : text) {
+            Matcher matcher = PLACEHOLDER.matcher(line);
+            while (matcher.find()) {
+                assertTrue(
+                        SUPPORTED_PLACEHOLDERS.contains(matcher.group()),
+                        "BROWSER.ITEM text uses " + matcher.group() + ", which WorthMenu never replaces"
+                );
+            }
+        }
+    }
+
+    private static YamlConfiguration loadWorth() throws Exception {
+        YamlConfiguration worth = new YamlConfiguration();
+        worth.options().parseComments(true);
+        worth.load(Path.of("src/main/resources/worth.yml").toFile());
+        return worth;
     }
 }


### PR DESCRIPTION
Closes #196

Opening `/worth` gave you a grid of items with a name on each one and nothing underneath it. `WorthMenu` builds every item's lore from `BROWSER.ITEM.LORE` in `worth.yml`, and that key was never shipped in the bundled file. `getStringList` on a missing path returns an empty list, and `ItemUtils.createItem` skips `setLore` when the list is empty, so the items came out bare.

## Where the values were hiding

`languages/en_US.yml` has carried `CONFIG.WORTH.BROWSER.ITEM.NAME` and `.LORE` since the first commit, which is why the keys look like they already exist. They never reach the menu. `LanguageManager.localize` hands back the configuration it was given without applying any language section, so `getWorth()` only ever sees the raw `worth.yml`. Switching that on would change every config that goes through it, so instead the defaults now ship where the rest of the player-facing worth text already lives, in `worth.yml` next to `DISPLAY.FORMAT` and `BROWSER.TITLE`.

## Prices are compact

The lore uses `{unit_price_compact}` and `{stack_price_compact}`, so a stack reads `$2B` instead of `$2,000,000,000.00`. That matches what the browser already sends to chat when you click an item, and it fits in a tooltip. `en_US.yml` moved onto the same placeholders so the two files agree.

## Notes

- `BROWSER.ITEM` is not on the user-managed list in `ConfigManager.isUserManagedBundledPath`, so existing servers pick the block up on the next start without editing anything themselves.
- All 8 language files carry a translated `BROWSER.ITEM` block.
- Three tests in `WorthMenuTest` cover it: the keys ship, the lore quotes a unit price and a stack price, and every placeholder in that text is one `WorthMenu` actually replaces. Suite is 314 green.
