### PR TITLE
fix(config): ship the missing combat manager defaults (#214)

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -718,8 +718,15 @@ COMBAT-MANAGER:
   ENABLED: true
   # The numerical value for Cooldown. Available options: Any valid integer
   COOLDOWN: 16
+  # Determines whether Kill On Logout is enabled or disabled. When true, a player who
+  # disconnects while their combat tag is still running is killed, so logging out mid-fight
+  # is not a way to escape a fight. Available options: true, false
+  KILL-ON-LOGOUT: false
   # The text or value for Action Bar. Available options: Any valid string text
   ACTION-BAR: '&fCombat: &b${time}s'
+  # Determines whether Mobs is enabled or disabled. When true, damage from mobs also puts
+  # players into combat, not just damage dealt by other players. Available options: true, false
+  MOBS: false
   # Determines whether Ender Crystal is enabled or disabled. Available options: true, false
   ENDER-CRYSTAL: true
   # Determines whether Ender Pearl is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/CombatListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/CombatListenerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,14 +55,58 @@ class CombatListenerTest {
         ));
     }
 
+    /**
+     * Every path CombatManager and CombatListener read off COMBAT-MANAGER. A key the code reads
+     * but the bundled config never ships is invisible to admins and silently keeps its java
+     * fallback, so the feature behind it can never be switched on.
+     */
+    private static final List<String> COMBAT_PATHS = List.of(
+            "COMBAT-MANAGER.ENABLED",
+            "COMBAT-MANAGER.COOLDOWN",
+            "COMBAT-MANAGER.KILL-ON-LOGOUT",
+            "COMBAT-MANAGER.ACTION-BAR",
+            "COMBAT-MANAGER.MOBS",
+            "COMBAT-MANAGER.ENDER-CRYSTAL",
+            "COMBAT-MANAGER.ENDER-PEARL",
+            "COMBAT-MANAGER.RESPAWN-ANCHOR",
+            "COMBAT-MANAGER.ANTI-STASIS-CHAMBER.ENABLED",
+            "COMBAT-MANAGER.ANTI-STASIS-CHAMBER.MAX-DISTANCE",
+            "COMBAT-MANAGER.BLOCK-MESSAGE",
+            "COMBAT-MANAGER.BLOCK-COMMANDS",
+            "COMBAT-MANAGER.EXCLUDED-WORLDS"
+    );
+
+    @Test
+    void bundledConfigShipsEveryCombatPathTheCodeReads() {
+        YamlConfiguration config = bundledConfig();
+        for (String path : COMBAT_PATHS) {
+            assertTrue(
+                    config.contains(path),
+                    "config.yml must ship " + path + " or admins cannot find the setting"
+            );
+        }
+    }
+
     @Test
     void bundledConfigDisablesMobCombatByDefault() {
+        YamlConfiguration config = bundledConfig();
+        assertTrue(config.isBoolean("COMBAT-MANAGER.MOBS"));
+        assertFalse(config.getBoolean("COMBAT-MANAGER.MOBS"));
+    }
+
+    @Test
+    void bundledConfigDisablesKillOnLogoutByDefault() {
+        YamlConfiguration config = bundledConfig();
+        assertTrue(config.isBoolean("COMBAT-MANAGER.KILL-ON-LOGOUT"));
+        assertFalse(config.getBoolean("COMBAT-MANAGER.KILL-ON-LOGOUT"));
+    }
+
+    private static YamlConfiguration bundledConfig() {
         var stream = CombatListenerTest.class.getClassLoader().getResourceAsStream("config.yml");
         assertNotNull(stream);
 
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(
+        return YamlConfiguration.loadConfiguration(
                 new InputStreamReader(stream, StandardCharsets.UTF_8)
         );
-        assertFalse(config.getBoolean("COMBAT-MANAGER.MOBS"));
     }
 }


### PR DESCRIPTION
Closes #214

The plugin has had kill-on-logout implemented all along. What went missing was the config key that turns it on, so combat logging went unpunished on any server whose owner had not somehow guessed the key existed.

## What broke

`55f753a9` overhauled the yaml configs and dropped two keys from the `COMBAT-MANAGER` block: `KILL-ON-LOGOUT` and `MOBS`. The code kept reading both. `CombatManager` reads them with hardcoded java fallbacks of `false`, so nothing crashed and nothing was logged. The guard in `CombatListener#onQuit` returned early every time, and mob damage stopped tagging anyone into combat. Those two are the only `COMBAT-MANAGER` paths the code reads that the bundled config had stopped shipping.

Both are back where they used to sit, at their original value of `false`. `COMBAT-MANAGER` is not listed in `isUserManagedBundledPath`, so existing servers pick the keys up on their next startup through the normal bundled-default merge instead of needing a config reset.

## Why they stay false

`false` is what the plugin shipped for its entire history before the deletion. Restoring them as `true` would quietly start killing players on every server that updates, which nobody asked for. The fix here is that the switch is present and findable, and turning it on stays the admin's decision.

## Notes

The old test asserted `config.getBoolean("COMBAT-MANAGER.MOBS")` was `false`, which is exactly why the deletion slipped past CI: `getBoolean` also returns `false` for a key that is not there at all, so the assertion kept passing once the key was gone. It now checks `isBoolean` as well, and a new test walks every `COMBAT-MANAGER` path the code reads and asserts the bundled config actually ships it. Deleting `KILL-ON-LOGOUT` again fails both.

No wiki change. `docs/wiki/` has no `COMBAT-MANAGER` section at all, and that gap covers all thirteen keys rather than these two, so it is worth a separate pass.

Suite is green at 326 tests.
