### PR TITLE
feat(staff): add a seehomes command for browsing player homes (#226)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -60,6 +60,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/freeze` | `/freeze <player>` | Freeze or unfreeze a target player | `ultimatedonutsmp.admin.freeze` |
 | `/invsee` | `/invsee <player>` | Inspect and edit player inventory in real-time | `ultimatedonutsmp.admin.invsee` |
 | `/ecsee` | `/ecsee <player>` | Inspect and edit player Ender Chest | `ultimatedonutsmp.admin.ecsee` |
+| `/seehomes` | `/seehomes <player>` (Alias `/homesee`) | Browse another player's homes and warp to any of them | `ultimatedonutsmp.staff.seehomes` |
 | `/chat` | `/chat <mute\|unmute\|delay\|clear>` | Global chat moderation controls | `ultimatedonutsmp.admin.chat` |
 | `/logs` | `/logs <player>` | Browse one player's activity log, chat included | `ultimatedonutsmp.admin.logs` |
 | `/chatlog` | `/chatlog [player]` | Browse public chat for the whole server, or for one player | `ultimatedonutsmp.admin.chatlog` |

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -28,6 +28,24 @@ Freezes the target player on top of an ice block and disables movement, block br
 - Inspect player Ender Chest: `/ecsee <player>`
 - Allows staff to add, remove, or modify items directly inside player inventories.
 
+### 5. Home Inspection (`/seehomes <player>`)
+Opens the target's saved homes as a paged list, one bed per home, and clicking a bed sends the
+staff member there. The world, along with the exact block the home sits on, is written into the
+lore, and a home pointing at a world the server no longer loads shows as a barrier rather than
+teleporting anyone into nothing. Offline players work too, since the homes come from the database
+when nobody is holding them in memory.
+
+This is the same list the profile viewer has always shown behind its Homes button; the command
+skips the profile screen and drops you straight into it, which matters when you only need to check
+where somebody built. `/homesee` does the same thing.
+
+- Permission: `ultimatedonutsmp.staff.seehomes`, plus `ultimatedonutsmp.command.seehomes` to run the
+  command at all. Anyone already carrying `ultimatedonutsmp.staff.profileviewer` passes the first
+  check without a new node, since that permission already opens this menu.
+- Styled from `PROFILE-VIEWER-HOMES-MENU` in `menus.yml`. Arriving from `/seehomes` swaps the Back
+  button for `CLOSE-BUTTON`, because there is no profile screen to go back to.
+- Turning off the `PROFILE_VIEWER` feature disables `/seehomes` alongside `/profileviewer`.
+
 ---
 
 ## Punishments

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -691,6 +691,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("vanish", new VanishCommand(this), FeatureManager.Feature.STAFF_MODE);
         setExecutor("invsee", new InvseeCommand(this));
         setExecutor("profileviewer", new ProfileViewerCommand(this), FeatureManager.Feature.PROFILE_VIEWER);
+        setExecutor("seehomes", new SeeHomesCommand(this), FeatureManager.Feature.PROFILE_VIEWER);
         setExecutor("punishments", new PunishmentHistoryCommand(this), FeatureManager.Feature.PUNISHMENTS);
         PunishmentCommand punishmentCommand = new PunishmentCommand(this);
         setExecutor("ban", punishmentCommand, FeatureManager.Feature.PUNISHMENTS);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/SeeHomesCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/SeeHomesCommand.java
@@ -1,0 +1,59 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.ProfileViewerManager;
+import com.bx.ultimateDonutSmp.menus.ProfileViewerHomesMenu;
+import com.bx.ultimateDonutSmp.models.ProfileSnapshot;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permissible;
+
+public class SeeHomesCommand implements CommandExecutor {
+
+    public static final String PERMISSION = "ultimatedonutsmp.staff.seehomes";
+
+    private final UltimateDonutSmp plugin;
+
+    public SeeHomesCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * The profile viewer already opens this exact menu, so anyone allowed to use it keeps working
+     * without a second permission being handed out.
+     */
+    public static boolean canSeeHomes(Permissible permissible) {
+        return PermissionUtils.hasAny(permissible, PERMISSION, ProfileViewerManager.VIEW_PERMISSION);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Player only.");
+            return true;
+        }
+
+        if (!canSeeHomes(player)) {
+            player.sendMessage(ColorUtils.toComponent("&cYou do not have permission to view other players' homes."));
+            return true;
+        }
+
+        if (args.length == 0) {
+            player.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <player>"));
+            return true;
+        }
+
+        ProfileSnapshot snapshot = plugin.getProfileViewerManager().resolveProfile(args[0]).orElse(null);
+        if (snapshot == null) {
+            player.sendMessage(ColorUtils.toComponent("&cNo player named &f" + args[0] + " &chas ever joined this server."));
+            return true;
+        }
+
+        new ProfileViewerHomesMenu(plugin, snapshot.getUuid(), false).open(player);
+        return true;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -84,7 +84,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "ecsee" -> completeEcsee(sender, args);
             case "sellhand" -> singleArg(args, AMOUNTS);
             case "worth" -> completeWorth(sender, args);
-            case "balance", "stats", "playtime", "alts", "profileviewer", "punishments", "logs" ->
+            case "balance", "stats", "playtime", "alts", "profileviewer", "seehomes", "punishments", "logs" ->
                     completeKnownPlayer(args, sender, true);
             case "ping", "findplayer" -> completeOnlinePlayer(args, sender, true);
             case "pay", "shardpay" -> completePayment(sender, args);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -230,7 +230,7 @@ public class FeatureManager {
             case "helpop", "report" -> new Feature[]{Feature.STAFF_ALERTS};
             case "spawnstash" -> new Feature[]{Feature.SPAWN_STASH};
             case "invsee" -> new Feature[]{Feature.INVSEE};
-            case "profileviewer" -> new Feature[]{Feature.PROFILE_VIEWER};
+            case "profileviewer", "seehomes" -> new Feature[]{Feature.PROFILE_VIEWER};
             case "punishments", "ban", "tempban", "mute", "tempmute", "warn", "kick", "blacklist",
                     "unban", "unmute", "unblacklist" -> new Feature[]{Feature.PUNISHMENTS};
             case "bounty" -> new Feature[]{Feature.BOUNTY};

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ProfileViewerHomesMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ProfileViewerHomesMenu.java
@@ -33,6 +33,7 @@ public class ProfileViewerHomesMenu extends BaseMenu {
     private static final int LAST_PAGE_SLOT = 53;
 
     private final UUID targetUuid;
+    private final boolean returnToProfileViewer;
     private final Map<Integer, Home> slotHomes = new HashMap<>();
 
     private ProfileSnapshot snapshot;
@@ -41,9 +42,10 @@ public class ProfileViewerHomesMenu extends BaseMenu {
     private boolean hasPreviousPage;
     private boolean hasNextPage;
 
-    public ProfileViewerHomesMenu(UltimateDonutSmp plugin, UUID targetUuid) {
+    public ProfileViewerHomesMenu(UltimateDonutSmp plugin, UUID targetUuid, boolean returnToProfileViewer) {
         super(plugin, configuredTitle(plugin, targetUuid), configuredSize(plugin));
         this.targetUuid = targetUuid;
+        this.returnToProfileViewer = returnToProfileViewer;
     }
 
     @Override
@@ -98,7 +100,11 @@ public class ProfileViewerHomesMenu extends BaseMenu {
     public void handleClick(int slot, Player player) {
         if (slot == BACK_SLOT) {
             SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
-            new ProfileViewerMenu(plugin, targetUuid).open(player);
+            if (returnToProfileViewer && plugin.getProfileViewerManager().canView(player)) {
+                new ProfileViewerMenu(plugin, targetUuid).open(player);
+            } else {
+                player.closeInventory();
+            }
             return;
         }
 
@@ -183,12 +189,16 @@ public class ProfileViewerHomesMenu extends BaseMenu {
     }
 
     private void buildBackButton() {
+        String path = returnToProfileViewer ? MENU_PATH + ".BACK-BUTTON" : MENU_PATH + ".CLOSE-BUTTON";
+        String fallbackName = returnToProfileViewer ? "&cBack" : "&cClose";
+        List<String> fallbackLore = returnToProfileViewer
+                ? List.of("&7Return to the main profile viewer.")
+                : List.of("&7Close this home list.");
+
         set(BACK_SLOT, ItemUtils.createItem(
-                ItemUtils.parseMaterial(menus().getString(MENU_PATH + ".BACK-BUTTON.MATERIAL", "RED_STAINED_GLASS_PANE")),
-                menus().getString(MENU_PATH + ".BACK-BUTTON.DISPLAY-NAME", "&cBack"),
-                menus().getStringList(MENU_PATH + ".BACK-BUTTON.LORE").isEmpty()
-                        ? List.of("&7Return to the main profile viewer.")
-                        : menus().getStringList(MENU_PATH + ".BACK-BUTTON.LORE")
+                ItemUtils.parseMaterial(menus().getString(path + ".MATERIAL", "RED_STAINED_GLASS_PANE")),
+                menus().getString(path + ".DISPLAY-NAME", fallbackName),
+                defaultIfEmpty(menus().getStringList(path + ".LORE"), fallbackLore)
         ));
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ProfileViewerMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ProfileViewerMenu.java
@@ -156,7 +156,7 @@ public class ProfileViewerMenu extends BaseMenu {
                 replacePlaceholders(menus().getString(MENU_PATH + ".BUTTONS.HOMES.DISPLAY-NAME", "&bHomes"), snapshot),
                 lore
         ));
-        slotActions.put(slot, (player, clickType) -> new ProfileViewerHomesMenu(plugin, targetUuid).open(player));
+        slotActions.put(slot, (player, clickType) -> new ProfileViewerHomesMenu(plugin, targetUuid, true).open(player));
     }
 
     private void buildCurrentLocationButton() {

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1288,6 +1288,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cSchließen"
+      LORE:
+      - "&7Diese Home-Liste schließen"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1293,6 +1293,10 @@ MENUS:
       DISPLAY-NAME: '&#6BF18DRefresh'
       LORE:
       - '&7Reload this player''s homes'
+    CLOSE-BUTTON:
+      DISPLAY-NAME: '&cClose'
+      LORE:
+      - '&7Close this home list'
   PUNISHMENT-HISTORY-MENU:
     TITLE: '&8Punishments ({player})'
     BUTTONS:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1153,6 +1153,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cCerrar"
+      LORE:
+      - "&7Cerrar esta lista de homes"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1152,6 +1152,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cFermer"
+      LORE:
+      - "&7Fermer cette liste de homes"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1289,6 +1289,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cTutup"
+      LORE:
+      - "&7Tutup daftar home ini"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1153,6 +1153,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cFechar"
+      LORE:
+      - "&7Fechar esta lista de homes"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1152,6 +1152,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&cЗакрыть"
+      LORE:
+      - "&7Закрыть этот список домов"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1151,6 +1151,10 @@ MENUS:
       DISPLAY-NAME: "&cBack"
       LORE:
       - "&7Return to the main profile viewer"
+    CLOSE-BUTTON:
+      DISPLAY-NAME: "&c关闭"
+      LORE:
+      - "&7关闭此 home 列表"
     REFRESH-BUTTON:
       DISPLAY-NAME: "&#6BF18DRefresh"
       LORE:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1918,6 +1918,11 @@ PROFILE-VIEWER-HOMES-MENU:
     DISPLAY-NAME: '&cBack'
     LORE:
     - '&7Return to the main profile viewer'
+  CLOSE-BUTTON:
+    MATERIAL: RED_STAINED_GLASS_PANE
+    DISPLAY-NAME: '&cClose'
+    LORE:
+    - '&7Close this home list'
   REFRESH-BUTTON:
     MATERIAL: CLOCK
     DISPLAY-NAME: '&#6BF18DRefresh'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -414,6 +414,13 @@ commands:
     - pv
     permission: ultimatedonutsmp.command.profileviewer
     permission-message: "&cYou do not have permission to use /profileviewer."
+  seehomes:
+    description: Browse another player's homes and teleport to them
+    usage: /seehomes <player>
+    aliases:
+    - homesee
+    permission: ultimatedonutsmp.command.seehomes
+    permission-message: "&cYou do not have permission to use /seehomes."
   punishments:
     description: Browse every punishment on the server, or one player's history
     usage: /punishments [player]
@@ -820,6 +827,7 @@ permissions:
       ultimatedonutsmp.staff.alts: true
       ultimatedonutsmp.staff.invsee: true
       ultimatedonutsmp.staff.profileviewer: true
+      ultimatedonutsmp.staff.seehomes: true
       ultimatedonutsmp.staff.punishments.view: true
       ultimatedonutsmp.staff.punishments.create: true
       ultimatedonutsmp.staff.punishments.remove: true
@@ -976,6 +984,7 @@ permissions:
       ultimatedonutsmp.staff.alerts.bypass-cooldown: true
       ultimatedonutsmp.staff.invsee: true
       ultimatedonutsmp.staff.profileviewer: true
+      ultimatedonutsmp.staff.seehomes: true
       ultimatedonutsmp.staff.punishments.view: true
       ultimatedonutsmp.staff.punishments.create: true
       ultimatedonutsmp.staff.punishments.remove: true
@@ -1059,6 +1068,9 @@ permissions:
     default: op
   ultimatedonutsmp.staff.profileviewer:
     description: View player profiles and homes for moderation purposes
+    default: op
+  ultimatedonutsmp.staff.seehomes:
+    description: Browse any player's homes and teleport to them
     default: op
   ultimatedonutsmp.staff.punishments.view:
     description: View punishment history for moderation purposes
@@ -1241,6 +1253,7 @@ permissions:
       ultimatedonutsmp.command.vanish: true
       ultimatedonutsmp.command.invsee: true
       ultimatedonutsmp.command.profileviewer: true
+      ultimatedonutsmp.command.seehomes: true
       ultimatedonutsmp.command.punishments: true
       ultimatedonutsmp.command.ban: true
       ultimatedonutsmp.command.tempban: true
@@ -1500,6 +1513,9 @@ permissions:
     default: op
   ultimatedonutsmp.command.profileviewer:
     description: Access to /profileviewer command
+    default: op
+  ultimatedonutsmp.command.seehomes:
+    description: Access to /seehomes command
     default: op
   ultimatedonutsmp.command.punishments:
     description: Access to /punishments command

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/SeeHomesCommandTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/SeeHomesCommandTest.java
@@ -1,0 +1,128 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.managers.ProfileViewerManager;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SeeHomesCommandTest {
+
+    @Test
+    void theDedicatedPermissionOpensTheHomeList() {
+        assertTrue(SeeHomesCommand.canSeeHomes(new TestPermissible().grant(SeeHomesCommand.PERMISSION)));
+    }
+
+    @Test
+    void staffWhoAlreadyHaveTheProfileViewerKeepWorkingWithoutASecondNode() {
+        assertTrue(SeeHomesCommand.canSeeHomes(new TestPermissible().grant(ProfileViewerManager.VIEW_PERMISSION)));
+    }
+
+    @Test
+    void everybodyElseIsTurnedAway() {
+        assertFalse(SeeHomesCommand.canSeeHomes(new TestPermissible()));
+        assertFalse(SeeHomesCommand.canSeeHomes(new TestPermissible().grant("ultimatedonutsmp.command.homes")));
+        assertFalse(SeeHomesCommand.canSeeHomes(null));
+    }
+
+    @Test
+    void pluginMetadataDeclaresTheCommandAndBothPermissions() {
+        YamlConfiguration pluginYaml = YamlConfiguration.loadConfiguration(new File("src/main/resources/plugin.yml"));
+
+        assertEquals("ultimatedonutsmp.command.seehomes", pluginYaml.getString("commands.seehomes.permission"));
+        assertTrue(pluginYaml.getStringList("commands.seehomes.aliases").contains("homesee"));
+        assertEquals("op", pluginYaml.getString("permissions.ultimatedonutsmp.command.seehomes.default"));
+        assertEquals("op", pluginYaml.getString("permissions." + SeeHomesCommand.PERMISSION + ".default"));
+        assertTrue(pluginYaml.getBoolean(
+                "permissions.ultimatedonutsmp.command.*.children.ultimatedonutsmp.command.seehomes"));
+        assertTrue(pluginYaml.getBoolean(
+                "permissions.ultimatedonutsmp.admin.children." + SeeHomesCommand.PERMISSION));
+    }
+
+    private static final class TestPermissible implements Permissible {
+        private final Set<PermissionAttachmentInfo> effectivePermissions = new LinkedHashSet<>();
+        private boolean op;
+
+        private TestPermissible grant(String permission) {
+            effectivePermissions.add(new PermissionAttachmentInfo(this, permission, null, true));
+            return this;
+        }
+
+        @Override
+        public boolean isPermissionSet(String name) {
+            return effectivePermissions.stream()
+                    .anyMatch(info -> info.getPermission().equalsIgnoreCase(name));
+        }
+
+        @Override
+        public boolean isPermissionSet(Permission permission) {
+            return permission != null && isPermissionSet(permission.getName());
+        }
+
+        @Override
+        public boolean hasPermission(String name) {
+            return effectivePermissions.stream()
+                    .anyMatch(info -> info.getValue() && info.getPermission().equalsIgnoreCase(name));
+        }
+
+        @Override
+        public boolean hasPermission(Permission permission) {
+            return permission != null && hasPermission(permission.getName());
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, int ticks) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeAttachment(PermissionAttachment attachment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void recalculatePermissions() {
+        }
+
+        @Override
+        public Set<PermissionAttachmentInfo> getEffectivePermissions() {
+            return effectivePermissions;
+        }
+
+        @Override
+        public boolean isOp() {
+            return op;
+        }
+
+        @Override
+        public void setOp(boolean value) {
+            op = value;
+        }
+    }
+}


### PR DESCRIPTION
Closes #226

Staff could already look at somebody else's homes, but only by running `/profileviewer <player>` and clicking through to the Homes button, and only while holding `ultimatedonutsmp.staff.profileviewer`, which also hands over stats, punishment history and a warp to wherever the player happens to be standing. `/seehomes <player>` opens that same home list directly, behind its own permission, so you can let a moderator check where somebody built without giving them the rest of the profile screen.

## The command
`/seehomes <player>`, aliased `/homesee`, player-only, tab-completing against everyone who has ever joined. Offline targets work too, since the homes come out of the database when nobody is holding them in memory. The list itself is untouched: one bed per home, world and coordinates in the lore, click to teleport, paging along the bottom row, and a barrier in place of the bed when a home points at a world the server no longer loads.

## Permissions
Typing the command needs `ultimatedonutsmp.command.seehomes` and opening the menu needs `ultimatedonutsmp.staff.seehomes`. Both default to op, and both sit in the same bundles that already carry the profileviewer nodes, so a server granting `ultimatedonutsmp.admin` or `ultimatedonutsmp.command.*` wholesale picks them up with no config edit. Anyone already carrying `ultimatedonutsmp.staff.profileviewer` clears the second check without a new node, since that permission opens this exact menu today.

## The back button
`ProfileViewerHomesMenu` always sent you back to the profile viewer, which is wrong when you never came from there. It now takes a flag, the way `PunishmentHistoryMenu` already does for `/punishments <player>`: arriving from the profile viewer still gives you Back, arriving from `/seehomes` gives you Close and shuts the inventory. That needed a `CLOSE-BUTTON` section under `PROFILE-VIEWER-HOMES-MENU` in `menus.yml`, carried across all 8 language files.

## Notes
The `PROFILE_VIEWER` feature toggle covers `/seehomes` as well, so switching the feature off takes both commands away rather than leaving a half-working one behind. `SeeHomesCommandTest` adds four cases: the dedicated permission, the profileviewer fallback, everybody else being turned away, and the plugin.yml wiring. Suite is 348 green.
