### PR TITLE
fix(settings): keep the username visible with money nametags on (#182)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -846,9 +846,9 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true
-  # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
-  # to the player by the client, so this never affects how closely it follows them.
-  # Available options: 1 to 40
+  # How quickly a balance change shows up on the line, in ticks. The line is moved onto its
+  # player every tick no matter what this says, so it never affects how closely the line
+  # follows them. Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
   # Gap between the bottom of the username and the top of the balance line, in blocks.
   # The username itself is never touched or hidden, the balance is simply parked under it.
@@ -869,7 +869,7 @@ MONEY-NAMETAGS:
 | `MONEY-NAMETAGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `MONEY-NAMETAGS` system. Set to `false` to take the option out of the game entirely, whatever players picked in `/settings`. |
 | `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a${balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
 | `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `true` | `true` writes `1.1K`, `1.1M`, `1.1B`, `1.1T` and `1.1Q` where `false` writes them out in full as `1,100,000`. Leaving it on keeps the line narrow once balances run into the billions. |
-| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often each line re-reads its owner's balance. It has nothing to do with how closely the line follows the player, because the viewer's client draws the line riding its owner and pins it there. Lower it if you want balance changes to appear faster. |
+| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often each line re-reads its owner's balance. It has nothing to do with how closely the line follows the player, since the line is moved onto them every tick regardless. Lower it if you want balance changes to appear faster. |
 | `MONEY-NAMETAGS.LINE-GAP` | `float` | Any decimal number | `0.05` | Gap between the bottom of the username and the top of the balance line, in blocks. Raising it pushes the balance further below the name, and a negative value tucks it closer. The username is never moved or hidden to make room. |
 | `MONEY-NAMETAGS.VIEW-RANGE` | `float` | Any decimal number | `32.0` | How far away, in blocks, the line is still drawn. |
 | `MONEY-NAMETAGS.HIDE-WHILE-SNEAKING` | `bool` | `true`, `false` | `true` | Drops the line while the player sneaks, matching what vanilla does with the username above their head. |
@@ -892,10 +892,15 @@ MONEY-NAMETAGS:
 The username keeps its normal place and is never hidden, moved or replaced. The balance is parked
 directly under it, so the two read as a two line nametag: the name on top, the balance below it.
 
-Minecraft draws a username half a block above the point anything riding a player hangs from, so the
-balance line is lifted back up by that much, minus its own height and the `LINE-GAP` above. If the
-two lines look too close or too far apart on your resource pack, `LINE-GAP` is the only value worth
-touching.
+The balance line stands as its own entity rather than riding the player. Riding would pin it
+perfectly, but Minecraft refuses to draw a username on any player carrying a passenger, so a ride
+costs the very name the balance is meant to sit under. Instead the line is moved onto its player
+every tick, which puts it in the same broadcast as the player's own movement and gives both the same
+smoothing.
+
+Minecraft hangs a username half a block above the player's height and its glyphs drop from there, so
+the balance sits below all of that, its own half height and `LINE-GAP` lower again. If the two lines
+look too close or too far apart on your resource pack, `LINE-GAP` is the only value worth touching.
 
 ### 5. Who Sees The Line
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -4,14 +4,6 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.events.PacketListener;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -21,33 +13,24 @@ import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
-import org.bukkit.util.Transformation;
-import org.joml.Vector3f;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
 
 /**
  * Renders a player's balance on a floating line under their username.
  *
- * <p>The line is a {@link TextDisplay} that every viewer's client is told to draw riding its owner,
- * so it is pinned to the player the same way the username is and never trails behind a sprint. The
- * ride only exists in the packet: server side the display stays a free entity, because Spigot
- * refuses to teleport a player who is carrying real passengers and mounting it for real would
- * quietly break every warp, home and teleport request on the server.</p>
+ * <p>The line is a {@link TextDisplay} standing on its own rather than riding its owner. A ride
+ * would pin it perfectly, but Minecraft refuses to draw a username on any player carrying a
+ * passenger, so the ride costs the very name the balance is meant to sit under. Nothing here
+ * touches the username: it keeps its normal place and the balance is parked below it.</p>
  *
- * <p>The vanilla username is left exactly as it is. Passengers hang from the same anchor the
- * username is measured against, half a block below the name itself, so the line is pushed back up
- * to sit directly underneath it and the two read as one two line nametag.</p>
- *
- * <p>Because the ride is a fiction the server does not share, the server keeps broadcasting the
- * display's own movement. A client that hears both puts the line on the player one tick and back on
- * the entity the next, which reads as a line bobbing up and down, so those movement packets are
- * dropped on the way out and the vehicle is left as the only thing placing it.</p>
+ * <p>Standing on its own means the line has to be moved onto its owner, which happens every tick so
+ * the server broadcasts it in the same breath as the player's own movement. The two then carry
+ * matching interpolation and travel together instead of one chasing the other.</p>
  *
  * <p>Every player decides for themselves whether they see the line through
  * {@code /settings > Money Nametags}, so a line only exists while somebody online has that setting
@@ -58,17 +41,19 @@ public class MoneyNametagManager {
     private static final String DISPLAY_TAG = "uds_money_nametag";
     private static final String BALANCE_PLACEHOLDER = "{balance}";
 
-    /** Vanilla draws a username half a block above the point a passenger hangs from. */
-    private static final float NAME_TAG_HEIGHT = 0.5F;
-    /** A line of display text is the same height as a username, both drawn at 0.025 scale. */
-    private static final float LINE_HEIGHT = 0.25F;
+    /** Vanilla hangs a username half a block above the player's height. */
+    private static final double NAME_TAG_BASE = 0.5D;
+    /** The username's own glyphs drop about a fifth of a block below where they hang from. */
+    private static final double NAME_TAG_TEXT_HEIGHT = 0.2D;
+    /** Display text is drawn at the same scale as a username, centred on the entity. */
+    private static final double LINE_HALF_HEIGHT = 0.1D;
+    /** Matches the three tick smoothing a client gives any other entity that moves. */
+    private static final int LERP_TICKS = 3;
 
     private final UltimateDonutSmp plugin;
     private final Map<UUID, UUID> displays = new ConcurrentHashMap<>();
     private final Map<UUID, String> renderedText = new ConcurrentHashMap<>();
-    private final Set<Integer> displayEntityIds = ConcurrentHashMap.newKeySet();
-    private ProtocolManager protocolManager;
-    private PacketListener movementListener;
+    private long tick;
 
     public MoneyNametagManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -84,6 +69,7 @@ public class MoneyNametagManager {
         return config().getBoolean("MONEY-NAMETAGS.ENABLED", true);
     }
 
+    /** How often the balance written on a line is re-read, in ticks. */
     public long getUpdateIntervalTicks() {
         return Math.max(1L, config().getLong("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS", 10L));
     }
@@ -97,8 +83,12 @@ public class MoneyNametagManager {
         return data != null && data.isMoneyNametagsEnabled();
     }
 
-    /** Refreshes the balance on every line and keeps each one riding its owner. */
-    public void updateAll() {
+    /**
+     * Runs every tick. Moving each line onto its owner is cheap and has to happen at the rate the
+     * player moves, while re-reading balances and re-checking who can see what is not, so that part
+     * waits for the configured interval.
+     */
+    public void tick() {
         if (!isEnabled()) {
             clearAll();
             return;
@@ -108,7 +98,8 @@ public class MoneyNametagManager {
             clearAll();
             return;
         }
-        plugin.getSpigotScheduler().forEachOnlinePlayer(owner -> refresh(owner, viewers));
+        boolean full = tick++ % getUpdateIntervalTicks() == 0L;
+        plugin.getSpigotScheduler().forEachOnlinePlayer(owner -> refresh(owner, viewers, full));
     }
 
     /** Brings one player's own line up to date, spawning it when somebody wants to see it. */
@@ -118,7 +109,7 @@ public class MoneyNametagManager {
         }
         Set<UUID> viewers = viewers();
         if (!viewers.isEmpty()) {
-            refresh(owner, viewers);
+            refresh(owner, viewers, true);
         }
     }
 
@@ -141,7 +132,6 @@ public class MoneyNametagManager {
             Player owner = Bukkit.getPlayer(ownerUuid);
             if (wanted && owner != null && viewer.canSee(owner)) {
                 viewer.showEntity(plugin, display);
-                mount(viewer, owner, display);
             } else {
                 viewer.hideEntity(plugin, display);
             }
@@ -159,7 +149,6 @@ public class MoneyNametagManager {
         }
         Entity entity = Bukkit.getEntity(displayUuid);
         if (entity != null) {
-            displayEntityIds.remove(entity.getEntityId());
             entity.remove();
         }
     }
@@ -178,16 +167,6 @@ public class MoneyNametagManager {
 
     public void shutdown() {
         clearAll();
-        displayEntityIds.clear();
-        ProtocolManager manager = protocolManager();
-        if (movementListener != null && manager != null) {
-            try {
-                manager.removePacketListener(movementListener);
-            } catch (RuntimeException | LinkageError ignored) {
-                // The server is going down anyway, a listener left behind costs nothing.
-            }
-        }
-        movementListener = null;
     }
 
     /**
@@ -205,7 +184,7 @@ public class MoneyNametagManager {
         }
     }
 
-    private void refresh(Player owner, Set<UUID> viewers) {
+    private void refresh(Player owner, Set<UUID> viewers, boolean full) {
         if (owner == null || !owner.isOnline()) {
             return;
         }
@@ -224,6 +203,12 @@ public class MoneyNametagManager {
             if (display == null) {
                 return;
             }
+            full = true;
+        }
+
+        follow(display, owner);
+        if (!full) {
+            return;
         }
 
         String text = ColorUtils.colorize(currentText(owner), owner);
@@ -231,7 +216,6 @@ public class MoneyNametagManager {
             display.setText(text);
             renderedText.put(owner.getUniqueId(), text);
         }
-        keepInTrackingRange(display, owner);
         applyVisibility(display, owner, viewers);
     }
 
@@ -269,12 +253,10 @@ public class MoneyNametagManager {
                 textDisplay.setGravity(false);
                 textDisplay.setSilent(true);
                 textDisplay.setVisibleByDefault(false);
-                applyLinePlacement(textDisplay);
+                textDisplay.setTeleportDuration(LERP_TICKS);
             });
             renderedText.remove(owner.getUniqueId());
             displays.put(owner.getUniqueId(), display.getUniqueId());
-            displayEntityIds.add(display.getEntityId());
-            registerMovementListener();
             return display;
         } catch (RuntimeException error) {
             plugin.getLogger().warning("Unable to spawn a money nametag for " + owner.getName() + ".");
@@ -282,30 +264,10 @@ public class MoneyNametagManager {
         }
     }
 
-    /**
-     * Lifts the text from the anchor a passenger hangs from up to just under the username, leaving
-     * the configured gap between the bottom of the name and the top of the balance.
-     */
-    private void applyLinePlacement(TextDisplay display) {
-        Transformation transformation = display.getTransformation();
-        float gap = (float) config().getDouble("MONEY-NAMETAGS.LINE-GAP", 0.05D);
-        Vector3f translation = new Vector3f(0.0F, NAME_TAG_HEIGHT - LINE_HEIGHT - gap, 0.0F);
-        display.setTransformation(new Transformation(
-                translation,
-                transformation.getLeftRotation(),
-                transformation.getScale(),
-                transformation.getRightRotation()));
-    }
-
-    /**
-     * The client draws the line on its owner and never hears about these moves, so the entity's own
-     * position only decides whether a viewer is sent it at all. Keeping it on top of the player
-     * keeps that decision matching the player's own, and leaves the entity somewhere sensible for
-     * the moment between a client being sent the line and being told what it rides.
-     */
-    private void keepInTrackingRange(TextDisplay display, Player owner) {
+    /** Moves the line onto its owner, skipping the work while neither of them has moved. */
+    private void follow(TextDisplay display, Player owner) {
         Location anchor = anchor(owner);
-        if (display.getLocation().distanceSquared(anchor) < 0.01D) {
+        if (display.getLocation().distanceSquared(anchor) < 0.0001D) {
             return;
         }
         if (plugin.getSpigotScheduler().isFolia()) {
@@ -315,13 +277,17 @@ public class MoneyNametagManager {
         display.teleport(anchor);
     }
 
+    /**
+     * Sits the line directly under the username. The name hangs half a block above the player's
+     * height and its glyphs drop from there, so the balance goes below all of that, its own half
+     * height and the configured gap lower again.
+     */
     private Location anchor(Player owner) {
         Location location = owner.getLocation();
-        return new Location(
-                owner.getWorld(),
-                location.getX(),
-                location.getY() + owner.getHeight(),
-                location.getZ());
+        double gap = config().getDouble("MONEY-NAMETAGS.LINE-GAP", 0.05D);
+        double height = location.getY() + owner.getHeight()
+                + NAME_TAG_BASE - NAME_TAG_TEXT_HEIGHT - gap - LINE_HALF_HEIGHT;
+        return new Location(owner.getWorld(), location.getX(), height, location.getZ());
     }
 
     /**
@@ -332,97 +298,10 @@ public class MoneyNametagManager {
         for (Player viewer : Bukkit.getOnlinePlayers()) {
             if (viewers.contains(viewer.getUniqueId()) && viewer.canSee(owner)) {
                 viewer.showEntity(plugin, display);
-                mount(viewer, owner, display);
             } else {
                 viewer.hideEntity(plugin, display);
             }
         }
-    }
-
-    /**
-     * Tells one viewer's client that the line rides its owner. Anything genuinely riding the player
-     * is listed alongside it, otherwise the client would drop those the moment this packet lands.
-     */
-    private void mount(Player viewer, Player owner, TextDisplay display) {
-        ProtocolManager manager = protocolManager();
-        if (manager == null || viewer == null || !viewer.isOnline() || !sharesWorld(viewer, owner)) {
-            return;
-        }
-        try {
-            PacketContainer packet = manager.createPacket(PacketType.Play.Server.MOUNT);
-            packet.getIntegers().write(0, owner.getEntityId());
-            packet.getIntegerArrays().write(0, passengerIds(owner, display));
-            manager.sendServerPacket(viewer, packet, false);
-        } catch (RuntimeException | LinkageError error) {
-            plugin.getLogger().log(Level.FINE, "Unable to pin a money nametag to its player.", error);
-        }
-    }
-
-    /**
-     * Drops the display's own movement packets on the way to the client. The client already places
-     * it on the player it rides, and letting the server's idea of where the entity is arrive as well
-     * makes the line flick between the two positions every tick.
-     */
-    private void registerMovementListener() {
-        if (movementListener != null) {
-            return;
-        }
-        ProtocolManager manager = protocolManager();
-        if (manager == null) {
-            return;
-        }
-        try {
-            movementListener = new PacketAdapter(
-                    plugin,
-                    ListenerPriority.NORMAL,
-                    PacketType.Play.Server.ENTITY_TELEPORT,
-                    PacketType.Play.Server.REL_ENTITY_MOVE,
-                    PacketType.Play.Server.REL_ENTITY_MOVE_LOOK,
-                    PacketType.Play.Server.ENTITY_LOOK,
-                    PacketType.Play.Server.ENTITY_HEAD_ROTATION,
-                    PacketType.Play.Server.ENTITY_VELOCITY
-            ) {
-                @Override
-                public void onPacketSending(PacketEvent event) {
-                    if (displayEntityIds.isEmpty()) {
-                        return;
-                    }
-                    Integer entityId = event.getPacket().getIntegers().readSafely(0);
-                    if (entityId != null && displayEntityIds.contains(entityId)) {
-                        event.setCancelled(true);
-                    }
-                }
-            };
-            manager.addPacketListener(movementListener);
-        } catch (RuntimeException | LinkageError error) {
-            movementListener = null;
-            plugin.getLogger().log(Level.FINE, "Unable to silence money nametag movement.", error);
-        }
-    }
-
-    private int[] passengerIds(Player owner, TextDisplay display) {
-        java.util.List<Entity> riders = owner.getPassengers();
-        int[] ids = new int[riders.size() + 1];
-        for (int index = 0; index < riders.size(); index++) {
-            ids[index] = riders.get(index).getEntityId();
-        }
-        ids[riders.size()] = display.getEntityId();
-        return ids;
-    }
-
-    private boolean sharesWorld(Player viewer, Player owner) {
-        return viewer.getWorld().equals(owner.getWorld());
-    }
-
-    private ProtocolManager protocolManager() {
-        if (protocolManager == null) {
-            try {
-                protocolManager = ProtocolLibrary.getProtocolManager();
-            } catch (RuntimeException | LinkageError ignored) {
-                return null;
-            }
-        }
-        return protocolManager;
     }
 
     /** The players who currently want to see balances, resolved once per pass. */

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/MoneyNametagTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/MoneyNametagTask.java
@@ -3,7 +3,9 @@ package com.bx.ultimateDonutSmp.tasks;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 
 /**
- * Keeps every money nametag under its owner and up to date with their balance.
+ * Keeps every money nametag under its owner and up to date with their balance. It runs every tick
+ * so the lines move in step with the players they belong to; the manager decides for itself how
+ * much work each tick is worth.
  */
 public class MoneyNametagTask implements Runnable {
 
@@ -15,12 +17,11 @@ public class MoneyNametagTask implements Runnable {
 
     @Override
     public void run() {
-        plugin.getMoneyNametagManager().updateAll();
+        plugin.getMoneyNametagManager().tick();
     }
 
     public static void start(UltimateDonutSmp plugin) {
         plugin.getMoneyNametagManager().purgeOrphanedDisplays();
-        long interval = plugin.getMoneyNametagManager().getUpdateIntervalTicks();
-        plugin.getSpigotScheduler().runGlobalTimer(new MoneyNametagTask(plugin), interval, interval);
+        plugin.getSpigotScheduler().runGlobalTimer(new MoneyNametagTask(plugin), 1L, 1L);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -305,12 +305,12 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true
-  # How quickly a balance change shows up on the line, in ticks. The line itself is pinned
-  # to the player by the client, so this never affects how closely it follows them.
-  # Available options: 1 to 40
+  # How quickly a balance change shows up on the line, in ticks. The line is moved onto its
+  # player every tick no matter what this says, so it never affects how closely the line
+  # follows them. Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
   # Gap between the bottom of the username and the top of the balance line, in blocks.
-  # The username itself is never touched or hidden, the balance is simply parked under it.
+  # The username is never touched, moved or hidden, the balance is simply parked under it.
   # Raise this to push the balance further down, or use a negative number to tuck it
   # closer. Available options: Any decimal number
   LINE-GAP: 0.05


### PR DESCRIPTION
Follow-up to #200, reported against #182.

Switching money nametags on made the player's username disappear. Switching it back off brought the name back, so the balance and the name could never be on screen at the same time.

## Why the name went missing

Since #198 the line was pinned to its owner by telling each viewer's client that the display rides the player. Minecraft will not draw a username on any player that is carrying a passenger, so the moment that packet landed the client stopped rendering the name. The two goals turned out to be mutually exclusive: a line that rides a player cannot sit under a name, because there is no longer a name to sit under.

The ride is gone. Nothing sends passenger packets any more, and the movement suppression that only existed to stop the ride fighting the server went with it, along with the ProtocolLib listener that carried both.

## Keeping it attached without the ride

A free standing line has to be moved onto its owner, and the reason it trailed behind in #198 was the cadence: it moved every other tick while the player moved every tick, so half the time it was catching up. It now moves every tick, which puts it in the same broadcast as the player's own movement, and its teleport duration matches the three tick smoothing a client gives any other moving entity. Both then interpolate the same way over the same span.

Only the move runs every tick. Re-reading balances and re-checking who can see whom still waits for UPDATE-INTERVAL-TICKS, so the extra work per tick is one position comparison and, when the player has actually moved, one teleport.

## Height

Without a ride the line sits at a plain world position rather than hanging off an anchor nobody can see, so the height is arithmetic instead of guesswork. Minecraft hangs a username half a block above the player's height and its glyphs drop about a fifth of a block from there, so the balance goes below all of that, its own half height and LINE-GAP lower again.

## Notes

No config keys changed. LINE-GAP still means the same thing and still measures from the bottom of the name.

Suite is 315 green.
