### PR TITLE
style(messages): capitalize the sign input timeout message

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/utils/SignInputUtil.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/SignInputUtil.java
@@ -124,7 +124,7 @@ public final class SignInputUtil {
             org.bukkit.scheduler.BukkitTask task = scheduler.runEntityLater(player, () -> {
                 if (PLUGINS.containsKey(uuid)) {
                     cancel(player);
-                    player.sendMessage(org.bukkit.ChatColor.RED + "sign input timed out.");
+                    player.sendMessage(org.bukkit.ChatColor.RED + "Sign input timed out.");
                 }
             }, 900L);
             HIDE_TASK.put(uuid, task);


### PR DESCRIPTION
The small-caps rewrite in #201 left one message in lowercase. `SignInputUtil` builds it as
`ChatColor.RED + "sign input timed out."`, and the conversion treats a literal that follows a `+` as
the continuation of a sentence, which is right for `"&aGave &f" + n + "&a to &f"` but wrong when the
thing before the `+` is a colour constant rather than words.

Checked the other 143 concatenated fragments the rewrite touched: every one of them follows a real
value (a name, a count, an array element, or another literal in the same sentence), so this was the
only case.
