### PR TITLE
docs(config): explain what the adaptive-task switches actually do (#220)

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -658,11 +658,17 @@ OPTIMIZATION:
   RECOVERY-SAMPLES: 3
   # Determines whether Log State Changes is enabled or disabled. Available options: true, false
   LOG-STATE-CHANGES: true
-  # Configuration section for Adaptive Tasks.
+  # Configuration section for Adaptive Tasks. Each entry below decides how often one task is
+  # allowed to run while the server is struggling. None of them switch a feature on or off; the
+  # switches for that live in their own sections, either at the top level of this file or in the
+  # file named after the feature.
   ADAPTIVE-TASKS:
     # Configuration section for Scoreboard.
     SCOREBOARD:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      # Whether the scoreboard task may be slowed down while the server is under load. Setting this
+      # to false removes the slowdown and lets the task keep running at full rate; it does not turn
+      # the scoreboard off. That switch is SCOREBOARD.ENABLED in scoreboard.yml.
+      # Available options: true, false
       ENABLED: true
       # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
       WARN-MIN-INTERVAL-TICKS: 4
@@ -670,7 +676,10 @@ OPTIMIZATION:
       CRITICAL-MIN-INTERVAL-TICKS: 10
     # Configuration section for Tablist.
     TABLIST:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      # Whether the tablist task may be slowed down while the server is under load. Setting this to
+      # false removes the slowdown and lets the task keep running at full rate; it does not turn the
+      # tablist off. That switch is the TABLIST section near the top of this file.
+      # Available options: true, false
       ENABLED: true
       # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
       WARN-MIN-INTERVAL-TICKS: 80
@@ -678,7 +687,10 @@ OPTIMIZATION:
       CRITICAL-MIN-INTERVAL-TICKS: 140
     # Configuration section for Lunar Teammates.
     LUNAR-TEAMMATES:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      # Whether the lunar teammates task may be slowed down while the server is under load. Setting
+      # this to false removes the slowdown and lets the task keep running at full rate; it does not
+      # turn the lunar teammate overlay off.
+      # Available options: true, false
       ENABLED: true
       # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
       WARN-MIN-INTERVAL-TICKS: 40


### PR DESCRIPTION
Closes #220

Three comments in `config.yml` described the adaptive-task switches as if they turned features on and off. They do the opposite of that, and the wording gave no hint of it.

## What they actually do

`shouldRun` treats a task whose throttle is not enabled as free to run: it returns `true` and skips the interval check entirely. So `ADAPTIVE-TASKS.TABLIST.ENABLED: false` does not stop the tablist. It removes the slowdown that would otherwise be applied while the server is struggling, leaving the task running at full rate under exactly the conditions it was meant to back off from.

Every one of the three carried the same generated line, which says nothing either way:

```
# Determines whether Enabled is enabled or disabled. Available options: true, false
```

## Why it matters more for the tablist one

`TABLIST` is the only section name in `config.yml` that appears at two depths with an `ENABLED:` under both. The other is the real switch for the tablist system, sixty lines earlier. Someone searching the file for `TABLIST`, wanting to hand their tab list to another plugin, can land on the throttle by mistake, set it to false, and get more tablist work rather than none, with nothing in the file or the console to correct them. That is not hypothetical; it came within one message of happening on #208.

Each of the three now says what the switch does, says plainly that turning it off removes the throttle rather than the feature, and the two that have a real switch elsewhere name where it lives.

## Notes

Comments only. No key, value or default changed, and nothing reads these comments at runtime.

`CLEAR-LAG` and the other top-level sections keep the generated wording. Their `ENABLED` keys really are feature switches, so the line is unhelpful there but not misleading, and rewording all ninety-odd of them is a separate job from fixing the three that point the wrong way.

Full suite run locally: 328 passing.
