### PR TITLE
docs(wiki): drop an em dash from the player wipe page (#225)

### DIFF
--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -136,7 +136,7 @@ It works on offline players as well as online ones, and it clears:
 
 - Kills, deaths, kill streaks, playtime, blocks placed and broken, and mobs killed
 - Money (back to `SETTINGS.MONEY-PER-DEFAULT` in `config.yml`) and shards
-- Homes, and their team — a leader taking a wipe disbands the team
+- Homes, and their team. A leader taking a wipe disbands the team
 - Ender chest contents and crate keys
 - Shop favourites, sell history and sell totals
 - Auction listings and claims, orders and deliveries


### PR DESCRIPTION
Follow-up to #228.

The `/playerwipe` section I added to Staff-and-Security had an em dash in one of the bullets. Every other page under `docs/wiki/` has none, so it stuck out. Split into two sentences instead, which reads the same.

No behaviour change, one line touched.
