### PR TITLE
fix(settings): sit money nametags under the username (#182)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -843,17 +843,18 @@ MONEY-NAMETAGS:
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
   # Available options: Any valid string text
   FORMAT: '&a${balance}'
-  # Determines whether balances are shortened to 1.25M instead of 1,250,000.
-  # Available options: true, false
-  SHORT-FORMAT: false
+  # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
+  # being written out as 1,100,000. Available options: true, false
+  SHORT-FORMAT: true
   # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
   # to the player by the client, so this never affects how closely it follows them.
   # Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
-  # Vertical offset from the username, in blocks. The line hangs off the same anchor the
-  # username uses, so negative values drop it below the name and positive values push it
-  # above. Available options: Any decimal number
-  LINE-OFFSET: -0.3
+  # Gap between the bottom of the username and the top of the balance line, in blocks.
+  # The username itself is never touched or hidden, the balance is simply parked under it.
+  # Raise this to push the balance further down, or use a negative number to tuck it
+  # closer. Available options: Any decimal number
+  LINE-GAP: 0.05
   # How far away the line stays readable, in blocks. Available options: Any decimal number
   VIEW-RANGE: 32.0
   # Determines whether the line disappears while the player sneaks, the way the vanilla
@@ -867,9 +868,9 @@ MONEY-NAMETAGS:
 | :--- | :--- | :--- | :--- | :--- |
 | `MONEY-NAMETAGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `MONEY-NAMETAGS` system. Set to `false` to take the option out of the game entirely, whatever players picked in `/settings`. |
 | `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a${balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
-| `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `false` | `true` writes `1.25M` where `false` writes `1,250,000`. Worth switching on if your balances run into the billions and the line gets too wide. |
+| `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `true` | `true` writes `1.1K`, `1.1M`, `1.1B`, `1.1T` and `1.1Q` where `false` writes them out in full as `1,100,000`. Leaving it on keeps the line narrow once balances run into the billions. |
 | `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often each line re-reads its owner's balance. It has nothing to do with how closely the line follows the player, because the viewer's client draws the line riding its owner and pins it there. Lower it if you want balance changes to appear faster. |
-| `MONEY-NAMETAGS.LINE-OFFSET` | `float` | Any decimal number | `-0.3` | Vertical offset from the username, in blocks. The line hangs off the same anchor point the username uses, so negative values drop it below the name and positive values push it above. |
+| `MONEY-NAMETAGS.LINE-GAP` | `float` | Any decimal number | `0.05` | Gap between the bottom of the username and the top of the balance line, in blocks. Raising it pushes the balance further below the name, and a negative value tucks it closer. The username is never moved or hidden to make room. |
 | `MONEY-NAMETAGS.VIEW-RANGE` | `float` | Any decimal number | `32.0` | How far away, in blocks, the line is still drawn. |
 | `MONEY-NAMETAGS.HIDE-WHILE-SNEAKING` | `bool` | `true`, `false` | `true` | Drops the line while the player sneaks, matching what vanilla does with the username above their head. |
 
@@ -881,12 +882,22 @@ MONEY-NAMETAGS:
   FORMAT: '&6&l${balance}'
   SHORT-FORMAT: true
   UPDATE-INTERVAL-TICKS: 10
-  LINE-OFFSET: -0.35
+  LINE-GAP: 0.1
   VIEW-RANGE: 24.0
   HIDE-WHILE-SNEAKING: true
 ```
 
-### 4. Who Sees The Line
+### 4. Where The Line Sits
+
+The username keeps its normal place and is never hidden, moved or replaced. The balance is parked
+directly under it, so the two read as a two line nametag: the name on top, the balance below it.
+
+Minecraft draws a username half a block above the point anything riding a player hangs from, so the
+balance line is lifted back up by that much, minus its own height and the `LINE-GAP` above. If the
+two lines look too close or too far apart on your resource pack, `LINE-GAP` is the only value worth
+touching.
+
+### 5. Who Sees The Line
 
 Every player carries their own switch under `/settings > Money Nametags`, and it starts turned off.
 It only decides what that player sees above other people, never whether their own balance is on

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -40,8 +40,9 @@ import java.util.logging.Level;
  * refuses to teleport a player who is carrying real passengers and mounting it for real would
  * quietly break every warp, home and teleport request on the server.</p>
  *
- * <p>Passengers hang off the same anchor point the username uses, so the height is a small offset
- * from the name rather than a distance off the ground.</p>
+ * <p>The vanilla username is left exactly as it is. Passengers hang from the same anchor the
+ * username is measured against, half a block below the name itself, so the line is pushed back up
+ * to sit directly underneath it and the two read as one two line nametag.</p>
  *
  * <p>Because the ride is a fiction the server does not share, the server keeps broadcasting the
  * display's own movement. A client that hears both puts the line on the player one tick and back on
@@ -56,6 +57,11 @@ public class MoneyNametagManager {
 
     private static final String DISPLAY_TAG = "uds_money_nametag";
     private static final String BALANCE_PLACEHOLDER = "{balance}";
+
+    /** Vanilla draws a username half a block above the point a passenger hangs from. */
+    private static final float NAME_TAG_HEIGHT = 0.5F;
+    /** A line of display text is the same height as a username, both drawn at 0.025 scale. */
+    private static final float LINE_HEIGHT = 0.25F;
 
     private final UltimateDonutSmp plugin;
     private final Map<UUID, UUID> displays = new ConcurrentHashMap<>();
@@ -233,7 +239,7 @@ public class MoneyNametagManager {
         return render(
                 config().getString("MONEY-NAMETAGS.FORMAT", "&a${balance}"),
                 plugin.getEconomyManager().getBalance(owner),
-                config().getBoolean("MONEY-NAMETAGS.SHORT-FORMAT", false));
+                config().getBoolean("MONEY-NAMETAGS.SHORT-FORMAT", true));
     }
 
     /**
@@ -263,7 +269,7 @@ public class MoneyNametagManager {
                 textDisplay.setGravity(false);
                 textDisplay.setSilent(true);
                 textDisplay.setVisibleByDefault(false);
-                applyLineOffset(textDisplay);
+                applyLinePlacement(textDisplay);
             });
             renderedText.remove(owner.getUniqueId());
             displays.put(owner.getUniqueId(), display.getUniqueId());
@@ -276,13 +282,14 @@ public class MoneyNametagManager {
         }
     }
 
-    /** Shifts the text off the anchor it shares with the username so the two do not overlap. */
-    private void applyLineOffset(TextDisplay display) {
+    /**
+     * Lifts the text from the anchor a passenger hangs from up to just under the username, leaving
+     * the configured gap between the bottom of the name and the top of the balance.
+     */
+    private void applyLinePlacement(TextDisplay display) {
         Transformation transformation = display.getTransformation();
-        Vector3f translation = new Vector3f(
-                0.0F,
-                (float) config().getDouble("MONEY-NAMETAGS.LINE-OFFSET", -0.3D),
-                0.0F);
+        float gap = (float) config().getDouble("MONEY-NAMETAGS.LINE-GAP", 0.05D);
+        Vector3f translation = new Vector3f(0.0F, NAME_TAG_HEIGHT - LINE_HEIGHT - gap, 0.0F);
         display.setTransformation(new Transformation(
                 translation,
                 transformation.getLeftRotation(),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -302,17 +302,18 @@ MONEY-NAMETAGS:
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
   # Available options: Any valid string text
   FORMAT: '&a${balance}'
-  # Determines whether balances are shortened to 1.25M instead of 1,250,000.
-  # Available options: true, false
-  SHORT-FORMAT: false
+  # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
+  # being written out as 1,100,000. Available options: true, false
+  SHORT-FORMAT: true
   # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
   # to the player by the client, so this never affects how closely it follows them.
   # Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
-  # Vertical offset from the username, in blocks. The line hangs off the same anchor the
-  # username uses, so negative values drop it below the name and positive values push it
-  # above. Available options: Any decimal number
-  LINE-OFFSET: -0.3
+  # Gap between the bottom of the username and the top of the balance line, in blocks.
+  # The username itself is never touched or hidden, the balance is simply parked under it.
+  # Raise this to push the balance further down, or use a negative number to tuck it
+  # closer. Available options: Any decimal number
+  LINE-GAP: 0.05
   # How far away the line stays readable, in blocks. Available options: Any decimal number
   VIEW-RANGE: 32.0
   # Determines whether the line disappears while the player sneaks, the way the vanilla

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
@@ -31,6 +31,15 @@ class MoneyNametagConfigurationTest {
     }
 
     @Test
+    void compactBalancesClimbThroughEverySuffix() {
+        assertEquals("&a$1.1K", MoneyNametagManager.render("&a${balance}", 1_100D, true));
+        assertEquals("&a$1.1M", MoneyNametagManager.render("&a${balance}", 1_100_000D, true));
+        assertEquals("&a$1.1B", MoneyNametagManager.render("&a${balance}", 1_100_000_000D, true));
+        assertEquals("&a$1.1T", MoneyNametagManager.render("&a${balance}", 1_100_000_000_000D, true));
+        assertEquals("&a$2.3M", MoneyNametagManager.render("&a${balance}", 2_300_000D, true));
+    }
+
+    @Test
     void aFormatWithoutThePlaceholderIsLeftAlone() {
         assertEquals("&7Balance hidden", MoneyNametagManager.render("&7Balance hidden", 1_000D, false));
         assertEquals("1,000", MoneyNametagManager.render(null, 1_000D, false));
@@ -44,9 +53,9 @@ class MoneyNametagConfigurationTest {
         assertTrue(config.isConfigurationSection("MONEY-NAMETAGS"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.ENABLED"));
         assertEquals("&a${balance}", config.getString("MONEY-NAMETAGS.FORMAT"));
-        assertFalse(config.getBoolean("MONEY-NAMETAGS.SHORT-FORMAT"));
+        assertTrue(config.getBoolean("MONEY-NAMETAGS.SHORT-FORMAT"));
         assertEquals(10, config.getInt("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS"));
-        assertEquals(-0.3D, config.getDouble("MONEY-NAMETAGS.LINE-OFFSET"));
+        assertEquals(0.05D, config.getDouble("MONEY-NAMETAGS.LINE-GAP"));
         assertEquals(32.0D, config.getDouble("MONEY-NAMETAGS.VIEW-RANGE"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.HIDE-WHILE-SNEAKING"));
     }


### PR DESCRIPTION
Follow-up to #199, reported against #182.

The balance was hanging too low to read as part of the nametag. It sat around the top of the player's head with a visible gap between it and their username, rather than the two stacking into one block of text.

## Where the line sits

Anything riding a player hangs from an anchor at the top of their head, and Minecraft draws the username half a block above that same anchor. The balance was being pushed further down from the anchor instead of up toward the name, which put half a block of empty air between them.

It is now lifted to the anchor plus that half block, less its own line height and the gap configured above it, so it lands directly beneath the username. A line of display text and a username are drawn at the same scale, so the two match in size and read as a single two line tag.

The username is not touched at any point. Nothing in this manager hides, moves or re-teams a player, and the only entity it ever shows or hides is the balance line itself.

## Compact balances

SHORT-FORMAT already collapsed balances through K, M, B, T and Q, but it shipped off, so a fresh config wrote balances out in full and a nine figure balance made for a very wide line. It now ships on, which suits a nametag better.

## Config changes

LINE-OFFSET is replaced by LINE-GAP, defaulting to 0.05. It is the gap between the bottom of the username and the top of the balance rather than a raw offset from an anchor players never see, so the number means something you can picture. Raising it pushes the balance further down and a negative value tucks it closer.

It is a new key again rather than a new meaning for LINE-OFFSET, so a server that already has the old block does not get its line thrown somewhere strange by a value that was measured against something else.

## Notes

Servers upgrading keep their old SHORT-FORMAT and LINE-OFFSET lines, since the config merge never overwrites a value that is already there. SHORT-FORMAT: true and the new LINE-GAP have to be set by hand on those.

A test walks a balance up through 1.1K, 1.1M, 1.1B and 1.1T, and the config test follows the new key and default. Suite is 315 green.
