### PR TITLE
fix(teleport): stop spigot teleports failing on players carrying passengers

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/SpigotScheduler.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -212,7 +213,37 @@ public final class SpigotScheduler {
             }
         } catch (Exception ignored) {
         }
-        return CompletableFuture.completedFuture(entity.teleport(location, cause));
+        return CompletableFuture.completedFuture(teleportCarryingPassengers(entity, location, cause));
+    }
+
+    /**
+     * Spigot's own teleport refuses to move anything carrying passengers and quietly answers false,
+     * which strands a player the moment another plugin parks an entity on them. Paper never reaches
+     * here because its {@code teleportAsync} has no such rule.
+     *
+     * <p>Anything riding the entity comes off first and climbs back on once it has arrived, whether
+     * or not the move succeeded, so the ride survives a refused teleport too.</p>
+     */
+    private boolean teleportCarryingPassengers(
+            Entity entity,
+            Location location,
+            PlayerTeleportEvent.TeleportCause cause
+    ) {
+        List<Entity> passengers = entity.getPassengers();
+        if (passengers.isEmpty()) {
+            return entity.teleport(location, cause);
+        }
+
+        passengers.forEach(entity::removePassenger);
+        try {
+            return entity.teleport(location, cause);
+        } finally {
+            for (Entity passenger : passengers) {
+                if (passenger.isValid()) {
+                    entity.addPassenger(passenger);
+                }
+            }
+        }
     }
 
     public boolean isOwnedByCurrentRegion(Entity entity) {


### PR DESCRIPTION
A player carrying a passenger could not be teleported on Spigot, so a staff member disguised through `/hide` was quietly stuck: `/spawn`, `/home`, `/tpa`, `/rtp` and warps all answered false and did nothing.

## Where the rule lives

`CraftEntity.teleport` and `CraftPlayer.teleport` bail out with `if (!RETAIN_PASSENGERS && isVehicle()) return false`. Checked against the bytecode of the Paper jars on hand rather than from memory: the guard is there on 1.21.8, it is gone on 26.1.2, and `teleportAsync` has never carried it on any version.

That narrows the damage a long way. `SpigotScheduler.teleport` reaches for `teleportAsync` first and only falls back to the synchronous call when the server has no such method, and the plugin makes no direct `.teleport()` calls anywhere, so every teleport it performs goes through that one place. Paper never meets the guard, Folia has its own bridge, and pure Spigot on 1.21 is the only thing that ever hits it.

## The fallback

Anything riding the entity now comes off before the teleport and climbs back on afterwards. Reattaching happens in a finally block, so a teleport the server refuses for some other reason still leaves the ride where it was rather than dropping it on the floor.

Only the Spigot fallback changed. Paper and Folia take earlier branches and never reach this code.

## What this does not fix

`/hide` still mounts its alias nametag as a real passenger, so on Spigot another plugin calling `player.teleport` on a disguised staff member still gets a silent false. Teleports from this plugin are covered; EssentialsX and friends are not. Moving that display to a packet only ride would close it, and is worth doing separately.

## Notes

Suite is 315 green. The behaviour itself is not reachable from a unit test, since it needs a live entity with a passenger.
