### PR TITLE
fix(config): ship the missing rtp and shop menu lore defaults

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -500,18 +500,38 @@ RTP-MENU:
       SLOT: 11
       WORLD: world
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
     NETHER:
       DISPLAY-NAME: '&#FF4B4BNether'
       MATERIAL: NETHERRACK
       SLOT: 13
       WORLD: world_nether
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'
     THE_END:
       DISPLAY-NAME: '&#A84BFFThe End'
       MATERIAL: END_STONE
       SLOT: 15
       WORLD: world_the_end
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -526,16 +546,19 @@ RTP-MENU:
 | `RTP-MENU.BUTTONS.OVERWORLD.SLOT` | `int` | Any valid integer number | `'11'` | Configures the technical `SLOT` parameter for `RTP-MENU.BUTTONS.OVERWORLD.SLOT` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.OVERWORLD.WORLD` | `str` | Any string text | `'world'` | Configures the technical `WORLD` parameter for `RTP-MENU.BUTTONS.OVERWORLD.WORLD` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.OVERWORLD.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `RTP-MENU` system. Set to `true` to enable, `false` to disable. |
+| `RTP-MENU.BUTTONS.OVERWORLD.LORE` | `list` | List of configured items/strings | `['&fClick to randomly teleport', ...]` | Tooltip lines on this button in the `/rtp` menu. Supports `{players}`, `{world}`, `{ping}`, `{min_radius}`, `{max_radius}`, `{cooldown}`, `{required_playtime}`, and `{status}`. Leave it empty to show no tooltip. |
 | `RTP-MENU.BUTTONS.NETHER.DISPLAY-NAME` | `str` | Any string text | `'&#FF4B4BNether'` | Configures the technical `DISPLAY-NAME` parameter for `RTP-MENU.BUTTONS.NETHER.DISPLAY-NAME` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.NETHER.MATERIAL` | `str` | Any string text | `'NETHERRACK'` | Configures the technical `MATERIAL` parameter for `RTP-MENU.BUTTONS.NETHER.MATERIAL` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.NETHER.SLOT` | `int` | Any valid integer number | `'13'` | Configures the technical `SLOT` parameter for `RTP-MENU.BUTTONS.NETHER.SLOT` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.NETHER.WORLD` | `str` | Any string text | `'world_nether'` | Configures the technical `WORLD` parameter for `RTP-MENU.BUTTONS.NETHER.WORLD` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.NETHER.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `RTP-MENU` system. Set to `true` to enable, `false` to disable. |
+| `RTP-MENU.BUTTONS.NETHER.LORE` | `list` | List of configured items/strings | `['&fClick to randomly teleport', ...]` | Tooltip lines on this button in the `/rtp` menu. Supports `{players}`, `{world}`, `{ping}`, `{min_radius}`, `{max_radius}`, `{cooldown}`, `{required_playtime}`, and `{status}`. Leave it empty to show no tooltip. |
 | `RTP-MENU.BUTTONS.THE_END.DISPLAY-NAME` | `str` | Any string text | `'&#A84BFFThe End'` | Configures the technical `DISPLAY-NAME` parameter for `RTP-MENU.BUTTONS.THE_END.DISPLAY-NAME` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.THE_END.MATERIAL` | `str` | Any string text | `'END_STONE'` | Configures the technical `MATERIAL` parameter for `RTP-MENU.BUTTONS.THE_END.MATERIAL` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.THE_END.SLOT` | `int` | Any valid integer number | `'15'` | Configures the technical `SLOT` parameter for `RTP-MENU.BUTTONS.THE_END.SLOT` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.THE_END.WORLD` | `str` | Any string text | `'world_the_end'` | Configures the technical `WORLD` parameter for `RTP-MENU.BUTTONS.THE_END.WORLD` in `rtp.yml`. |
 | `RTP-MENU.BUTTONS.THE_END.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `RTP-MENU` system. Set to `true` to enable, `false` to disable. |
+| `RTP-MENU.BUTTONS.THE_END.LORE` | `list` | List of configured items/strings | `['&fClick to randomly teleport', ...]` | Tooltip lines on this button in the `/rtp` menu. Supports `{players}`, `{world}`, `{ping}`, `{min_radius}`, `{max_radius}`, `{cooldown}`, `{required_playtime}`, and `{status}`. Leave it empty to show no tooltip. |
 
 ### 3. Practical Setup Example
 
@@ -552,18 +575,38 @@ RTP-MENU:
       SLOT: 11
       WORLD: world
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
     NETHER:
       DISPLAY-NAME: '&#FF4B4BNether'
       MATERIAL: NETHERRACK
       SLOT: 13
       WORLD: world_nether
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'
     THE_END:
       DISPLAY-NAME: '&#A84BFFThe End'
       MATERIAL: END_STONE
       SLOT: 15
       WORLD: world_the_end
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'
 ```
 
 ---

--- a/docs/wiki/Config-shop.yml.md
+++ b/docs/wiki/Config-shop.yml.md
@@ -1108,6 +1108,17 @@ BACK-BUTTON:
 ```yaml
 SHOP-GUI:
   SHOW-AUCTION-PRICE: true
+  # Configuration section for Item.
+  ITEM:
+    # Configuration section for Lore.
+    LORE:
+    - '&7Shop price: {shop_price}'
+    - '{auction_line}'
+    - ''
+    - '{favorite_line}'
+    - '&eLeft-click to buy from the shop'
+    - '{auction_action}'
+    - '{favorite_action}'
   FAVORITES:
     ENABLED: true
   WEB-SERVER:
@@ -1125,6 +1136,7 @@ SHOP-GUI:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `SHOP-GUI.SHOW-AUCTION-PRICE` | `bool` | `true`, `false` | `true` | Configures the technical `SHOW-AUCTION-PRICE` parameter for `SHOP-GUI.SHOW-AUCTION-PRICE` in `shop.yml`. |
+| `SHOP-GUI.ITEM.LORE` | `list` | List of configured items/strings | `['&7Shop price: {shop_price}', ...]` | Tooltip lines shown under every item in the shop menu. Supports `{shop_price}`, `{shop_unit_price}`, `{item}`, and the lines built from the other `SHOP-GUI.ITEM` keys: `{auction_line}`, `{auction_action}`, `{favorite_line}`, `{favorite_action}`. Leave it empty to show no tooltip. |
 | `SHOP-GUI.FAVORITES.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `SHOP-GUI` system. Set to `true` to enable, `false` to disable. |
 | `SHOP-GUI.WEB-SERVER.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `SHOP-GUI` system. Set to `true` to enable, `false` to disable. |
 | `SHOP-GUI.WEB-SERVER.PORT` | `int` | Any valid integer number | `'8080'` | Configures the technical `PORT` parameter for `SHOP-GUI.WEB-SERVER.PORT` in `shop.yml`. |
@@ -1135,6 +1147,17 @@ SHOP-GUI:
 ```yaml
 SHOP-GUI:
   SHOW-AUCTION-PRICE: true
+  # Configuration section for Item.
+  ITEM:
+    # Configuration section for Lore.
+    LORE:
+    - '&7Shop price: {shop_price}'
+    - '{auction_line}'
+    - ''
+    - '{favorite_line}'
+    - '&eLeft-click to buy from the shop'
+    - '{auction_action}'
+    - '{favorite_action}'
   FAVORITES:
     ENABLED: true
   WEB-SERVER:

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -138,15 +138,35 @@ RTP-MENU:
       SLOT: 11
       WORLD: world
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
     NETHER:
       DISPLAY-NAME: '&#FF4B4BNether'
       MATERIAL: NETHERRACK
       SLOT: 13
       WORLD: world_nether
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'
     THE_END:
       DISPLAY-NAME: '&#A84BFFThe End'
       MATERIAL: END_STONE
       SLOT: 15
       WORLD: world_the_end
       ENABLED: true
+      LORE:
+      - '&fClick to randomly teleport'
+      - ''
+      - '&7Players: &b{players}'
+      - '&7Range: &b{min_radius}-{max_radius}'
+      - '&7Cooldown: &b{cooldown}s'
+      - '&7Required playtime: &b{required_playtime}'

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -677,6 +677,17 @@ BACK-BUTTON:
 # Configuration section for Shop Web Analytics Server
 SHOP-GUI:
   SHOW-AUCTION-PRICE: true
+  # Configuration section for Item.
+  ITEM:
+    # Configuration section for Lore.
+    LORE:
+    - '&7Shop price: {shop_price}'
+    - '{auction_line}'
+    - ''
+    - '{favorite_line}'
+    - '&eLeft-click to buy from the shop'
+    - '{auction_action}'
+    - '{favorite_action}'
   FAVORITES:
     ENABLED: true
   WEB-SERVER:

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/MenuLoreDefaultsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/MenuLoreDefaultsTest.java
@@ -1,0 +1,111 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * These menus read their lore straight off the bundled config with no java fallback, so a missing
+ * key renders the buttons with no lore at all rather than falling back to something readable.
+ */
+class MenuLoreDefaultsTest {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("[{][a-z_]+[}]");
+
+    private static final List<String> RTP_BUTTONS = List.of("OVERWORLD", "NETHER", "THE_END");
+
+    // mirrors RTPMenu#replacePlaceholders
+    private static final Set<String> RTP_PLACEHOLDERS = Set.of(
+            "{players}",
+            "{ping}",
+            "{world}",
+            "{min_radius}",
+            "{max_radius}",
+            "{required_playtime}",
+            "{cooldown}",
+            "{status}"
+    );
+
+    // mirrors ShopMenu#replaceShopGuiPlaceholders
+    private static final Set<String> SHOP_PLACEHOLDERS = Set.of(
+            "{shop_price}",
+            "{shop_unit_price}",
+            "{auction_line}",
+            "{auction_action}",
+            "{favorite_line}",
+            "{favorite_action}",
+            "{item}"
+    );
+
+    @Test
+    void rtpMenuButtonsShipLore() throws Exception {
+        YamlConfiguration rtp = load("rtp.yml");
+        for (String button : RTP_BUTTONS) {
+            String path = "RTP-MENU.BUTTONS." + button + ".LORE";
+            assertFalse(
+                    rtp.getStringList(path).isEmpty(),
+                    "rtp.yml must ship " + path + " or the button renders with no lore"
+            );
+        }
+    }
+
+    @Test
+    void rtpMenuLoreOnlyUsesPlaceholdersTheMenuReplaces() throws Exception {
+        YamlConfiguration rtp = load("rtp.yml");
+        for (String button : RTP_BUTTONS) {
+            String path = "RTP-MENU.BUTTONS." + button + ".LORE";
+            assertPlaceholdersSupported(rtp.getStringList(path), RTP_PLACEHOLDERS, path);
+        }
+    }
+
+    @Test
+    void shopItemsShipLore() throws Exception {
+        YamlConfiguration shop = load("shop.yml");
+        List<String> lore = shop.getStringList("SHOP-GUI.ITEM.LORE");
+        assertFalse(
+                lore.isEmpty(),
+                "shop.yml must ship SHOP-GUI.ITEM.LORE or shop items render without a price"
+        );
+        assertTrue(
+                lore.stream().anyMatch(line -> line.contains("{shop_price}")),
+                "SHOP-GUI.ITEM.LORE must show the shop price"
+        );
+    }
+
+    @Test
+    void shopItemLoreOnlyUsesPlaceholdersTheMenuReplaces() throws Exception {
+        YamlConfiguration shop = load("shop.yml");
+        assertPlaceholdersSupported(
+                shop.getStringList("SHOP-GUI.ITEM.LORE"),
+                SHOP_PLACEHOLDERS,
+                "SHOP-GUI.ITEM.LORE"
+        );
+    }
+
+    private static void assertPlaceholdersSupported(List<String> lore, Set<String> supported, String path) {
+        for (String line : lore) {
+            Matcher matcher = PLACEHOLDER.matcher(line);
+            while (matcher.find()) {
+                assertTrue(
+                        supported.contains(matcher.group()),
+                        path + " uses " + matcher.group() + ", which the menu never replaces"
+                );
+            }
+        }
+    }
+
+    private static YamlConfiguration load(String name) throws Exception {
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.options().parseComments(true);
+        configuration.load(Path.of("src/main/resources", name).toFile());
+        return configuration;
+    }
+}


### PR DESCRIPTION
Two bundled config defaults that never shipped, both the same defect as #196. A menu reads its lore straight off the config with no java fallback, the bundled file never carried the key, and the buttons come out with nothing under the name.

## The /rtp menu

`RTPManager.loadConfiguredDestinations` reads `button.getStringList("LORE")` and hands the result to `RTPMenu`, which substitutes `{players}`, `{min_radius}`, `{max_radius}`, `{cooldown}` and `{required_playtime}` into each line. `rtp.yml` defined the three buttons with a display name, material, slot, world and enabled flag, and no lore at all, so every button showed its name and nothing else. The text has been sitting in all 8 language files the whole time, which is why the keys look like they already exist.

## The shop menu

`ShopMenu.createShopItem` loops over `SHOP-GUI.ITEM.LORE` to append the price line along with the auction and favorite lines. `shop.yml` shipped `SHOP-GUI` with only `SHOW-AUCTION-PRICE`, `FAVORITES.ENABLED` and the web server block, so that loop had nothing to walk and shop items carried no price at all. The other `SHOP-GUI.ITEM` keys it depends on, `AUCTION` and `FAVORITE-ON` and the rest, all have java fallbacks, so the lore itself was the only thing missing.

## What the audit covered

I went through all 149 keys that live in `languages/en_US.yml` under a `CONFIG.*` tree with no counterpart in the feature's own yml. These four are the only ones that actually reach a player. Everything else, including all 93 auction house GUI keys and the 12 fakeplayer messages, is read through a helper that passes a java fallback, so the text renders fine and the language entry simply goes unused.

## Notes

- `RTP-MENU` and `SHOP-GUI` are both mergeable in `ConfigManager.isUserManagedBundledPath`, so existing servers pick the keys up on the next start without editing anything.
- No language file changed. The rtp lore is already translated in all 8, and the other 7 have no `CONFIG.SHOP` tree at all, which is a separate translation gap rather than something to fill in halfway here.
- `MenuLoreDefaultsTest` covers both cases: the keys ship, and every placeholder in them is one the matching menu actually replaces. Reverting just the two yml files fails it. Suite is 319 green.
