### PR TITLE
feat(admin): add a per-player data wipe command (#225)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -98,6 +98,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/booster` | `/booster <give\|list>` | Give global server shard/money boosters | `ultimatedonutsmp.admin.booster` |
 | `/billford` | `/billford <gui\|reload>` | Manage Billford rotating trades NPC | `ultimatedonutsmp.admin.billford` |
 | `/serverwipe` | `/serverwipe <confirm\|cancel>` | Guarded admin server wipe execution | `ultimatedonutsmp.admin.serverwipe` |
+| `/playerwipe` | `/playerwipe <player> [confirm]` | Wipe everything stored about one player | `ultimatedonutsmp.admin.playerwipe` |
 | `/uds` | `/uds <reload|version|status>` | Main plugin administration & hot-reload | `ultimatedonutsmp.admin.uds` |
 
 ---

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -115,3 +115,35 @@ UltimateDonutSMP includes a guarded `/serverwipe` command to safely reset player
 - Command: `/serverwipe confirm`
 - Prompts multi-stage confirmation to prevent accidental wipe execution.
 - Automatically creates a pre-wipe SQL/JSON backup archive before resetting player state.
+
+---
+
+## Wiping One Player (`/playerwipe`)
+
+Where `/serverwipe` resets the whole server, `/playerwipe` clears a single player. It is the command
+to reach for when someone asks for a fresh start, or when a punished account should lose what it
+gained. `/pwipe` and `/wipe` do the same thing.
+
+Running `/playerwipe <player>` on its own shows what would go, broken down by category, and changes
+nothing. Adding `confirm` carries it out:
+
+```
+/playerwipe Notch
+/playerwipe Notch confirm
+```
+
+It works on offline players as well as online ones, and it clears:
+
+- Kills, deaths, kill streaks, playtime, blocks placed and broken, and mobs killed
+- Money (back to `SETTINGS.MONEY-PER-DEFAULT` in `config.yml`) and shards
+- Homes, and their team — a leader taking a wipe disbands the team
+- Ender chest contents and crate keys
+- Shop favourites, sell history and sell totals
+- Auction listings and claims, orders and deliveries
+- Duel and FFA records, bounties on them and bounties they placed
+- Friends, ignores, and their activity log
+
+Punishments, IP history, and freeze or staff-mode state survive a wipe, so a ban history stays intact
+and alt tracking still works. Spawners they placed are left standing as well, since those are blocks
+in the world rather than stored progress. There is no undo, so take a database backup first if the
+account matters.

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -101,6 +101,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private PunishmentManager punishmentManager;
     private OffenseManager offenseManager;
     private StatsWipeManager statsWipeManager;
+    private PlayerWipeManager playerWipeManager;
     private ServerWipeManager serverWipeManager;
     private SpawnerManager spawnerManager;
     private AntiEspManager antiEspManager;
@@ -238,6 +239,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         anvilModerationManager = new AnvilModerationManager(this);
         anvilModerationManager.load();
         statsWipeManager = new StatsWipeManager(this);
+        playerWipeManager = new PlayerWipeManager(this);
         spawnerManager = new SpawnerManager(this);
         antiEspManager = new AntiEspManager(this);
         spawnStashManager = new SpawnStashManager(this);
@@ -776,6 +778,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ServerWipeCommand serverWipeCommand = new ServerWipeCommand(this);
         setExecutor("serverwipe", serverWipeCommand);
         setTabCompleter("serverwipe", serverWipeCommand);
+        PlayerWipeCommand playerWipeCommand = new PlayerWipeCommand(this);
+        setExecutor("playerwipe", playerWipeCommand);
+        setTabCompleter("playerwipe", playerWipeCommand);
 
         AnvilModerationCommand anvilModCommand = new AnvilModerationCommand(this);
         setExecutor("amod", anvilModCommand);
@@ -1407,6 +1412,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public StatsWipeManager getStatsWipeManager() {
         return statsWipeManager;
+    }
+
+    public PlayerWipeManager getPlayerWipeManager() {
+        return playerWipeManager;
     }
 
     public ServerWipeManager getServerWipeManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
@@ -1,0 +1,133 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.DatabaseManager;
+import com.bx.ultimateDonutSmp.managers.PlayerWipeManager;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class PlayerWipeCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PERMISSION = "ultimatedonutsmp.admin.playerwipe";
+
+    private final UltimateDonutSmp plugin;
+
+    public PlayerWipeCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!PermissionUtils.has(sender, PERMISSION)) {
+            send(sender, "&cYou do not have permission to wipe player data.");
+            return true;
+        }
+        if (args.length == 0) {
+            send(sender, "&cUsage: /" + label + " <player> [confirm]");
+            return true;
+        }
+
+        PlayerWipeManager wipeManager = plugin.getPlayerWipeManager();
+        PlayerWipeManager.Target target = wipeManager.resolveTarget(args[0]);
+        if (target == null) {
+            send(sender, "&cNo player named &f" + args[0] + " &chas ever joined this server.");
+            return true;
+        }
+
+        if (args.length < 2 || !args[1].equalsIgnoreCase("confirm")) {
+            sendPreview(sender, label, target);
+            return true;
+        }
+
+        PlayerWipeManager.WipeResult result = wipeManager.wipe(target, sender.getName());
+        if (result.busy()) {
+            send(sender, "&cA player wipe is already running.");
+            return true;
+        }
+        if (!result.success()) {
+            String error = result.errorMessage() == null || result.errorMessage().isBlank()
+                    ? "unknown error"
+                    : result.errorMessage();
+            send(sender, "&cPlayer wipe failed: &f" + error);
+            return true;
+        }
+
+        send(sender, "&aWiped &f" + target.name() + "&a. Records removed: &f" + result.counts().total() + "&a.");
+        for (String key : PlayerWipeManager.COUNT_KEYS) {
+            int affected = result.counts().affected(key);
+            if (affected > 0) {
+                send(sender, "&8- &7" + PlayerWipeManager.label(key) + ": &f" + affected);
+            }
+        }
+        return true;
+    }
+
+    private void sendPreview(CommandSender sender, String label, PlayerWipeManager.Target target) {
+        DatabaseManager.PlayerWipePreview preview = plugin.getPlayerWipeManager().preview(target.uuid());
+        send(sender, "&6Player wipe preview &8- &f" + target.name());
+
+        if (preview.total() == 0) {
+            send(sender, "&7This plugin has nothing stored for them.");
+            return;
+        }
+
+        for (String key : PlayerWipeManager.COUNT_KEYS) {
+            int count = preview.count(key);
+            if (count > 0) {
+                send(sender, "&8- &7" + PlayerWipeManager.label(key) + ": &f" + count);
+            }
+        }
+        send(sender, "&7Punishments, IP history and their placed spawners are kept.");
+        send(sender, "&cThis cannot be undone. Run &f/" + label + " " + target.name() + " confirm &cto wipe them.");
+    }
+
+    private void send(CommandSender sender, String message) {
+        sender.sendMessage(ColorUtils.toComponent(message));
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!PermissionUtils.has(sender, PERMISSION)) {
+            return List.of();
+        }
+        if (args.length == 1) {
+            return matches(knownPlayerNames(), args[0]);
+        }
+        if (args.length == 2) {
+            return matches(List.of("confirm"), args[1]);
+        }
+        return List.of();
+    }
+
+    private List<String> knownPlayerNames() {
+        Set<String> names = new LinkedHashSet<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            names.add(player.getName());
+        }
+        names.addAll(plugin.getDatabaseManager().loadKnownPlayerNames());
+        return names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList();
+    }
+
+    private List<String> matches(List<String> candidates, String input) {
+        String normalized = input.toLowerCase(Locale.ROOT);
+        List<String> matches = new ArrayList<>();
+        for (String candidate : candidates) {
+            if (candidate.toLowerCase(Locale.ROOT).startsWith(normalized)) {
+                matches.add(candidate);
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -83,6 +83,34 @@ public class DatabaseManager {
         }
     }
 
+    public record PlayerWipePreview(Map<String, Integer> counts) {
+        public int count(String key) {
+            return counts.getOrDefault(key, 0);
+        }
+
+        public int total() {
+            int total = 0;
+            for (int value : counts.values()) {
+                total += value;
+            }
+            return total;
+        }
+    }
+
+    public record PlayerWipeResult(Map<String, Integer> affectedCounts) {
+        public int affected(String key) {
+            return affectedCounts.getOrDefault(key, 0);
+        }
+
+        public int total() {
+            int total = 0;
+            for (int value : affectedCounts.values()) {
+                total += value;
+            }
+            return total;
+        }
+    }
+
     public enum DatabaseType {
         SQLITE,
         MYSQL,
@@ -4602,6 +4630,206 @@ public class DatabaseManager {
         } catch (SQLException exception) {
             plugin.getLogger().log(Level.WARNING, "Failed to inspect server wipe commit " + wipeId, exception);
             return false;
+        }
+    }
+
+    private static final Map<String, List<String>> PLAYER_WIPE_TABLES = playerWipeTables();
+
+    private static Map<String, List<String>> playerWipeTables() {
+        Map<String, List<String>> tables = new LinkedHashMap<>();
+        tables.put("homes", List.of("player_uuid"));
+        tables.put("team_members", List.of("player_uuid"));
+        tables.put("ender_chest_items", List.of("player_uuid"));
+        tables.put("ender_chest_profiles", List.of("player_uuid"));
+        tables.put("player_crate_keys", List.of("player_uuid"));
+        tables.put("sell_history", List.of("player_uuid"));
+        tables.put("sell_progress", List.of("player_uuid"));
+        tables.put("sell_summary_players", List.of("player_uuid"));
+        tables.put("shop_favorites", List.of("player_uuid"));
+        tables.put("player_logs", List.of("player_uuid"));
+        tables.put("bounties", List.of("target_uuid", "placer_uuid"));
+        tables.put("player_friends", List.of("follower_uuid", "followed_uuid"));
+        tables.put("player_ignores", List.of("owner_uuid", "ignored_uuid"));
+        tables.put("auction_listings", List.of("seller_uuid"));
+        tables.put("auction_claims", List.of("owner_uuid"));
+        tables.put("player_auction_preferences", List.of("player_uuid"));
+        tables.put("orders", List.of("owner_uuid"));
+        tables.put("order_deliveries", List.of("deliverer_uuid"));
+        tables.put("order_claims", List.of("owner_uuid"));
+        tables.put("order_ui_preferences", List.of("player_uuid"));
+        tables.put("duel_stats", List.of("player_uuid"));
+        tables.put("duel_matches", List.of("player_one_uuid", "player_two_uuid"));
+        tables.put("duel_claims", List.of("player_uuid"));
+        tables.put("ffa_stats", List.of("player_uuid"));
+        tables.put("ffa_matches", List.of("player_one_uuid", "player_two_uuid"));
+        return Collections.unmodifiableMap(tables);
+    }
+
+    private static final Map<String, String> PLAYER_WIPE_GROUPS = playerWipeGroups();
+
+    private static Map<String, String> playerWipeGroups() {
+        Map<String, String> groups = new LinkedHashMap<>();
+        groups.put("homes", "homes");
+        groups.put("team_members", "team");
+        groups.put("ender_chest_items", "ender_chest");
+        groups.put("ender_chest_profiles", "ender_chest");
+        groups.put("player_crate_keys", "crate_keys");
+        groups.put("sell_history", "sell_records");
+        groups.put("sell_progress", "sell_records");
+        groups.put("sell_summary_players", "sell_records");
+        groups.put("shop_favorites", "shop_favorites");
+        groups.put("player_logs", "logs");
+        groups.put("bounties", "bounties");
+        groups.put("player_friends", "friends");
+        groups.put("player_ignores", "ignores");
+        groups.put("auction_listings", "auctions");
+        groups.put("auction_claims", "auctions");
+        groups.put("player_auction_preferences", "auctions");
+        groups.put("orders", "orders");
+        groups.put("order_deliveries", "orders");
+        groups.put("order_claims", "orders");
+        groups.put("order_ui_preferences", "orders");
+        groups.put("duel_stats", "duels");
+        groups.put("duel_matches", "duels");
+        groups.put("duel_claims", "duels");
+        groups.put("ffa_stats", "ffa");
+        groups.put("ffa_matches", "ffa");
+        return Collections.unmodifiableMap(groups);
+    }
+
+    /**
+     * Counts everything a player wipe would clear for one player. Punishments, IP history and staff
+     * records are deliberately left out: they are moderation evidence rather than player progress.
+     */
+    public PlayerWipePreview previewPlayerWipe(UUID playerUuid) {
+        if (playerUuid == null) {
+            return new PlayerWipePreview(Map.of());
+        }
+
+        String uuid = playerUuid.toString();
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("stats", countPlayerRows("players", List.of("uuid"), uuid));
+        for (Map.Entry<String, List<String>> entry : PLAYER_WIPE_TABLES.entrySet()) {
+            String group = PLAYER_WIPE_GROUPS.get(entry.getKey());
+            counts.merge(group, countPlayerRows(entry.getKey(), entry.getValue(), uuid), Integer::sum);
+        }
+        return new PlayerWipePreview(Map.copyOf(counts));
+    }
+
+    /**
+     * Clears one player's progress in a single transaction: their stored stats and balances go back
+     * to a fresh account, and every row they own in the per-player tables is deleted. Moderation
+     * records and world objects such as their spawners are left alone.
+     */
+    public PlayerWipeResult resetForPlayerWipe(UUID playerUuid, double startingMoney) throws SQLException {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        if (connection == null || connection.isClosed()) {
+            throw new SQLException("Database connection is not available.");
+        }
+
+        String uuid = playerUuid.toString();
+        Map<String, Integer> affected = new LinkedHashMap<>();
+        boolean autoCommitDisabled = false;
+        boolean originalAutoCommit = connection.getAutoCommit();
+        try {
+            connection.setAutoCommit(false);
+            autoCommitDisabled = true;
+
+            if (serverWipeTableExists("players")) {
+                try (PreparedStatement statement = connection.prepareStatement("""
+                        UPDATE players SET
+                            money = ?,
+                            shards = 0,
+                            kills = 0,
+                            deaths = 0,
+                            playtime_seconds = 0,
+                            blocks_placed = 0,
+                            blocks_broken = 0,
+                            mobs_killed = 0,
+                            kill_streak = 0,
+                            highest_kill_streak = 0,
+                            money_spent = 0,
+                            money_made = 0,
+                            keyall_remaining_seconds = -1,
+                            shard_booster_expiry = 0,
+                            mob_spawn_disabled_until = 0,
+                            phantom_disabled_until = 0
+                        WHERE uuid = ?
+                        """)) {
+                    statement.setDouble(1, Math.max(0D, startingMoney));
+                    statement.setString(2, uuid);
+                    affected.put("stats", statement.executeUpdate());
+                }
+            }
+
+            for (Map.Entry<String, List<String>> entry : PLAYER_WIPE_TABLES.entrySet()) {
+                String group = PLAYER_WIPE_GROUPS.get(entry.getKey());
+                affected.merge(group, deletePlayerRows(entry.getKey(), entry.getValue(), uuid), Integer::sum);
+            }
+
+            connection.commit();
+            return new PlayerWipeResult(Map.copyOf(affected));
+        } catch (SQLException exception) {
+            if (autoCommitDisabled) {
+                try {
+                    connection.rollback();
+                } catch (SQLException ignored) {
+                }
+            }
+            throw exception;
+        } finally {
+            if (autoCommitDisabled) {
+                try {
+                    connection.setAutoCommit(originalAutoCommit);
+                } catch (SQLException ignored) {
+                }
+            }
+        }
+    }
+
+    private int deletePlayerRows(String table, List<String> columns, String uuid) throws SQLException {
+        if (columns.isEmpty() || !serverWipeTableExists(table)) {
+            return 0;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "DELETE FROM " + quoteIdentifier(table) + " WHERE " + ownerPredicate(columns))) {
+            bindOwnerUuid(statement, columns, uuid);
+            return statement.executeUpdate();
+        }
+    }
+
+    private int countPlayerRows(String table, List<String> columns, String uuid) {
+        if (columns.isEmpty()) {
+            return 0;
+        }
+        try {
+            if (!serverWipeTableExists(table)) {
+                return 0;
+            }
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT COUNT(*) FROM " + quoteIdentifier(table) + " WHERE " + ownerPredicate(columns))) {
+                bindOwnerUuid(statement, columns, uuid);
+                try (ResultSet rs = statement.executeQuery()) {
+                    return rs.next() ? rs.getInt(1) : 0;
+                }
+            }
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to count player wipe rows in " + table, exception);
+            return 0;
+        }
+    }
+
+    private String ownerPredicate(List<String> columns) {
+        StringJoiner predicate = new StringJoiner(" OR ");
+        for (String column : columns) {
+            predicate.add(quoteIdentifier(column) + " = ?");
+        }
+        return predicate.toString();
+    }
+
+    private void bindOwnerUuid(PreparedStatement statement, List<String> columns, String uuid) throws SQLException {
+        for (int index = 0; index < columns.size(); index++) {
+            statement.setString(index + 1, uuid);
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
@@ -421,6 +421,12 @@ public class DuelManager {
         return statsCache.computeIfAbsent(uuid, this::loadStats);
     }
 
+    public void forgetStats(UUID uuid) {
+        if (uuid != null) {
+            statsCache.remove(uuid);
+        }
+    }
+
     public List<DuelClaim> getClaims(UUID uuid) {
         List<DuelClaim> claims = new ArrayList<>();
         if (uuid == null || connection() == null) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/EnderChestManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/EnderChestManager.java
@@ -393,6 +393,46 @@ public class EnderChestManager {
         return true;
     }
 
+    /**
+     * Drops one player's Ender Chest state without flushing it, so a wipe of their stored items is
+     * not undone by an open session saving itself back afterwards.
+     */
+    public void discardForPlayerWipe(UUID ownerUuid) {
+        if (ownerUuid == null) {
+            return;
+        }
+
+        closeInspectionsForTarget(ownerUuid);
+        releaseVisualViewer(ownerUuid);
+        activeSessions.remove(ownerUuid);
+
+        Player owner = Bukkit.getPlayer(ownerUuid);
+        if (owner != null && owner.isOnline() && isCustomEnderChestView(owner.getOpenInventory())) {
+            owner.closeInventory();
+        }
+    }
+
+    private void closeInspectionsForTarget(UUID targetUuid) {
+        Set<UUID> viewerUuids = inspectionViewersByTarget.get(targetUuid);
+        if (viewerUuids == null || viewerUuids.isEmpty()) {
+            return;
+        }
+
+        for (UUID viewerUuid : List.copyOf(viewerUuids)) {
+            EnderChestInspectionSession session = inspectionSessionsByViewer.get(viewerUuid);
+            if (session == null) {
+                continue;
+            }
+
+            removeInspectionSession(session);
+            Player viewer = Bukkit.getPlayer(viewerUuid);
+            if (viewer != null && viewer.isOnline()
+                    && viewer.getOpenInventory().getTopInventory() == session.getInventory()) {
+                viewer.closeInventory();
+            }
+        }
+    }
+
     public void discardAllForServerWipe() {
         closeAllInspections(true);
         cancelInspectionRefreshTask();

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FfaManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FfaManager.java
@@ -310,6 +310,12 @@ public class FfaManager {
         return statsCache.computeIfAbsent(uuid, this::loadStats);
     }
 
+    public void forgetStats(UUID uuid) {
+        if (uuid != null) {
+            statsCache.remove(uuid);
+        }
+    }
+
     public List<FfaArena> getArenas() {
         List<FfaArena> values = new ArrayList<>(arenas.values());
         values.sort(Comparator.comparing(FfaArena::getId, String.CASE_INSENSITIVE_ORDER));

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerWipeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerWipeManager.java
@@ -1,0 +1,249 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.Team;
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+/**
+ * Clears everything the plugin has stored about one player, in contrast to {@link StatsWipeManager}
+ * which clears a single category across everybody. Moderation records — punishments, IP history,
+ * freeze and staff-mode state — survive a player wipe, and so do world objects such as the
+ * spawners they placed.
+ */
+public class PlayerWipeManager {
+
+    /**
+     * The order the command prints wipe counts in. Every key here is produced by
+     * {@link DatabaseManager#previewPlayerWipe(UUID)}.
+     */
+    public static final List<String> COUNT_KEYS = List.of(
+            "stats",
+            "homes",
+            "team",
+            "ender_chest",
+            "crate_keys",
+            "shop_favorites",
+            "sell_records",
+            "bounties",
+            "auctions",
+            "orders",
+            "duels",
+            "ffa",
+            "friends",
+            "ignores",
+            "logs"
+    );
+
+    private static final Map<String, String> COUNT_LABELS = Map.ofEntries(
+            Map.entry("stats", "Stats and balance"),
+            Map.entry("homes", "Homes"),
+            Map.entry("team", "Team membership"),
+            Map.entry("ender_chest", "Ender chest"),
+            Map.entry("crate_keys", "Crate keys"),
+            Map.entry("shop_favorites", "Shop favourites"),
+            Map.entry("sell_records", "Sell records"),
+            Map.entry("bounties", "Bounties"),
+            Map.entry("auctions", "Auction house"),
+            Map.entry("orders", "Orders"),
+            Map.entry("duels", "Duels"),
+            Map.entry("ffa", "FFA"),
+            Map.entry("friends", "Friends"),
+            Map.entry("ignores", "Ignores"),
+            Map.entry("logs", "Activity logs")
+    );
+
+    public record Target(UUID uuid, String name) {
+    }
+
+    public record WipeResult(
+            boolean success,
+            boolean busy,
+            DatabaseManager.PlayerWipeResult counts,
+            String errorMessage
+    ) {
+        public static WipeResult alreadyRunning() {
+            return new WipeResult(false, true, null, null);
+        }
+
+        public static WipeResult failure(String errorMessage) {
+            return new WipeResult(false, false, null, errorMessage);
+        }
+    }
+
+    private final UltimateDonutSmp plugin;
+    private final AtomicBoolean wipeInProgress = new AtomicBoolean(false);
+
+    public PlayerWipeManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public static String label(String countKey) {
+        return COUNT_LABELS.getOrDefault(countKey, countKey);
+    }
+
+    public boolean isWipeInProgress() {
+        return wipeInProgress.get();
+    }
+
+    /**
+     * Finds the player an admin typed, online or not. Hidden players resolve by their real name so
+     * a disguise cannot dodge a wipe.
+     */
+    public Target resolveTarget(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+
+        String trimmed = input.trim();
+        Player online = Bukkit.getPlayerExact(trimmed);
+        if (online != null) {
+            return new Target(online.getUniqueId(), online.getName());
+        }
+
+        UUID storedUuid = plugin.getDatabaseManager().findPlayerUuidByUsername(trimmed);
+        if (storedUuid != null) {
+            String storedName = plugin.getDatabaseManager().getLastKnownUsername(storedUuid);
+            return new Target(storedUuid, storedName == null || storedName.isBlank() ? trimmed : storedName);
+        }
+
+        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(trimmed);
+        if (offlinePlayer.isOnline() || offlinePlayer.hasPlayedBefore()) {
+            String offlineName = offlinePlayer.getName();
+            return new Target(
+                    offlinePlayer.getUniqueId(),
+                    offlineName == null || offlineName.isBlank() ? trimmed : offlineName
+            );
+        }
+
+        return null;
+    }
+
+    public DatabaseManager.PlayerWipePreview preview(UUID playerUuid) {
+        return plugin.getDatabaseManager().previewPlayerWipe(playerUuid);
+    }
+
+    public WipeResult wipe(Target target, String actorName) {
+        if (target == null) {
+            return WipeResult.failure("no wipe target selected.");
+        }
+        if (!wipeInProgress.compareAndSet(false, true)) {
+            return WipeResult.alreadyRunning();
+        }
+
+        try {
+            Team team = plugin.getTeamManager().getTeam(target.uuid());
+            boolean wasLeader = team != null && team.isLeader(target.uuid());
+
+            discardOpenState(target.uuid());
+            DatabaseManager.PlayerWipeResult counts = plugin.getDatabaseManager()
+                    .resetForPlayerWipe(target.uuid(), defaultMoney());
+            applyTeamRemoval(team, target.uuid(), wasLeader);
+            clearCaches(target.uuid());
+            resetLiveData(target.uuid());
+            refreshDisplays(target.uuid());
+
+            plugin.getLogger().info("Player wipe completed by " + actorName + " for "
+                    + target.name() + " (" + target.uuid() + ").");
+            return new WipeResult(true, false, counts, null);
+        } catch (SQLException | RuntimeException exception) {
+            plugin.getLogger().log(Level.SEVERE, "player wipe failed for " + target.uuid(), exception);
+            return WipeResult.failure(exception.getMessage());
+        } finally {
+            wipeInProgress.set(false);
+        }
+    }
+
+    private double defaultMoney() {
+        return plugin.getConfigManager().getConfig().getDouble("SETTINGS.MONEY-PER-DEFAULT", 1000.0);
+    }
+
+    /**
+     * Drops anything still holding the player's old contents in memory, so nothing writes itself
+     * back over the rows the wipe is about to delete.
+     */
+    private void discardOpenState(UUID playerUuid) {
+        if (plugin.getEnderChestManager() != null) {
+            plugin.getEnderChestManager().discardForPlayerWipe(playerUuid);
+        }
+        plugin.getCrateManager().clearSession(playerUuid);
+        plugin.getCrateManager().clearPendingBind(playerUuid);
+    }
+
+    private void applyTeamRemoval(Team team, UUID playerUuid, boolean wasLeader) {
+        if (team == null) {
+            return;
+        }
+        if (wasLeader) {
+            plugin.getTeamManager().disbandTeam(team);
+            return;
+        }
+        plugin.getTeamManager().kickMember(team, playerUuid);
+    }
+
+    private void clearCaches(UUID playerUuid) {
+        plugin.getCrateManager().unloadKeyBalanceCache(playerUuid);
+        plugin.getShopManager().cleanupPlayer(playerUuid);
+        plugin.getHomeManager().unloadHomes(playerUuid);
+        plugin.getIgnoreManager().unloadPlayer(playerUuid);
+        plugin.getBountyManager().removeBounty(playerUuid);
+        plugin.getDuelManager().forgetStats(playerUuid);
+        plugin.getFfaManager().forgetStats(playerUuid);
+        if (plugin.getFriendsManager() != null) {
+            plugin.getFriendsManager().unloadPlayer(playerUuid);
+        }
+        if (plugin.getAuctionHouseManager() != null) {
+            plugin.getAuctionHouseManager().cleanupPlayer(playerUuid);
+        }
+        if (plugin.getOrdersManager() != null) {
+            plugin.getOrdersManager().forgetUiState(playerUuid);
+        }
+        if (plugin.getLeaderboardManager() != null) {
+            plugin.getLeaderboardManager().invalidateAll();
+        }
+
+        Player online = Bukkit.getPlayer(playerUuid);
+        if (online != null) {
+            plugin.getHomeManager().loadHomes(online);
+            plugin.getIgnoreManager().loadPlayer(playerUuid);
+            if (plugin.getFriendsManager() != null) {
+                plugin.getFriendsManager().loadPlayer(playerUuid);
+            }
+        }
+    }
+
+    /**
+     * Resets the in-memory copy of a player who is online, otherwise the next autosave would write
+     * their old totals straight back into the row that was just cleared.
+     */
+    private void resetLiveData(UUID playerUuid) {
+        PlayerData data = plugin.getPlayerDataManager().get(playerUuid);
+        if (data == null) {
+            return;
+        }
+
+        data.resetTrackedStats(System.currentTimeMillis());
+        data.setMoney(defaultMoney());
+        data.setShards(0L);
+        plugin.getDatabaseManager().savePlayer(data);
+    }
+
+    private void refreshDisplays(UUID playerUuid) {
+        plugin.getScoreboardManager().updateAll();
+        plugin.getTablistManager().updateAll();
+
+        Player online = Bukkit.getPlayer(playerUuid);
+        if (online != null) {
+            plugin.getTablistManager().updateTablistName(online);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -728,6 +728,14 @@ commands:
     description: Command serverwipe
     permission: ultimatedonutsmp.command.serverwipe
     permission-message: "&cYou do not have permission to use /serverwipe."
+  playerwipe:
+    description: Wipe everything this plugin stores about one player
+    usage: /playerwipe <player> [confirm]
+    aliases:
+    - pwipe
+    - wipe
+    permission: ultimatedonutsmp.command.playerwipe
+    permission-message: "&cYou do not have permission to use /playerwipe."
   amod:
     description: Command amod
     permission: ultimatedonutsmp.command.amod
@@ -773,6 +781,7 @@ permissions:
       ultimatedonutsmp.admin.crate.keyall: true
       ultimatedonutsmp.admin.reload: true
       ultimatedonutsmp.admin.statswipe: true
+      ultimatedonutsmp.admin.playerwipe: true
       ultimatedonutsmp.admin.optimize: true
       ultimatedonutsmp.admin.sellstats: true
       ultimatedonutsmp.admin.shards: true
@@ -904,6 +913,9 @@ permissions:
     default: op
   ultimatedonutsmp.admin.statswipe:
     description: Open and execute Stats Wipe tools
+    default: op
+  ultimatedonutsmp.admin.playerwipe:
+    description: Preview and wipe a single player's stored data
     default: op
   ultimatedonutsmp.admin.optimize:
     description: View and reload runtime optimization controls
@@ -1289,6 +1301,7 @@ permissions:
       ultimatedonutsmp.command.disguise: true
       ultimatedonutsmp.command.maintenance: true
       ultimatedonutsmp.command.serverwipe: true
+      ultimatedonutsmp.command.playerwipe: true
       ultimatedonutsmp.command.amod: true
   ultimatedonutsmp.command.team:
     description: Access to /team command
@@ -1695,6 +1708,9 @@ permissions:
     default: op
   ultimatedonutsmp.command.serverwipe:
     description: Access to /serverwipe command
+    default: op
+  ultimatedonutsmp.command.playerwipe:
+    description: Access to /playerwipe command
     default: op
   ultimatedonutsmp.command.amod:
     description: Access to /amod command

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerWipeTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerWipeTest.java
@@ -1,0 +1,216 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DatabaseManagerPlayerWipeTest {
+
+    private static final UUID TARGET = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID BYSTANDER = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @Test
+    void wipeClearsOneOwnerAndLeavesEverybodyElseAlone() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection, true);
+            seedData(connection);
+
+            DatabaseManager.PlayerWipePreview preview = manager.previewPlayerWipe(TARGET);
+            assertEquals(1, preview.count("stats"));
+            assertEquals(1, preview.count("homes"));
+            assertEquals(2, preview.count("ender_chest"));
+            assertEquals(3, preview.count("sell_records"));
+            assertEquals(2, preview.count("bounties"));
+            assertEquals(2, preview.count("duels"));
+
+            DatabaseManager.PlayerWipeResult result = manager.resetForPlayerWipe(TARGET, 1000D);
+            assertEquals(preview.total(), result.total());
+
+            assertEquals(1000D, money(connection, TARGET), 0.001D);
+            assertEquals(0, queryInt(connection, "SELECT kills FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(0, queryInt(connection, "SELECT shards FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(-1, queryInt(connection,
+                    "SELECT keyall_remaining_seconds FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(1, queryInt(connection,
+                    "SELECT scoreboard_visible FROM players WHERE uuid = '" + TARGET + "'"));
+
+            assertEquals(0, countWhere(connection, "homes", "player_uuid = '" + TARGET + "'"));
+            assertEquals(0, countWhere(connection, "shop_favorites", "player_uuid = '" + TARGET + "'"));
+            assertEquals(0, count(connection, "ender_chest_items"));
+            assertEquals(0, count(connection, "sell_history"));
+            assertEquals(0, count(connection, "player_logs"));
+            assertEquals(0, count(connection, "bounties"));
+            assertEquals(0, count(connection, "player_friends"));
+            assertEquals(0, count(connection, "player_ignores"));
+            assertEquals(0, count(connection, "duel_matches"));
+            assertEquals(0, count(connection, "ffa_matches"));
+
+            // The bystander keeps every one of their own rows.
+            assertEquals(500D, money(connection, BYSTANDER), 0.001D);
+            assertEquals(9, queryInt(connection, "SELECT kills FROM players WHERE uuid = '" + BYSTANDER + "'"));
+            assertEquals(1, countWhere(connection, "homes", "player_uuid = '" + BYSTANDER + "'"));
+            assertEquals(1, countWhere(connection, "shop_favorites", "player_uuid = '" + BYSTANDER + "'"));
+
+            // Moderation records and world objects are not player progress.
+            assertEquals(1, count(connection, "punishments"));
+            assertEquals(1, count(connection, "player_ip_history"));
+            assertEquals(1, count(connection, "spawners"));
+        }
+    }
+
+    @Test
+    void wipeRollsBackWhenATableCannotBeCleared() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection, false);
+            seedData(connection);
+
+            assertThrows(
+                    java.sql.SQLException.class,
+                    () -> manager.resetForPlayerWipe(TARGET, 1000D)
+            );
+
+            assertEquals(250D, money(connection, TARGET), 0.001D);
+            assertEquals(7, queryInt(connection, "SELECT kills FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(1, countWhere(connection, "shop_favorites", "player_uuid = '" + TARGET + "'"));
+        }
+    }
+
+    private DatabaseManager managerWithConnection(Connection connection) throws Exception {
+        DatabaseManager manager = new DatabaseManager(null);
+        Field connectionField = DatabaseManager.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(manager, connection);
+        return manager;
+    }
+
+    private void createSchema(Connection connection, boolean homesAreWipeable) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    CREATE TABLE players (
+                        uuid TEXT PRIMARY KEY,
+                        username TEXT,
+                        money REAL,
+                        shards INTEGER,
+                        kills INTEGER,
+                        deaths INTEGER,
+                        playtime_seconds INTEGER,
+                        blocks_placed INTEGER,
+                        blocks_broken INTEGER,
+                        mobs_killed INTEGER,
+                        kill_streak INTEGER,
+                        highest_kill_streak INTEGER,
+                        money_spent REAL,
+                        money_made REAL,
+                        scoreboard_visible INTEGER,
+                        keyall_remaining_seconds INTEGER,
+                        shard_booster_expiry INTEGER,
+                        mob_spawn_disabled_until BIGINT,
+                        phantom_disabled_until BIGINT
+                    )
+                    """);
+            statement.execute("CREATE TABLE homes (player_uuid TEXT, home_name TEXT)");
+            statement.execute("CREATE TABLE team_members (player_uuid TEXT, team_name TEXT)");
+            statement.execute("CREATE TABLE ender_chest_profiles (player_uuid TEXT)");
+            statement.execute("CREATE TABLE ender_chest_items (player_uuid TEXT, slot INTEGER)");
+            statement.execute("CREATE TABLE player_crate_keys (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_history (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_progress (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_summary_players (player_uuid TEXT)");
+            statement.execute("CREATE TABLE shop_favorites (player_uuid TEXT, favorite_id TEXT)");
+            statement.execute("CREATE TABLE player_logs (player_uuid TEXT)");
+            statement.execute("CREATE TABLE bounties (target_uuid TEXT, placer_uuid TEXT)");
+            statement.execute("CREATE TABLE player_friends (follower_uuid TEXT, followed_uuid TEXT)");
+            statement.execute("CREATE TABLE player_ignores (owner_uuid TEXT, ignored_uuid TEXT)");
+            statement.execute("CREATE TABLE duel_stats (player_uuid TEXT)");
+            statement.execute("CREATE TABLE duel_matches (player_one_uuid TEXT, player_two_uuid TEXT)");
+            statement.execute("CREATE TABLE ffa_matches (player_one_uuid TEXT, player_two_uuid TEXT)");
+            statement.execute("CREATE TABLE punishments (target_uuid TEXT, reason TEXT)");
+            statement.execute("CREATE TABLE player_ip_history (player_uuid TEXT, ip_address TEXT)");
+            statement.execute("CREATE TABLE spawners (id INTEGER PRIMARY KEY, owner_uuid TEXT)");
+
+            if (!homesAreWipeable) {
+                // Homes are cleared first, so blocking them proves the players update that ran
+                // before it is rolled back too.
+                statement.execute("""
+                        CREATE TRIGGER block_home_delete BEFORE DELETE ON homes
+                        BEGIN
+                            SELECT RAISE(ABORT, 'homes are locked');
+                        END
+                        """);
+            }
+        }
+    }
+
+    private void seedData(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(playerRow(TARGET, "Target", 250, 40, 7));
+            statement.executeUpdate(playerRow(BYSTANDER, "Bystander", 500, 25, 9));
+
+            statement.executeUpdate("INSERT INTO homes VALUES ('" + TARGET + "', 'base')");
+            statement.executeUpdate("INSERT INTO homes VALUES ('" + BYSTANDER + "', 'base')");
+            statement.executeUpdate("INSERT INTO ender_chest_profiles VALUES ('" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO ender_chest_items VALUES ('" + TARGET + "', 0)");
+            statement.executeUpdate("INSERT INTO sell_history VALUES ('" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO sell_progress VALUES ('" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO sell_summary_players VALUES ('" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO shop_favorites VALUES ('" + TARGET + "', 'diamond')");
+            statement.executeUpdate("INSERT INTO shop_favorites VALUES ('" + BYSTANDER + "', 'diamond')");
+            statement.executeUpdate("INSERT INTO player_logs VALUES ('" + TARGET + "')");
+
+            // Rows that reference the target through either of two owner columns.
+            statement.executeUpdate("INSERT INTO bounties VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+            statement.executeUpdate("INSERT INTO bounties VALUES ('" + BYSTANDER + "', '" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO player_friends VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+            statement.executeUpdate("INSERT INTO player_friends VALUES ('" + BYSTANDER + "', '" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO player_ignores VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+            statement.executeUpdate("INSERT INTO duel_stats VALUES ('" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO duel_matches VALUES ('" + BYSTANDER + "', '" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO ffa_matches VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+
+            statement.executeUpdate("INSERT INTO punishments VALUES ('" + TARGET + "', 'keep-this-ban')");
+            statement.executeUpdate("INSERT INTO player_ip_history VALUES ('" + TARGET + "', '127.0.0.1')");
+            statement.executeUpdate("INSERT INTO spawners VALUES (1, '" + TARGET + "')");
+        }
+    }
+
+    private String playerRow(UUID uuid, String username, int money, int shards, int kills) {
+        return "INSERT INTO players VALUES ('" + uuid + "', '" + username + "', " + money + ", " + shards + ", "
+                + kills + ", 3, 900, 12, 13, 14, 4, 8, 200, 300, 1, 60, 12345, 0, 0)";
+    }
+
+    private double money(Connection connection, UUID uuid) throws Exception {
+        return queryDouble(connection, "SELECT money FROM players WHERE uuid = '" + uuid + "'");
+    }
+
+    private int count(Connection connection, String table) throws Exception {
+        return queryInt(connection, "SELECT COUNT(*) FROM " + table);
+    }
+
+    private int countWhere(Connection connection, String table, String predicate) throws Exception {
+        return queryInt(connection, "SELECT COUNT(*) FROM " + table + " WHERE " + predicate);
+    }
+
+    private int queryInt(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getInt(1) : 0;
+        }
+    }
+
+    private double queryDouble(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getDouble(1) : 0D;
+        }
+    }
+}


### PR DESCRIPTION
Closes #225

Every wipe in this plugin was all-or-nothing until now. `/serverwipe` flattens the whole database and the configured worlds, and `/uds statswipe <target>` clears one category across everybody who has ever joined; neither can touch a single account. So there was no way to give one player a fresh start, or to strip what a cheater gained, without taking the rest of the server down with them. `/playerwipe <player>` does that one account and leaves everyone else where they were.

## The command

`/playerwipe <player>` on its own is a dry run: it prints what would go, grouped by category, and writes nothing. Adding `confirm` carries it out. That's the same shape as `/uds statswipe <target> confirm`, which felt better than borrowing the console-only token dance from `/serverwipe`. That guard exists because a server wipe restarts the box and moves world folders around, and none of that applies here. A typo still costs somebody their account, though, hence the preview and the explicit `confirm`.

Aliases are `/pwipe` and `/wipe`, both spellings the reporter asked about. Permission is `ultimatedonutsmp.admin.playerwipe`, op by default and folded into the existing admin bundle. Offline players work: the target resolves through the stored username first and falls back to `hasPlayedBefore`, so someone who quit last month can still be wiped.

## What it clears, and what it deliberately doesn't

The reporter listed kills, deaths, shards, money, playtime, homes, teams, ender chest, shop favourites and sell stats. All of those go, along with crate keys, auction listings and claims, orders and deliveries, duel and FFA records, bounties both on them and placed by them, friends, ignores, and their activity log. The wipe resets the `players` row rather than deleting it, matching `resetForServerWipe`: money returns to `SETTINGS.MONEY-PER-DEFAULT`, every counter goes to zero, and their personal toggles survive, since clearing someone's progress is no reason to flip their scoreboard back on.

Some things stay behind on purpose. Punishments and IP history are moderation evidence, so wiping a player's stats shouldn't quietly erase a ban record or break alt tracking, and freeze and staff-mode state sit in the same bucket. Spawners they placed are blocks in the world; deleting the rows without removing the blocks would leave orphans behind, so those stay standing. The preview says as much on screen before you confirm.

## Keeping memory from undoing the wipe

The database half is one transaction that rolls back whole if any table fails, but that alone isn't enough, because plenty of this data has a cached copy in memory that would write itself straight back. An open Ender Chest saves on close, `PlayerData` autosaves the old totals, and `CrateManager`, `ShopManager` and both PvP stat maps each hold their own copies.

So the wipe drops the Ender Chest session without flushing it (`discardForPlayerWipe`, which also boots anyone inspecting them), evicts every per-player cache, and resets the live `PlayerData` for a player who happens to be online. Teams go through `disbandTeam` or `kickMember` rather than a raw delete, so the rest of the team gets told and the tablist updates. Wiping a leader disbands the team, which is the only sane reading of it.

`DuelManager` and `FfaManager` each gained a three-line `forgetStats(UUID)` because their `statsCache` had no eviction path at all; without it `/ffastats` and the duel queue menu would keep serving the old numbers until the next restart.

## Notes

- No schema change: existing rows are updated or deleted, nothing added or altered.
- `plugin.yml` gains the command entry and two permission nodes. No message keys, so the eight language files are untouched.
- `DatabaseManagerPlayerWipeTest` seeds two players and checks the target is emptied while the bystander keeps everything, including the two-column cases where the target sits in either half of a pair (bounty target vs placer, both sides of a friendship, either player in a duel match). It also asserts punishments, IP history and spawners survive, and that a delete failing mid-transaction rolls the `players` update back.
- Wiki: a `/playerwipe` row in Commands-and-Permissions and a section under Staff-and-Security next to the server wipe.
- Suite is 344 tests, all green.
