### PR TITLE
feat(settings): draw money nametags in the vanilla below-name slot (#182)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -836,8 +836,8 @@ WORTH-LORE:
 
 ```yaml
 MONEY-NAMETAGS:
-  # Determines whether Money Nametags is enabled or disabled. Turning this off hides the
-  # line for everyone and stops the tracking task, whatever players picked in /settings.
+  # Determines whether Money Nametags is enabled or disabled. Turning this off takes the
+  # line away from everyone, whatever players picked in /settings.
   # Available options: true, false
   ENABLED: true
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
@@ -846,20 +846,10 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true
-  # How quickly a balance change shows up on the line, in ticks. The line is moved onto its
-  # player every tick no matter what this says, so it never affects how closely the line
-  # follows them. Available options: 1 to 40
+  # How quickly a balance change shows up on the line, in ticks. Where the line sits is the
+  # client's business, so this only decides how fresh the number is.
+  # Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
-  # Gap between the bottom of the username and the top of the balance line, in blocks.
-  # The username itself is never touched or hidden, the balance is simply parked under it.
-  # Raise this to push the balance further down, or use a negative number to tuck it
-  # closer. Available options: Any decimal number
-  LINE-GAP: 0.05
-  # How far away the line stays readable, in blocks. Available options: Any decimal number
-  VIEW-RANGE: 32.0
-  # Determines whether the line disappears while the player sneaks, the way the vanilla
-  # username does. Available options: true, false
-  HIDE-WHILE-SNEAKING: true
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -869,10 +859,7 @@ MONEY-NAMETAGS:
 | `MONEY-NAMETAGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `MONEY-NAMETAGS` system. Set to `false` to take the option out of the game entirely, whatever players picked in `/settings`. |
 | `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a${balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
 | `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `true` | `true` writes `1.1K`, `1.1M`, `1.1B`, `1.1T` and `1.1Q` where `false` writes them out in full as `1,100,000`. Leaving it on keeps the line narrow once balances run into the billions. |
-| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often each line re-reads its owner's balance. It has nothing to do with how closely the line follows the player, since the line is moved onto them every tick regardless. Lower it if you want balance changes to appear faster. |
-| `MONEY-NAMETAGS.LINE-GAP` | `float` | Any decimal number | `0.05` | Gap between the bottom of the username and the top of the balance line, in blocks. Raising it pushes the balance further below the name, and a negative value tucks it closer. The username is never moved or hidden to make room. |
-| `MONEY-NAMETAGS.VIEW-RANGE` | `float` | Any decimal number | `32.0` | How far away, in blocks, the line is still drawn. |
-| `MONEY-NAMETAGS.HIDE-WHILE-SNEAKING` | `bool` | `true`, `false` | `true` | Drops the line while the player sneaks, matching what vanilla does with the username above their head. |
+| `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often balances are re-read and sent out. It has nothing to do with where the line sits or how it follows a player, since the client draws it as part of the nametag. Lower it if you want balance changes to appear faster. |
 
 ### 3. Practical Setup Example
 
@@ -881,34 +868,36 @@ MONEY-NAMETAGS:
   ENABLED: true
   FORMAT: '&6&l${balance}'
   SHORT-FORMAT: true
-  UPDATE-INTERVAL-TICKS: 10
-  LINE-GAP: 0.1
-  VIEW-RANGE: 24.0
-  HIDE-WHILE-SNEAKING: true
+  UPDATE-INTERVAL-TICKS: 4
 ```
 
 ### 4. Where The Line Sits
 
-The username keeps its normal place and is never hidden, moved or replaced. The balance is parked
-directly under it, so the two read as a two line nametag: the name on top, the balance below it.
+The username is never touched, moved or hidden. The balance goes in the scoreboard slot Minecraft
+reserves for a line under a username, the same slot a health display would use, so the client draws
+it itself directly beneath the name. It cannot drift away from the player, lag behind a sprint or
+land on top of the name, because it is drawn in the same pass as the name itself.
 
-The balance line stands as its own entity rather than riding the player. Riding would pin it
-perfectly, but Minecraft refuses to draw a username on any player carrying a passenger, so a ride
-costs the very name the balance is meant to sit under. Instead the line is moved onto its player
-every tick, which puts it in the same broadcast as the player's own movement and gives both the same
-smoothing.
+Two rules come with that slot and belong to the client rather than to this plugin:
 
-Minecraft hangs a username half a block above the player's height and its glyphs drop from there, so
-the balance sits below all of that, its own half height and `LINE-GAP` lower again. If the two lines
-look too close or too far apart on your resource pack, `LINE-GAP` is the only value worth touching.
+- **The line only appears within about ten blocks.** Further out the username still shows and the
+  balance does not. There is no setting for this; the distance is baked into Minecraft.
+- **Only one objective can hold that slot at a time.** Any other plugin using the below-name slot,
+  a health display for instance, will fight over it for players who switched money nametags on.
+
+The slot normally draws a raw score, which is an integer and no use for a balance in the billions,
+so each score carries a fixed number format holding the finished text instead. That needs Minecraft
+1.20.3 or newer; on anything older the feature logs a warning once and stays off rather than
+printing a wrong number.
 
 ### 5. Who Sees The Line
 
 Every player carries their own switch under `/settings > Money Nametags`, and it starts turned off.
-It only decides what that player sees above other people, never whether their own balance is on
-show, so nobody can hide their balance by turning the option off. Lines exist only while at least
-one player online has the option turned on, and a player who has hidden their identity through
-`/hide` never gets one.
+It only decides what that player sees under other people, never whether their own balance is on
+show, so nobody can hide their balance by turning the option off. Nothing is written to anybody's
+real scoreboard either: the objective is sent straight to the players who asked for it, so a player
+who left the setting off never hears about it. A player who has hidden their identity through
+`/hide` never gets a line.
 
 Admins who want the option gone can either set `ENABLED: false` here or drop
 `SETTINGS-MENU.BUTTONS.MONEY_NAMETAGS.ENABLED: false` into `menus.yml`; the second one also takes

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -4,56 +4,60 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+import com.comphenix.protocol.wrappers.WrappedNumberFormat;
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Display;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
- * Renders a player's balance on a floating line under their username.
+ * Renders a player's balance on the line under their username.
  *
- * <p>The line is a {@link TextDisplay} standing on its own rather than riding its owner. A ride
- * would pin it perfectly, but Minecraft refuses to draw a username on any player carrying a
- * passenger, so the ride costs the very name the balance is meant to sit under. Nothing here
- * touches the username: it keeps its normal place and the balance is parked below it.</p>
+ * <p>This is the line Minecraft draws for a scoreboard objective in the {@code BELOW_NAME} slot, so
+ * the client places it itself as part of the nametag. It cannot drift, lag behind a sprint or cover
+ * the username, because it is drawn in the same pass as the name and always one line beneath it.</p>
  *
- * <p>Standing on its own means the line has to be moved onto its owner, which happens every tick so
- * the server broadcasts it in the same breath as the player's own movement. The two then carry
- * matching interpolation and travel together instead of one chasing the other.</p>
+ * <p>The slot normally shows a raw score, which is an integer and no use for a balance in the
+ * billions, so each score carries a fixed number format holding the text to draw instead. That is a
+ * packet level feature with no Bukkit API, which is why everything here is sent through
+ * ProtocolLib.</p>
  *
- * <p>Every player decides for themselves whether they see the line through
- * {@code /settings > Money Nametags}, so a line only exists while somebody online has that setting
- * switched on, and it is only sent to the players who asked for it.</p>
+ * <p>Nothing is written to anybody's real scoreboard. Every packet goes to one viewer, so a player
+ * who left the setting off never hears about the objective at all, and the balances a viewer sees
+ * are decided entirely by which scores were sent to them.</p>
+ *
+ * <p>Two things about the slot are the client's rules rather than ours: it only draws within about
+ * ten blocks, and a server can only show one objective there at a time.</p>
  */
 public class MoneyNametagManager {
 
-    private static final String DISPLAY_TAG = "uds_money_nametag";
+    private static final String OBJECTIVE = "uds_money";
+    private static final String LEGACY_DISPLAY_TAG = "uds_money_nametag";
     private static final String BALANCE_PLACEHOLDER = "{balance}";
 
-    /** Vanilla hangs a username half a block above the player's height. */
-    private static final double NAME_TAG_BASE = 0.5D;
-    /** The username's own glyphs drop about a fifth of a block below where they hang from. */
-    private static final double NAME_TAG_TEXT_HEIGHT = 0.2D;
-    /** Display text is drawn at the same scale as a username, centred on the entity. */
-    private static final double LINE_HALF_HEIGHT = 0.1D;
-    /** Matches the three tick smoothing a client gives any other entity that moves. */
-    private static final int LERP_TICKS = 3;
+    private static final int OBJECTIVE_CREATE = 0;
+    private static final int OBJECTIVE_REMOVE = 1;
 
     private final UltimateDonutSmp plugin;
-    private final Map<UUID, UUID> displays = new ConcurrentHashMap<>();
-    private final Map<UUID, String> renderedText = new ConcurrentHashMap<>();
-    private long tick;
+    /** Viewer to the balance text each player was last sent, so unchanged lines are not resent. */
+    private final Map<UUID, Map<UUID, String>> sentText = new ConcurrentHashMap<>();
+    /** Viewers whose client has been told the objective exists. */
+    private final Set<UUID> installed = ConcurrentHashMap.newKeySet();
+    private ProtocolManager protocolManager;
+    private boolean warnedUnsupported;
 
     public MoneyNametagManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -69,12 +73,11 @@ public class MoneyNametagManager {
         return config().getBoolean("MONEY-NAMETAGS.ENABLED", true);
     }
 
-    /** How often the balance written on a line is re-read, in ticks. */
     public long getUpdateIntervalTicks() {
         return Math.max(1L, config().getLong("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS", 10L));
     }
 
-    /** Whether {@code viewer} asked to see balances above other players. */
+    /** Whether {@code viewer} asked to see balances under other players. */
     public boolean isEnabledFor(Player viewer) {
         if (viewer == null) {
             return false;
@@ -83,81 +86,62 @@ public class MoneyNametagManager {
         return data != null && data.isMoneyNametagsEnabled();
     }
 
-    /**
-     * Runs every tick. Moving each line onto its owner is cheap and has to happen at the rate the
-     * player moves, while re-reading balances and re-checking who can see what is not, so that part
-     * waits for the configured interval.
-     */
-    public void tick() {
-        if (!isEnabled()) {
+    /** Sends every viewer who wants balances the ones that have changed since their last update. */
+    public void updateAll() {
+        if (!isEnabled() || !isNumberFormatSupported()) {
             clearAll();
             return;
         }
-        Set<UUID> viewers = viewers();
-        if (viewers.isEmpty()) {
-            clearAll();
-            return;
-        }
-        boolean full = tick++ % getUpdateIntervalTicks() == 0L;
-        plugin.getSpigotScheduler().forEachOnlinePlayer(owner -> refresh(owner, viewers, full));
-    }
-
-    /** Brings one player's own line up to date, spawning it when somebody wants to see it. */
-    public void update(Player owner) {
-        if (!isEnabled()) {
-            return;
-        }
-        Set<UUID> viewers = viewers();
-        if (!viewers.isEmpty()) {
-            refresh(owner, viewers, true);
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            if (isEnabledFor(viewer)) {
+                push(viewer);
+            } else {
+                clearViewer(viewer);
+            }
         }
     }
 
-    /** Re-applies one player's own choice to every line currently in the world. */
+    /** Pushes {@code player}'s balance out again, and gives them the objective if they want one. */
+    public void update(Player player) {
+        if (player == null || !isEnabled() || !isNumberFormatSupported()) {
+            return;
+        }
+        for (Map<UUID, String> known : sentText.values()) {
+            known.remove(player.getUniqueId());
+        }
+        refreshViewer(player);
+    }
+
+    /** Installs or removes the objective on one player's client to match their own choice. */
     public void refreshViewer(Player viewer) {
         if (viewer == null) {
             return;
         }
-        if (!isEnabled()) {
-            clearAll();
+        if (!isEnabled() || !isNumberFormatSupported() || !isEnabledFor(viewer)) {
+            clearViewer(viewer);
             return;
         }
-
-        boolean wanted = isEnabledFor(viewer);
-        for (UUID ownerUuid : Set.copyOf(displays.keySet())) {
-            TextDisplay display = display(ownerUuid);
-            if (display == null) {
-                continue;
-            }
-            Player owner = Bukkit.getPlayer(ownerUuid);
-            if (wanted && owner != null && viewer.canSee(owner)) {
-                viewer.showEntity(plugin, display);
-            } else {
-                viewer.hideEntity(plugin, display);
-            }
-        }
-        if (!wanted && viewers().isEmpty()) {
-            clearAll();
-        }
+        push(viewer);
     }
 
-    public void remove(UUID ownerUuid) {
-        renderedText.remove(ownerUuid);
-        UUID displayUuid = displays.remove(ownerUuid);
-        if (displayUuid == null) {
+    /** Drops everything remembered about a player, as a viewer and as somebody being viewed. */
+    public void remove(UUID playerUuid) {
+        if (playerUuid == null) {
             return;
         }
-        Entity entity = Bukkit.getEntity(displayUuid);
-        if (entity != null) {
-            entity.remove();
+        installed.remove(playerUuid);
+        sentText.remove(playerUuid);
+        for (Map<UUID, String> known : sentText.values()) {
+            known.remove(playerUuid);
         }
     }
 
     public void clearAll() {
-        for (UUID ownerUuid : Set.copyOf(displays.keySet())) {
-            remove(ownerUuid);
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            clearViewer(viewer);
         }
-        renderedText.clear();
+        installed.clear();
+        sentText.clear();
     }
 
     public void reload() {
@@ -170,168 +154,155 @@ public class MoneyNametagManager {
     }
 
     /**
-     * Deletes lines a crash or a reload left behind. They are spawned non-persistent so they never
-     * reach the region files, but a plugin reload leaves the previous run's entities loaded.
+     * Removes the floating text entities earlier versions used for this feature. They were spawned
+     * non-persistent so a restart clears them on its own, but a plugin reload leaves the previous
+     * run's entities behind.
      */
     public void purgeOrphanedDisplays() {
         for (World world : Bukkit.getWorlds()) {
             for (TextDisplay display : world.getEntitiesByClass(TextDisplay.class)) {
-                if (display.getScoreboardTags().contains(DISPLAY_TAG)
-                        && !displays.containsValue(display.getUniqueId())) {
+                if (display.getScoreboardTags().contains(LEGACY_DISPLAY_TAG)) {
                     display.remove();
                 }
             }
         }
     }
 
-    private void refresh(Player owner, Set<UUID> viewers, boolean full) {
-        if (owner == null || !owner.isOnline()) {
-            return;
-        }
-        if (!shouldDisplayFor(owner)) {
-            remove(owner.getUniqueId());
-            return;
+    private void push(Player viewer) {
+        if (installed.add(viewer.getUniqueId())) {
+            sendObjective(viewer, OBJECTIVE_CREATE);
+            sendDisplaySlot(viewer);
         }
 
-        TextDisplay display = display(owner.getUniqueId());
-        if (display != null && !owner.getWorld().equals(display.getWorld())) {
-            remove(owner.getUniqueId());
-            display = null;
-        }
-        if (display == null) {
-            display = spawn(owner);
-            if (display == null) {
-                return;
+        Map<UUID, String> known = sentText.computeIfAbsent(viewer.getUniqueId(), key -> new ConcurrentHashMap<>());
+        for (Player target : Bukkit.getOnlinePlayers()) {
+            if (!shouldDisplayFor(target) || !viewer.canSee(target)) {
+                known.remove(target.getUniqueId());
+                continue;
             }
-            full = true;
+            String text = ColorUtils.colorize(currentText(target), target);
+            if (!text.equals(known.get(target.getUniqueId()))) {
+                sendScore(viewer, target.getName(), text);
+                known.put(target.getUniqueId(), text);
+            }
         }
-
-        follow(display, owner);
-        if (!full) {
-            return;
-        }
-
-        String text = ColorUtils.colorize(currentText(owner), owner);
-        if (!text.equals(renderedText.get(owner.getUniqueId()))) {
-            display.setText(text);
-            renderedText.put(owner.getUniqueId(), text);
-        }
-        applyVisibility(display, owner, viewers);
     }
 
-    private String currentText(Player owner) {
+    private void clearViewer(Player viewer) {
+        sentText.remove(viewer.getUniqueId());
+        if (installed.remove(viewer.getUniqueId())) {
+            sendObjective(viewer, OBJECTIVE_REMOVE);
+        }
+    }
+
+    private String currentText(Player target) {
         return render(
                 config().getString("MONEY-NAMETAGS.FORMAT", "&a${balance}"),
-                plugin.getEconomyManager().getBalance(owner),
+                plugin.getEconomyManager().getBalance(target),
                 config().getBoolean("MONEY-NAMETAGS.SHORT-FORMAT", true));
     }
 
-    /**
-     * Hidden players keep their balance to themselves, and a sneaking player loses the line the
-     * same way they lose their username.
-     */
-    private boolean shouldDisplayFor(Player owner) {
-        if (owner.isSneaking() && config().getBoolean("MONEY-NAMETAGS.HIDE-WHILE-SNEAKING", true)) {
-            return false;
-        }
+    /** Hidden players keep their balance to themselves. */
+    private boolean shouldDisplayFor(Player target) {
         HideManager hideManager = plugin.getHideManager();
-        return hideManager == null || !hideManager.isHidden(owner.getUniqueId());
+        return hideManager == null || !hideManager.isHidden(target.getUniqueId());
     }
 
-    private TextDisplay spawn(Player owner) {
+    private void sendObjective(Player viewer, int method) {
+        ProtocolManager manager = protocolManager();
+        if (manager == null) {
+            return;
+        }
         try {
-            TextDisplay display = owner.getWorld().spawn(anchor(owner), TextDisplay.class, textDisplay -> {
-                textDisplay.addScoreboardTag(DISPLAY_TAG);
-                textDisplay.setBillboard(Display.Billboard.CENTER);
-                textDisplay.setDefaultBackground(false);
-                textDisplay.setBackgroundColor(Color.fromARGB(0, 0, 0, 0));
-                textDisplay.setShadowed(true);
-                textDisplay.setViewRange(viewRange());
-                textDisplay.setLineWidth(200);
-                textDisplay.setPersistent(false);
-                textDisplay.setInvulnerable(true);
-                textDisplay.setGravity(false);
-                textDisplay.setSilent(true);
-                textDisplay.setVisibleByDefault(false);
-                textDisplay.setTeleportDuration(LERP_TICKS);
-            });
-            renderedText.remove(owner.getUniqueId());
-            displays.put(owner.getUniqueId(), display.getUniqueId());
-            return display;
-        } catch (RuntimeException error) {
-            plugin.getLogger().warning("Unable to spawn a money nametag for " + owner.getName() + ".");
-            return null;
+            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_OBJECTIVE);
+            packet.getStrings().write(0, OBJECTIVE);
+            packet.getChatComponents().writeSafely(0, WrappedChatComponent.fromText(""));
+            packet.getRenderTypes().writeSafely(0, EnumWrappers.RenderType.INTEGER);
+            packet.getNumberFormats().writeSafely(0, WrappedNumberFormat.blank());
+            packet.getIntegers().write(0, method);
+            send(viewer, packet);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to set up the money nametag objective.", error);
         }
     }
 
-    /** Moves the line onto its owner, skipping the work while neither of them has moved. */
-    private void follow(TextDisplay display, Player owner) {
-        Location anchor = anchor(owner);
-        if (display.getLocation().distanceSquared(anchor) < 0.0001D) {
+    private void sendDisplaySlot(Player viewer) {
+        ProtocolManager manager = protocolManager();
+        if (manager == null) {
             return;
         }
-        if (plugin.getSpigotScheduler().isFolia()) {
-            plugin.getSpigotScheduler().teleport(display, anchor);
-            return;
+        try {
+            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_DISPLAY_OBJECTIVE);
+            packet.getDisplaySlots().write(0, EnumWrappers.DisplaySlot.BELOW_NAME);
+            packet.getStrings().write(0, OBJECTIVE);
+            send(viewer, packet);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to place the money nametag under the name.", error);
         }
-        display.teleport(anchor);
     }
 
     /**
-     * Sits the line directly under the username. The name hangs half a block above the player's
-     * height and its glyphs drop from there, so the balance goes below all of that, its own half
-     * height and the configured gap lower again.
+     * The score itself stays at zero and never reaches the screen. What the client draws is the
+     * fixed number format carried alongside it, which is where the formatted balance lives.
      */
-    private Location anchor(Player owner) {
-        Location location = owner.getLocation();
-        double gap = config().getDouble("MONEY-NAMETAGS.LINE-GAP", 0.05D);
-        double height = location.getY() + owner.getHeight()
-                + NAME_TAG_BASE - NAME_TAG_TEXT_HEIGHT - gap - LINE_HALF_HEIGHT;
-        return new Location(owner.getWorld(), location.getX(), height, location.getZ());
+    private void sendScore(Player viewer, String targetName, String text) {
+        ProtocolManager manager = protocolManager();
+        if (manager == null) {
+            return;
+        }
+        try {
+            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_SCORE);
+            packet.getStrings().write(0, targetName);
+            packet.getStrings().write(1, OBJECTIVE);
+            packet.getIntegers().write(0, 0);
+            packet.getNumberFormats().write(0, WrappedNumberFormat.fixed(WrappedChatComponent.fromLegacyText(text)));
+            send(viewer, packet);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to send a money nametag balance.", error);
+        }
+    }
+
+    private void send(Player viewer, PacketContainer packet) {
+        ProtocolManager manager = protocolManager();
+        if (manager == null || viewer == null || !viewer.isOnline()) {
+            return;
+        }
+        try {
+            manager.sendServerPacket(viewer, packet, false);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to send a money nametag packet.", error);
+        }
     }
 
     /**
-     * Only the players who asked for balances get the line sent to them, and only while they can
-     * see its owner in the first place.
+     * Without fixed number formats the slot can only draw a raw integer, which no balance worth
+     * showing fits into, so the feature stays off rather than printing a wrong number.
      */
-    private void applyVisibility(TextDisplay display, Player owner, Set<UUID> viewers) {
-        for (Player viewer : Bukkit.getOnlinePlayers()) {
-            if (viewers.contains(viewer.getUniqueId()) && viewer.canSee(owner)) {
-                viewer.showEntity(plugin, display);
-            } else {
-                viewer.hideEntity(plugin, display);
+    private boolean isNumberFormatSupported() {
+        try {
+            if (WrappedNumberFormat.isSupported()) {
+                return true;
+            }
+        } catch (RuntimeException | LinkageError ignored) {
+            // Treated the same as an unsupported server below.
+        }
+        if (!warnedUnsupported) {
+            warnedUnsupported = true;
+            plugin.getLogger().warning("Money nametags need a server that supports scoreboard number"
+                    + " formats (Minecraft 1.20.3 or newer). The feature will stay off.");
+        }
+        return false;
+    }
+
+    private ProtocolManager protocolManager() {
+        if (protocolManager == null) {
+            try {
+                protocolManager = ProtocolLibrary.getProtocolManager();
+            } catch (RuntimeException | LinkageError ignored) {
+                return null;
             }
         }
-    }
-
-    /** The players who currently want to see balances, resolved once per pass. */
-    private Set<UUID> viewers() {
-        Set<UUID> viewers = new HashSet<>();
-        for (Player viewer : Bukkit.getOnlinePlayers()) {
-            if (isEnabledFor(viewer)) {
-                viewers.add(viewer.getUniqueId());
-            }
-        }
-        return viewers;
-    }
-
-    /** The Bukkit view range is a multiplier of the 64 block default rather than a distance. */
-    private float viewRange() {
-        double blocks = Math.max(1.0D, config().getDouble("MONEY-NAMETAGS.VIEW-RANGE", 32.0D));
-        return (float) (blocks / 64.0D);
-    }
-
-    private TextDisplay display(UUID ownerUuid) {
-        UUID displayUuid = displays.get(ownerUuid);
-        if (displayUuid == null) {
-            return null;
-        }
-        Entity entity = Bukkit.getEntity(displayUuid);
-        if (entity instanceof TextDisplay display && display.isValid()) {
-            return display;
-        }
-        displays.remove(ownerUuid, displayUuid);
-        return null;
+        return protocolManager;
     }
 
     private FileConfiguration config() {

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/MoneyNametagTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/MoneyNametagTask.java
@@ -3,9 +3,8 @@ package com.bx.ultimateDonutSmp.tasks;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 
 /**
- * Keeps every money nametag under its owner and up to date with their balance. It runs every tick
- * so the lines move in step with the players they belong to; the manager decides for itself how
- * much work each tick is worth.
+ * Keeps the balance under every player's name up to date. The client draws the line itself, so
+ * there is no position to maintain and this only has to keep up with money changing hands.
  */
 public class MoneyNametagTask implements Runnable {
 
@@ -17,11 +16,12 @@ public class MoneyNametagTask implements Runnable {
 
     @Override
     public void run() {
-        plugin.getMoneyNametagManager().tick();
+        plugin.getMoneyNametagManager().updateAll();
     }
 
     public static void start(UltimateDonutSmp plugin) {
         plugin.getMoneyNametagManager().purgeOrphanedDisplays();
-        plugin.getSpigotScheduler().runGlobalTimer(new MoneyNametagTask(plugin), 1L, 1L);
+        long interval = plugin.getMoneyNametagManager().getUpdateIntervalTicks();
+        plugin.getSpigotScheduler().runGlobalTimer(new MoneyNametagTask(plugin), interval, interval);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -291,12 +291,15 @@ WORTH-LORE:
   ENABLED: true
   # The text or value for Format. Available options: Any valid string text
   FORMAT: '&7Worth: &a$%price%'
-# The floating balance line players can switch on under /settings > Money Nametags.
-# Every player keeps their own switch, so turning it on only changes what that player
-# sees above other players' heads.
+# The balance line players can switch on under /settings > Money Nametags. It uses the
+# scoreboard slot Minecraft reserves for a line under a username, so the client draws it
+# itself, one line below the name and never anywhere else. Two of the client's own rules
+# come with that: the line only appears within about ten blocks, and only one plugin can
+# own that slot at a time. Every player keeps their own switch, so turning it on only
+# changes what that player sees under other players' names.
 MONEY-NAMETAGS:
-  # Determines whether Money Nametags is enabled or disabled. Turning this off hides the
-  # line for everyone and stops the tracking task, whatever players picked in /settings.
+  # Determines whether Money Nametags is enabled or disabled. Turning this off takes the
+  # line away from everyone, whatever players picked in /settings.
   # Available options: true, false
   ENABLED: true
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
@@ -305,20 +308,10 @@ MONEY-NAMETAGS:
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true
-  # How quickly a balance change shows up on the line, in ticks. The line is moved onto its
-  # player every tick no matter what this says, so it never affects how closely the line
-  # follows them. Available options: 1 to 40
+  # How quickly a balance change shows up on the line, in ticks. Where the line sits is the
+  # client's business, so this only decides how fresh the number is.
+  # Available options: 1 to 40
   UPDATE-INTERVAL-TICKS: 10
-  # Gap between the bottom of the username and the top of the balance line, in blocks.
-  # The username is never touched, moved or hidden, the balance is simply parked under it.
-  # Raise this to push the balance further down, or use a negative number to tuck it
-  # closer. Available options: Any decimal number
-  LINE-GAP: 0.05
-  # How far away the line stays readable, in blocks. Available options: Any decimal number
-  VIEW-RANGE: 32.0
-  # Determines whether the line disappears while the player sneaks, the way the vanilla
-  # username does. Available options: true, false
-  HIDE-WHILE-SNEAKING: true
 # Configuration section for End Crystal.
 END-CRYSTAL:
   # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
@@ -55,9 +55,11 @@ class MoneyNametagConfigurationTest {
         assertEquals("&a${balance}", config.getString("MONEY-NAMETAGS.FORMAT"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.SHORT-FORMAT"));
         assertEquals(10, config.getInt("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS"));
-        assertEquals(0.05D, config.getDouble("MONEY-NAMETAGS.LINE-GAP"));
-        assertEquals(32.0D, config.getDouble("MONEY-NAMETAGS.VIEW-RANGE"));
-        assertTrue(config.getBoolean("MONEY-NAMETAGS.HIDE-WHILE-SNEAKING"));
+
+        // The client decides where the line goes, so nothing here tries to place it.
+        assertFalse(config.contains("MONEY-NAMETAGS.LINE-GAP"));
+        assertFalse(config.contains("MONEY-NAMETAGS.VIEW-RANGE"));
+        assertFalse(config.contains("MONEY-NAMETAGS.HIDE-WHILE-SNEAKING"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #202, reported against #182.

The balance still trailed behind a walking or sprinting player. Two entities moving under their own steam never quite agree on screen, however often the second one is dragged onto the first, so chasing the player was never going to work.

## Using the slot Minecraft already has for this

Minecraft reserves a scoreboard slot for a line under a username, the one a health display would normally sit in, and the client draws it as part of the nametag. Nothing has to follow anything: the line is rendered in the same pass as the name, one line beneath it, every frame. It cannot drift, lag or cover the name.

The floating text entity is gone entirely, and with it the per tick teleporting, the view range handling and the height arithmetic. Old entities from previous versions are still swept up on startup, since a reload leaves the previous run's behind.

## Getting a balance into a slot that holds an integer

The slot draws a score, and a score is an int, so a balance in the billions has nowhere to go and `1.1B` cannot render at all. Each score now carries a fixed number format holding the finished text, which is what the client draws in place of the number. The score itself stays at zero and never reaches the screen.

Number formats are a packet level feature with no Bukkit API, on Spigot or otherwise, so all of this goes through ProtocolLib, which is already a hard dependency. They landed in Minecraft 1.20.3; on anything older the feature warns once and stays off rather than printing a wrong number.

Nothing is written to any real scoreboard. The objective is sent straight to the players who asked for balances, so a viewer with the setting off never hears about it, and the balances a viewer sees are decided by which scores were sent to them. That also keeps it clear of the sidebar this plugin already manages.

## What the slot costs

Two of its rules belong to the client and cannot be configured away. The line only draws within about ten blocks, so further out the name shows and the balance does not. And only one objective can hold that slot at a time, so another plugin using the below-name slot will fight over it for players who switched money nametags on. Both are documented in the wiki page.

## Config changes

LINE-GAP, VIEW-RANGE and HIDE-WHILE-SNEAKING are gone. All three existed to place and size a floating entity, and none of them means anything now that the client does the placing. ENABLED, FORMAT and SHORT-FORMAT are unchanged, and UPDATE-INTERVAL-TICKS now only decides how fresh the number is.

## Notes

Balances are only sent to a viewer when the text has changed since that viewer last saw it, so a room full of players standing still costs nothing after the first pass.

Suite is 315 green.
