### PR TITLE
fix(nametags): turn money nametags off quietly when protocollib cannot build the packet (#212)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -63,7 +63,8 @@ public class MoneyNametagManager {
     private final Set<UUID> installed = ConcurrentHashMap.newKeySet();
     private ProtocolManager protocolManager;
     private boolean warnedUnsupported;
-    private boolean warnedPacketFailure;
+    /** Set once ProtocolLib proves it cannot build this server's scoreboard packets. */
+    private volatile boolean packetsUnsupported;
 
     public MoneyNametagManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -94,7 +95,7 @@ public class MoneyNametagManager {
 
     /** Sends every viewer who wants balances the ones that have changed since their last update. */
     public void updateAll() {
-        if (!isEnabled() || !isNumberFormatSupported()) {
+        if (!isEnabled() || !isPacketPathUsable()) {
             clearAll();
             return;
         }
@@ -109,7 +110,7 @@ public class MoneyNametagManager {
 
     /** Pushes {@code player}'s balance out again, and gives them the objective if they want one. */
     public void update(Player player) {
-        if (player == null || !isEnabled() || !isNumberFormatSupported()) {
+        if (player == null || !isEnabled() || !isPacketPathUsable()) {
             return;
         }
         for (Map<UUID, String> known : sentText.values()) {
@@ -123,7 +124,7 @@ public class MoneyNametagManager {
         if (viewer == null) {
             return;
         }
-        if (!isEnabled() || !isNumberFormatSupported() || !isEnabledFor(viewer)) {
+        if (!isEnabled() || !isPacketPathUsable() || !isEnabledFor(viewer)) {
             clearViewer(viewer);
             return;
         }
@@ -308,16 +309,30 @@ public class MoneyNametagManager {
     }
 
     /**
-     * The first packet that will not build or send is worth shouting about, since the line simply
-     * fails to appear and there is nothing else to go on. Everything after it stays quiet.
+     * A packet that will not build or send means ProtocolLib does not recognise this server's
+     * scoreboard packets, which nothing short of a ProtocolLib update will change. The feature
+     * turns itself off on the first failure and says so once, in the same plain terms an
+     * unsupported server gets from {@link #isNumberFormatSupported()}. The trace itself is kept at
+     * FINE for anyone debugging it.
      */
     private void warnPacketFailure(String message, Throwable error) {
-        if (warnedPacketFailure) {
+        if (packetsUnsupported) {
             plugin.getLogger().log(Level.FINE, message, error);
             return;
         }
-        warnedPacketFailure = true;
-        plugin.getLogger().log(Level.WARNING, message + " Money nametags may not show up.", error);
+        packetsUnsupported = true;
+        plugin.getLogger().warning("Money nametags need scoreboard packets that the installed"
+                + " ProtocolLib understands, and it cannot build them on this server. The feature"
+                + " will stay off until ProtocolLib supports this Minecraft build.");
+        plugin.getLogger().log(Level.FINE, message, error);
+    }
+
+    /**
+     * Both reasons the packet path can be unusable, checked together everywhere the feature starts
+     * work. Once either is known the answer cannot change while the server is running.
+     */
+    private boolean isPacketPathUsable() {
+        return !packetsUnsupported && isNumberFormatSupported();
     }
 
     private boolean send(Player viewer, PacketContainer packet) {


### PR DESCRIPTION
Closes #212

When ProtocolLib cannot build this server's scoreboard packets, money nametags used to announce it with a full stack trace at WARNING and then quietly try again on every join for the rest of the session. Neither part was useful. The trace reads like a crash to whoever runs the server, and retrying cannot help, because the answer does not change until ProtocolLib ships support for the Minecraft build.

## Saying it once, in plain words

`warnPacketFailure` now prints a single sentence naming the cause and what would fix it, with no trace attached. The wording follows `isNumberFormatSupported` a screen further down, which has always handled an unsupported server this way. Those two paths describe the same kind of problem and now sound alike.

The trace is not thrown away. It drops to FINE, alongside every later failure, so anyone actually debugging this can still turn it up.

## Not trying again

`warnedPacketFailure` becomes `packetsUnsupported` and now means something the rest of the class acts on rather than just a note about what has already been logged. A new `isPacketPathUsable` pairs it with the existing number format check, and the three entry points that previously called `isNumberFormatSupported` on its own call that instead. After the first failure the feature stops building packets altogether.

The field is volatile because the update task and the join listener reach it from different threads.

## Notes

Nothing changes on a server where the packets do build, which is the ordinary case.

`clearViewer` needed no guard. It only sends the removal packet for a viewer present in `installed`, and a viewer whose objective failed to install never gets added, so there is nothing left behind to remove.

No test added, for the same reason the class has none today: every path here needs a live ProtocolLib and a real player connection. `render` stays the one piece that is unit testable and it is untouched. Full suite run locally: 324 passing.
