### PR TITLE
feat(chat): log public chat messages and add a chat log browser (#222)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -61,6 +61,8 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/invsee` | `/invsee <player>` | Inspect and edit player inventory in real-time | `ultimatedonutsmp.admin.invsee` |
 | `/ecsee` | `/ecsee <player>` | Inspect and edit player Ender Chest | `ultimatedonutsmp.admin.ecsee` |
 | `/chat` | `/chat <mute\|unmute\|delay\|clear>` | Global chat moderation controls | `ultimatedonutsmp.admin.chat` |
+| `/logs` | `/logs <player>` | Browse one player's activity log, chat included | `ultimatedonutsmp.admin.logs` |
+| `/chatlog` | `/chatlog [player]` | Browse public chat for the whole server, or for one player | `ultimatedonutsmp.admin.chatlog` |
 | `/spawnstash` | `/spawnstash <give\|setup\|list>` (Alias `/stash`) | Manage spawn stash bait chests | `ultimatedonutsmp.admin.spawnstash` |
 | `/fakeplayer` | `/fakeplayer` (Alias `/fplayer`) | Spawn fake player bait entities | `ultimatedonutsmp.command.fakeplayer` |
 | `/amod` | `/amod <add\|reload>` | Manage the anvil rename word filter | `ultimatedonutsmp.command.amod` |

--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -529,6 +529,19 @@ CHAT:
   MAX-DELAY-SECONDS: 30
   # The numerical value for Clear Lines. Available options: Any valid integer
   CLEAR-LINES: 150
+  # Configuration section for Logging. Writes chat into each player's own log, so staff can
+  # read it back with /logs <player> or browse the whole server with /chatlog. None of these
+  # switches change what players see in chat.
+  LOGGING:
+    # Master switch for chat logging. With this off, neither public nor private messages are
+    # recorded, whatever the two switches below say. Available options: true, false
+    ENABLED: true
+    # Records normal public chat. Only messages that actually reach chat are stored, so muted,
+    # filtered and rate-limited messages are left out. Available options: true, false
+    PUBLIC-MESSAGES: true
+    # Records private messages sent with /msg and /reply, on both sides of the conversation.
+    # Available options: true, false
+    PRIVATE-MESSAGES: true
   # Configuration section for Filter.
   FILTER:
     # Determines whether Enabled is enabled or disabled. Available options: true, false
@@ -589,6 +602,9 @@ CHAT:
 | `CHAT.GLOBAL-CHAT-DELAY` | `int` | Any valid integer number | `'3'` | Configures the technical `GLOBAL-CHAT-DELAY` parameter for `CHAT.GLOBAL-CHAT-DELAY` in `config.yml`. |
 | `CHAT.MAX-DELAY-SECONDS` | `int` | Any valid integer number | `'30'` | Configures the technical `MAX-DELAY-SECONDS` parameter for `CHAT.MAX-DELAY-SECONDS` in `config.yml`. |
 | `CHAT.CLEAR-LINES` | `int` | Any valid integer number | `'150'` | Configures the technical `CLEAR-LINES` parameter for `CHAT.CLEAR-LINES` in `config.yml`. |
+| `CHAT.LOGGING.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for chat logging. Turn it off and nothing a player types is written to their log, whichever of the two switches below are on. |
+| `CHAT.LOGGING.PUBLIC-MESSAGES` | `bool` | `true`, `false` | `true` | Records normal public chat into the sender's log, readable with `/logs <player>` or `/chatlog`. Only messages that reach chat are stored, so muted, filtered and rate-limited ones are left out. |
+| `CHAT.LOGGING.PRIVATE-MESSAGES` | `bool` | `true`, `false` | `true` | Records `/msg` and `/reply` conversations into both players' logs, readable with `/logs <player>`. |
 | `CHAT.FILTER.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `CHAT` system. Set to `true` to enable, `false` to disable. |
 | `CHAT.FILTER.BLOCK-MESSAGE` | `str` | Any string text | `'&7Please avoid using inappropriate ...'` | Configures the technical `BLOCK-MESSAGE` parameter for `CHAT.FILTER.BLOCK-MESSAGE` in `config.yml`. |
 | `CHAT.FILTER.WORDS` | `list` | List of configured items/strings | `['fuck', 'shit', 'bitch']` | Configures the technical `WORDS` parameter for `CHAT.FILTER.WORDS` in `config.yml`. |

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -69,6 +69,18 @@ Automatically filters player chat for:
 ### 2. Anvil Moderation (`/anvilmoderation` & `anvil-moderation.yml`)
 Filters illegal, profane, or scam links renamed on item anvils before the item is created.
 
+### 3. Chat Logging (`/chatlog` & `CHAT.LOGGING` in `config.yml`)
+Every public chat message is written to the sender's own log, alongside their `/msg` conversations
+and the rest of their activity. `/chatlog` opens the whole server's chat newest first, `/chatlog
+<player>` narrows it to one player, and `/logs <player>` shows that player's chat mixed in with
+their shop, economy and death history. Each entry carries the player, the message and the time it
+was sent.
+
+Only messages that actually reach chat are stored, so anything a mute, the filter or the chat delay
+blocked never appears. Turn the whole thing off with `CHAT.LOGGING.ENABLED`, or drop public and
+private messages separately with `CHAT.LOGGING.PUBLIC-MESSAGES` and
+`CHAT.LOGGING.PRIVATE-MESSAGES`.
+
 ---
 
 ## Discord Webhook Logging (`discord.yml`)

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -601,6 +601,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("removemoney", new RemoveMoneyCommand(this));
         setExecutor("setmoney", new SetMoneyCommand(this));
         setExecutor("logs", new LogsCommand(this));
+        ChatLogCommand chatLogCommand = new ChatLogCommand(this);
+        setExecutor("chatlog", chatLogCommand);
+        setTabCompleter("chatlog", chatLogCommand);
 
         ShardsCommand shardsCmd = new ShardsCommand(this);
         setExecutor("shards", shardsCmd, FeatureManager.Feature.SHARDS);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/ChatLogCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/ChatLogCommand.java
@@ -1,0 +1,100 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.menus.ChatLogsMenu;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+public class ChatLogCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PERMISSION = "ultimatedonutsmp.admin.chatlog";
+
+    private final UltimateDonutSmp plugin;
+
+    public ChatLogCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player viewer)) {
+            sender.sendMessage("Player only.");
+            return true;
+        }
+
+        if (!viewer.hasPermission(PERMISSION)) {
+            viewer.sendMessage(ColorUtils.toComponent("&cYou do not have permission to use this command."));
+            return true;
+        }
+
+        if (args.length > 1) {
+            viewer.sendMessage(ColorUtils.toComponent("&cUsage: /chatlog [player]"));
+            return true;
+        }
+
+        if (args.length == 0) {
+            new ChatLogsMenu(plugin, null, null).open(viewer);
+            return true;
+        }
+
+        String input = args[0].trim();
+        Player onlineTarget = findOnlineTarget(input);
+        UUID targetUuid = onlineTarget == null
+                ? plugin.getDatabaseManager().findPlayerUuidByUsername(input)
+                : onlineTarget.getUniqueId();
+        if (targetUuid == null) {
+            viewer.sendMessage(ColorUtils.toComponent("&cPlayer not found."));
+            return true;
+        }
+
+        String targetName = onlineTarget == null
+                ? plugin.getDatabaseManager().getLastKnownUsername(targetUuid)
+                : onlineTarget.getName();
+        if (targetName == null || targetName.isBlank()) {
+            targetName = input;
+        }
+
+        new ChatLogsMenu(plugin, targetUuid, targetName).open(viewer);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!sender.hasPermission(PERMISSION) || args.length != 1) {
+            return Collections.emptyList();
+        }
+
+        String input = args[0].toLowerCase(Locale.ROOT);
+        List<String> suggestions = new ArrayList<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getName().toLowerCase(Locale.ROOT).startsWith(input)) {
+                suggestions.add(player.getName());
+            }
+        }
+        return suggestions;
+    }
+
+    private Player findOnlineTarget(String username) {
+        Player exact = Bukkit.getPlayerExact(username);
+        if (exact != null) {
+            return exact;
+        }
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getName().equalsIgnoreCase(username)) {
+                return player;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ChatManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ChatManager.java
@@ -248,6 +248,8 @@ public class ChatManager {
             return;
         }
 
+        logPublicChat(player, rawMessage);
+
         String normalized = normalizeMessage(rawMessage);
         if (!normalized.isBlank()) {
             lastAcceptedGlobalMessageByPlayer.put(player.getUniqueId(), normalized);
@@ -259,6 +261,34 @@ public class ChatManager {
 
         long nextAllowed = System.currentTimeMillis() + (getGlobalDelaySeconds() * 1000L);
         nextAllowedGlobalChatAtByPlayer.put(player.getUniqueId(), nextAllowed);
+    }
+
+    public boolean isChatLoggingEnabled() {
+        return config().getBoolean(CHAT_ROOT + ".LOGGING.ENABLED", true);
+    }
+
+    public boolean isPublicChatLoggingEnabled() {
+        return isChatLoggingEnabled()
+                && config().getBoolean(CHAT_ROOT + ".LOGGING.PUBLIC-MESSAGES", true);
+    }
+
+    public boolean isPrivateChatLoggingEnabled() {
+        return isChatLoggingEnabled()
+                && config().getBoolean(CHAT_ROOT + ".LOGGING.PRIVATE-MESSAGES", true);
+    }
+
+    private void logPublicChat(Player player, String rawMessage) {
+        if (rawMessage == null || rawMessage.isBlank() || !isPublicChatLoggingEnabled()) {
+            return;
+        }
+
+        plugin.getPlayerLogsManager().log(
+                player.getUniqueId(),
+                player.getName(),
+                PlayerLogsManager.CHAT_CATEGORY,
+                PlayerLogsManager.PUBLIC_CHAT_TYPE,
+                rawMessage.trim()
+        );
     }
 
     public void clearChatForAllPlayers() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -2620,6 +2620,60 @@ public class DatabaseManager {
         return 0;
     }
 
+    /** Newest-first log entries of one type. A null uuid reads every player on the server. */
+    public List<PlayerLogEntry> getLogsByType(UUID uuid, String logType, int limit, int offset) {
+        List<PlayerLogEntry> list = new ArrayList<>();
+        String where = uuid == null ? "log_type = ?" : "player_uuid = ? AND log_type = ?";
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT id, player_uuid, player_name, category, log_type, details, timestamp FROM player_logs " +
+                "WHERE " + where + " ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?")) {
+            int index = 1;
+            if (uuid != null) {
+                ps.setString(index++, uuid.toString());
+            }
+            ps.setString(index++, logType);
+            ps.setInt(index++, limit);
+            ps.setInt(index, offset);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(new PlayerLogEntry(
+                            rs.getLong("id"),
+                            UUID.fromString(rs.getString("player_uuid")),
+                            rs.getString("player_name"),
+                            rs.getString("category"),
+                            rs.getString("log_type"),
+                            rs.getString("details"),
+                            rs.getLong("timestamp")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to get logs by type", e);
+        }
+        return list;
+    }
+
+    /** Number of log entries of one type. A null uuid counts every player on the server. */
+    public int getLogsByTypeCount(UUID uuid, String logType) {
+        String where = uuid == null ? "log_type = ?" : "player_uuid = ? AND log_type = ?";
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT COUNT(*) FROM player_logs WHERE " + where)) {
+            int index = 1;
+            if (uuid != null) {
+                ps.setString(index++, uuid.toString());
+            }
+            ps.setString(index, logType);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to count logs by type", e);
+        }
+        return 0;
+    }
+
     public record SellHistoryRecord(UUID uuid, String itemName, int amount, double price, long timestamp) {
         public SellHistoryRecord(UUID uuid, String itemName, int amount, double price) {
             this(uuid, itemName, amount, price, System.currentTimeMillis());

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerLogsManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerLogsManager.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 
 public class PlayerLogsManager {
 
+    /** Category shared by every chat entry, so the logs menu can pick an icon for them. */
+    public static final String CHAT_CATEGORY = "chat";
+    /** Log type written for a public chat message, and the key the chat log browser reads back. */
+    public static final String PUBLIC_CHAT_TYPE = "CHAT_PUBLIC";
+
     private final UltimateDonutSmp plugin;
 
     public PlayerLogsManager(UltimateDonutSmp plugin) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PrivateMessageManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PrivateMessageManager.java
@@ -108,9 +108,15 @@ public class PrivateMessageManager {
         send(sender, applyPlaceholders(sentFormat, targetName, message));
         target.sendMessage(ColorUtils.toComponent(applyPlaceholders(receivedFormat, senderName, message), target));
 
+        boolean logPrivateMessages = plugin.getChatManager().isPrivateChatLoggingEnabled();
+
         if (sender instanceof Player player) {
             replyTargets.put(player.getUniqueId(), target.getUniqueId());
             replyTargets.put(target.getUniqueId(), player.getUniqueId());
+
+            if (!logPrivateMessages) {
+                return true;
+            }
 
             plugin.getPlayerLogsManager().log(
                     player.getUniqueId(),
@@ -126,7 +132,7 @@ public class PrivateMessageManager {
                     "MSG_RECEIVED",
                     "From " + player.getName() + ": " + message
             );
-        } else {
+        } else if (logPrivateMessages) {
             plugin.getPlayerLogsManager().log(
                     target.getUniqueId(),
                     target.getName(),

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ChatLogsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ChatLogsMenu.java
@@ -1,25 +1,28 @@
 package com.bx.ultimateDonutSmp.menus;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PlayerLogsManager;
 import com.bx.ultimateDonutSmp.models.PlayerLogEntry;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
-import com.bx.ultimateDonutSmp.utils.NumberUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-public class PlayerLogsMenu extends BaseMenu {
+public class ChatLogsMenu extends BaseMenu {
 
     private static final int PREVIOUS_PAGE_SLOT = 45;
     private static final int CLOSE_MENU_SLOT = 49;
     private static final int NEXT_PAGE_SLOT = 53;
     private static final int MAX_ITEMS_PER_PAGE = 45;
+    private static final int LORE_LINE_LENGTH = 40;
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     private final UUID targetUuid;
@@ -28,10 +31,11 @@ public class PlayerLogsMenu extends BaseMenu {
     private int totalItems;
     private int totalPages = 1;
 
-    public PlayerLogsMenu(UltimateDonutSmp plugin, UUID targetUuid, String targetName) {
+    /** Pass a null uuid to browse every player's public chat instead of one player's. */
+    public ChatLogsMenu(UltimateDonutSmp plugin, UUID targetUuid, String targetName) {
         super(
                 plugin,
-                "&8Logs: " + targetName,
+                targetUuid == null ? "&8Chat Log" : "&8Chat Log: " + targetName,
                 54
         );
         this.targetUuid = targetUuid;
@@ -43,7 +47,8 @@ public class PlayerLogsMenu extends BaseMenu {
         clear();
         fill(Material.GRAY_STAINED_GLASS_PANE);
 
-        totalItems = plugin.getDatabaseManager().getPlayerLogsCount(targetUuid);
+        totalItems = plugin.getDatabaseManager()
+                .getLogsByTypeCount(targetUuid, PlayerLogsManager.PUBLIC_CHAT_TYPE);
         totalPages = Math.max(1, (int) Math.ceil(totalItems / (double) MAX_ITEMS_PER_PAGE));
         if (page >= totalPages) {
             page = totalPages - 1;
@@ -53,11 +58,21 @@ public class PlayerLogsMenu extends BaseMenu {
         }
 
         int offset = page * MAX_ITEMS_PER_PAGE;
-        List<PlayerLogEntry> logs = plugin.getDatabaseManager().getPlayerLogs(targetUuid, MAX_ITEMS_PER_PAGE, offset);
+        List<PlayerLogEntry> logs = plugin.getDatabaseManager()
+                .getLogsByType(targetUuid, PlayerLogsManager.PUBLIC_CHAT_TYPE, MAX_ITEMS_PER_PAGE, offset);
+
+        if (logs.isEmpty()) {
+            set(22, ItemUtils.createItem(
+                    Material.BARRIER,
+                    "&cNo chat messages",
+                    List.of(targetUuid == null
+                            ? "&7Nobody has said anything in public chat yet."
+                            : "&7" + targetName + " has not said anything in public chat yet.")
+            ));
+        }
 
         for (int index = 0; index < logs.size() && index < MAX_ITEMS_PER_PAGE; index++) {
-            PlayerLogEntry entry = logs.get(index);
-            set(index, createLogItem(entry));
+            set(index, createChatItem(logs.get(index)));
         }
 
         buildNavigation();
@@ -92,7 +107,7 @@ public class PlayerLogsMenu extends BaseMenu {
         set(CLOSE_MENU_SLOT, ItemUtils.createItem(
                 Material.BARRIER,
                 "&cClose Menu",
-                List.of("&7Click to close this log view.")
+                List.of("&7Click to close this chat log.")
         ));
 
         // Previous Page Button
@@ -118,27 +133,55 @@ public class PlayerLogsMenu extends BaseMenu {
         }
     }
 
-    private ItemStack createLogItem(PlayerLogEntry entry) {
-        Material material;
-        switch (entry.category().toLowerCase()) {
-            case "shop" -> material = Material.CHEST;
-            case "auctions" -> material = Material.DIAMOND;
-            case "economy" -> material = Material.GOLD_INGOT;
-            case "crates" -> material = Material.TRIPWIRE_HOOK;
-            case "spawners" -> material = Material.SPAWNER;
-            case "deaths" -> material = Material.SKELETON_SKULL;
-            case "messages", "msg" -> material = Material.WRITABLE_BOOK;
-            case "chat" -> material = Material.BOOK;
-            default -> material = Material.PAPER;
+    private ItemStack createChatItem(PlayerLogEntry entry) {
+        String name = entry.playerName() == null || entry.playerName().isBlank()
+                ? "Unknown"
+                : entry.playerName();
+
+        List<String> lore = new ArrayList<>();
+        lore.add("&7Time: &f" + DATE_FORMAT.format(new Date(entry.timestamp())));
+        lore.add("&7Message:");
+        for (String line : wrap(entry.details())) {
+            lore.add("&f" + line);
         }
 
-        String formattedTime = DATE_FORMAT.format(new Date(entry.timestamp()));
-        List<String> lore = List.of(
-                "&7Time: &f" + formattedTime,
-                "&7Details: &f" + entry.details(),
-                "&8(Category: " + entry.category() + ")"
+        return ItemUtils.createPlayerHead(
+                Bukkit.getOfflinePlayer(entry.playerUuid()),
+                "&e&l" + name,
+                lore
         );
+    }
 
-        return ItemUtils.createItem(material, "&e&l" + entry.logType(), lore);
+    /** Breaks a chat message over several lore lines so long messages stay readable. */
+    static List<String> wrap(String message) {
+        List<String> lines = new ArrayList<>();
+        if (message == null || message.isBlank()) {
+            lines.add("");
+            return lines;
+        }
+
+        StringBuilder line = new StringBuilder();
+        for (String word : message.trim().split("\s+")) {
+            while (word.length() > LORE_LINE_LENGTH) {
+                if (line.length() > 0) {
+                    lines.add(line.toString());
+                    line.setLength(0);
+                }
+                lines.add(word.substring(0, LORE_LINE_LENGTH));
+                word = word.substring(LORE_LINE_LENGTH);
+            }
+            if (line.length() > 0 && line.length() + 1 + word.length() > LORE_LINE_LENGTH) {
+                lines.add(line.toString());
+                line.setLength(0);
+            }
+            if (line.length() > 0) {
+                line.append(' ');
+            }
+            line.append(word);
+        }
+        if (line.length() > 0) {
+            lines.add(line.toString());
+        }
+        return lines;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -180,6 +180,19 @@ CHAT:
   MAX-DELAY-SECONDS: 30
   # The numerical value for Clear Lines. Available options: Any valid integer
   CLEAR-LINES: 150
+  # Configuration section for Logging. Writes chat into each player's own log, so staff can
+  # read it back with /logs <player> or browse the whole server with /chatlog. None of these
+  # switches change what players see in chat.
+  LOGGING:
+    # Master switch for chat logging. With this off, neither public nor private messages are
+    # recorded, whatever the two switches below say. Available options: true, false
+    ENABLED: true
+    # Records normal public chat. Only messages that actually reach chat are stored, so muted,
+    # filtered and rate-limited messages are left out. Available options: true, false
+    PUBLIC-MESSAGES: true
+    # Records private messages sent with /msg and /reply, on both sides of the conversation.
+    # Available options: true, false
+    PRIVATE-MESSAGES: true
   # Configuration section for Filter.
   FILTER:
     # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -659,6 +659,11 @@ commands:
     description: Command logs
     permission: ultimatedonutsmp.command.logs
     permission-message: "&cYou do not have permission to use /logs."
+  chatlog:
+    description: Browse public chat for the whole server, or for one player
+    usage: /chatlog [player]
+    permission: ultimatedonutsmp.command.chatlog
+    permission-message: "&cYou do not have permission to use /chatlog."
   addshards:
     description: Command addshards
     permission: ultimatedonutsmp.command.addshards
@@ -760,6 +765,7 @@ permissions:
       ultimatedonutsmp.admin.freeze: true
       ultimatedonutsmp.admin.staffmode: true
       ultimatedonutsmp.admin.invsee: true
+      ultimatedonutsmp.admin.chatlog: true
       ultimatedonutsmp.admin.spawner: true
       ultimatedonutsmp.admin.spawner.seeall: true
       ultimatedonutsmp.admin.crate: true
@@ -1267,6 +1273,7 @@ permissions:
       ultimatedonutsmp.command.ultimatedonutsmp: true
       ultimatedonutsmp.command.ecsee: true
       ultimatedonutsmp.command.logs: true
+      ultimatedonutsmp.command.chatlog: true
       ultimatedonutsmp.command.addshards: true
       ultimatedonutsmp.command.removeshards: true
       ultimatedonutsmp.command.setshards: true
@@ -1637,6 +1644,12 @@ permissions:
     default: op
   ultimatedonutsmp.command.logs:
     description: Access to /logs command
+    default: op
+  ultimatedonutsmp.command.chatlog:
+    description: Access to /chatlog command
+    default: op
+  ultimatedonutsmp.admin.chatlog:
+    description: Browse logged public chat messages
     default: op
   ultimatedonutsmp.command.addshards:
     description: Access to /addshards command

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ChatLogsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ChatLogsTest.java
@@ -1,0 +1,130 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PlayerLogEntry;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChatLogsTest {
+
+    private static final UUID ALEX = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID STEVE = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    @Test
+    void theServerWideViewReadsPublicChatFromEveryPlayerNewestFirst() throws Exception {
+        try (Connection connection = openLogTable()) {
+            insert(connection, ALEX, "Alex", "chat", "CHAT_PUBLIC", "first", 1_000L);
+            insert(connection, STEVE, "Steve", "chat", "CHAT_PUBLIC", "second", 2_000L);
+            insert(connection, ALEX, "Alex", "messages", "MSG_SENT", "To Steve: hidden", 3_000L);
+            insert(connection, ALEX, "Alex", "shop", "SHOP_BUY", "ignored", 4_000L);
+
+            DatabaseManager manager = managerOn(connection);
+
+            List<PlayerLogEntry> logs = manager.getLogsByType(null, PlayerLogsManager.PUBLIC_CHAT_TYPE, 45, 0);
+
+            assertEquals(2, manager.getLogsByTypeCount(null, PlayerLogsManager.PUBLIC_CHAT_TYPE));
+            assertEquals(List.of("second", "first"), logs.stream().map(PlayerLogEntry::details).toList());
+            assertEquals(List.of("Steve", "Alex"), logs.stream().map(PlayerLogEntry::playerName).toList());
+        }
+    }
+
+    @Test
+    void askingForOnePlayerLeavesTheRestOfTheServerOut() throws Exception {
+        try (Connection connection = openLogTable()) {
+            insert(connection, ALEX, "Alex", "chat", "CHAT_PUBLIC", "alex talking", 1_000L);
+            insert(connection, STEVE, "Steve", "chat", "CHAT_PUBLIC", "steve talking", 2_000L);
+
+            DatabaseManager manager = managerOn(connection);
+
+            List<PlayerLogEntry> logs = manager.getLogsByType(ALEX, PlayerLogsManager.PUBLIC_CHAT_TYPE, 45, 0);
+
+            assertEquals(1, manager.getLogsByTypeCount(ALEX, PlayerLogsManager.PUBLIC_CHAT_TYPE));
+            assertEquals(List.of("alex talking"), logs.stream().map(PlayerLogEntry::details).toList());
+        }
+    }
+
+    @Test
+    void pagingWalksBackThroughOlderMessages() throws Exception {
+        try (Connection connection = openLogTable()) {
+            for (int i = 1; i <= 5; i++) {
+                insert(connection, ALEX, "Alex", "chat", "CHAT_PUBLIC", "message " + i, i * 1_000L);
+            }
+
+            DatabaseManager manager = managerOn(connection);
+
+            assertEquals(
+                    List.of("message 5", "message 4"),
+                    manager.getLogsByType(null, PlayerLogsManager.PUBLIC_CHAT_TYPE, 2, 0)
+                            .stream().map(PlayerLogEntry::details).toList()
+            );
+            assertEquals(
+                    List.of("message 3", "message 2"),
+                    manager.getLogsByType(null, PlayerLogsManager.PUBLIC_CHAT_TYPE, 2, 2)
+                            .stream().map(PlayerLogEntry::details).toList()
+            );
+            assertEquals(
+                    List.of("message 1"),
+                    manager.getLogsByType(null, PlayerLogsManager.PUBLIC_CHAT_TYPE, 2, 4)
+                            .stream().map(PlayerLogEntry::details).toList()
+            );
+        }
+    }
+
+    @Test
+    void chatLoggingShipsOnForBothPublicAndPrivateMessages() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "config.yml").toFile());
+        ConfigurationSection logging = config.getConfigurationSection("CHAT.LOGGING");
+
+        assertNotNull(logging, "config.yml has no CHAT.LOGGING section");
+        assertTrue(logging.getBoolean("ENABLED"));
+        assertTrue(logging.getBoolean("PUBLIC-MESSAGES"));
+        assertTrue(logging.getBoolean("PRIVATE-MESSAGES"));
+    }
+
+    private static Connection openLogTable() throws Exception {
+        Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        try (var statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE player_logs ("
+                    + "id INTEGER PRIMARY KEY AUTOINCREMENT, player_uuid TEXT NOT NULL, "
+                    + "player_name TEXT NOT NULL, category TEXT NOT NULL, log_type TEXT NOT NULL, "
+                    + "details TEXT NOT NULL, timestamp INTEGER NOT NULL)");
+        }
+        return connection;
+    }
+
+    private static DatabaseManager managerOn(Connection connection) throws Exception {
+        DatabaseManager manager = new DatabaseManager(null);
+        Field connectionField = DatabaseManager.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(manager, connection);
+        return manager;
+    }
+
+    private static void insert(Connection connection, UUID uuid, String name, String category,
+                               String type, String details, long timestamp) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "INSERT INTO player_logs (player_uuid, player_name, category, log_type, details, timestamp) "
+                        + "VALUES (?,?,?,?,?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, name);
+            ps.setString(3, category);
+            ps.setString(4, type);
+            ps.setString(5, details);
+            ps.setLong(6, timestamp);
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/ChatLogsMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/ChatLogsMenuTest.java
@@ -1,0 +1,43 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChatLogsMenuTest {
+
+    @Test
+    void aShortMessageStaysOnOneLine() {
+        assertEquals(List.of("hello everyone"), ChatLogsMenu.wrap("hello everyone"));
+    }
+
+    @Test
+    void longMessagesAreBrokenOverSeveralLoreLines() {
+        String message = "this is a very long chat message that will not fit on a single line of item lore";
+
+        List<String> wrapped = ChatLogsMenu.wrap(message);
+
+        assertTrue(wrapped.size() > 1, "a long message should span more than one line");
+        for (String line : wrapped) {
+            assertTrue(line.length() <= 40, "line too long: " + line);
+        }
+        assertEquals(message, String.join(" ", wrapped));
+    }
+
+    @Test
+    void aSingleUnbrokenWordIsSplitInsteadOfOverflowing() {
+        List<String> wrapped = ChatLogsMenu.wrap("a".repeat(95));
+
+        assertEquals(3, wrapped.size());
+        assertEquals(95, String.join("", wrapped).length());
+    }
+
+    @Test
+    void anEmptyMessageStillProducesALine() {
+        assertEquals(List.of(""), ChatLogsMenu.wrap("   "));
+        assertEquals(List.of(""), ChatLogsMenu.wrap(null));
+    }
+}


### PR DESCRIPTION
Closes #222

Public chat never made it into a player's UDS log. Private messages did, so `/logs <player>` showed the `/msg` side of a conversation and nothing the player said out loud. This puts public chat in the same log and gives staff a way to read it back, for one player or for the whole server.

## Logging

The log entry is written from `ChatManager.trackAcceptedGlobalMessage`, the one point both accepted-chat exits in `ChatListener` already funnel through. Only messages that actually reach chat get stored that way: a mute, the word filter, the caps and anti-link rules, and the chat delay all cancel the event before it, and pending menu input and team chat never reach it at all. Entries reuse the existing `player_logs` table with category `chat` and log type `CHAT_PUBLIC`, so there is no schema change and the rows turn up in the existing `/logs <player>` menu right away, with their own book icon.

## Browsing

`/chatlog` opens the whole server's public chat newest first and `/chatlog <player>` narrows it to one player, which is the shape `/punishments` already uses for the same global-or-single choice. Each entry shows the sender's head, the timestamp, and the message wrapped over as many lore lines as it needs. Two new `DatabaseManager` queries back it, both taking a nullable uuid so the server-wide and per-player views share one code path, and the existing `idx_player_logs_type_time` index already covers the server-wide query.

## Config

A new `CHAT.LOGGING` block: `ENABLED` as a master switch, plus `PUBLIC-MESSAGES` and `PRIVATE-MESSAGES` to drop either half. All three default to true, so an existing server keeps the private-message logging it already had and picks up public chat on top. The reporter asked for the two switches separately, and wiring `PRIVATE-MESSAGES` means the `/msg` logging that used to be unconditional can now be turned off.

## Notes

- The command checks `ultimatedonutsmp.admin.chatlog` and sits behind `ultimatedonutsmp.command.chatlog` in `plugin.yml`, matching how `/logs` and `/punishments` are set up. Both nodes are `default: op` and both are in the `ultimatedonutsmp.admin` children list.
- No player-facing message keys were added, so the eight language files are untouched.
- Docs: the `CHAT.LOGGING` keys in `Config-config.yml.md`, `/chatlog` plus the previously undocumented `/logs` in `Commands-and-Permissions.md`, and a chat logging section in `Staff-and-Security.md`.
- Eight new tests cover the server-wide and per-player queries, paging, lore wrapping, and the config defaults as shipped. Full suite is 336 tests, all passing.
