### PR TITLE
feat(shop): add a shop editor menu for enchanted and custom items (#217)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -27,6 +27,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/shards` | `/shards [player]` | None | Check shard balance | `ultimatedonutsmp.command.shards` |
 | `/shardpay` | `/shardpay <player> <amount>` | None | Pay shards to another player | `ultimatedonutsmp.command.shardpay` |
 | `/shop` | `/shop` | None | Open GUI shop | `ultimatedonutsmp.command.shop` |
+| `/shopedit` | `/shopedit <menu>` | None | Edit a shop menu in game | `ultimatedonutsmp.admin.shop` |
 | `/sell` | `/sell` | None | Open GUI sell container | `ultimatedonutsmp.command.sell` |
 | `/sellhand` | `/sellhand [amount]` | None | Sell item currently held in hand | `ultimatedonutsmp.command.sellhand` |
 | `/sellall` | `/sellall` | None | Sell all sellable items in inventory | `ultimatedonutsmp.command.sellall` |

--- a/docs/wiki/Config-shop.yml.md
+++ b/docs/wiki/Config-shop.yml.md
@@ -1172,3 +1172,40 @@ SHOP-GUI:
 
 ---
 
+## Section: `ITEM-DATA` (written by `/shopedit`)
+
+### 1. Commented Setup Code Example
+
+```yaml
+END-MENU:
+  TITLE: '&8shop - end'
+  SIZE: 27
+  # An ordinary hand-written entry: the buyer gets a plain item of this material.
+  END-STONE-ITEM:
+    MATERIAL: END_STONE
+    DISPLAY-NAME: '&fEnd Stone'
+    SLOT: 11
+    PRICE-PER-UNIT: 8.0
+  # An entry placed through /shopedit: ITEM-DATA carries the whole item.
+  FIREWORK-ROCKET-ITEM:
+    MATERIAL: FIREWORK_ROCKET
+    DISPLAY-NAME: '&fFirework Rocket'
+    SLOT: 12
+    PRICE-PER-UNIT: 120.0
+    ENCHANTMENTS: []
+    ITEM-DATA: 'ITEM_BYTES_V1:CgpGaXJld29yay4uLg=='
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Key Path | Data Type | Allowed Values | Default | Functional Behavior |
+|---|---|---|---|---|
+| `<MENU>.<ITEM>.ITEM-DATA` | `string` | A serialized item written by `/shopedit` | *(absent)* | The complete item, so enchantments, potion data, firework flight duration, trims, custom names and any other item data reach the buyer intact. When present it takes priority over `MATERIAL`, `ENCHANTMENTS` and `GLINT`, which stay in the file so the entry is still readable and still works if the stored data ever fails to load. |
+
+### 3. Practical Setup Example
+
+Rather than writing `ITEM-DATA` by hand, run `/shopedit <menu>` (for example `/shopedit end`), which needs `ultimatedonutsmp.admin.shop`. Click the item you want to sell in your own inventory, then click the shop slot it should sit in. To set a price, rename the item to `[PRICE] 250` in an anvil first — the rename is read as the price and then stripped, so it never reaches the buyer. Without it the price comes from `worth.yml`, and an item with no worth entry is refused instead of being listed for nothing.
+
+Clicking a filled slot with nothing selected removes that entry. Changes are saved to `shop.yml` as you make them, so no reload is needed.
+
+---

--- a/docs/wiki/Economy-and-Marketplaces.md
+++ b/docs/wiki/Economy-and-Marketplaces.md
@@ -27,6 +27,10 @@ Shards are an exclusive secondary currency earned from Shard Cuboids, play time,
 ### 1. Shop GUI (`/shop`)
 Opens the configured multi-category item shop where players can buy blocks, items, spawners, and gear.
 
+**Editing a shop in game (`/shopedit <menu>`)**: opens the chosen shop menu as an editor, the same way `/crate edit` works for crates. Click an item in your own inventory to pick it up as a template, then click a shop slot to put it there. Clicking a filled slot with nothing selected clears it, and every change is written to `shop.yml` straight away.
+
+Items placed this way are stored whole, so enchantments, potion data, firework flight duration, custom names and any other item data survive into what the buyer receives. Set the price by renaming the item to `[PRICE] 250` before you place it; without that rename the item's `worth.yml` value is used, and an item with no worth entry is refused rather than listed for nothing. The slots the menu keeps for its own back and paging buttons are blocked off in the editor.
+
 ### 2. Sell Container & Commands (`/sell`)
 - `/sell` (Aliases: `/sellmulti`, `/sellmultiplier`, `/sellprogress`): Opens a GUI chest container and Sell Multiplier progress menu. Players drop items inside and close the GUI to instantly sell all items for Vault money.
 - **Sell Category Item Preview**: Clicking the category header icon inside `/sellmulti` (or right-clicking category buttons in `/sell`) opens an item catalog GUI in `WorthMenu` showing only the items that fit in that category.

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -621,6 +621,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ShopCommand shopCommand = new ShopCommand(this);
         setExecutor("shop", shopCommand, FeatureManager.Feature.SHOP);
         setExecutor("shardshop", shopCommand, FeatureManager.Feature.SHOP, FeatureManager.Feature.SHARDS);
+        ShopEditCommand shopEditCommand = new ShopEditCommand(this);
+        setExecutor("shopedit", shopEditCommand, FeatureManager.Feature.SHOP);
+        setTabCompleter("shopedit", shopEditCommand);
         setExecutor("orders", new OrdersCommand(this), FeatureManager.Feature.ORDERS);
         setExecutor("duel", new DuelCommand(this), FeatureManager.Feature.DUELS);
         setExecutor("create", new CreateCommand(this), FeatureManager.Feature.DUELS);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/ShopEditCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/ShopEditCommand.java
@@ -1,0 +1,86 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.menus.ShopEditorMenu;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class ShopEditCommand implements CommandExecutor, TabCompleter {
+
+    private final UltimateDonutSmp plugin;
+
+    public ShopEditCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ColorUtils.colorize("&cOnly players can use /" + label + "."));
+            return true;
+        }
+
+        if (!PermissionUtils.has(sender, "ultimatedonutsmp.admin.shop")) {
+            sender.sendMessage(ColorUtils.colorize("&cYou do not have permission to edit the shop."));
+            return true;
+        }
+
+        List<String> menus = plugin.getShopManager().getEditableMenuSections();
+        if (menus.isEmpty()) {
+            player.sendMessage(ColorUtils.toComponent("&cThere are no shop menus to edit."));
+            return true;
+        }
+
+        if (args.length == 0) {
+            player.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <menu>"));
+            player.sendMessage(ColorUtils.toComponent("&7Menus: &f" + String.join("&7, &f", friendlyNames(menus))));
+            return true;
+        }
+
+        String menuSection = plugin.getShopManager().resolveMenuSection(args[0]);
+        if (menuSection == null) {
+            player.sendMessage(ColorUtils.toComponent("&cThere is no shop menu called &f" + args[0] + "&c."));
+            player.sendMessage(ColorUtils.toComponent("&7Menus: &f" + String.join("&7, &f", friendlyNames(menus))));
+            return true;
+        }
+
+        new ShopEditorMenu(plugin, menuSection).open(player);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length != 1 || !PermissionUtils.has(sender, "ultimatedonutsmp.admin.shop")) {
+            return List.of();
+        }
+
+        String prefix = args[0].toLowerCase(Locale.US);
+        List<String> matches = new ArrayList<>();
+        for (String name : friendlyNames(plugin.getShopManager().getEditableMenuSections())) {
+            if (name.startsWith(prefix)) {
+                matches.add(name);
+            }
+        }
+        return matches;
+    }
+
+    private List<String> friendlyNames(List<String> menuSections) {
+        List<String> names = new ArrayList<>();
+        for (String section : menuSections) {
+            String trimmed = section.endsWith("-MENU")
+                    ? section.substring(0, section.length() - "-MENU".length())
+                    : section;
+            names.add(trimmed.toLowerCase(Locale.US));
+        }
+        return names;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/InventoryClickListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/InventoryClickListener.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.listeners;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.BaseMenu;
 import com.bx.ultimateDonutSmp.menus.CrateEditorMenu;
+import com.bx.ultimateDonutSmp.menus.ShopEditorMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersInventoryItemMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersDepositMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersNewMenu;
@@ -46,6 +47,11 @@ public class InventoryClickListener implements Listener {
 
         if (menu instanceof CrateEditorMenu crateEditorMenu) {
             crateEditorMenu.handleInventoryClick(event);
+            return;
+        }
+
+        if (menu instanceof ShopEditorMenu shopEditorMenu) {
+            shopEditorMenu.handleInventoryClick(event);
             return;
         }
 
@@ -99,6 +105,11 @@ public class InventoryClickListener implements Listener {
 
         if (menu instanceof CrateEditorMenu crateEditorMenu) {
             crateEditorMenu.handleInventoryDrag(event);
+            return;
+        }
+
+        if (menu instanceof ShopEditorMenu shopEditorMenu) {
+            shopEditorMenu.handleInventoryDrag(event);
             return;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -2059,6 +2059,7 @@ public class ConfigManager {
     public FileConfiguration getOriginalDuels() { return duels; }
     public FileConfiguration getOriginalFfa() { return ffa; }
     public FileConfiguration getOriginalMenus() { return menus; }
+    public FileConfiguration getOriginalShop() { return shop; }
     public FileConfiguration getSpawners()      { return localized("CONFIG.SPAWNERS", spawners); }
     public FileConfiguration getSpawnStash()    { return localized("CONFIG.SPAWN_STASH", spawnStash); }
     public FileConfiguration getNetwork()       { return localized("CONFIG.NETWORK", network); }
@@ -2104,6 +2105,7 @@ public class ConfigManager {
     public boolean saveDuels() { return save("duels.yml", duels); }
     public boolean saveFfa() { return save("ffa.yml", ffa); }
     public boolean saveCrates() { return save("crates.yml", crates); }
+    public boolean saveShop() { return save("shop.yml", shop); }
     public boolean saveMenus() { return save("menus.yml", menus); }
     public boolean saveAuctionHouse() { return save("auction-house.yml", auctionHouse); }
     public boolean saveDatabase() { return save("database.yml", database); }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrashProtectionManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrashProtectionManager.java
@@ -33,6 +33,7 @@ public class CrashProtectionManager {
         ORDERS("Orders"),
         ENDER_CHEST("Ender Chest"),
         CRATES("Crates"),
+        SHOP("Shop"),
         DUELS("Duels"),
         DATABASE_LOAD("Database Load");
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -11,6 +11,7 @@ import com.bx.ultimateDonutSmp.models.SellCategory;
 import com.bx.ultimateDonutSmp.models.ShopPreference;
 import com.bx.ultimateDonutSmp.storage.ShopPreferenceRepository;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemSerializationUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
@@ -18,13 +19,16 @@ import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionType;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -43,6 +47,7 @@ import java.util.logging.Level;
 
 public class ShopManager {
 
+    private static final String PRICE_TAG_PREFIX = "[PRICE] ";
     private static final Set<String> CATEGORY_META_KEYS = Set.of("MENU-TITLE", "MENU-SIZE", "ORDER");
     private static final Set<String> MENU_META_KEYS = Set.of(
             "TITLE",
@@ -239,7 +244,8 @@ public class ShopManager {
             AmethystToolType amethystToolType,
             long amethystDurationSeconds,
             List<String> enchantments,
-            Boolean glint
+            Boolean glint,
+            String serializedItemData
     ) {
         public ShopItem(
                 String key,
@@ -264,8 +270,42 @@ public class ShopManager {
                     key, menuSection, material, displayName, lore, slot, pricePerUnit,
                     currency, command, giveItem, permission, minQuantity, maxQuantity,
                     defaultQuantity, hideQuantityButtons, amethystToolType, amethystDurationSeconds,
-                    List.of(), null
+                    List.of(), null, null
             );
+        }
+
+        /** Kept so callers that predate custom item data keep compiling. */
+        public ShopItem(
+                String key,
+                String menuSection,
+                Material material,
+                String displayName,
+                List<String> lore,
+                int slot,
+                double pricePerUnit,
+                Currency currency,
+                String command,
+                boolean giveItem,
+                String permission,
+                int minQuantity,
+                int maxQuantity,
+                int defaultQuantity,
+                Boolean hideQuantityButtons,
+                AmethystToolType amethystToolType,
+                long amethystDurationSeconds,
+                List<String> enchantments,
+                Boolean glint
+        ) {
+            this(
+                    key, menuSection, material, displayName, lore, slot, pricePerUnit,
+                    currency, command, giveItem, permission, minQuantity, maxQuantity,
+                    defaultQuantity, hideQuantityButtons, amethystToolType, amethystDurationSeconds,
+                    enchantments, glint, null
+            );
+        }
+
+        public boolean hasCustomItemData() {
+            return serializedItemData != null && !serializedItemData.isBlank();
         }
 
         public boolean isAmethystToolReward() {
@@ -278,6 +318,7 @@ public class ShopManager {
     private final UltimateDonutSmp plugin;
     private final ShopPreferenceRepository preferenceRepository;
     private final Map<UUID, ShopPreference> preferenceCache = new ConcurrentHashMap<>();
+    private final Map<String, ItemStack> customItemCache = new ConcurrentHashMap<>();
 
     public ShopManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -287,6 +328,7 @@ public class ShopManager {
     }
 
     public void reload() {
+        customItemCache.clear();
         validateShopConfiguration();
     }
 
@@ -552,7 +594,8 @@ public class ShopManager {
                     null,
                     -1L,
                     enchantments,
-                    glint
+                    glint,
+                    itemSec.getString("ITEM-DATA")
             ));
         }
 
@@ -953,6 +996,12 @@ public class ShopManager {
     }
 
     private ItemStack createPurchasedItem(ShopItem item, int amount) {
+        ItemStack custom = createCustomItem(item);
+        if (custom != null) {
+            custom.setAmount(Math.max(1, amount));
+            return custom;
+        }
+
         ItemStack stack = new ItemStack(item.material(), Math.max(1, amount));
         if (item.enchantments() != null && !item.enchantments().isEmpty()) {
             ItemUtils.addEnchantments(stack, item.enchantments());
@@ -961,6 +1010,326 @@ public class ShopManager {
             ItemUtils.setGlint(stack, item.glint());
         }
         return stack;
+    }
+
+    /**
+     * The exact item an admin stored through the shop editor, or null when the entry is a plain
+     * MATERIAL one. Menus use this so the icon matches what the buyer actually receives.
+     */
+    public ItemStack createCustomItem(ShopItem item) {
+        if (item == null || !item.hasCustomItemData()) {
+            return null;
+        }
+
+        ItemStack cached = customItemCache.get(item.serializedItemData());
+        if (cached != null) {
+            return cached.clone();
+        }
+
+        try {
+            ItemStack stored = ItemSerializationUtils.deserialize(item.serializedItemData());
+            if (stored == null || stored.getType().isAir()) {
+                return null;
+            }
+            customItemCache.put(item.serializedItemData(), stored.clone());
+            return stored;
+        } catch (IOException | ClassNotFoundException | IllegalArgumentException exception) {
+            plugin.getLogger().log(Level.WARNING,
+                    "Failed to read ITEM-DATA for shop item " + item.key() + " in " + item.menuSection(), exception);
+            return null;
+        }
+    }
+
+    // ── Shop editor ─────────────────────────────────────────────────────────────
+
+    /** Outcome of an edit made through the shop editor menu. */
+    public record EditResult(boolean success, String message) {}
+
+    /** An item with its shop price, once a {@code [PRICE] <amount>} rename has been read off it. */
+    public record PricedItem(ItemStack item, Double price) {}
+
+    /**
+     * Reads a {@code [PRICE] <amount>} rename off an item and hands back the item with that rename
+     * removed, so the price tag never ends up baked into what the buyer receives. Items without the
+     * tag come back untouched and with a null price.
+     */
+    public PricedItem readPriceTag(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) {
+            return new PricedItem(item, null);
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) {
+            return new PricedItem(item, null);
+        }
+
+        Double parsed = parsePriceTag(ColorUtils.strip(meta.getDisplayName()));
+        if (parsed == null) {
+            return new PricedItem(item, null);
+        }
+
+        ItemStack cleaned = item.clone();
+        ItemMeta cleanedMeta = cleaned.getItemMeta();
+        if (cleanedMeta != null) {
+            cleanedMeta.setDisplayName(null);
+            cleaned.setItemMeta(cleanedMeta);
+        }
+        return new PricedItem(cleaned, parsed);
+    }
+
+    /**
+     * Pulls the amount out of a {@code [PRICE] 250} rename, or null when the name is not a price tag
+     * or the amount will not do as a price.
+     */
+    public static Double parsePriceTag(String displayName) {
+        if (displayName == null) {
+            return null;
+        }
+
+        String trimmed = displayName.trim();
+        if (!trimmed.toUpperCase(Locale.US).startsWith(PRICE_TAG_PREFIX)) {
+            return null;
+        }
+
+        double parsed;
+        try {
+            parsed = Double.parseDouble(trimmed.substring(PRICE_TAG_PREFIX.length()).trim().replace(",", ""));
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+
+        return parsed > 0 && Double.isFinite(parsed) ? parsed : null;
+    }
+
+    /** Menu sections an admin can open in the editor, in the order the categories menu shows them. */
+    public List<String> getEditableMenuSections() {
+        List<String> sections = new ArrayList<>();
+        for (ShopCategory category : loadCategories()) {
+            if (!sections.contains(category.menuSection())) {
+                sections.add(category.menuSection());
+            }
+        }
+        return List.copyOf(sections);
+    }
+
+    /** Turns what an admin typed ("end", "end-menu", "{end-menu}") into a real shop.yml section. */
+    public String resolveMenuSection(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+
+        String normalized = input.replace("{", "").replace("}", "").trim().toUpperCase(Locale.US);
+        List<String> sections = getEditableMenuSections();
+        if (sections.contains(normalized)) {
+            return normalized;
+        }
+
+        String suffixed = normalized.endsWith("-MENU") ? normalized : normalized + "-MENU";
+        return sections.contains(suffixed) ? suffixed : null;
+    }
+
+    public int getMenuSize(String menuSection) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getShop()
+                .getConfigurationSection(menuSection);
+        int configured = menuConfig == null ? 27 : menuConfig.getInt("SIZE", 27);
+        int bounded = Math.max(9, Math.min(54, configured));
+        return bounded % 9 == 0 ? bounded : ((bounded / 9) + 1) * 9;
+    }
+
+    /** Where a shop menu puts its back button, which the editor reuses for its close button. */
+    public int getBackButtonSlot(String menuSection) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getShop()
+                .getConfigurationSection(menuSection);
+        int size = getMenuSize(menuSection);
+        return menuConfig == null ? size - 9 : menuConfig.getInt("BACK-BUTTON-SLOT", size - 9);
+    }
+
+    /**
+     * Slots a shop menu keeps for its own back and paging buttons. An item parked on one of these is
+     * what makes ShopMenu give up on configured slots and fall back to paging, so the editor refuses
+     * to place there.
+     */
+    public Set<Integer> getReservedSlots(String menuSection) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getShop()
+                .getConfigurationSection(menuSection);
+        int size = getMenuSize(menuSection);
+        if (menuConfig == null) {
+            return Set.of();
+        }
+
+        Set<Integer> reserved = new HashSet<>();
+        reserved.add(getBackButtonSlot(menuSection));
+        reserved.add(menuConfig.getInt("FIRST-PAGE-SLOT", size - 8));
+        reserved.add(menuConfig.getInt("PREVIOUS-PAGE-SLOT", size - 7));
+        reserved.add(menuConfig.getInt("PAGE-INFO-SLOT", size - 5));
+        reserved.add(menuConfig.getInt("NEXT-PAGE-SLOT", size - 3));
+        reserved.add(menuConfig.getInt("LAST-PAGE-SLOT", size - 2));
+        return Set.copyOf(reserved);
+    }
+
+    /**
+     * Stores {@code item} in {@code slot} of {@code menuSection}, replacing whatever was there. The
+     * whole item is written as ITEM-DATA so enchantments and every other bit of item data survive the
+     * round trip, with MATERIAL and friends written alongside so the entry stays readable in shop.yml.
+     */
+    public EditResult upsertMenuItem(String menuSection, int slot, ItemStack item, Double price) {
+        if (item == null || item.getType().isAir()) {
+            return new EditResult(false, "&cSelect an item from your inventory first.");
+        }
+
+        ConfigurationSection menuConfig = plugin.getConfigManager().getOriginalShop()
+                .getConfigurationSection(menuSection);
+        if (menuConfig == null) {
+            return new EditResult(false, "&cThat shop menu no longer exists.");
+        }
+
+        if (slot < 0 || slot >= getMenuSize(menuSection)) {
+            return new EditResult(false, "&cThat slot is outside this shop menu.");
+        }
+
+        if (getReservedSlots(menuSection).contains(slot)) {
+            return new EditResult(false, "&cThat slot belongs to the menu buttons. Pick another one.");
+        }
+
+        ItemStack storedItem = item.clone();
+        storedItem.setAmount(1);
+
+        CrashProtectionManager.ValidationResult safetyResult = plugin.getCrashProtectionManager()
+                .validateForStorage(storedItem, CrashProtectionManager.Context.SHOP);
+        if (!safetyResult.allowed()) {
+            plugin.getCrashProtectionManager().logBlockedItem(
+                    "shop " + menuSection + " slot " + slot,
+                    storedItem,
+                    CrashProtectionManager.Context.SHOP,
+                    safetyResult
+            );
+            return new EditResult(false, plugin.getConfigManager().getMessageOrDefault(
+                    "CRASH_PROTECTION.ITEM_BLOCKED",
+                    "&cThat item cannot be used here because its data looks unsafe. &7context: &f{context}&7. reason: &f{reason}",
+                    "{context}", CrashProtectionManager.Context.SHOP.displayName(),
+                    "{reason}", safetyResult.reason()
+            ));
+        }
+
+        double resolvedPrice = price != null ? price : getWorth(storedItem);
+        if (resolvedPrice <= 0) {
+            return new EditResult(false, "&cThat item has no worth entry, so it needs a price. "
+                    + "Rename it to &f[PRICE] 250&c and place it again.");
+        }
+
+        String serializedItemData;
+        try {
+            serializedItemData = ItemSerializationUtils.serialize(storedItem);
+        } catch (IOException exception) {
+            plugin.getLogger().log(Level.WARNING,
+                    "Failed to serialize shop item for " + menuSection + " slot " + slot, exception);
+            return new EditResult(false, "&cFailed to store that item in the shop.");
+        }
+
+        ConfigurationSection itemsSection = menuConfig.getConfigurationSection("ITEMS");
+        String basePath = menuSection + (itemsSection != null ? ".ITEMS." : ".");
+        String existingKey = findItemKeyBySlot(menuSection, slot);
+        boolean editing = existingKey != null;
+        String itemKey = editing ? existingKey : generateItemKey(menuSection, storedItem.getType(), slot);
+        String path = basePath + itemKey;
+
+        FileConfiguration shopConfig = plugin.getConfigManager().getOriginalShop();
+        ItemMeta meta = storedItem.getItemMeta();
+        String displayName = editorDisplayName(meta, storedItem.getType());
+
+        shopConfig.set(path + ".MATERIAL", storedItem.getType().name());
+        shopConfig.set(path + ".DISPLAY-NAME", displayName);
+        shopConfig.set(path + ".SLOT", slot);
+        shopConfig.set(path + ".PRICE-PER-UNIT", resolvedPrice);
+        shopConfig.set(path + ".ENCHANTMENTS", editorEnchantments(storedItem));
+        shopConfig.set(path + ".ITEM-DATA", serializedItemData);
+
+        if (!plugin.getConfigManager().saveShop()) {
+            return new EditResult(false, "&cFailed to save shop.yml while updating that slot.");
+        }
+
+        reload();
+        return new EditResult(true, "&aStored &f" + ColorUtils.strip(displayName)
+                + "&a in slot &f" + slot + "&a at &f" + NumberUtils.format(resolvedPrice) + "&a.");
+    }
+
+    /** Drops whatever item sits in {@code slot} of {@code menuSection} out of shop.yml. */
+    public EditResult removeMenuItem(String menuSection, int slot) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getOriginalShop()
+                .getConfigurationSection(menuSection);
+        if (menuConfig == null) {
+            return new EditResult(false, "&cThat shop menu no longer exists.");
+        }
+
+        String itemKey = findItemKeyBySlot(menuSection, slot);
+        if (itemKey == null) {
+            return new EditResult(false, "&cThere is nothing in slot &f" + slot + "&c.");
+        }
+
+        ConfigurationSection itemsSection = menuConfig.getConfigurationSection("ITEMS");
+        String path = menuSection + (itemsSection != null ? ".ITEMS." : ".") + itemKey;
+        plugin.getConfigManager().getOriginalShop().set(path, null);
+
+        if (!plugin.getConfigManager().saveShop()) {
+            return new EditResult(false, "&cFailed to save shop.yml while clearing that slot.");
+        }
+
+        reload();
+        return new EditResult(true, "&aCleared slot &f" + slot + "&a.");
+    }
+
+    private String findItemKeyBySlot(String menuSection, int slot) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getOriginalShop()
+                .getConfigurationSection(menuSection);
+        if (menuConfig == null) {
+            return null;
+        }
+
+        ConfigurationSection itemsSection = menuConfig.getConfigurationSection("ITEMS");
+        ConfigurationSection sourceSection = itemsSection != null ? itemsSection : menuConfig;
+        for (String key : sourceSection.getKeys(false)) {
+            if (sourceSection == menuConfig && MENU_META_KEYS.contains(key.toUpperCase(Locale.US))) {
+                continue;
+            }
+
+            ConfigurationSection itemSec = sourceSection.getConfigurationSection(key);
+            if (itemSec != null && itemSec.contains("MATERIAL") && itemSec.getInt("SLOT", -1) == slot) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private String generateItemKey(String menuSection, Material material, int slot) {
+        ConfigurationSection menuConfig = plugin.getConfigManager().getOriginalShop()
+                .getConfigurationSection(menuSection);
+        ConfigurationSection itemsSection = menuConfig == null ? null : menuConfig.getConfigurationSection("ITEMS");
+        ConfigurationSection sourceSection = itemsSection != null ? itemsSection : menuConfig;
+
+        String base = material.name().replace('_', '-') + "-ITEM";
+        if (sourceSection == null || !sourceSection.contains(base)) {
+            return base;
+        }
+        return base + "-" + slot;
+    }
+
+    private String editorDisplayName(ItemMeta meta, Material material) {
+        if (meta == null || !meta.hasDisplayName()) {
+            return "&f" + plugin.getWorthManager().prettifyMaterial(material);
+        }
+        return meta.getDisplayName().replace('\u00A7', '&');
+    }
+
+    private List<String> editorEnchantments(ItemStack item) {
+        if (item == null || item.getEnchantments().isEmpty()) {
+            return List.of();
+        }
+
+        List<String> enchantments = new ArrayList<>();
+        for (Map.Entry<org.bukkit.enchantments.Enchantment, Integer> entry : item.getEnchantments().entrySet()) {
+            enchantments.add(entry.getKey().getKey().getKey() + ":" + entry.getValue());
+        }
+        return enchantments;
     }
 
     private boolean canFitPurchasedItem(Player player, ShopItem item, int amount) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
@@ -132,12 +132,18 @@ public class PurchaseShopMenu extends BaseMenu {
         lore.add("&7Allowed: &f" + restriction.minQuantity() + "&7 - &f" + restriction.maxQuantity());
         lore.add("&7Currency: &f" + plugin.getCurrencyManager().plural(currencyType()));
 
-        ItemStack preview = ItemUtils.createItem(item.material(), item.displayName(), lore);
-        if (item.enchantments() != null && !item.enchantments().isEmpty()) {
-            ItemUtils.addEnchantments(preview, item.enchantments());
-        }
-        if (item.glint() != null) {
-            ItemUtils.setGlint(preview, item.glint());
+        ItemStack custom = plugin.getShopManager().createCustomItem(item);
+        ItemStack preview;
+        if (custom != null) {
+            preview = ItemUtils.withDisplay(custom, item.displayName(), lore);
+        } else {
+            preview = ItemUtils.createItem(item.material(), item.displayName(), lore);
+            if (item.enchantments() != null && !item.enchantments().isEmpty()) {
+                ItemUtils.addEnchantments(preview, item.enchantments());
+            }
+            if (item.glint() != null) {
+                ItemUtils.setGlint(preview, item.glint());
+            }
         }
         preview.setAmount(Math.min(quantity, preview.getMaxStackSize()));
         set(getPreviewSlot(), preview);

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopEditorMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopEditorMenu.java
@@ -1,0 +1,192 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.ShopManager;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class ShopEditorMenu extends BaseMenu {
+
+    private final String menuSection;
+    private final Set<Integer> reservedSlots;
+    private final int closeSlot;
+    private ItemStack selectedTemplate;
+    private boolean instructionsSent;
+
+    public ShopEditorMenu(UltimateDonutSmp plugin, String menuSection) {
+        super(plugin, "&8Editing shop: " + friendlyName(menuSection), plugin.getShopManager().getMenuSize(menuSection));
+        this.menuSection = menuSection;
+        this.reservedSlots = plugin.getShopManager().getReservedSlots(menuSection);
+        this.closeSlot = resolveCloseSlot(plugin, menuSection, inventory.getSize());
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+
+        for (ShopManager.ShopItem item : plugin.getShopManager().loadMenuItems(menuSection)) {
+            if (item.slot() < 0 || item.slot() >= inventory.getSize() || item.slot() == closeSlot) {
+                continue;
+            }
+            set(item.slot(), createEditorItem(item));
+        }
+
+        for (int reserved : reservedSlots) {
+            if (reserved == closeSlot || reserved < 0 || reserved >= inventory.getSize()) {
+                continue;
+            }
+            set(reserved, ItemUtils.createItem(
+                    Material.GRAY_STAINED_GLASS_PANE,
+                    "&7Menu button slot",
+                    List.of("&7The shop uses this slot for its own buttons.")
+            ));
+        }
+
+        set(closeSlot, ItemUtils.createItem(
+                Material.BARRIER,
+                "&cClose Editor",
+                List.of(
+                        "&7Click to close this editor.",
+                        "&7Changes are saved instantly."
+                )
+        ));
+
+        if (!instructionsSent) {
+            instructionsSent = true;
+            player.sendMessage(ColorUtils.toComponent("&8[&bShop&8] &7Click an item in your inventory to select it, then click a shop slot to place or replace it."));
+            player.sendMessage(ColorUtils.toComponent("&8[&bShop&8] &7Rename it to &f[PRICE] 250 &7first to set the price, otherwise its worth is used."));
+            player.sendMessage(ColorUtils.toComponent("&8[&bShop&8] &7Click a filled slot with nothing selected to clear it."));
+        }
+    }
+
+    public void handleInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        int rawSlot = event.getRawSlot();
+        if (rawSlot >= 0 && rawSlot < inventory.getSize()) {
+            event.setCancelled(true);
+
+            if (rawSlot == closeSlot) {
+                SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                player.closeInventory();
+                return;
+            }
+
+            if (reservedSlots.contains(rawSlot)) {
+                player.sendMessage(ColorUtils.toComponent("&cThat slot belongs to the menu buttons. Pick another one."));
+                return;
+            }
+
+            if (selectedTemplate != null) {
+                ShopManager.PricedItem priced = plugin.getShopManager().readPriceTag(selectedTemplate);
+                ShopManager.EditResult result = plugin.getShopManager()
+                        .upsertMenuItem(menuSection, rawSlot, priced.item(), priced.price());
+                player.sendMessage(ColorUtils.toComponent(result.message()));
+                if (result.success()) {
+                    SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                    build(player);
+                }
+                return;
+            }
+
+            ItemStack current = inventory.getItem(rawSlot);
+            if (current == null || current.getType().isAir()) {
+                player.sendMessage(ColorUtils.toComponent("&cSelect an item from your inventory first."));
+                return;
+            }
+
+            ShopManager.EditResult result = plugin.getShopManager().removeMenuItem(menuSection, rawSlot);
+            player.sendMessage(ColorUtils.toComponent(result.message()));
+            if (result.success()) {
+                SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+                build(player);
+            }
+            return;
+        }
+
+        event.setCancelled(true);
+        if (event.getClickedInventory() == null || event.getCurrentItem() == null || event.getCurrentItem().getType().isAir()) {
+            return;
+        }
+
+        selectedTemplate = event.getCurrentItem().clone();
+        player.sendMessage(ColorUtils.toComponent("&aSelected &f" + readableItemName(selectedTemplate) + "&a. Click a shop slot to place it."));
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+    }
+
+    public void handleInventoryDrag(InventoryDragEvent event) {
+        event.setCancelled(true);
+    }
+
+    @Override
+    public void onClose(Player player) {
+        selectedTemplate = null;
+    }
+
+    private ItemStack createEditorItem(ShopManager.ShopItem item) {
+        List<String> lore = new ArrayList<>();
+        lore.add("&7Price: &a" + NumberUtils.format(item.pricePerUnit()));
+        lore.add("&7Currency: &f" + item.currency().name());
+        if (item.hasCustomItemData()) {
+            lore.add("&7Sold exactly as stored.");
+        }
+        lore.add("");
+        lore.add("&7Click with an item selected to replace.");
+        lore.add("&7Click with nothing selected to clear.");
+
+        ItemStack custom = plugin.getShopManager().createCustomItem(item);
+        if (custom != null) {
+            ItemStack preview = custom.clone();
+            preview.setAmount(1);
+            ItemMeta meta = preview.getItemMeta();
+            if (meta != null) {
+                meta.setLore(ColorUtils.colorizeList(lore));
+                preview.setItemMeta(meta);
+            }
+            return preview;
+        }
+
+        ItemStack preview = ItemUtils.createItem(item.material(), item.displayName(), lore);
+        if (item.enchantments() != null && !item.enchantments().isEmpty()) {
+            ItemUtils.addEnchantments(preview, item.enchantments());
+        }
+        if (item.glint() != null) {
+            ItemUtils.setGlint(preview, item.glint());
+        }
+        return preview;
+    }
+
+    private String readableItemName(ItemStack item) {
+        if (item.hasItemMeta() && item.getItemMeta() != null && item.getItemMeta().hasDisplayName()) {
+            return ColorUtils.strip(item.getItemMeta().getDisplayName());
+        }
+        return plugin.getWorthManager().prettifyMaterial(item.getType());
+    }
+
+    private static int resolveCloseSlot(UltimateDonutSmp plugin, String menuSection, int size) {
+        int backSlot = plugin.getShopManager().getBackButtonSlot(menuSection);
+        return backSlot >= 0 && backSlot < size ? backSlot : size - 1;
+    }
+
+    private static String friendlyName(String menuSection) {
+        String trimmed = menuSection.endsWith("-MENU")
+                ? menuSection.substring(0, menuSection.length() - "-MENU".length())
+                : menuSection;
+        return trimmed.toLowerCase(Locale.US).replace('-', ' ');
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
@@ -284,11 +284,15 @@ public class ShopMenu extends BaseMenu {
             lore.add(replaceShopGuiPlaceholders(line, item, quote, favorite));
         }
 
-        ItemStack displayStack = ItemUtils.createItem(
-                item.material(),
-                plugin.getCurrencyManager().applyStaticPlaceholders(item.displayName()),
-                plugin.getCurrencyManager().applyStaticPlaceholders(lore)
-        );
+        String displayName = plugin.getCurrencyManager().applyStaticPlaceholders(item.displayName());
+        List<String> displayLore = plugin.getCurrencyManager().applyStaticPlaceholders(lore);
+
+        ItemStack custom = plugin.getShopManager().createCustomItem(item);
+        if (custom != null) {
+            return ItemUtils.withDisplay(custom, displayName, displayLore);
+        }
+
+        ItemStack displayStack = ItemUtils.createItem(item.material(), displayName, displayLore);
         if (item.enchantments() != null && !item.enchantments().isEmpty()) {
             ItemUtils.addEnchantments(displayStack, item.enchantments());
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ItemUtils.java
@@ -49,6 +49,28 @@ public class ItemUtils {
         return createItem(material, displayName, null);
     }
 
+    /**
+     * Puts a menu name and lore on a copy of an existing item, leaving everything else about it
+     * alone. Used where the icon has to stay the real item but still read as a menu entry.
+     */
+    public static ItemStack withDisplay(ItemStack item, String displayName, List<String> lore) {
+        if (item == null) return null;
+
+        ItemStack copy = item.clone();
+        ItemMeta meta = copy.getItemMeta();
+        if (meta == null) return copy;
+
+        if (displayName != null && !displayName.isEmpty()) {
+            meta.setDisplayName(ColorUtils.colorize(displayName));
+        }
+        if (lore != null && !lore.isEmpty()) {
+            meta.setLore(ColorUtils.colorizeList(lore));
+        }
+
+        copy.setItemMeta(meta);
+        return copy;
+    }
+
     public static ItemStack createPlayerHead(OfflinePlayer player, String displayName, List<String> lore) {
         return createPlayerHead(player, null, displayName, lore);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -118,6 +118,11 @@ commands:
     usage: /shop [reload]
     permission: ultimatedonutsmp.command.shop
     permission-message: "&cYou do not have permission to use /shop."
+  shopedit:
+    description: Edit a shop menu in game
+    usage: /shopedit <menu>
+    permission: ultimatedonutsmp.admin.shop
+    permission-message: "&cYou do not have permission to edit the shop."
   orders:
     description: Open the Orders board
     usage: /orders [my|collect|reload]

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
@@ -106,6 +106,23 @@ class ShopManagerTest {
         assertFalse(ShopManager.shouldDeliverConfiguredItem(managedSpawner));
     }
 
+    @Test
+    void readsPriceTagRename() {
+        assertEquals(250D, ShopManager.parsePriceTag("[PRICE] 250"));
+        assertEquals(2500.5D, ShopManager.parsePriceTag("[PRICE] 2,500.5"));
+        assertEquals(75D, ShopManager.parsePriceTag("  [price] 75  "));
+    }
+
+    @Test
+    void ignoresNamesThatAreNotUsablePriceTags() {
+        assertNull(ShopManager.parsePriceTag(null));
+        assertNull(ShopManager.parsePriceTag("Ender Pearl"));
+        assertNull(ShopManager.parsePriceTag("[PRICE] free"));
+        assertNull(ShopManager.parsePriceTag("[PRICE] 0"));
+        assertNull(ShopManager.parsePriceTag("[PRICE] -10"));
+        assertNull(ShopManager.parsePriceTag("[PRICE] "));
+    }
+
     private AuctionListing listing(
             long id,
             UUID seller,


### PR DESCRIPTION
Closes #217

The shop could only ever sell a bare material. Every entry in `shop.yml` is a `MATERIAL` plus a name and some lore, and the item handed over on purchase was built fresh from that material, so anything living in the item's own data was lost on the way through. Enchantments and a glint were reachable if you hand-wrote the `ENCHANTMENTS` key, but a firework with flight duration 3, or a tipped arrow, or anything else carrying real item data, could not go in the shop at all. This adds `/shopedit`, which opens a shop menu as an editor and stores whatever you drop into it whole.

## The editor

`/shopedit <menu>`, for example `/shopedit end`, opens that menu as an editing view. It uses the existing `ultimatedonutsmp.admin.shop` node rather than a new one. It works the way the crate editor already does: click an item in your own inventory to pick it up as a template, then click a shop slot to place or replace it. Clicking a filled slot with nothing selected clears it. Changes go into `shop.yml` as you make them, so there is nothing to reload afterwards.

Prices come from a `[PRICE] 250` rename on the item. That mirrors the `[MONEY]` and `[SHARDS]` shorthand the crate editor already uses for the same problem, since there is no chat-prompt helper anywhere in the codebase to borrow. The rename is read and then stripped, so it never reaches the buyer. With no tag the item's `worth.yml` value is used instead, and an item with no worth entry is refused outright rather than quietly listed for nothing.

## Storing the whole item

Entries placed through the editor get an `ITEM-DATA` key holding the serialized item, the same mechanism crates use for `GRANT.ITEM-DATA`. `MATERIAL`, `DISPLAY-NAME` and `ENCHANTMENTS` are still written next to it, so the entry stays readable in `shop.yml` and still renders if the stored data ever fails to load. `createPurchasedItem` prefers `ITEM-DATA` when it is there, and both the shop menu and the purchase confirmation menu now show the real item, so the icon matches what actually lands in the buyer's inventory.

## Reserved slots

`ShopMenu` only honours configured `SLOT` values when no item sits on one of the six slots it keeps for its back and paging buttons. One item in the wrong place silently flips the whole menu into paging mode and rearranges it. The editor blocks those slots off and refuses to write to them, so nobody walks into that by accident.

## Notes

- New config key: `<MENU>.<ITEM>.ITEM-DATA`, written by the editor rather than by hand. No new language keys, since the editor's messages are hardcoded English the way `CrateEditorMenu`'s are.
- Items go through `CrashProtectionManager` before being stored, with a new `SHOP` context added alongside the existing `CRATES` one.
- Deserialized items are cached per serialized string, and the cache is cleared on reload, so opening a shop page does not re-parse every stored item.
- The price tag parser is split out as a static so it can be covered without a live server. Six new assertions across two tests. Full suite is 328 tests, all passing.
- Wiki pages updated: the command table, the `shop.yml` reference, and the shop section of the economy page.
