### PR TITLE
feat(teams): add a team info menu for looking up any team (#224)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -8,7 +8,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 
 | Command | Usage Syntax | Aliases | Description | Permission Node |
 | :--- | :--- | :--- | :--- | :--- |
-| `/team` | `/team <create\|disband\|invite\|kick\|join\|leave\|home\|sethome\|delhome\|chat\|info\|pvp>` | None | Team management & alliance controls | `ultimatedonutsmp.command.team` |
+| `/team` | `/team <create\|disband\|invite\|kick\|join\|leave\|home\|sethome\|delhome\|chat\|info\|pvp>` | None | Team management. `/team info <team>` opens a read-only roster of any team on the server, everything else acts on your own team | `ultimatedonutsmp.command.team` |
 | `/msg` | `/msg <player> <message>` | `/message`, `/tell`, `/whisper`, `/w` | Send private message to player | `ultimatedonutsmp.command.msg` |
 | `/reply` | `/reply <message>` | `/r` | Reply to last private message | `ultimatedonutsmp.command.reply` |
 | `/pm` | `/pm` | `/togglepm`, `/privatemessages` | Toggle private messaging on/off | `ultimatedonutsmp.command.pm` |

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -115,6 +115,30 @@ TEAM-MENUS:
       NOT-IN-TEAM: '&cYou are not part of the team.'
       NO-PERMISSION: '&cYou don''t have permissions to do this.'
       CANT-EDIT-SELF: '&cYou can''t do this yourself!'
+  TEAM-INFO:
+    TITLE: '&8Team {team_name}'
+    SIZE: 54
+    MAX-ITEMS-PER-PAGE: 45
+    PLAYER-BUTTON:
+      ONLINE-SYMBOL: "&a■"
+      OFFLINE-SYMBOL: "&4■"
+      LEADER-LORE: '&6Leader'
+    SUMMARY-BUTTON:
+      TITLE: '&#6BF18DTeam {team_name}'
+      MATERIAL: IRON_HELMET
+      SLOT: 49
+      ON-STATE: '&a&lON'
+      OFF-STATE: '&c&lOFF'
+      LORE:
+      - '&7Leader: &f{leader}'
+      - '&7Members: &f{members}&7/&f{max_members}'
+      - '&7PvP: {state}'
+    PAGE-BUTTON:
+      TITLE: '&fPage {page}&7/&f{total_pages}'
+      MATERIAL: PAPER
+      SLOT: 50
+      LORE:
+      - '&7Browse team members.'
   TEAM-EDIT-MEMBER:
     TITLE: '&8Edit {player}'
     SIZE: 27
@@ -184,6 +208,22 @@ TEAM-MENUS:
 | `TEAM-MENUS.TEAM.PVP-BUTTON.SLOT` | `int` | Any valid integer number | `'53'` | Configures the technical `SLOT` parameter for `TEAM-MENUS.TEAM.PVP-BUTTON.SLOT` in `menus.yml`. |
 | `TEAM-MENUS.TEAM.PVP-BUTTON.ON-STATE` | `str` | Any string text | `'&a&lON'` | Configures the technical `ON-STATE` parameter for `TEAM-MENUS.TEAM.PVP-BUTTON.ON-STATE` in `menus.yml`. |
 | `TEAM-MENUS.TEAM.PVP-BUTTON.OFF-STATE` | `str` | Any string text | `'&c&lOFF'` | Configures the technical `OFF-STATE` parameter for `TEAM-MENUS.TEAM.PVP-BUTTON.OFF-STATE` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.TITLE` | `str` | Any string text | `'&8Team {team_name}'` | Title of the read-only menu `/team info <team>` opens. `{team_name}` is the team being looked up. |
+| `TEAM-MENUS.TEAM-INFO.SIZE` | `int` | Any valid integer number | `'54'` | Configures the technical `SIZE` parameter for `TEAM-MENUS.TEAM-INFO.SIZE` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.MAX-ITEMS-PER-PAGE` | `int` | Any valid integer number | `'45'` | How many member heads fit on one page before the arrows appear. |
+| `TEAM-MENUS.TEAM-INFO.PLAYER-BUTTON.ONLINE-SYMBOL` | `str` | Any string text | `'&a■'` | Configures the technical `ONLINE-SYMBOL` parameter for `TEAM-MENUS.TEAM-INFO.PLAYER-BUTTON.ONLINE-SYMBOL` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.PLAYER-BUTTON.OFFLINE-SYMBOL` | `str` | Any string text | `'&4■'` | Configures the technical `OFFLINE-SYMBOL` parameter for `TEAM-MENUS.TEAM-INFO.PLAYER-BUTTON.OFFLINE-SYMBOL` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.PLAYER-BUTTON.LEADER-LORE` | `str` | Any string text | `'&6Leader'` | Extra lore line added to the head of the team leader. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.TITLE` | `str` | Any string text | `'&#6BF18DTeam {team_name}'` | Configures the technical `TITLE` parameter for `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.TITLE` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.MATERIAL` | `str` | Any string text | `'IRON_HELMET'` | Configures the technical `MATERIAL` parameter for `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.MATERIAL` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.SLOT` | `int` | Any valid integer number | `'49'` | Configures the technical `SLOT` parameter for `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.SLOT` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.ON-STATE` | `str` | Any string text | `'&a&lON'` | Fills `{state}` in the summary lore while the team has friendly fire on. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.OFF-STATE` | `str` | Any string text | `'&c&lOFF'` | Fills `{state}` in the summary lore while the team has friendly fire off. |
+| `TEAM-MENUS.TEAM-INFO.SUMMARY-BUTTON.LORE` | `list` | List of configured items/strings | `['&7Leader: &f{leader}', '&7Members: &f{members}&7/&f{max_members}', '&7PvP: {state}']` | Summary lore. Supports `{team_name}`, `{leader}`, `{members}`, `{max_members}` and `{state}`. |
+| `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.TITLE` | `str` | Any string text | `'&fPage {page}&7/&f{total_pages}'` | Page counter shown once the roster spans more than one page. Supports `{page}` and `{total_pages}`. |
+| `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.MATERIAL` | `str` | Any string text | `'PAPER'` | Configures the technical `MATERIAL` parameter for `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.MATERIAL` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.SLOT` | `int` | Any valid integer number | `'50'` | Configures the technical `SLOT` parameter for `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.SLOT` in `menus.yml`. |
+| `TEAM-MENUS.TEAM-INFO.PAGE-BUTTON.LORE` | `list` | List of configured items/strings | `['&7Browse team members.']` | Lore under the page counter. Supports `{page}` and `{total_pages}`. |
 | *(68 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/TeamCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/TeamCommand.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.TeamDisbandConfirmMenu;
+import com.bx.ultimateDonutSmp.menus.TeamInfoMenu;
 import com.bx.ultimateDonutSmp.menus.TeamMenu;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.models.Team;
@@ -48,6 +49,7 @@ public class TeamCommand implements CommandExecutor {
             case "sethome" -> handleSetHome(player);
             case "delhome" -> handleDeleteHome(player);
             case "chat" -> handleChat(player);
+            case "info" -> handleInfo(player, args);
             case "pvp" -> handlePvp(player);
             default -> new TeamMenu(plugin).open(player);
         }
@@ -310,6 +312,21 @@ public class TeamCommand implements CommandExecutor {
         send(player, enabled
                 ? plugin.getConfigManager().getMessage("TEAM.TEAM-CHAT-ENABLED")
                 : plugin.getConfigManager().getMessage("TEAM.TEAM-CHAT-DISABLED"));
+    }
+
+    private void handleInfo(Player player, String[] args) {
+        if (args.length < 2) {
+            send(player, "&cUsage: /team info <team>");
+            return;
+        }
+
+        Team team = plugin.getTeamManager().getTeam(args[1]);
+        if (team == null) {
+            send(player, plugin.getConfigManager().getMessage("TEAM.TEAM-NOT-EXIST"));
+            return;
+        }
+
+        new TeamInfoMenu(plugin, team).open(player);
     }
 
     private void handlePvp(Player player) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -34,8 +34,8 @@ public class UniversalCommandTabCompleter implements TabCompleter {
     );
     private static final List<String> DURATIONS = List.of("30s", "15m", "1h", "2h", "1d", "7d");
     private static final List<String> TOGGLES = List.of("true", "false", "on", "off");
-    private static final List<String> TEAM_SUBCOMMANDS = List.of(
-            "create", "disband", "invite", "join", "leave", "kick", "home", "sethome", "delhome", "chat", "pvp"
+    static final List<String> TEAM_SUBCOMMANDS = List.of(
+            "create", "disband", "invite", "join", "leave", "kick", "home", "sethome", "delhome", "chat", "info", "pvp"
     );
     private static final List<String> ARENA_SUBCOMMANDS = List.of(
             "create", "delete", "setpos1", "setpos2", "setreturn", "setdisplay", "enable", "disable", "queue", "list", "reload"
@@ -130,8 +130,15 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "invite" -> partial(args[1], onlinePlayerNames(sender, false));
             case "join" -> partial(args[1], plugin.getTeamManager().getPendingInvites(player.getUniqueId()));
             case "kick" -> partial(args[1], teamMemberNames(player, false));
+            case "info" -> partial(args[1], teamNames());
             default -> List.of();
         };
+    }
+
+    private List<String> teamNames() {
+        return plugin.getTeamManager().getAllTeams().stream()
+                .map(Team::getName)
+                .toList();
     }
 
     private List<String> completeHome(CommandSender sender, String commandName, String[] args) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/TeamInfoMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/TeamInfoMenu.java
@@ -1,0 +1,235 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.HideManager;
+import com.bx.ultimateDonutSmp.models.Team;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * Read-only view of a team anyone can open with /team info, so the roster of a team you are not in
+ * is visible without joining it. Nothing in here edits the team.
+ */
+public class TeamInfoMenu extends BaseMenu {
+
+    private static final String MENU_PATH = "TEAM-MENUS.TEAM-INFO";
+
+    private final Team team;
+    private int page;
+
+    public TeamInfoMenu(UltimateDonutSmp plugin, Team team) {
+        super(plugin, configuredTitle(plugin, team), configuredSize(plugin));
+        this.team = team;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        fill(Material.GRAY_STAINED_GLASS_PANE);
+
+        List<UUID> members = orderMembers(team, memberUuid -> realName(memberUuid, null));
+        int perPage = Math.max(1, menus().getInt(MENU_PATH + ".MAX-ITEMS-PER-PAGE", 45));
+        int totalPages = pageCount(members.size(), perPage);
+        page = Math.max(0, Math.min(page, totalPages - 1));
+
+        int startIndex = page * perPage;
+        int endIndex = Math.min(members.size(), startIndex + perPage);
+        for (int index = startIndex; index < endIndex; index++) {
+            set(index - startIndex, createMemberItem(player, members.get(index)));
+        }
+
+        renderSummaryButton(player);
+        renderPageButtons(totalPages);
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+
+        int perPage = Math.max(1, menus().getInt(MENU_PATH + ".MAX-ITEMS-PER-PAGE", 45));
+        int totalPages = pageCount(team.getMemberCount(), perPage);
+
+        if (slot == 47 && page > 0) {
+            page--;
+            build(player);
+            return;
+        }
+        if (slot == 51 && page < totalPages - 1) {
+            page++;
+            build(player);
+        }
+    }
+
+    /** Leader first, then everyone else by name, so the roster reads the same on every page load. */
+    static List<UUID> orderMembers(Team team, Function<UUID, String> nameResolver) {
+        List<UUID> ordered = new ArrayList<>(team.getMemberUuids());
+        ordered.sort(Comparator
+                .comparing((UUID uuid) -> !team.isLeader(uuid))
+                .thenComparing(uuid -> nameResolver.apply(uuid) == null)
+                .thenComparing(uuid -> {
+                    String name = nameResolver.apply(uuid);
+                    return name == null ? "" : name.toLowerCase(Locale.ROOT);
+                }));
+        return ordered;
+    }
+
+    static int pageCount(int memberCount, int perPage) {
+        int size = Math.max(1, perPage);
+        return Math.max(1, (int) Math.ceil(memberCount / (double) size));
+    }
+
+    private ItemStack createMemberItem(Player viewer, UUID memberUuid) {
+        HideManager hideManager = plugin.getHideManager();
+        boolean disguised = hideManager.isHidden(memberUuid) && !hideManager.canSeeRealIdentity(viewer);
+        OfflinePlayer member = Bukkit.getOfflinePlayer(memberUuid);
+        boolean online = member.isOnline();
+
+        List<String> lore = new ArrayList<>();
+        lore.add((online
+                ? menus().getString(MENU_PATH + ".PLAYER-BUTTON.ONLINE-SYMBOL", "&a■")
+                : menus().getString(MENU_PATH + ".PLAYER-BUTTON.OFFLINE-SYMBOL", "&4■"))
+                + "&7 " + (online ? "online" : "offline"));
+        if (team.isLeader(memberUuid)) {
+            lore.add(menus().getString(MENU_PATH + ".PLAYER-BUTTON.LEADER-LORE", "&6Leader"));
+        }
+
+        String title = "&f" + displayName(viewer, memberUuid);
+        // A disguised member gets a blank head, otherwise the menu hands out the skin behind the alias.
+        return disguised
+                ? ItemUtils.createItem(Material.PLAYER_HEAD, title, lore)
+                : ItemUtils.createPlayerHead(member, title, lore);
+    }
+
+    private void renderSummaryButton(Player viewer) {
+        String path = MENU_PATH + ".SUMMARY-BUTTON";
+        String pvpState = team.isFriendlyFireEnabled()
+                ? menus().getString(path + ".ON-STATE", "&a&lOn")
+                : menus().getString(path + ".OFF-STATE", "&c&lOff");
+
+        Map<String, String> placeholders = Map.of(
+                "team_name", team.getName(),
+                "leader", displayName(viewer, team.getLeaderUuid()),
+                "members", String.valueOf(team.getMemberCount()),
+                "max_members", String.valueOf(plugin.getConfigManager().getConfig().getInt("TEAM.LIMIT-MEMBERS", 10)),
+                "state", pvpState
+        );
+
+        set(
+                menus().getInt(path + ".SLOT", 49),
+                ItemUtils.createItem(
+                        material(path + ".MATERIAL", Material.IRON_HELMET),
+                        replace(menus().getString(path + ".TITLE", "&#6BF18DTeam {team_name}"), placeholders),
+                        replace(menus().getStringList(path + ".LORE"), placeholders)
+                )
+        );
+    }
+
+    private void renderPageButtons(int totalPages) {
+        if (totalPages <= 1) {
+            return;
+        }
+
+        FileConfiguration menus = menus();
+        String globalPath = "GLOBAL.PAGE-MENU";
+        Material material = material(globalPath + ".MATERIAL", Material.ARROW);
+
+        if (page > 0) {
+            set(47, ItemUtils.createItem(
+                    material,
+                    menus.getString(globalPath + ".BACK-BUTTON", "&aBack"),
+                    menus.getStringList(globalPath + ".BACK-LORE")
+            ));
+        }
+
+        String pagePath = MENU_PATH + ".PAGE-BUTTON";
+        Map<String, String> placeholders = Map.of(
+                "page", String.valueOf(page + 1),
+                "total_pages", String.valueOf(totalPages)
+        );
+        set(
+                menus.getInt(pagePath + ".SLOT", 50),
+                ItemUtils.createItem(
+                        material(pagePath + ".MATERIAL", Material.PAPER),
+                        replace(menus.getString(pagePath + ".TITLE", "&fPage {page}&7/&f{total_pages}"), placeholders),
+                        replace(menus.getStringList(pagePath + ".LORE"), placeholders)
+                )
+        );
+
+        if (page < totalPages - 1) {
+            set(51, ItemUtils.createItem(
+                    material,
+                    menus.getString(globalPath + ".NEXT-BUTTON", "&aNext"),
+                    menus.getStringList(globalPath + ".NEXT-LORE")
+            ));
+        }
+    }
+
+    /** Mirrors HideManager#visibleName, except it also has to work for members who are offline. */
+    private String displayName(Player viewer, UUID memberUuid) {
+        HideManager hideManager = plugin.getHideManager();
+        String realName = realName(memberUuid, "unknown");
+        if (!hideManager.isHidden(memberUuid)) {
+            return realName;
+        }
+        return hideManager.canSeeRealIdentity(viewer)
+                ? hideManager.staffMarker() + realName
+                : hideManager.publicName(memberUuid, realName);
+    }
+
+    private String realName(UUID memberUuid, String fallback) {
+        String name = Bukkit.getOfflinePlayer(memberUuid).getName();
+        if (name == null) {
+            name = plugin.getDatabaseManager().getLastKnownUsername(memberUuid);
+        }
+        return name == null || name.isBlank() ? fallback : name;
+    }
+
+    private FileConfiguration menus() {
+        return plugin.getConfigManager().getMenus();
+    }
+
+    private Material material(String path, Material fallback) {
+        return ItemUtils.parseMaterial(menus().getString(path, fallback.name()));
+    }
+
+    private String replace(String value, Map<String, String> placeholders) {
+        String output = value == null ? "" : value;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            output = output.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return output;
+    }
+
+    private List<String> replace(List<String> values, Map<String, String> placeholders) {
+        List<String> output = new ArrayList<>();
+        for (String value : values) {
+            output.add(replace(value, placeholders));
+        }
+        return output;
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin, Team team) {
+        String title = plugin.getConfigManager().getMenus().getString(MENU_PATH + ".TITLE", "&8Team {team_name}");
+        return title.replace("{team_name}", team.getName());
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int size = plugin.getConfigManager().getMenus().getInt(MENU_PATH + ".SIZE", 54);
+        return size >= 9 && size % 9 == 0 ? size : 54;
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -477,6 +477,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Team {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Anführer"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DTeam {team_name}"
+        ON-STATE: "&a&lAN"
+        OFF-STATE: "&c&lAUS"
+        LORE:
+        - "&7Anführer: &f{leader}"
+        - "&7Mitglieder: &f{members}&7/&f{max_members}"
+        - "&7PvP: {state}"
+      PAGE-BUTTON:
+        TITLE: "&fSeite {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Teammitglieder durchsehen."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -478,6 +478,22 @@ MENUS:
         TITLE: '&#00FC00Confirm'
         LORE:
         - '&fClick to confirm'
+    TEAM-INFO:
+      TITLE: '&8Team {team_name}'
+      PLAYER-BUTTON:
+        LEADER-LORE: '&6Leader'
+      SUMMARY-BUTTON:
+        TITLE: '&#6BF18DTeam {team_name}'
+        ON-STATE: '&a&lON'
+        OFF-STATE: '&c&lOFF'
+        LORE:
+        - '&7Leader: &f{leader}'
+        - '&7Members: &f{members}&7/&f{max_members}'
+        - '&7PvP: {state}'
+      PAGE-BUTTON:
+        TITLE: '&fPage {page}&7/&f{total_pages}'
+        LORE:
+        - '&7Browse team members.'
   HOME-MENU-LEGACY:
     TITLE: '&8Homes'
     TELEPORT:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -342,6 +342,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Equipo {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Líder"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DEquipo {team_name}"
+        ON-STATE: "&a&lACTIVADO"
+        OFF-STATE: "&c&lDESACTIVADO"
+        LORE:
+        - "&7Líder: &f{leader}"
+        - "&7Miembros: &f{members}&7/&f{max_members}"
+        - "&7PvP: {state}"
+      PAGE-BUTTON:
+        TITLE: "&fPágina {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Consulta los miembros del equipo."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -341,6 +341,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Équipe {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Chef"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DÉquipe {team_name}"
+        ON-STATE: "&a&lACTIVÉ"
+        OFF-STATE: "&c&lDÉSACTIVÉ"
+        LORE:
+        - "&7Chef : &f{leader}"
+        - "&7Membres : &f{members}&7/&f{max_members}"
+        - "&7PvP : {state}"
+      PAGE-BUTTON:
+        TITLE: "&fPage {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Parcourir les membres de l'équipe."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -478,6 +478,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Tim {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Ketua"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DTim {team_name}"
+        ON-STATE: "&a&lAKTIF"
+        OFF-STATE: "&c&lMATI"
+        LORE:
+        - "&7Ketua: &f{leader}"
+        - "&7Anggota: &f{members}&7/&f{max_members}"
+        - "&7PvP: {state}"
+      PAGE-BUTTON:
+        TITLE: "&fHalaman {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Lihat anggota tim."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -342,6 +342,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Time {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Líder"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DTime {team_name}"
+        ON-STATE: "&a&lLIGADO"
+        OFF-STATE: "&c&lDESLIGADO"
+        LORE:
+        - "&7Líder: &f{leader}"
+        - "&7Membros: &f{members}&7/&f{max_members}"
+        - "&7PvP: {state}"
+      PAGE-BUTTON:
+        TITLE: "&fPágina {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Veja os membros do time."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -341,6 +341,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8Команда {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6Лидер"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18DКоманда {team_name}"
+        ON-STATE: "&a&lВКЛ"
+        OFF-STATE: "&c&lВЫКЛ"
+        LORE:
+        - "&7Лидер: &f{leader}"
+        - "&7Участники: &f{members}&7/&f{max_members}"
+        - "&7PvP: {state}"
+      PAGE-BUTTON:
+        TITLE: "&fСтраница {page}&7/&f{total_pages}"
+        LORE:
+        - "&7Просмотр участников команды."
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -340,6 +340,22 @@ MENUS:
         TITLE: "&#00FC00Confirm"
         LORE:
         - "&fClick to confirm"
+    TEAM-INFO:
+      TITLE: "&8队伍 {team_name}"
+      PLAYER-BUTTON:
+        LEADER-LORE: "&6队长"
+      SUMMARY-BUTTON:
+        TITLE: "&#6BF18D队伍 {team_name}"
+        ON-STATE: "&a&l开启"
+        OFF-STATE: "&c&l关闭"
+        LORE:
+        - "&7队长：&f{leader}"
+        - "&7成员：&f{members}&7/&f{max_members}"
+        - "&7PvP：{state}"
+      PAGE-BUTTON:
+        TITLE: "&f第 {page}&7/&f{total_pages} 页"
+        LORE:
+        - "&7浏览队伍成员。"
   HOME-MENU-LEGACY:
     TITLE: "&8Homes"
     TELEPORT:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -60,6 +60,30 @@ TEAM-MENUS:
       NOT-IN-TEAM: '&cYou are not part of the team.'
       NO-PERMISSION: '&cYou don''t have permissions to do this.'
       CANT-EDIT-SELF: '&cYou can''t do this yourself!'
+  TEAM-INFO:
+    TITLE: '&8Team {team_name}'
+    SIZE: 54
+    MAX-ITEMS-PER-PAGE: 45
+    PLAYER-BUTTON:
+      ONLINE-SYMBOL: "&a■"
+      OFFLINE-SYMBOL: "&4■"
+      LEADER-LORE: '&6Leader'
+    SUMMARY-BUTTON:
+      TITLE: '&#6BF18DTeam {team_name}'
+      MATERIAL: IRON_HELMET
+      SLOT: 49
+      ON-STATE: '&a&lON'
+      OFF-STATE: '&c&lOFF'
+      LORE:
+      - '&7Leader: &f{leader}'
+      - '&7Members: &f{members}&7/&f{max_members}'
+      - '&7PvP: {state}'
+    PAGE-BUTTON:
+      TITLE: '&fPage {page}&7/&f{total_pages}'
+      MATERIAL: PAPER
+      SLOT: 50
+      LORE:
+      - '&7Browse team members.'
   TEAM-EDIT-MEMBER:
     TITLE: '&8Edit {player}'
     SIZE: 27

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/TeamSubcommandsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/TeamSubcommandsTest.java
@@ -1,0 +1,51 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The usage line in plugin.yml is what players read when they get /team wrong, so a subcommand
+ * listed there and nowhere else reads as a command that exists when it does not.
+ */
+class TeamSubcommandsTest {
+
+    private static final Pattern USAGE_ARGUMENTS = Pattern.compile("<([^>]+)>");
+
+    @Test
+    void pluginYamlUsageAndTabCompletionListTheSameSubcommands() throws Exception {
+        assertEquals(
+                new TreeSet<>(usageSubcommands()),
+                new TreeSet<>(UniversalCommandTabCompleter.TEAM_SUBCOMMANDS)
+        );
+    }
+
+    @Test
+    void usageAdvertisesTheTeamLookup() throws Exception {
+        assertTrue(usageSubcommands().contains("info"));
+    }
+
+    private static List<String> usageSubcommands() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        plugin.load(new File("src/main/resources/plugin.yml"));
+
+        String usage = plugin.getString("commands.team.usage", "");
+        Matcher matcher = USAGE_ARGUMENTS.matcher(usage);
+        assertTrue(matcher.find(), "commands.team.usage must list its subcommands: " + usage);
+
+        List<String> subcommands = new ArrayList<>();
+        for (String option : matcher.group(1).split("\\|")) {
+            subcommands.add(option.trim());
+        }
+        return subcommands;
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/TeamInfoMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/TeamInfoMenuTest.java
@@ -1,0 +1,73 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.models.Team;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TeamInfoMenuTest {
+
+    private final Map<UUID, String> names = new HashMap<>();
+
+    @Test
+    void leaderComesFirstAndTheRestAreAlphabetical() {
+        UUID leader = named("Marcus");
+        UUID zara = named("zara");
+        UUID alice = named("Alice");
+        UUID bob = named("bob");
+
+        Team team = new Team("Dawn", leader);
+        team.addMember(zara);
+        team.addMember(leader);
+        team.addMember(bob);
+        team.addMember(alice);
+
+        assertEquals(
+                List.of(leader, alice, bob, zara),
+                TeamInfoMenu.orderMembers(team, names::get)
+        );
+    }
+
+    @Test
+    void membersWithNoKnownNameSortLastWithoutBreakingTheOrder() {
+        UUID leader = named("Marcus");
+        UUID unknown = UUID.randomUUID();
+        UUID alice = named("Alice");
+
+        Team team = new Team("Dawn", leader);
+        team.addMember(unknown);
+        team.addMember(leader);
+        team.addMember(alice);
+
+        assertEquals(
+                List.of(leader, alice, unknown),
+                TeamInfoMenu.orderMembers(team, names::get)
+        );
+    }
+
+    @Test
+    void pagingCoversEveryMemberAndNeverDropsBelowOnePage() {
+        assertEquals(1, TeamInfoMenu.pageCount(0, 45));
+        assertEquals(1, TeamInfoMenu.pageCount(45, 45));
+        assertEquals(2, TeamInfoMenu.pageCount(46, 45));
+        assertEquals(2, TeamInfoMenu.pageCount(90, 45));
+        assertEquals(3, TeamInfoMenu.pageCount(91, 45));
+    }
+
+    @Test
+    void anUnusablePageSizeFallsBackToOneMemberPerPage() {
+        assertEquals(4, TeamInfoMenu.pageCount(4, 0));
+        assertEquals(4, TeamInfoMenu.pageCount(4, -10));
+    }
+
+    private UUID named(String name) {
+        UUID uuid = UUID.randomUUID();
+        names.put(uuid, name);
+        return uuid;
+    }
+}


### PR DESCRIPTION
Closes #224

`/team info` was already in the `/team` usage line and in the wiki command table, but the switch in `TeamCommand` had no branch for it, so typing it just reopened your own team menu. This adds the subcommand the docs had been promising: `/team info Dawn` opens a read-only view of that team whether or not you belong to it.

## The menu

The layout follows the existing team menu. Leader first, then the rest alphabetically, each head marked online or offline and the leader labelled. The summary item in slot 49 carries the team name, who leads it, the member count against `TEAM.LIMIT-MEMBERS`, and whether friendly fire is on. Nothing in there is clickable except the page arrows, and those only appear if a server raises the member limit past 45.

Every string and slot reads out of a new `TEAM-MENUS.TEAM-INFO` block in `menus.yml`.

## Hidden players

A disguised member shows up under their alias with a blank head instead of the skin behind it; staff holding `ultimatedonutsmp.hide.bypass` still see the real name with the usual marker in front of it. Handing out the real skin through a menu anyone can open would have made `/hide` useless for anybody in a team.

## Allies

The request asked for allies as well, and there is nothing to read them from. `Team` stores a name, a leader, a home, a friendly-fire flag and its members, and that is the whole model. The only mention of alliances anywhere in the project was a stray phrase in the command table, which this corrects. An alliance system is its own feature, not part of a lookup command.

## Notes

- `UniversalCommandTabCompleter` now offers `info` and completes team names after it. `TEAM_SUBCOMMANDS` had been missing it for as long as `plugin.yml` had been advertising it.
- New config keys: `TEAM-MENUS.TEAM-INFO.*` in `menus.yml`, with translations in all eight language files.
- `TeamSubcommandsTest` pins the `plugin.yml` usage line to the tab-completion list so the two can't drift apart again, and `TeamInfoMenuTest` covers member ordering, unknown names and the paging maths. Suite sits at 342 and passes.
