### PR TITLE
fix(settings): pin money nametags to the player instead of trailing behind (#182)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -846,12 +846,14 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.25M instead of 1,250,000.
   # Available options: true, false
   SHORT-FORMAT: false
-  # How often the line follows the player and picks up balance changes, in ticks.
-  # Lower values track movement more closely and cost more. Available options: 1 to 20
-  UPDATE-INTERVAL-TICKS: 2
-  # How far above the player's feet the line sits. Raise it if the line covers the
-  # username, lower it if the line floats too high. Available options: Any decimal number
-  Y-OFFSET: 1.85
+  # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
+  # to the player by the client, so this never affects how closely it follows them.
+  # Available options: 1 to 40
+  UPDATE-INTERVAL-TICKS: 10
+  # Vertical offset from the username, in blocks. The line hangs off the same anchor the
+  # username uses, so negative values drop it below the name and positive values push it
+  # above. Available options: Any decimal number
+  LINE-OFFSET: -0.3
   # How far away the line stays readable, in blocks. Available options: Any decimal number
   VIEW-RANGE: 32.0
   # Determines whether the line disappears while the player sneaks, the way the vanilla
@@ -866,8 +868,8 @@ MONEY-NAMETAGS:
 | `MONEY-NAMETAGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `MONEY-NAMETAGS` system. Set to `false` to take the option out of the game entirely, whatever players picked in `/settings`. |
 | `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a${balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
 | `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `false` | `true` writes `1.25M` where `false` writes `1,250,000`. Worth switching on if your balances run into the billions and the line gets too wide. |
-| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `20` | `2` | How often each line catches up with its owner and re-reads their balance. The move is interpolated over the same span, so `2` keeps the line glued to a sprinting player. Raising it saves work at the cost of the line trailing behind. |
-| `MONEY-NAMETAGS.Y-OFFSET` | `float` | Any decimal number | `1.85` | Height above the player's feet, in blocks. The vanilla username sits at roughly `2.05`, so the default leaves the balance just underneath it. |
+| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often each line re-reads its owner's balance. It has nothing to do with how closely the line follows the player, because the viewer's client draws the line riding its owner and pins it there. Lower it if you want balance changes to appear faster. |
+| `MONEY-NAMETAGS.LINE-OFFSET` | `float` | Any decimal number | `-0.3` | Vertical offset from the username, in blocks. The line hangs off the same anchor point the username uses, so negative values drop it below the name and positive values push it above. |
 | `MONEY-NAMETAGS.VIEW-RANGE` | `float` | Any decimal number | `32.0` | How far away, in blocks, the line is still drawn. |
 | `MONEY-NAMETAGS.HIDE-WHILE-SNEAKING` | `bool` | `true`, `false` | `true` | Drops the line while the player sneaks, matching what vanilla does with the username above their head. |
 
@@ -878,8 +880,8 @@ MONEY-NAMETAGS:
   ENABLED: true
   FORMAT: '&6&l${balance}'
   SHORT-FORMAT: true
-  UPDATE-INTERVAL-TICKS: 2
-  Y-OFFSET: 1.9
+  UPDATE-INTERVAL-TICKS: 10
+  LINE-OFFSET: -0.35
   VIEW-RANGE: 24.0
   HIDE-WHILE-SNEAKING: true
 ```

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -4,6 +4,10 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -13,19 +17,27 @@ import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
+import org.bukkit.util.Transformation;
+import org.joml.Vector3f;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * Renders a player's balance on a floating line under their username.
  *
- * <p>The line is a {@link TextDisplay} that follows its owner around rather than a passenger riding
- * them: Spigot refuses to teleport a player who is carrying passengers, so mounting the line would
+ * <p>The line is a {@link TextDisplay} that every viewer's client is told to draw riding its owner,
+ * so it is pinned to the player the same way the username is and never trails behind a sprint. The
+ * ride only exists in the packet: server side the display stays a free entity, because Spigot
+ * refuses to teleport a player who is carrying real passengers and mounting it for real would
  * quietly break every warp, home and teleport request on the server.</p>
+ *
+ * <p>Passengers hang off the same anchor point the username uses, so the height is a small offset
+ * from the name rather than a distance off the ground.</p>
  *
  * <p>Every player decides for themselves whether they see the line through
  * {@code /settings > Money Nametags}, so a line only exists while somebody online has that setting
@@ -39,6 +51,7 @@ public class MoneyNametagManager {
     private final UltimateDonutSmp plugin;
     private final Map<UUID, UUID> displays = new ConcurrentHashMap<>();
     private final Map<UUID, String> renderedText = new ConcurrentHashMap<>();
+    private ProtocolManager protocolManager;
 
     public MoneyNametagManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -55,7 +68,7 @@ public class MoneyNametagManager {
     }
 
     public long getUpdateIntervalTicks() {
-        return Math.max(1L, config().getLong("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS", 2L));
+        return Math.max(1L, config().getLong("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS", 10L));
     }
 
     /** Whether {@code viewer} asked to see balances above other players. */
@@ -67,7 +80,7 @@ public class MoneyNametagManager {
         return data != null && data.isMoneyNametagsEnabled();
     }
 
-    /** Moves every line to its owner and refreshes the balance written on it. */
+    /** Refreshes the balance on every line and keeps each one riding its owner. */
     public void updateAll() {
         if (!isEnabled()) {
             clearAll();
@@ -111,6 +124,7 @@ public class MoneyNametagManager {
             Player owner = Bukkit.getPlayer(ownerUuid);
             if (wanted && owner != null && viewer.canSee(owner)) {
                 viewer.showEntity(plugin, display);
+                mount(viewer, owner, display);
             } else {
                 viewer.hideEntity(plugin, display);
             }
@@ -185,7 +199,7 @@ public class MoneyNametagManager {
             display.setText(text);
             renderedText.put(owner.getUniqueId(), text);
         }
-        move(display, anchor(owner));
+        keepInTrackingRange(display, owner);
         applyVisibility(display, owner, viewers);
     }
 
@@ -210,7 +224,7 @@ public class MoneyNametagManager {
 
     private TextDisplay spawn(Player owner) {
         try {
-            TextDisplay display = owner.getWorld().spawn(anchor(owner), TextDisplay.class, textDisplay -> {
+            TextDisplay display = owner.getWorld().spawn(owner.getLocation(), TextDisplay.class, textDisplay -> {
                 textDisplay.addScoreboardTag(DISPLAY_TAG);
                 textDisplay.setBillboard(Display.Billboard.CENTER);
                 textDisplay.setDefaultBackground(false);
@@ -223,7 +237,7 @@ public class MoneyNametagManager {
                 textDisplay.setGravity(false);
                 textDisplay.setSilent(true);
                 textDisplay.setVisibleByDefault(false);
-                textDisplay.setTeleportDuration(teleportDuration());
+                applyLineOffset(textDisplay);
             });
             renderedText.remove(owner.getUniqueId());
             displays.put(owner.getUniqueId(), display.getUniqueId());
@@ -234,6 +248,37 @@ public class MoneyNametagManager {
         }
     }
 
+    /** Shifts the text off the anchor it shares with the username so the two do not overlap. */
+    private void applyLineOffset(TextDisplay display) {
+        Transformation transformation = display.getTransformation();
+        Vector3f translation = new Vector3f(
+                0.0F,
+                (float) config().getDouble("MONEY-NAMETAGS.LINE-OFFSET", -0.3D),
+                0.0F);
+        display.setTransformation(new Transformation(
+                translation,
+                transformation.getLeftRotation(),
+                transformation.getScale(),
+                transformation.getRightRotation()));
+    }
+
+    /**
+     * The client draws the line on its owner, so the entity's own position only decides whether a
+     * viewer is sent it at all. Keeping it on top of the player keeps that decision matching the
+     * player's own.
+     */
+    private void keepInTrackingRange(TextDisplay display, Player owner) {
+        Location location = owner.getLocation();
+        if (display.getLocation().distanceSquared(location) < 0.01D) {
+            return;
+        }
+        if (plugin.getSpigotScheduler().isFolia()) {
+            plugin.getSpigotScheduler().teleport(display, location);
+            return;
+        }
+        display.teleport(location);
+    }
+
     /**
      * Only the players who asked for balances get the line sent to them, and only while they can
      * see its owner in the first place.
@@ -242,10 +287,55 @@ public class MoneyNametagManager {
         for (Player viewer : Bukkit.getOnlinePlayers()) {
             if (viewers.contains(viewer.getUniqueId()) && viewer.canSee(owner)) {
                 viewer.showEntity(plugin, display);
+                mount(viewer, owner, display);
             } else {
                 viewer.hideEntity(plugin, display);
             }
         }
+    }
+
+    /**
+     * Tells one viewer's client that the line rides its owner. Anything genuinely riding the player
+     * is listed alongside it, otherwise the client would drop those the moment this packet lands.
+     */
+    private void mount(Player viewer, Player owner, TextDisplay display) {
+        ProtocolManager manager = protocolManager();
+        if (manager == null || viewer == null || !viewer.isOnline() || !sharesWorld(viewer, owner)) {
+            return;
+        }
+        try {
+            PacketContainer packet = manager.createPacket(PacketType.Play.Server.MOUNT);
+            packet.getIntegers().write(0, owner.getEntityId());
+            packet.getIntegerArrays().write(0, passengerIds(owner, display));
+            manager.sendServerPacket(viewer, packet, false);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to pin a money nametag to its player.", error);
+        }
+    }
+
+    private int[] passengerIds(Player owner, TextDisplay display) {
+        java.util.List<Entity> riders = owner.getPassengers();
+        int[] ids = new int[riders.size() + 1];
+        for (int index = 0; index < riders.size(); index++) {
+            ids[index] = riders.get(index).getEntityId();
+        }
+        ids[riders.size()] = display.getEntityId();
+        return ids;
+    }
+
+    private boolean sharesWorld(Player viewer, Player owner) {
+        return viewer.getWorld().equals(owner.getWorld());
+    }
+
+    private ProtocolManager protocolManager() {
+        if (protocolManager == null) {
+            try {
+                protocolManager = ProtocolLibrary.getProtocolManager();
+            } catch (RuntimeException | LinkageError ignored) {
+                return null;
+            }
+        }
+        return protocolManager;
     }
 
     /** The players who currently want to see balances, resolved once per pass. */
@@ -259,35 +349,10 @@ public class MoneyNametagManager {
         return viewers;
     }
 
-    private void move(TextDisplay display, Location location) {
-        if (plugin.getSpigotScheduler().isFolia()) {
-            plugin.getSpigotScheduler().teleport(display, location);
-            return;
-        }
-        display.teleport(location);
-    }
-
-    private Location anchor(Player owner) {
-        Location location = owner.getLocation();
-        return new Location(
-                owner.getWorld(),
-                location.getX(),
-                location.getY() + config().getDouble("MONEY-NAMETAGS.Y-OFFSET", 1.85D),
-                location.getZ());
-    }
-
     /** The Bukkit view range is a multiplier of the 64 block default rather than a distance. */
     private float viewRange() {
         double blocks = Math.max(1.0D, config().getDouble("MONEY-NAMETAGS.VIEW-RANGE", 32.0D));
         return (float) (blocks / 64.0D);
-    }
-
-    /**
-     * Interpolating the move over the gap between updates is what keeps the line glued to a running
-     * player instead of snapping along behind them.
-     */
-    private int teleportDuration() {
-        return (int) Math.min(59L, getUpdateIntervalTicks());
     }
 
     private TextDisplay display(UUID ownerUuid) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -305,12 +305,14 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.25M instead of 1,250,000.
   # Available options: true, false
   SHORT-FORMAT: false
-  # How often the line follows the player and picks up balance changes, in ticks.
-  # Lower values track movement more closely and cost more. Available options: 1 to 20
-  UPDATE-INTERVAL-TICKS: 2
-  # How far above the player's feet the line sits. Raise it if the line covers the
-  # username, lower it if the line floats too high. Available options: Any decimal number
-  Y-OFFSET: 1.85
+  # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
+  # to the player by the client, so this never affects how closely it follows them.
+  # Available options: 1 to 40
+  UPDATE-INTERVAL-TICKS: 10
+  # Vertical offset from the username, in blocks. The line hangs off the same anchor the
+  # username uses, so negative values drop it below the name and positive values push it
+  # above. Available options: Any decimal number
+  LINE-OFFSET: -0.3
   # How far away the line stays readable, in blocks. Available options: Any decimal number
   VIEW-RANGE: 32.0
   # Determines whether the line disappears while the player sneaks, the way the vanilla

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
@@ -45,8 +45,8 @@ class MoneyNametagConfigurationTest {
         assertTrue(config.getBoolean("MONEY-NAMETAGS.ENABLED"));
         assertEquals("&a${balance}", config.getString("MONEY-NAMETAGS.FORMAT"));
         assertFalse(config.getBoolean("MONEY-NAMETAGS.SHORT-FORMAT"));
-        assertEquals(2, config.getInt("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS"));
-        assertEquals(1.85D, config.getDouble("MONEY-NAMETAGS.Y-OFFSET"));
+        assertEquals(10, config.getInt("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS"));
+        assertEquals(-0.3D, config.getDouble("MONEY-NAMETAGS.LINE-OFFSET"));
         assertEquals(32.0D, config.getDouble("MONEY-NAMETAGS.VIEW-RANGE"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.HIDE-WHILE-SNEAKING"));
     }


### PR DESCRIPTION
Follow-up to #189, reported against #182.

The balance line lagged behind whoever it belonged to. It was a free entity teleported onto the player every couple of ticks, so a walking player stayed about half a block ahead of their own number and a sprinting one left it drifting somewhere behind their back. It read as a floating label rather than part of the nametag.

## Pinning the line to the player

The line now rides its owner. Each viewer's client is sent a set-passengers packet listing the display on the player, so the client draws it on them every frame the way it draws the username. Nothing has to catch up any more, because nothing is following anything.

The ride only exists in the packet. Server side the display is still a free entity and never a real passenger, and that is the important part: Spigot refuses to teleport a player who is carrying passengers, so a real mount would have broken homes, warps and teleport requests for everyone the moment somebody switched the option on. Anything genuinely riding the player is listed in the same packet, so a real passenger does not get dropped when ours lands.

The display still gets moved onto the player, but only so the entity tracker decides to send it to the same people who can see the player. Its position no longer has anything to do with where the line is drawn.

## Config changes

Passengers hang off the same anchor point the username uses, so height is now an offset from the name rather than a distance off the ground. Y-OFFSET is gone and LINE-OFFSET replaces it, defaulting to -0.3 to drop the line just under the username. Negative moves it down, positive pushes it above the name. It is a new key rather than a new meaning for the old one, so a server that already tuned Y-OFFSET does not end up with the line thrown a block and a half into the air.

UPDATE-INTERVAL-TICKS now only decides how quickly a balance change appears, since the line no longer needs frequent moves to look right. The default goes from 2 to 10, which is five times less work for the same result on screen.

## Notes

Servers that already have the old block keep their stale Y-OFFSET entry sitting there unread, which is how the config merge treats removed keys.

docs/wiki/Config-config.yml.md follows the renamed key and the new default, and the config test asserts both. Suite is 298 green.
