### PR TITLE
fix(placeholders): never resolve a uds placeholder to an empty string (#208)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/api/EconomyExpansion.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/api/EconomyExpansion.java
@@ -183,15 +183,18 @@ public class EconomyExpansion extends PlaceholderExpansion {
             return team != null ? team.toUpperCase() : "none";
         }
 
-        if (offlinePlayer == null) return "";
-
-        // All others require player data
-        PlayerData data = plugin.getPlayerDataManager().get(offlinePlayer.getUniqueId());
-        if (data == null && offlinePlayer.isOnline()) {
-            data = plugin.getPlayerDataManager().get(offlinePlayer.getPlayer());
-        }
-        if (data == null && offlinePlayer.getUniqueId() != null) {
-            data = plugin.getDatabaseManager().loadPlayer(offlinePlayer.getUniqueId());
+        // All others require player data. A caller that hands us no player still gets the zeroed
+        // defaults below rather than an empty string, so an unresolved placeholder is never
+        // mistaken for a real blank value.
+        PlayerData data = null;
+        if (offlinePlayer != null) {
+            data = plugin.getPlayerDataManager().get(offlinePlayer.getUniqueId());
+            if (data == null && offlinePlayer.isOnline()) {
+                data = plugin.getPlayerDataManager().get(offlinePlayer.getPlayer());
+            }
+            if (data == null) {
+                data = plugin.getDatabaseManager().loadPlayer(offlinePlayer.getUniqueId());
+            }
         }
         if (data == null) {
             return switch (params) {

--- a/src/main/java/com/bx/ultimateDonutSmp/api/HideExpansion.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/api/HideExpansion.java
@@ -1,6 +1,7 @@
 package com.bx.ultimateDonutSmp.api;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.HideManager;
 import com.bx.ultimateDonutSmp.models.HideState;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
@@ -39,20 +40,35 @@ public class HideExpansion extends PlaceholderExpansion {
 
     @Override
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
-        if (player == null || plugin.getHideManager() == null) {
-            return "";
-        }
-        HideState state = plugin.getHideManager().getState(player.getUniqueId());
+        HideManager hideManager = plugin.getHideManager();
+        HideState state = player == null || hideManager == null
+                ? null
+                : hideManager.getState(player.getUniqueId());
+
         return switch (params.toLowerCase(Locale.ROOT)) {
             case "active" -> String.valueOf(state != null);
-            case "public_name", "name" ->
-                    plugin.getHideManager().publicName(player.getUniqueId(), player.getName());
-            case "plain_name", "plain_public_name" ->
-                    plugin.getHideManager().plainPublicName(player.getUniqueId(), player.getName());
+            case "public_name", "name" -> publicName(player, hideManager, false);
+            case "plain_name", "plain_public_name" -> publicName(player, hideManager, true);
             case "mode" -> state == null ? "NONE" : state.mode().name();
             case "alias" -> state == null ? "" : state.alias();
             case "skin" -> state == null ? "" : state.skinUsername();
             default -> null;
         };
+    }
+
+    /**
+     * Falls back to the raw account name when there is no player to look up or the hide system is
+     * not running, so a name placeholder never resolves to an empty string.
+     */
+    private @Nullable String publicName(OfflinePlayer player, HideManager hideManager, boolean plain) {
+        if (player == null) {
+            return null;
+        }
+        if (hideManager == null) {
+            return player.getName();
+        }
+        return plain
+                ? hideManager.plainPublicName(player.getUniqueId(), player.getName())
+                : hideManager.publicName(player.getUniqueId(), player.getName());
     }
 }


### PR DESCRIPTION
Closes #208

A server owner running TAB reported that UDS placeholders come out as a gap inside TAB's `customtabname`, while the very same placeholders resolve correctly under `/papi parse me`. They isolated it themselves: `%player%` renders, a third party placeholder verified through `/papi parse me` first renders beside ours, and every one of ours stays blank. TAB's own `errors.log` holds nothing from us, so nothing is throwing. That leaves the paths where our expansions hand back an empty string without complaint, and there were two of them.

## Hide expansion

`onRequest` opened by returning an empty string whenever there was no player, or whenever the hide system was not running. That bailout sat in front of the switch, so it swallowed every `hide_*` placeholder, including the ones this expansion does not own and should have declined. Returning an empty string tells PlaceholderAPI "this resolved, to nothing", which is how a placeholder ends up rendering as a gap with no error anywhere.

State lookup is now conditional instead, and the switch always runs. Unknown parameters reach `default` and return null, which is how an expansion declines a placeholder. `%hide_active%` answers `true` or `false` in every case rather than sometimes answering nothing at all. The two name placeholders fall back to the raw account name when the hide system is unavailable, and only return null when there is genuinely no player to name.

## Economy expansion

Same shape, one line: a bare `return ""` sat between the team branch and the player data lookup, so any caller passing no player blanked the entire `economy_*` surface.

The player data lookup is now guarded rather than the method being abandoned, which lets a null player fall through to the zeroed defaults that were already written directly below it. `%economy_money%` answers a formatted zero instead of nothing, and the same holds for shards, kills, deaths and the rest. A redundant `getUniqueId() != null` check went with it, since `OfflinePlayer` never returns a null UUID.

## Notes

This closes every route by which our own code can produce a blank, which also makes it the experiment that settles the remaining question on the issue. The team placeholder has always answered `none` rather than an empty string, so it could not have been blanked by either path above. If the reporter still sees a gap where `%economy_team%` should be after this ships, then our expansions are not being called at all and the answer lies on TAB's side rather than ours. That is worth knowing either way, and the reporter has been asked to check exactly that.

No behaviour changes for an online player with loaded data, which is every ordinary case.

No test added. There is no mocking framework in the build, the expansions need a live plugin instance to construct, and the suite carries no expansion tests to extend. Standing up a harness for two guard clauses was not a trade worth making. Full suite run locally: 324 passing.
