### PR TITLE
feat(notifications): configurable join leave and marketplace announcements (#195)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -640,6 +640,115 @@ CHAT:
 
 ---
 
+## Section: `SERVER-NOTIFICATIONS`
+
+Server-wide announcement lines for joins, leaves, first joins, and the two marketplaces. Every
+line ships switched off, so updating the jar never changes how an existing server's chat looks —
+turn on the ones you want.
+
+### 1. Commented Setup Code Example
+
+```yaml
+SERVER-NOTIFICATIONS:
+  # The line everyone sees when a player connects. While this is off the server's own join
+  # message is relayed instead, exactly as it is today.
+  JOIN:
+    ENABLED: false
+    MESSAGE: '&8[&a+&8] &a{player} &7joined the server.'
+  LEAVE:
+    ENABLED: false
+    MESSAGE: '&8[&c-&8] &c{player} &7left the server.'
+  # Sent in place of the join line the very first time a player ever connects.
+  FIRST-JOIN:
+    ENABLED: false
+    MESSAGE: '&aWelcome &e{player} &ato the server for the first time!'
+  AUCTION-HOUSE:
+    ENABLED: true
+    LISTING:
+      ENABLED: false
+      MESSAGE: '&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'
+    PURCHASE:
+      ENABLED: false
+      MESSAGE: '&8[&6AH&8] &f{player} &7bought &e{amount}x {item} &7for &a{price_formatted}&7.'
+  ORDERS:
+    ENABLED: true
+    CREATE:
+      ENABLED: false
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7created an order for &e{amount}x {item} &7at &a{price_formatted} &7each.'
+    COMPLETE:
+      ENABLED: false
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7completed &e{owner}&7''s order for &e{amount}x {item}&7.'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SERVER-NOTIFICATIONS.JOIN.ENABLED` | `bool` | `true`, `false` | `false` | `true` replaces the server's own join line with `JOIN.MESSAGE`. `false` relays the server's line unchanged. |
+| `SERVER-NOTIFICATIONS.JOIN.MESSAGE` | `str` | Any string text | `'&8[&a+&8] &a{player} &7joined the server.'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.LEAVE.ENABLED` | `bool` | `true`, `false` | `false` | `true` replaces the server's own quit line with `LEAVE.MESSAGE`. |
+| `SERVER-NOTIFICATIONS.LEAVE.MESSAGE` | `str` | Any string text | `'&8[&c-&8] &c{player} &7left the server.'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.ENABLED` | `bool` | `true`, `false` | `false` | `true` sends `FIRST-JOIN.MESSAGE` instead of the join line the first time a player ever connects, so nobody is announced twice. It works on its own — `JOIN` does not have to be on. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.MESSAGE` | `str` | Any string text | `'&aWelcome &e{player} &ato the server for the first time!'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for both Auction House lines. Turning it off silences them whatever `LISTING` and `PURCHASE` say. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.ENABLED` | `bool` | `true`, `false` | `false` | Announces every item a player puts up for sale. Bot listings are never announced. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.MESSAGE` | `str` | Any string text | `'&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'` | Supports `{player}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}` and `{category}`. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.PURCHASE.ENABLED` | `bool` | `true`, `false` | `false` | Announces every completed purchase. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.PURCHASE.MESSAGE` | `str` | Any string text | `'&8[&6AH&8] &f{player} &7bought &e{amount}x {item} &7for &a{price_formatted}&7.'` | Supports `{player}` (the buyer), `{seller}`, `{item}`, `{amount}`, `{price}` and `{price_formatted}`. |
+| `SERVER-NOTIFICATIONS.ORDERS.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for both Order lines. |
+| `SERVER-NOTIFICATIONS.ORDERS.CREATE.ENABLED` | `bool` | `true`, `false` | `false` | Announces every new order a player opens. Bot orders are never announced. |
+| `SERVER-NOTIFICATIONS.ORDERS.CREATE.MESSAGE` | `str` | Any string text | `'&8[&6ORDER&8] &f{player} &7created an order for &e{amount}x {item} &7at &a{price_formatted} &7each.'` | Supports `{player}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{total}` and `{total_formatted}`. |
+| `SERVER-NOTIFICATIONS.ORDERS.COMPLETE.ENABLED` | `bool` | `true`, `false` | `false` | Announces an order once it has been filled all the way. Partial deliveries stay quiet. |
+| `SERVER-NOTIFICATIONS.ORDERS.COMPLETE.MESSAGE` | `str` | Any string text | `'&8[&6ORDER&8] &f{player} &7completed &e{owner}&7''s order for &e{amount}x {item}&7.'` | Supports `{player}` (whoever handed over the last of it), `{owner}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{total}` and `{total_formatted}`. |
+
+### 3. Practical Setup Example
+
+```yaml
+SERVER-NOTIFICATIONS:
+  JOIN:
+    ENABLED: true
+    MESSAGE: '&#57F287+ &f{player}'
+  LEAVE:
+    ENABLED: true
+    MESSAGE: '&#ED4245- &f{player}'
+  FIRST-JOIN:
+    ENABLED: true
+    MESSAGE: '&#FEE75C&l✦ &fwelcome &e{player} &fto the server!'
+  AUCTION-HOUSE:
+    ENABLED: true
+    LISTING:
+      ENABLED: true
+      MESSAGE: '&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'
+    PURCHASE:
+      ENABLED: false
+  ORDERS:
+    ENABLED: true
+    CREATE:
+      ENABLED: true
+    COMPLETE:
+      ENABLED: true
+```
+
+### 4. Colours And Who Sees Them
+
+Messages here take the same colour codes as the rest of the plugin: `&a` style codes, `&#RRGGBB`
+for one hex colour, and `<#RRGGBB>text</#RRGGBB>` for a gradient. Placeholders are filled in
+before the colours are applied, and PlaceholderAPI placeholders resolve too when it is installed.
+
+Two per-player switches under `/settings` still apply on top of everything configured here. Join,
+leave and first-join lines follow **Join/Leave Messages**, which is the same option that already
+governs the server's own join and quit text and can be narrowed to friends only. The Auction House
+and Order lines follow **Server Broadcasts**, plus **Auction Alerts** and **Order Alerts**
+respectively, so a player who muted one marketplace does not get its announcements back through
+this system.
+
+One thing the config cannot override: if another plugin suppresses a join or quit message
+entirely, nothing is announced for that player. The configured line replaces the server's own
+message rather than being sent alongside it, so there is nothing to send when the server had no
+message to begin with.
+
+---
+
 ## Section: `AFK-SYSTEM`
 
 ### 1. Commented Setup Code Example

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -761,6 +761,71 @@ CHAT:
 
 ---
 
+## Section: `SERVER-NOTIFICATIONS` - Join, Leave & Marketplace Announcements
+
+### Fully Commented Setup Code Example
+```yaml
+SERVER-NOTIFICATIONS:
+  # The line everyone sees when a player connects. While this is off the server's own join
+  # message is relayed instead, exactly as it is today.
+  JOIN:
+    # Determines whether Join is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The text or value for Message. Supports {player}. Available options: Any valid string text
+    MESSAGE: '&8[&a+&8] &a{player} &7joined the server.'
+  LEAVE:
+    ENABLED: false
+    MESSAGE: '&8[&c-&8] &c{player} &7left the server.'
+  # Sent in place of the join line the very first time a player ever connects.
+  FIRST-JOIN:
+    ENABLED: false
+    MESSAGE: '&aWelcome &e{player} &ato the server for the first time!'
+  # Announcements for the Auction House. Bot listings are never announced.
+  AUCTION-HOUSE:
+    ENABLED: true
+    LISTING:
+      ENABLED: false
+      MESSAGE: '&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'
+    PURCHASE:
+      ENABLED: false
+      MESSAGE: '&8[&6AH&8] &f{player} &7bought &e{amount}x {item} &7for &a{price_formatted}&7.'
+  # Announcements for Orders. Bot orders are never announced.
+  ORDERS:
+    ENABLED: true
+    CREATE:
+      ENABLED: false
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7created an order for &e{amount}x {item} &7at &a{price_formatted} &7each.'
+    COMPLETE:
+      ENABLED: false
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7completed &e{owner}&7''s order for &e{amount}x {item}&7.'
+```
+
+### Key Options & Setup Breakdown
+| Key / Option Path | Data Type | Allowed Values / Options | Default | Functional Behavior & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SERVER-NOTIFICATIONS.JOIN.ENABLED` | `bool` | true, false | `False` | Replaces the server's own join line with `JOIN.MESSAGE`. Off relays the server's line unchanged. |
+| `SERVER-NOTIFICATIONS.JOIN.MESSAGE` | `str` | Any string text | `&8[&a+&8] &a{player} &7joined the server.` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.LEAVE.ENABLED` | `bool` | true, false | `False` | Replaces the server's own quit line with `LEAVE.MESSAGE`. |
+| `SERVER-NOTIFICATIONS.LEAVE.MESSAGE` | `str` | Any string text | `&8[&c-&8] &c{player} &7left the server.` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.ENABLED` | `bool` | true, false | `False` | Sends `FIRST-JOIN.MESSAGE` instead of the join line the first time a player ever connects. Works whether or not `JOIN` is on. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.MESSAGE` | `str` | Any string text | `&aWelcome &e{player} &ato the server for the first time!` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.ENABLED` | `bool` | true, false | `True` | Master switch for both Auction House lines. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.ENABLED` | `bool` | true, false | `False` | Announces every item a player puts up for sale. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.MESSAGE` | `str` | Any string text | `&8[&6AH&8] &f{player} &7listed &e{amount}x {item}...` | Supports `{player}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{category}`. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.PURCHASE.ENABLED` | `bool` | true, false | `False` | Announces every completed purchase. |
+| `SERVER-NOTIFICATIONS.AUCTION-HOUSE.PURCHASE.MESSAGE` | `str` | Any string text | `&8[&6AH&8] &f{player} &7bought &e{amount}x {item}...` | Supports `{player}`, `{seller}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`. |
+| `SERVER-NOTIFICATIONS.ORDERS.ENABLED` | `bool` | true, false | `True` | Master switch for both Order lines. |
+| `SERVER-NOTIFICATIONS.ORDERS.CREATE.ENABLED` | `bool` | true, false | `False` | Announces every new order a player opens. |
+| `SERVER-NOTIFICATIONS.ORDERS.CREATE.MESSAGE` | `str` | Any string text | `&8[&6ORDER&8] &f{player} &7created an order for...` | Supports `{player}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{total}`, `{total_formatted}`. |
+| `SERVER-NOTIFICATIONS.ORDERS.COMPLETE.ENABLED` | `bool` | true, false | `False` | Announces an order once it is filled all the way. Partial deliveries stay quiet. |
+| `SERVER-NOTIFICATIONS.ORDERS.COMPLETE.MESSAGE` | `str` | Any string text | `&8[&6ORDER&8] &f{player} &7completed &e{owner}&7's order...` | Supports `{player}`, `{owner}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{total}`, `{total_formatted}`. |
+
+Join, leave and first-join lines follow each player's **Join/Leave Messages** choice under
+`/settings`. The Auction House and Order lines follow **Server Broadcasts** plus **Auction
+Alerts** and **Order Alerts**. Bot listings and bot orders are never announced.
+
+---
+
 ## Section: `AFK-SYSTEM` - AFK Reward Zone & Auto Teleport
 
 ### Fully Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -80,6 +80,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private FfaManager ffaManager;
     private AuctionHouseManager auctionHouseManager;
     private AuctionOrderBotManager auctionOrderBotManager;
+    private ServerNotificationManager serverNotificationManager;
     private BillfordManager billfordManager;
     private LeaderboardManager leaderboardManager;
     private ScoreboardManager scoreboardManager;
@@ -221,6 +222,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ffaManager = new FfaManager(this);
         auctionHouseManager = new AuctionHouseManager(this);
         auctionOrderBotManager = new AuctionOrderBotManager(this);
+        serverNotificationManager = new ServerNotificationManager(this);
         billfordManager = new BillfordManager(this);
         billfordManager.load();
         leaderboardManager = new LeaderboardManager(this);
@@ -1303,6 +1305,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public AuctionOrderBotManager getAuctionOrderBotManager() {
         return auctionOrderBotManager;
+    }
+
+    public ServerNotificationManager getServerNotificationManager() {
+        return serverNotificationManager;
     }
 
     public BillfordManager getBillfordManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -217,7 +217,8 @@ public class PlayerJoinQuitListener implements Listener {
         }
         plugin.getPlayerVisibilityManager().handleJoin(player);
 
-        if (!player.hasPlayedBefore()) {
+        boolean firstJoin = !player.hasPlayedBefore();
+        if (firstJoin) {
             boolean randomSpawnStarted = plugin.getFirstJoinSpawnManager() != null
                     && plugin.getFirstJoinSpawnManager().handleFirstJoin(player);
             boolean spawnOnFirstJoin = plugin.getConfigManager().getConfig().getBoolean("SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN", true);
@@ -256,13 +257,28 @@ public class PlayerJoinQuitListener implements Listener {
         }
 
         if (joinMsg != null && !joinMsg.isEmpty()) {
-            final String finalJoinMsg = joinMsg;
-            plugin.getSpigotScheduler().forEachOnlinePlayer(p -> {
-                if (shouldReceiveJoinLeaveMessage(p, player)) {
-                    p.sendMessage(ColorUtils.toComponent(finalJoinMsg));
-                }
-            });
+            String announcement = plugin.getServerNotificationManager() == null
+                    ? null
+                    : plugin.getServerNotificationManager().joinAnnouncement(player, firstJoin);
+            broadcastJoinLeave(player, announcement == null ? joinMsg : announcement);
         }
+    }
+
+    /**
+     * Sends a join or leave line to everyone allowed to see it. A configured announcement takes
+     * the place of the server's own message and travels the same route, so a player who turned
+     * join and leave messages off in /settings stays quiet either way. Nothing is sent when the
+     * server had no message to begin with, which is how other plugins suppress a join.
+     */
+    private void broadcastJoinLeave(Player subject, String message) {
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        plugin.getSpigotScheduler().forEachOnlinePlayer(p -> {
+            if (shouldReceiveJoinLeaveMessage(p, subject)) {
+                p.sendMessage(ColorUtils.toComponent(message));
+            }
+        });
     }
 
     /**
@@ -417,12 +433,10 @@ public class PlayerJoinQuitListener implements Listener {
         plugin.getTeamManager().clearSearchState(player.getUniqueId());
 
         if (quitMsg != null && !quitMsg.isEmpty()) {
-            final String finalQuitMsg = quitMsg;
-            plugin.getSpigotScheduler().forEachOnlinePlayer(p -> {
-                if (shouldReceiveJoinLeaveMessage(p, player)) {
-                    p.sendMessage(ColorUtils.toComponent(finalQuitMsg));
-                }
-            });
+            String announcement = plugin.getServerNotificationManager() == null
+                    ? null
+                    : plugin.getServerNotificationManager().leaveAnnouncement(player);
+            broadcastJoinLeave(player, announcement == null ? quitMsg : announcement);
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/AuctionHouseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/AuctionHouseManager.java
@@ -544,6 +544,9 @@ public final class AuctionHouseManager {
                             "AUCTION_LIST",
                             "Listed " + describeItem(created.listing().item()) + " for " + plugin.getCurrencyManager().formatMoney(price)
                     );
+                    if (plugin.getServerNotificationManager() != null) {
+                        plugin.getServerNotificationManager().announceAuctionListing(seller, created.listing());
+                    }
                     result.complete(new CreateListingResult(true, null, created.listing(), listingFee));
                 });
             } finally {
@@ -641,6 +644,9 @@ public final class AuctionHouseManager {
                                             "AUCTION_BUY",
                                             "Bought " + describeItem(purchased.item()) + " from " + purchased.sellerName() + " for " + plugin.getCurrencyManager().formatMoney(purchased.price())
                                     );
+                                    if (deliveryError == null && plugin.getServerNotificationManager() != null) {
+                                        plugin.getServerNotificationManager().announceAuctionPurchase(buyer, purchased);
+                                    }
                                     result.complete(new PurchaseListingResult(
                                             deliveryError == null,
                                             deliveryError == null ? null : PurchaseFailureReason.DATABASE_ERROR,

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/OrdersManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/OrdersManager.java
@@ -1128,7 +1128,11 @@ public class OrdersManager {
         plugin.getDatabaseManager().savePlayer(ownerData);
         pendingCreations.remove(player.getUniqueId());
         publishOrderEvent("CREATE", orderId);
-        return new CreateOrderResult(true, null, getOrder(orderId), creationFee);
+        Order created = getOrder(orderId);
+        if (plugin.getServerNotificationManager() != null) {
+            plugin.getServerNotificationManager().announceOrderCreated(player, created);
+        }
+        return new CreateOrderResult(true, null, created, creationFee);
     }
 
     public boolean selectOrderItem(
@@ -2430,7 +2434,12 @@ public class OrdersManager {
                 delivererData.addMoneyMade(payout);
                 plugin.getDatabaseManager().savePlayer(delivererData);
                 publishOrderEvent("DELIVER", liveOrder.id());
-                return new DeliverOrderResult(true, null, getOrder(liveOrder.id()), quantity, payout);
+                Order delivered = getOrder(liveOrder.id());
+                // Announce only once the order is full, so a run of partial deliveries stays quiet.
+                if (delivered != null && delivered.filled() && plugin.getServerNotificationManager() != null) {
+                    plugin.getServerNotificationManager().announceOrderCompleted(player, delivered);
+                }
+                return new DeliverOrderResult(true, null, delivered, quantity, payout);
             } finally {
                 releaseNetworkOrderLock(networkLock);
             }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ServerNotificationManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ServerNotificationManager.java
@@ -1,0 +1,215 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.AuctionListing;
+import com.bx.ultimateDonutSmp.models.Order;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Builds and sends the server-wide announcements configured under SERVER-NOTIFICATIONS.
+ *
+ * <p>Join, leave and first-join text is handed back to PlayerJoinQuitListener rather than
+ * broadcast from here, because that listener already decides who is allowed to see a join
+ * line and the configured text has to travel the same route as the server's own.</p>
+ */
+public class ServerNotificationManager {
+
+    private static final String ROOT = "SERVER-NOTIFICATIONS.";
+
+    private final UltimateDonutSmp plugin;
+
+    public ServerNotificationManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * The join line for a player, or null when the server's own message should be relayed
+     * instead. A brand new player gets the first-join text when that is switched on, so
+     * nobody is announced twice.
+     */
+    public String joinAnnouncement(Player player, boolean firstJoin) {
+        if (firstJoin && isEnabled("FIRST-JOIN")) {
+            return format(message("FIRST-JOIN"), "{player}", publicName(player));
+        }
+        if (!isEnabled("JOIN")) {
+            return null;
+        }
+        return format(message("JOIN"), "{player}", publicName(player));
+    }
+
+    /** The leave line for a player, or null to relay the server's own message. */
+    public String leaveAnnouncement(Player player) {
+        if (!isEnabled("LEAVE")) {
+            return null;
+        }
+        return format(message("LEAVE"), "{player}", publicName(player));
+    }
+
+    public void announceAuctionListing(Player seller, AuctionListing listing) {
+        if (listing == null || !isEnabled("AUCTION-HOUSE") || !isEnabled("AUCTION-HOUSE.LISTING")) {
+            return;
+        }
+        broadcast(
+                format(
+                        message("AUCTION-HOUSE.LISTING"),
+                        "{player}", publicName(seller),
+                        "{item}", describeAuctionItem(listing.item()),
+                        "{amount}", String.valueOf(amountOf(listing.item())),
+                        "{price}", NumberUtils.format(listing.price()),
+                        "{price_formatted}", plugin.getCurrencyManager().formatMoney(listing.price()),
+                        "{category}", listing.category()
+                ),
+                PlayerSettingUtils.NotificationChannel.AUCTION
+        );
+    }
+
+    public void announceAuctionPurchase(Player buyer, AuctionListing listing) {
+        if (listing == null || !isEnabled("AUCTION-HOUSE") || !isEnabled("AUCTION-HOUSE.PURCHASE")) {
+            return;
+        }
+        broadcast(
+                format(
+                        message("AUCTION-HOUSE.PURCHASE"),
+                        "{player}", publicName(buyer),
+                        "{seller}", sellerName(listing),
+                        "{item}", describeAuctionItem(listing.item()),
+                        "{amount}", String.valueOf(amountOf(listing.item())),
+                        "{price}", NumberUtils.format(listing.price()),
+                        "{price_formatted}", plugin.getCurrencyManager().formatMoney(listing.price())
+                ),
+                PlayerSettingUtils.NotificationChannel.AUCTION
+        );
+    }
+
+    public void announceOrderCreated(Player owner, Order order) {
+        if (order == null || !isEnabled("ORDERS") || !isEnabled("ORDERS.CREATE")) {
+            return;
+        }
+        broadcast(
+                format(
+                        message("ORDERS.CREATE"),
+                        "{player}", publicName(owner),
+                        "{item}", describeOrderItem(order.requestedItem()),
+                        "{amount}", String.valueOf(order.requestedQuantity()),
+                        "{price}", NumberUtils.format(order.priceEach()),
+                        "{price_formatted}", plugin.getCurrencyManager().formatMoney(order.priceEach()),
+                        "{total}", NumberUtils.format(order.totalBudget()),
+                        "{total_formatted}", plugin.getCurrencyManager().formatMoney(order.totalBudget())
+                ),
+                PlayerSettingUtils.NotificationChannel.ORDER
+        );
+    }
+
+    public void announceOrderCompleted(Player deliverer, Order order) {
+        if (order == null || !isEnabled("ORDERS") || !isEnabled("ORDERS.COMPLETE")) {
+            return;
+        }
+        broadcast(
+                format(
+                        message("ORDERS.COMPLETE"),
+                        "{player}", publicName(deliverer),
+                        "{owner}", ownerName(order),
+                        "{item}", describeOrderItem(order.requestedItem()),
+                        "{amount}", String.valueOf(order.requestedQuantity()),
+                        "{price}", NumberUtils.format(order.priceEach()),
+                        "{price_formatted}", plugin.getCurrencyManager().formatMoney(order.priceEach()),
+                        "{total}", NumberUtils.format(order.totalBudget()),
+                        "{total_formatted}", plugin.getCurrencyManager().formatMoney(order.totalBudget())
+                ),
+                PlayerSettingUtils.NotificationChannel.ORDER
+        );
+    }
+
+    private void broadcast(String message, PlayerSettingUtils.NotificationChannel channel) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        plugin.getSpigotScheduler().forEachOnlinePlayer(viewer -> {
+            if (!PlayerSettingUtils.notificationEnabled(
+                    plugin,
+                    viewer,
+                    PlayerSettingUtils.NotificationChannel.SERVER_BROADCAST
+            )) {
+                return;
+            }
+            if (!PlayerSettingUtils.notificationEnabled(plugin, viewer, channel)) {
+                return;
+            }
+            viewer.sendMessage(ColorUtils.toComponent(message));
+        });
+    }
+
+    /** Fills the placeholders in, treating a missing value as an empty one. */
+    static String format(String message, String... replacements) {
+        if (message == null || message.isBlank()) {
+            return null;
+        }
+        String result = message;
+        for (int index = 0; index + 1 < replacements.length; index += 2) {
+            String value = replacements[index + 1];
+            result = result.replace(replacements[index], value == null ? "" : value);
+        }
+        return result;
+    }
+
+    private String publicName(Player player) {
+        if (player == null) {
+            return "";
+        }
+        return plugin.getHideManager() == null ? player.getName() : plugin.getHideManager().publicName(player);
+    }
+
+    private String sellerName(AuctionListing listing) {
+        String fallback = listing.sellerName() == null ? "" : listing.sellerName();
+        return plugin.getHideManager() == null
+                ? fallback
+                : plugin.getHideManager().publicName(listing.sellerUuid(), fallback);
+    }
+
+    private String ownerName(Order order) {
+        String fallback = order.ownerName() == null ? "" : order.ownerName();
+        return plugin.getHideManager() == null
+                ? fallback
+                : plugin.getHideManager().publicName(order.ownerUuid(), fallback);
+    }
+
+    private String describeAuctionItem(ItemStack item) {
+        return plugin.getAuctionHouseManager() == null
+                ? fallbackItemName(item)
+                : plugin.getAuctionHouseManager().describeItem(item);
+    }
+
+    private String describeOrderItem(ItemStack item) {
+        return plugin.getOrdersManager() == null
+                ? fallbackItemName(item)
+                : plugin.getOrdersManager().describeItem(item);
+    }
+
+    private String fallbackItemName(ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return "Unknown Item";
+        }
+        return plugin.getWorthManager().prettifyMaterial(item.getType());
+    }
+
+    private static int amountOf(ItemStack item) {
+        return item == null ? 0 : Math.max(0, item.getAmount());
+    }
+
+    private boolean isEnabled(String path) {
+        return config().getBoolean(ROOT + path + ".ENABLED", false);
+    }
+
+    private String message(String path) {
+        return config().getString(ROOT + path + ".MESSAGE", "");
+    }
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getConfig();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -247,6 +247,75 @@ CHAT:
         VALUE: 100
         # The text or value for Block Message. Available options: Any valid string text
         BLOCK-MESSAGE: '&cYour message is too long! (Max: %max%)'
+# Server-wide announcements for joins, leaves and the marketplaces. Every message here uses
+# the same colour codes as the rest of the plugin: &a style codes, &#RRGGBB for a single hex
+# colour and <#RRGGBB>text</#RRGGBB> for a gradient. Each announcement ships switched off, so
+# updating the jar never changes how an existing server's chat looks - turn on the ones you
+# want. Join, leave and first-join lines still follow each player's Join/Leave Messages choice
+# under /settings, and the marketplace lines follow their Server Broadcasts switch.
+SERVER-NOTIFICATIONS:
+  # The line everyone sees when a player connects. While this is off the server's own join
+  # message is relayed instead, exactly as it is today.
+  JOIN:
+    # Determines whether Join is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The text or value for Message. Supports {player}. Available options: Any valid string text
+    MESSAGE: '&8[&a+&8] &a{player} &7joined the server.'
+  # The line everyone sees when a player disconnects. While this is off the server's own quit
+  # message is relayed instead, exactly as it is today.
+  LEAVE:
+    # Determines whether Leave is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The text or value for Message. Supports {player}. Available options: Any valid string text
+    MESSAGE: '&8[&c-&8] &c{player} &7left the server.'
+  # Sent in place of the join line the very first time a player ever connects. It replaces the
+  # join message rather than arriving alongside it, so nobody gets announced twice.
+  FIRST-JOIN:
+    # Determines whether First Join is enabled or disabled. Available options: true, false
+    ENABLED: false
+    # The text or value for Message. Supports {player}. Available options: Any valid string text
+    MESSAGE: '&aWelcome &e{player} &ato the server for the first time!'
+  # Announcements for the Auction House. Bot listings are never announced.
+  AUCTION-HOUSE:
+    # Determines whether Auction House announcements are enabled or disabled. Turning this off
+    # silences both lines below. Available options: true, false
+    ENABLED: true
+    # Sent when a player puts an item up for sale.
+    LISTING:
+      # Determines whether Listing is enabled or disabled. Available options: true, false
+      ENABLED: false
+      # The text or value for Message. Supports {player}, {item}, {amount}, {price},
+      # {price_formatted} and {category}. Available options: Any valid string text
+      MESSAGE: '&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'
+    # Sent when a player buys a listing.
+    PURCHASE:
+      # Determines whether Purchase is enabled or disabled. Available options: true, false
+      ENABLED: false
+      # The text or value for Message. Supports {player}, {seller}, {item}, {amount}, {price}
+      # and {price_formatted}. Available options: Any valid string text
+      MESSAGE: '&8[&6AH&8] &f{player} &7bought &e{amount}x {item} &7for &a{price_formatted}&7.'
+  # Announcements for Orders. Bot orders are never announced.
+  ORDERS:
+    # Determines whether Order announcements are enabled or disabled. Turning this off silences
+    # both lines below. Available options: true, false
+    ENABLED: true
+    # Sent when a player opens a new order.
+    CREATE:
+      # Determines whether Create is enabled or disabled. Available options: true, false
+      ENABLED: false
+      # The text or value for Message. Supports {player}, {item}, {amount}, {price},
+      # {price_formatted}, {total} and {total_formatted}.
+      # Available options: Any valid string text
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7created an order for &e{amount}x {item} &7at &a{price_formatted} &7each.'
+    # Sent once an order has been filled all the way, not on every partial delivery. {player}
+    # is whoever handed over the last of it and {owner} is whoever opened the order.
+    COMPLETE:
+      # Determines whether Complete is enabled or disabled. Available options: true, false
+      ENABLED: false
+      # The text or value for Message. Supports {player}, {owner}, {item}, {amount}, {price},
+      # {price_formatted}, {total} and {total_formatted}.
+      # Available options: Any valid string text
+      MESSAGE: '&8[&6ORDER&8] &f{player} &7completed &e{owner}&7''s order for &e{amount}x {item}&7.'
 # Configuration section for Afk System.
 AFK-SYSTEM:
   # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ServerNotificationConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ServerNotificationConfigurationTest.java
@@ -1,0 +1,112 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServerNotificationConfigurationTest {
+
+    private static final List<String> ANNOUNCEMENTS = List.of(
+            "JOIN",
+            "LEAVE",
+            "FIRST-JOIN",
+            "AUCTION-HOUSE.LISTING",
+            "AUCTION-HOUSE.PURCHASE",
+            "ORDERS.CREATE",
+            "ORDERS.COMPLETE"
+    );
+
+    @Test
+    void everyAnnouncementShipsSwitchedOffWithTextReadyToUse() throws Exception {
+        ConfigurationSection section = notifications();
+
+        for (String announcement : ANNOUNCEMENTS) {
+            assertFalse(
+                    section.getBoolean(announcement + ".ENABLED"),
+                    announcement + " must ship off so updating the jar leaves chat alone"
+            );
+            String message = section.getString(announcement + ".MESSAGE");
+            assertNotNull(message, announcement + " has no message");
+            assertFalse(message.isBlank(), announcement + " has a blank message");
+            assertTrue(message.contains("{player}"), announcement + " never names the player");
+        }
+    }
+
+    @Test
+    void theMarketplaceParentsAreOnSoOnlyTheIndividualLinesNeedTurningOn() throws Exception {
+        ConfigurationSection section = notifications();
+
+        assertTrue(section.getBoolean("AUCTION-HOUSE.ENABLED"));
+        assertTrue(section.getBoolean("ORDERS.ENABLED"));
+    }
+
+    @Test
+    void marketplaceMessagesCarryTheirItemPlaceholders() throws Exception {
+        ConfigurationSection section = notifications();
+
+        for (String announcement : List.of(
+                "AUCTION-HOUSE.LISTING",
+                "AUCTION-HOUSE.PURCHASE",
+                "ORDERS.CREATE",
+                "ORDERS.COMPLETE"
+        )) {
+            String message = section.getString(announcement + ".MESSAGE", "");
+            assertTrue(message.contains("{item}"), announcement + " never names the item");
+            assertTrue(message.contains("{amount}"), announcement + " never gives the amount");
+        }
+
+        assertTrue(section.getString("ORDERS.COMPLETE.MESSAGE", "").contains("{owner}"));
+    }
+
+    @Test
+    void placeholdersAreFilledInAndMissingValuesFallAway() {
+        assertEquals(
+                "&aWelcome &eSteve &ato the server!",
+                ServerNotificationManager.format(
+                        "&aWelcome &e{player} &ato the server!",
+                        "{player}", "Steve"
+                )
+        );
+        assertEquals(
+                "Alex listed 3x Diamond Sword",
+                ServerNotificationManager.format(
+                        "{player} listed {amount}x {item}",
+                        "{player}", "Alex",
+                        "{amount}", "3",
+                        "{item}", "Diamond Sword"
+                )
+        );
+        assertEquals(
+                "Alex listed an item from ",
+                ServerNotificationManager.format(
+                        "{player} listed an item from {category}",
+                        "{player}", "Alex",
+                        "{category}", null
+                )
+        );
+    }
+
+    @Test
+    void anEmptyMessageProducesNothingToBroadcast() {
+        assertNull(ServerNotificationManager.format(null, "{player}", "Steve"));
+        assertNull(ServerNotificationManager.format("", "{player}", "Steve"));
+        assertNull(ServerNotificationManager.format("   ", "{player}", "Steve"));
+    }
+
+    private static ConfigurationSection notifications() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "config.yml").toFile());
+        ConfigurationSection section = config.getConfigurationSection("SERVER-NOTIFICATIONS");
+        assertNotNull(section, "config.yml has no SERVER-NOTIFICATIONS section");
+        return section;
+    }
+}


### PR DESCRIPTION
Closes #195

Adds a `SERVER-NOTIFICATIONS` block to `config.yml` so a server owner can write their own join, leave and first-join lines, and switch on server-wide announcements when someone lists or buys on the Auction House or opens and fills an Order. Every line ships switched off, so updating the jar does not change how an existing server's chat looks.

## Join, leave and first join

The plugin already intercepted the join and quit messages and sent them out itself so it could honour each player's Join/Leave Messages setting. That route is unchanged. The configured text now takes the place of the server's own message before it goes out, which keeps the vanish check, the friends-only choice and the off switch working exactly as they did.

First join replaces the join line rather than arriving next to it, so a new player is announced once rather than twice. It works whether or not `JOIN` is on.

If another plugin suppresses a join or quit message outright, nothing is announced. The configured line stands in for the server's message, so there is nothing to stand in for when the server had no message.

## Auction House and Orders

Four announcements hang off the existing marketplace code: listing and purchase in `AuctionHouseManager`, create and complete in `OrdersManager`. Bot listings and bot orders go through their own `*Direct` methods and are never announced.

An Order is only announced once it has been filled all the way. Announcing on delivery instead would fire again on every partial handover of the same order.

The four lines go out through `NotificationChannel.SERVER_BROADCAST`, the channel crates and Billford already use, and also respect Auction Alerts or Order Alerts, so a player who muted one marketplace does not get its announcements back through this system.

## What is not here

The request asked for MiniMessage formatting. That is not this plugin's format: every message runs through `ColorUtils`, which reads `&` codes, `&#RRGGBB` and `<#RRGGBB>text</#RRGGBB>` gradients. Supporting `<gray>` and `<green>` in only these seven messages would be inconsistent, and supporting them everywhere means rewriting `ColorUtils`, which every message in the plugin goes through. The new messages take the same colours as the rest of the config, hex included.

## Notes

Player names go through `HideManager.publicName`, so an aliased player is announced under their alias rather than their real name.

The keys live in `config.yml` only, so no language file changes. Each message lists its own placeholders in the config comments and in the wiki tables.

Both `docs/wiki/Config-config.yml.md` and `docs/wiki/Configuration-Reference.md` get a `SERVER-NOTIFICATIONS` section.

New `ServerNotificationConfigurationTest` covers the bundled defaults, the placeholders each message carries and the substitution itself. Suite is 320 tests, all green.
