### PR TITLE
perf(scoreboard): stop rebuilding the whole sidebar every two ticks (#236)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
@@ -17,12 +17,18 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PlayerWipeCommand implements CommandExecutor, TabCompleter {
 
     private static final String PERMISSION = "ultimatedonutsmp.admin.playerwipe";
+    private static final long STORED_NAMES_TTL_MS = 60_000L;
 
     private final UltimateDonutSmp plugin;
+    private final AtomicBoolean storedNamesLoading = new AtomicBoolean();
+
+    private volatile List<String> storedNames = List.of();
+    private volatile long storedNamesLoadedAt;
 
     public PlayerWipeCommand(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -116,8 +122,27 @@ public class PlayerWipeCommand implements CommandExecutor, TabCompleter {
         for (Player player : Bukkit.getOnlinePlayers()) {
             names.add(player.getName());
         }
-        names.addAll(plugin.getDatabaseManager().loadKnownPlayerNames());
+        names.addAll(storedNames());
         return names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList();
+    }
+
+    /**
+     * Tab completion runs on the main thread and fires on every keystroke, so the stored names come
+     * from a snapshot that is refreshed off-thread rather than from a query the server waits on.
+     */
+    private List<String> storedNames() {
+        long now = System.currentTimeMillis();
+        if (now - storedNamesLoadedAt >= STORED_NAMES_TTL_MS && storedNamesLoading.compareAndSet(false, true)) {
+            plugin.getSpigotScheduler().runAsync(() -> {
+                try {
+                    storedNames = List.copyOf(plugin.getDatabaseManager().loadKnownPlayerNames());
+                    storedNamesLoadedAt = System.currentTimeMillis();
+                } finally {
+                    storedNamesLoading.set(false);
+                }
+            });
+        }
+        return storedNames;
     }
 
     private List<String> matches(List<String> candidates, String input) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateVisualManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateVisualManager.java
@@ -38,6 +38,7 @@ public class CrateVisualManager {
     private static final String HOLOGRAM_TAG = "uds_crate_hologram";
     private static final String PERSONAL_TAG = "uds_crate_personal_hologram";
     private static final String PREVIEW_TAG = "uds_crate_preview";
+    private static final long GATE_RECHECK_INTERVAL_MS = 1000L;
 
     private final UltimateDonutSmp plugin;
     private final Map<CrateManager.CrateBlockKey, List<UUID>> holograms = new HashMap<>();
@@ -54,6 +55,9 @@ public class CrateVisualManager {
 
     private BukkitTask animationTask;
     private int animationPulse;
+
+    private long gateCheckedAtMillis;
+    private boolean gateOpen = true;
 
     public CrateVisualManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -1018,6 +1022,19 @@ public class CrateVisualManager {
         return plugin.getConfigManager().getCrates().getBoolean("SETTINGS.PREVIEW.ENABLED", true);
     }
 
+    /**
+     * The animation task ticks every couple of ticks, and walking the config tree for both toggles
+     * cost far more than the animation it guards. One second of staleness on a toggle is fine.
+     */
+    private boolean previewGateOpen() {
+        long now = System.currentTimeMillis();
+        if (now - gateCheckedAtMillis >= GATE_RECHECK_INTERVAL_MS) {
+            gateCheckedAtMillis = now;
+            gateOpen = isCratesEnabled() && isPreviewEnabled();
+        }
+        return gateOpen;
+    }
+
     private double getPreviewOffsetY() {
         return plugin.getConfigManager().getCrates().getDouble("SETTINGS.PREVIEW.OFFSET-Y", 1.25D);
     }
@@ -1138,9 +1155,10 @@ public class CrateVisualManager {
             animationTask.cancel();
         }
         animationPulse = 0;
+        gateCheckedAtMillis = 0L;
         long updateInterval = getPreviewUpdateIntervalTicks();
         animationTask = plugin.getSpigotScheduler().runGlobalTimer(() -> {
-            if (!isCratesEnabled() || !isPreviewEnabled()) {
+            if (!previewGateOpen()) {
                 if (animationTask != null) {
                     animationTask.cancel();
                     animationTask = null;

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -181,7 +181,15 @@ public class FeatureManager {
         if (feature == null) {
             return true;
         }
-        return featureCache.computeIfAbsent(feature, f -> isEnabled(plugin.getConfigManager().getConfig(), f));
+        // A capturing lambda would be allocated on every call, cache hit included, and this runs on
+        // per-tick paths. Read first, compute only on a miss.
+        Boolean cached = featureCache.get(feature);
+        if (cached != null) {
+            return cached;
+        }
+        boolean resolved = isEnabled(plugin.getConfigManager().getConfig(), feature);
+        featureCache.put(feature, resolved);
+        return resolved;
     }
 
     public boolean areEnabled(Feature... features) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -53,8 +53,15 @@ public class ScoreboardManager {
     // Line and title caching to avoid redundant Bukkit/Packet updates
     private final Map<UUID, String[]> playerLastLines = new ConcurrentHashMap<>();
     private final Map<UUID, String> playerLastTitle = new ConcurrentHashMap<>();
+    private final Map<UUID, String> playerLastRawTitle = new ConcurrentHashMap<>();
     private final Map<UUID, String[]> foliaLastLines = new ConcurrentHashMap<>();
     private final Map<UUID, String> foliaLastTitle = new ConcurrentHashMap<>();
+
+    // Bukkit handles for the board a player already owns. Looking these up per frame allocates a
+    // fresh CraftObjective every time and costs three name lookups per line.
+    private final Map<UUID, Objective> playerObjectives = new ConcurrentHashMap<>();
+    private final Map<UUID, Team[]> playerTeams = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> playerLineCounts = new ConcurrentHashMap<>();
 
     private int titleIndex = 0;
 
@@ -91,6 +98,7 @@ public class ScoreboardManager {
     }
 
     public void applyVisibility(Player player) {
+        SidebarSettings settings = readSettings();
         if (folia) {
             if (!isEnabled()) {
                 releasePlayerFolia(player);
@@ -100,7 +108,7 @@ public class ScoreboardManager {
                 hidePlayerFolia(player);
                 return;
             }
-            updateFolia(player);
+            updateFolia(player, settings);
         } else {
             if (!isEnabled()) {
                 releaseOwnedBoardSpigot(player);
@@ -111,19 +119,20 @@ public class ScoreboardManager {
                 return;
             }
             if (!playerBoards.containsKey(player.getUniqueId())) {
-                setupPlayerSpigot(player);
+                setupPlayerSpigot(player, settings);
                 return;
             }
-            updateSpigot(player);
+            updateSpigot(player, settings);
         }
     }
 
     /** Called once on player join. */
     public void setupPlayer(Player player) {
+        SidebarSettings settings = readSettings();
         if (folia) {
-            setupPlayerFolia(player);
+            setupPlayerFolia(player, settings);
         } else {
-            setupPlayerSpigot(player);
+            setupPlayerSpigot(player, settings);
         }
     }
 
@@ -136,10 +145,11 @@ public class ScoreboardManager {
     }
 
     public void update(Player player) {
+        SidebarSettings settings = readSettings();
         if (folia) {
-            updateFolia(player);
+            updateFolia(player, settings);
         } else {
-            updateSpigot(player);
+            updateSpigot(player, settings);
         }
     }
 
@@ -149,16 +159,18 @@ public class ScoreboardManager {
             return;
         }
 
-        List<String> titles = plugin.getConfigManager().getScoreboard().getStringList("SCOREBOARD.TITLE");
-        if (!titles.isEmpty()) {
-            titleIndex = (titleIndex + 1) % titles.size();
+        // One read of the sidebar config for the whole pass. Reading it per player, and again per
+        // line, was the bulk of this task's cost with a full server online.
+        SidebarSettings settings = readSettings();
+        if (!settings.titles().isEmpty()) {
+            titleIndex = (titleIndex + 1) % settings.titles().size();
         }
 
         if (folia) {
-            plugin.getSpigotScheduler().forEachOnlinePlayer(this::updateFolia);
+            plugin.getSpigotScheduler().forEachOnlinePlayer(player -> updateFolia(player, settings));
         } else {
             for (Player player : Bukkit.getOnlinePlayers()) {
-                updateSpigot(player);
+                updateSpigot(player, settings);
             }
         }
     }
@@ -176,6 +188,10 @@ public class ScoreboardManager {
             playerBoards.clear();
             playerLastLines.clear();
             playerLastTitle.clear();
+            playerLastRawTitle.clear();
+            playerObjectives.clear();
+            playerTeams.clear();
+            playerLineCounts.clear();
         }
     }
 
@@ -185,12 +201,16 @@ public class ScoreboardManager {
             playerBoards.remove(uuid);
             playerLastLines.remove(uuid);
             playerLastTitle.remove(uuid);
+            playerLastRawTitle.remove(uuid);
+            playerObjectives.remove(uuid);
+            playerTeams.remove(uuid);
+            playerLineCounts.remove(uuid);
         }
     }
 
     // ── Folia Implementations ──────────────────────────────────────────────────
 
-    private void setupPlayerFolia(Player player) {
+    private void setupPlayerFolia(Player player, SidebarSettings settings) {
         if (!isEnabled()) {
             releasePlayerFolia(player);
             return;
@@ -199,7 +219,7 @@ public class ScoreboardManager {
             hidePlayerFolia(player);
             return;
         }
-        renderPlayerFolia(player);
+        renderPlayerFolia(player, settings);
     }
 
     private void removePlayerFolia(UUID uuid) {
@@ -207,7 +227,7 @@ public class ScoreboardManager {
         sidebarRenderer.remove(uuid);
     }
 
-    private void updateFolia(Player player) {
+    private void updateFolia(Player player, SidebarSettings settings) {
         if (!isEnabled()) {
             releasePlayerFolia(player);
             return;
@@ -216,13 +236,13 @@ public class ScoreboardManager {
             hidePlayerFolia(player);
             return;
         }
-        renderPlayerFolia(player);
+        renderPlayerFolia(player, settings);
     }
 
-    private void renderPlayerFolia(Player player) {
+    private void renderPlayerFolia(Player player, SidebarSettings settings) {
         UUID uuid = player.getUniqueId();
-        String title = getTitle(player);
-        List<String> renderedLines = getRenderedLines(player);
+        String title = getTitle(player, settings);
+        List<String> renderedLines = getRenderedLines(player, settings);
         String oldTitle = foliaLastTitle.get(uuid);
         String[] oldLines = foliaLastLines.get(uuid);
         boolean changed = oldTitle == null || !oldTitle.equals(title) || oldLines == null || oldLines.length != renderedLines.size();
@@ -279,7 +299,7 @@ public class ScoreboardManager {
 
     // ── Spigot/Paper Implementations ───────────────────────────────────────────
 
-    private void setupPlayerSpigot(Player player) {
+    private void setupPlayerSpigot(Player player, SidebarSettings settings) {
         if (!isEnabled()) {
             releaseOwnedBoardSpigot(player);
             return;
@@ -293,12 +313,13 @@ public class ScoreboardManager {
         clearCacheSpigot(player.getUniqueId());
 
         Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
-        Objective obj = board.registerNewObjective("sidebar", Criteria.DUMMY, getTitle(player));
+        Objective obj = board.registerNewObjective("sidebar", Criteria.DUMMY, getTitle(player, settings));
         obj.setDisplaySlot(DisplaySlot.SIDEBAR);
 
         playerBoards.put(player.getUniqueId(), board);
+        playerObjectives.put(player.getUniqueId(), obj);
         player.setScoreboard(board);
-        updateTextSpigot(player, board, obj);
+        updateTextSpigot(player, board, obj, settings);
     }
 
     private void removePlayerSpigot(UUID uuid) {
@@ -306,7 +327,7 @@ public class ScoreboardManager {
         clearCacheSpigot(uuid);
     }
 
-    private void updateSpigot(Player player) {
+    private void updateSpigot(Player player, SidebarSettings settings) {
         if (!isEnabled()) {
             releaseOwnedBoardSpigot(player);
             return;
@@ -316,33 +337,52 @@ public class ScoreboardManager {
             return;
         }
 
-        Scoreboard board = playerBoards.get(player.getUniqueId());
+        UUID uuid = player.getUniqueId();
+        Scoreboard board = playerBoards.get(uuid);
         if (board == null) {
-            setupPlayerSpigot(player);
+            setupPlayerSpigot(player, settings);
             return;
         }
 
-        Objective obj = board.getObjective("sidebar");
-        if (obj == null) return;
-        updateTextSpigot(player, board, obj);
+        Objective obj = playerObjectives.get(uuid);
+        if (obj == null) {
+            obj = board.getObjective("sidebar");
+            if (obj == null) return;
+            playerObjectives.put(uuid, obj);
+        }
+
+        try {
+            updateTextSpigot(player, board, obj, settings);
+        } catch (IllegalStateException unregistered) {
+            // Something unregistered the objective or a team out from under us. Drop the handles and
+            // rebuild the board rather than leaving the player with a half-drawn sidebar.
+            playerBoards.remove(uuid);
+            clearCacheSpigot(uuid);
+            setupPlayerSpigot(player, settings);
+        }
     }
 
-    private void updateTextSpigot(Player player, Scoreboard board, Objective obj) {
+    private void updateTextSpigot(Player player, Scoreboard board, Objective obj, SidebarSettings settings) {
         UUID uuid = player.getUniqueId();
-        List<String> titles = plugin.getConfigManager().getScoreboard().getStringList("SCOREBOARD.TITLE");
+        List<String> titles = settings.titles();
         if (!titles.isEmpty()) {
             String title = titles.get(titleIndex % titles.size());
-            String formattedTitle = ColorUtils.toComponent(title, player);
-            String oldTitle = playerLastTitle.get(uuid);
-            if (oldTitle == null || !oldTitle.equals(formattedTitle)) {
-                obj.setDisplayName(formattedTitle);
-                playerLastTitle.put(uuid, formattedTitle);
+            // A title with no placeholder in it renders to the same string every pass, so the render
+            // that is already on screen still stands and there is nothing to format.
+            if (hasPlaceholder(title) || !title.equals(playerLastRawTitle.get(uuid))) {
+                String formattedTitle = ColorUtils.toComponent(title, player);
+                String oldTitle = playerLastTitle.get(uuid);
+                if (oldTitle == null || !oldTitle.equals(formattedTitle)) {
+                    obj.setDisplayName(formattedTitle);
+                    playerLastTitle.put(uuid, formattedTitle);
+                }
+                playerLastRawTitle.put(uuid, title);
             }
         }
 
-        List<String> lines = getLines(player);
+        List<String> lines = getLines(player, settings);
         int count = Math.min(lines.size(), MAX_LINES);
-        syncLineSlotsSpigot(board, obj, count);
+        Team[] teams = syncLineSlotsSpigot(board, obj, count, uuid);
 
         String[] oldLines = playerLastLines.get(uuid);
         if (oldLines == null || oldLines.length != MAX_LINES) {
@@ -351,10 +391,10 @@ public class ScoreboardManager {
         }
 
         for (int i = 0; i < count; i++) {
-            Team team = board.getTeam("sb_" + i);
+            Team team = teams[i];
             if (team == null) continue;
             String text = ColorUtils.colorize(lines.get(i), player);
-            text = alignSidebarIconColumn(text);
+            text = alignSidebarIconColumn(text, settings);
             if (!text.equals(oldLines[i])) {
                 applyLineSpigot(team, text);
                 oldLines[i] = text;
@@ -362,22 +402,46 @@ public class ScoreboardManager {
         }
 
         for (int i = count; i < MAX_LINES; i++) {
-            Team team = board.getTeam("sb_" + i);
+            Team team = teams[i];
             if (team != null && !"".equals(oldLines[i])) {
                 applyLineSpigot(team, "");
                 oldLines[i] = "";
             }
         }
 
-        numberHider.hide(player, obj);
+        numberHider.hide(player, obj, settings.hideNumbers());
     }
 
-    private void syncLineSlotsSpigot(Scoreboard board, Objective obj, int count) {
+    /**
+     * Resolves the team handle for every slot and returns them. Scores are only rewritten when the
+     * line count moves, since that is the only thing they depend on.
+     */
+    private Team[] syncLineSlotsSpigot(Scoreboard board, Objective obj, int count, UUID uuid) {
+        Team[] teams = playerTeams.get(uuid);
+        if (teams == null) {
+            teams = new Team[MAX_LINES];
+            playerTeams.put(uuid, teams);
+        }
+
+        boolean missing = false;
+        for (int i = 0; i < MAX_LINES; i++) {
+            if (teams[i] == null) {
+                teams[i] = board.getTeam("sb_" + i);
+            }
+            if (teams[i] == null && i < count) {
+                missing = true;
+            }
+        }
+
+        Integer lastCount = playerLineCounts.get(uuid);
+        if (!missing && lastCount != null && lastCount == count) {
+            return teams;
+        }
+
         for (int i = 0; i < count; i++) {
-            Team team = board.getTeam("sb_" + i);
-            if (team == null) {
-                team = board.registerNewTeam("sb_" + i);
-                team.addEntry(ENTRIES[i]);
+            if (teams[i] == null) {
+                teams[i] = board.registerNewTeam("sb_" + i);
+                teams[i].addEntry(ENTRIES[i]);
             }
             obj.getScore(ENTRIES[i]).setScore(count - i);
         }
@@ -385,19 +449,24 @@ public class ScoreboardManager {
         for (int i = count; i < MAX_LINES; i++) {
             board.resetScores(ENTRIES[i]);
         }
+
+        playerLineCounts.put(uuid, count);
+        return teams;
     }
 
     private void applyLineSpigot(Team team, String text) {
+        // The caller has already run the text through ColorUtils; a second pass would redo the whole
+        // placeholder and colour pipeline on a string that is finished.
         if (text.length() <= 64) {
-            team.setPrefix(ColorUtils.toComponent(text));
-            team.setSuffix(ColorUtils.toComponent(""));
+            team.setPrefix(text);
+            team.setSuffix("");
             return;
         }
 
         int split = findSafeSplit(text, 64);
         int end = findSafeSplit(text, split + 64);
-        team.setPrefix(ColorUtils.toComponent(text.substring(0, split)));
-        team.setSuffix(ColorUtils.toComponent(text.substring(split, end)));
+        team.setPrefix(text.substring(0, split));
+        team.setSuffix(text.substring(split, end));
     }
 
     private void hidePlayerSpigot(Player player) {
@@ -415,6 +484,10 @@ public class ScoreboardManager {
         playerBoards.clear();
         playerLastLines.clear();
         playerLastTitle.clear();
+        playerLastRawTitle.clear();
+        playerObjectives.clear();
+        playerTeams.clear();
+        playerLineCounts.clear();
     }
 
     private void releaseOwnedBoardSpigot(Player player) {
@@ -437,6 +510,10 @@ public class ScoreboardManager {
     private void clearCacheSpigot(UUID uuid) {
         playerLastLines.remove(uuid);
         playerLastTitle.remove(uuid);
+        playerLastRawTitle.remove(uuid);
+        playerObjectives.remove(uuid);
+        playerTeams.remove(uuid);
+        playerLineCounts.remove(uuid);
         if (numberHider != null) {
             numberHider.forget(uuid);
         }
@@ -444,17 +521,35 @@ public class ScoreboardManager {
 
     // ── Common Shared Utilities ────────────────────────────────────────────────
 
-    private List<String> getLines(Player player) {
+    /** Reads every sidebar config value the render needs, once, for a whole update pass. */
+    private SidebarSettings readSettings() {
         FileConfiguration scoreboard = plugin.getConfigManager().getScoreboard();
+        return new SidebarSettings(
+                scoreboard.getStringList("SCOREBOARD.TITLE"),
+                scoreboard.getStringList("SCOREBOARD.LINES"),
+                scoreboard.getString("SCOREBOARD.TEAM"),
+                scoreboard.getString("SCOREBOARD.SHARD-BOOSTER"),
+                scoreboard.getString("SCOREBOARD.SHARD-CUBOID"),
+                Math.max(0, scoreboard.getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10)),
+                scoreboard.getBoolean("SCOREBOARD.ALIGN-ICON-COLUMN", true),
+                scoreboard.getBoolean("SCOREBOARD.HIDE-NUMBERS", true)
+        );
+    }
+
+    private static boolean hasPlaceholder(String text) {
+        return text != null && (text.indexOf('%') >= 0 || text.indexOf('{') >= 0);
+    }
+
+    private List<String> getLines(Player player, SidebarSettings settings) {
         List<String> lines = new ArrayList<>();
-        String teamLine = scoreboard.getString("SCOREBOARD.TEAM");
-        String boosterLine = scoreboard.getString("SCOREBOARD.SHARD-BOOSTER");
-        String shardCuboidLine = scoreboard.getString("SCOREBOARD.SHARD-CUBOID");
+        String teamLine = settings.teamLine();
+        String boosterLine = settings.boosterLine();
+        String shardCuboidLine = settings.shardCuboidLine();
         boolean inTeam = plugin.getTeamManager().isInTeam(player.getUniqueId());
         boolean hasBooster = plugin.getShardManager().hasBooster(player.getUniqueId());
         boolean showShardCuboid = plugin.getShardManager().shouldShowShardCuboidLine(player.getUniqueId());
 
-        for (String line : scoreboard.getStringList("SCOREBOARD.LINES")) {
+        for (String line : settings.lines()) {
             String resolved = resolveConfiguredLine(
                     line,
                     teamLine,
@@ -466,7 +561,7 @@ public class ScoreboardManager {
             );
             if (resolved != null) {
                 resolved = applySidebarEconomyPlaceholders(resolved, player);
-                lines.add(applySidebarLayoutPlaceholders(resolved));
+                lines.add(applySidebarLayoutPlaceholders(resolved, settings));
             }
         }
 
@@ -521,7 +616,7 @@ public class ScoreboardManager {
                 .replace("%economy_shards%", shardsShort);
     }
 
-    private String applySidebarLayoutPlaceholders(String line) {
+    private String applySidebarLayoutPlaceholders(String line, SidebarSettings settings) {
         if (line == null || line.isEmpty()) {
             return "";
         }
@@ -530,33 +625,37 @@ public class ScoreboardManager {
                 .replace("{money_icon}", paddedSidebarIcon(
                         plugin.getCurrencyManager().symbolColor(CurrencyManager.CurrencyType.MONEY)
                                 + "&l"
-                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.MONEY)))
+                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.MONEY),
+                        settings))
                 .replace("{shards_icon}", paddedSidebarIcon(
                         plugin.getCurrencyManager().symbolColor(CurrencyManager.CurrencyType.SHARDS)
                                 + "&l"
-                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.SHARDS)));
+                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.SHARDS),
+                        settings));
+
+        if (result.indexOf("{sb_icon:") < 0) {
+            return result;
+        }
 
         Matcher matcher = SIDEBAR_ICON_PATTERN.matcher(result);
         StringBuffer buffer = new StringBuffer();
         while (matcher.find()) {
-            matcher.appendReplacement(buffer, Matcher.quoteReplacement(paddedSidebarIcon(matcher.group(1))));
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(paddedSidebarIcon(matcher.group(1), settings)));
         }
         matcher.appendTail(buffer);
         return buffer.toString();
     }
 
-    private String paddedSidebarIcon(String icon) {
-        int columnWidth = Math.max(0, plugin.getConfigManager().getScoreboard()
-                .getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10));
+    private String paddedSidebarIcon(String icon, SidebarSettings settings) {
+        int columnWidth = settings.iconColumnWidth();
         int iconWidth = minecraftTextWidth(icon);
         int missingWidth = Math.max(0, columnWidth - iconWidth);
         int spaces = Math.max(1, Math.round(missingWidth / 4F));
         return icon + " ".repeat(spaces);
     }
 
-    private String alignSidebarIconColumn(String text) {
-        if (text == null || text.isEmpty() || !plugin.getConfigManager().getScoreboard()
-                .getBoolean("SCOREBOARD.ALIGN-ICON-COLUMN", true)) {
+    private String alignSidebarIconColumn(String text, SidebarSettings settings) {
+        if (text == null || text.isEmpty() || !settings.alignIconColumn()) {
             return text == null ? "" : text;
         }
 
@@ -589,8 +688,7 @@ public class ScoreboardManager {
         }
 
         String iconText = text.substring(0, iconEnd);
-        int columnWidth = Math.max(0, plugin.getConfigManager().getScoreboard()
-                .getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10));
+        int columnWidth = settings.iconColumnWidth();
         int iconWidth = minecraftTextWidth(iconText);
         int missingWidth = Math.max(0, columnWidth - iconWidth);
         int spaces = Math.max(1, Math.round(missingWidth / 4F));
@@ -685,23 +783,23 @@ public class ScoreboardManager {
         };
     }
 
-    private String getTitle(Player player) {
-        List<String> titles = plugin.getConfigManager().getScoreboard().getStringList("SCOREBOARD.TITLE");
+    private String getTitle(Player player, SidebarSettings settings) {
+        List<String> titles = settings.titles();
         if (titles.isEmpty()) {
             return ColorUtils.colorize("EconomySMP", player);
         }
         return ColorUtils.colorize(titles.get(titleIndex % titles.size()), player);
     }
 
-    private List<String> getRenderedLines(Player player) {
-        List<String> lines = getLines(player);
+    private List<String> getRenderedLines(Player player, SidebarSettings settings) {
+        List<String> lines = getLines(player, settings);
         List<String> rendered = new ArrayList<>(Math.min(lines.size(), MAX_LINES));
         for (String line : lines) {
             if (rendered.size() >= MAX_LINES) {
                 break;
             }
             String text = ColorUtils.colorize(line, player);
-            rendered.add(alignSidebarIconColumn(text));
+            rendered.add(alignSidebarIconColumn(text, settings));
         }
         return rendered;
     }
@@ -718,5 +816,18 @@ public class ScoreboardManager {
         if (split > 0 && Character.isHighSurrogate(text.charAt(split - 1))) split--;
         if (split > 0 && text.charAt(split - 1) == '\u00A7') split--;
         return split;
+    }
+
+    /** The sidebar config as it stood at the start of one update pass. */
+    private record SidebarSettings(
+            List<String> titles,
+            List<String> lines,
+            String teamLine,
+            String boosterLine,
+            String shardCuboidLine,
+            int iconColumnWidth,
+            boolean alignIconColumn,
+            boolean hideNumbers
+    ) {
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
@@ -73,9 +73,18 @@ public class ColorUtils {
         }
         String result = normalizeText(text);
         result = transformAllCaps(result);
-        result = translateTaggedGradients(result);
-        result = translateTaggedHex(result);
-        return translateHex(result).replace('&', SECTION_CHAR);
+        // Every pattern below needs a literal marker character, so a missing marker rules the pass
+        // out without building a Matcher. Scoreboard lines run this ten times a second per player.
+        if (result.indexOf("</#") >= 0) {
+            result = translateTaggedGradients(result);
+        }
+        if (result.indexOf('<') >= 0) {
+            result = translateTaggedHex(result);
+        }
+        if (result.indexOf('#') >= 0) {
+            result = translateHex(result);
+        }
+        return result.replace('&', SECTION_CHAR);
     }
 
     public static String colorize(String text, Player player) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ScoreboardNumberHider.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ScoreboardNumberHider.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,6 +28,7 @@ public final class ScoreboardNumberHider {
     private static final Map<String, Method> METHOD_CACHE = new java.util.concurrent.ConcurrentHashMap<>();
     private static final Map<Class<?>, Method> NUMBER_FORMAT_SETTER_CACHE = new java.util.concurrent.ConcurrentHashMap<>();
     private static final Map<Class<?>, Field> OBJECTIVE_FIELD_CACHE = new java.util.concurrent.ConcurrentHashMap<>();
+    private static final Map<Class<?>, SenderRoute> SENDER_ROUTE_CACHE = new java.util.concurrent.ConcurrentHashMap<>();
     private static final Method NULL_METHOD_SENTINEL;
     private static final Field NULL_FIELD_SENTINEL;
 
@@ -44,6 +46,9 @@ public final class ScoreboardNumberHider {
 
     private final UltimateDonutSmp plugin;
     private final Map<String, Long> lastSent = new ConcurrentHashMap<>();
+    // Objectives whose NMS number format is already blank. Re-setting it costs a reflective call and
+    // makes the server broadcast an objective packet of its own on top of the one sent below.
+    private final Set<String> blankedObjectives = ConcurrentHashMap.newKeySet();
 
     private boolean disabled;
     private boolean warned;
@@ -68,10 +73,16 @@ public final class ScoreboardNumberHider {
         }
         String prefix = uuid + ":";
         lastSent.keySet().removeIf(key -> key.startsWith(prefix));
+        blankedObjectives.removeIf(key -> key.startsWith(prefix));
     }
 
     public void hide(Player player, Objective objective) {
-        if (disabled || !isEnabled() || player == null || objective == null || !player.isOnline()) {
+        hide(player, objective, isEnabled());
+    }
+
+    /** Overload for callers that already read {@code SCOREBOARD.HIDE-NUMBERS} for this render pass. */
+    public void hide(Player player, Objective objective, boolean enabled) {
+        if (disabled || !enabled || player == null || objective == null || !player.isOnline()) {
             return;
         }
 
@@ -85,7 +96,13 @@ public final class ScoreboardNumberHider {
         try {
             Object nmsObjective = getObjectiveHandle(objective);
             Object format = getBlankFormat();
-            boolean objectiveUpdated = applyNumberFormatToObjective(nmsObjective, format);
+            boolean objectiveUpdated = blankedObjectives.contains(key);
+            if (!objectiveUpdated) {
+                objectiveUpdated = applyNumberFormatToObjective(nmsObjective, format);
+                if (objectiveUpdated) {
+                    blankedObjectives.add(key);
+                }
+            }
             Object packet = createObjectiveUpdatePacket(nmsObjective, format, objectiveUpdated);
             sendPacket(player, packet);
             lastSent.put(key, now);
@@ -330,9 +347,19 @@ public final class ScoreboardNumberHider {
     }
 
     private PacketSender findPacketSender(Object root, Object packet) throws ReflectiveOperationException {
-        PacketSender sender = findSenderOn(root, packet);
-        if (sender != null) {
-            return sender;
+        // Discovery walks every declared method of the whole player-handle hierarchy, so it must not
+        // run per send. The route it finds is the same for every player on a given server build.
+        SenderRoute known = SENDER_ROUTE_CACHE.get(root.getClass());
+        if (known != null) {
+            PacketSender sender = known.bind(root);
+            if (sender != null) {
+                return sender;
+            }
+        }
+
+        SenderRoute route = findSenderOn(root, packet);
+        if (route != null) {
+            return remember(root, route);
         }
 
         for (Class<?> current = root.getClass(); current != null; current = current.getSuperclass()) {
@@ -342,9 +369,9 @@ public final class ScoreboardNumberHider {
                 if (value == null) {
                     continue;
                 }
-                sender = findSenderOn(value, packet);
-                if (sender != null) {
-                    return sender;
+                route = findSenderOn(value, packet);
+                if (route != null) {
+                    return remember(root, route.through(field));
                 }
             }
         }
@@ -352,24 +379,30 @@ public final class ScoreboardNumberHider {
         return null;
     }
 
-    private PacketSender findSenderOn(Object target, Object packet) {
-        PacketSender fallback = null;
+    private PacketSender remember(Object root, SenderRoute route) throws ReflectiveOperationException {
+        route.prepare();
+        SENDER_ROUTE_CACHE.put(root.getClass(), route);
+        return route.bind(root);
+    }
+
+    private SenderRoute findSenderOn(Object target, Object packet) {
+        SenderRoute fallback = null;
         for (Class<?> current = target.getClass(); current != null; current = current.getSuperclass()) {
             for (Method method : current.getDeclaredMethods()) {
                 Class<?>[] parameters = method.getParameterTypes();
                 if (parameters.length == 1 && acceptsPacket(parameters[0], packet)) {
-                    PacketSender sender = new PacketSender(target, method, false);
+                    SenderRoute route = new SenderRoute(null, method, false);
                     if (isPreferredSendMethod(method)) {
-                        return sender;
+                        return route;
                     }
-                    fallback = sender;
+                    fallback = route;
                 }
                 if (parameters.length == 2 && acceptsPacket(parameters[0], packet)) {
-                    PacketSender sender = new PacketSender(target, method, true);
+                    SenderRoute route = new SenderRoute(null, method, true);
                     if (isPreferredSendMethod(method)) {
-                        return sender;
+                        return route;
                     }
-                    fallback = sender;
+                    fallback = route;
                 }
             }
         }
@@ -392,7 +425,6 @@ public final class ScoreboardNumberHider {
         if (method == null) {
             throw new NoSuchMethodException(name);
         }
-        method.setAccessible(true);
         return method.invoke(target);
     }
 
@@ -406,6 +438,7 @@ public final class ScoreboardNumberHider {
         for (Class<?> current = type; current != null; current = current.getSuperclass()) {
             for (Method method : current.getDeclaredMethods()) {
                 if (method.getParameterCount() == 0 && method.getName().equals(name)) {
+                    method.setAccessible(true);
                     METHOD_CACHE.put(key, method);
                     return method;
                 }
@@ -457,6 +490,37 @@ public final class ScoreboardNumberHider {
                 + ex.getClass().getSimpleName() + ": " + ex.getMessage());
     }
 
+    /** A resolved way to reach the send method, independent of which player it is invoked for. */
+    private static final class SenderRoute {
+
+        private final Field field;
+        private final Method method;
+        private final boolean trailingNull;
+
+        private SenderRoute(Field field, Method method, boolean trailingNull) {
+            this.field = field;
+            this.method = method;
+            this.trailingNull = trailingNull;
+        }
+
+        /** The same route, reached through a field of the player handle rather than the handle itself. */
+        private SenderRoute through(Field owner) {
+            return new SenderRoute(owner, method, trailingNull);
+        }
+
+        private void prepare() {
+            method.setAccessible(true);
+            if (field != null) {
+                field.setAccessible(true);
+            }
+        }
+
+        private PacketSender bind(Object root) throws ReflectiveOperationException {
+            Object target = field == null ? root : field.get(root);
+            return target == null ? null : new PacketSender(target, method, trailingNull);
+        }
+    }
+
     private static final class PacketSender {
 
         private final Object target;
@@ -470,7 +534,6 @@ public final class ScoreboardNumberHider {
         }
 
         private void send(Object packet) throws ReflectiveOperationException {
-            method.setAccessible(true);
             if (trailingNull) {
                 method.invoke(target, packet, null);
             } else {

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
@@ -98,4 +98,39 @@ class ColorUtilsTest {
         String stripped4 = ColorUtils.strip("<#FF0000>Hello");
         assertEquals("Hello", stripped4);
     }
+
+    private static String legacyHex(String hex) {
+        StringBuilder out = new StringBuilder("§x");
+        for (char digit : hex.toCharArray()) {
+            out.append('§').append(digit);
+        }
+        return out.toString();
+    }
+
+    @Test
+    void testGradientStillExpandsBetweenTags() {
+        String colorized = ColorUtils.colorize("<#FF0000>Ab</#0000FF>");
+        assertEquals(legacyHex("FF0000") + "A" + legacyHex("0000FF") + "b", colorized);
+    }
+
+    @Test
+    void testColorizingTwiceChangesNothing() {
+        // The sidebar hands finished text straight to the team prefix, so a second pass over an
+        // already-colorized line has to be a no-op.
+        String[] lines = {
+                "&#00A4FC §fTeam &#00A4FCAlpha     ",
+                "&f&lBALANCE: &a1,234",
+                "&7ᴘɪɴɢ: &f25ms",
+                "<#FF0000>Kills</#0000FF> &710",
+                "{#FF0000}Shards &f42",
+                "&f\\u1D18\\u026A\\u0274\\u0262",
+                "🗡 &fKills &7★",
+                "plain text with no codes"
+        };
+
+        for (String line : lines) {
+            String once = ColorUtils.colorize(line);
+            assertEquals(once, ColorUtils.colorize(once), "second pass changed: " + line);
+        }
+    }
 }


### PR DESCRIPTION
Closes #236

A spark profile off a live server put nearly all of this plugin's server-thread time in one place: the sidebar. `ScoreboardTask` fires every two ticks, and for each player it re-read the config, ran the placeholder and colour pipeline over every line, fetched the objective and all fifteen team handles back out of Bukkit, then rewrote scores that hadn't moved. Only at the very end did it compare the rendered text against the previous frame, so that check saved packets and none of the work behind them.

## One config read per pass

`SCOREBOARD.TITLE`, `LINES`, `TEAM`, `SHARD-BOOSTER`, `SHARD-CUBOID`, `ICON-COLUMN-WIDTH` and `ALIGN-ICON-COLUMN` now come from a `SidebarSettings` snapshot taken at the top of `updateAll()` and passed down through the render. `getStringList` copies a fresh ArrayList out of the YAML tree every time you call it, and the icon column width came out of the config once per line, so a fifteen-line sidebar meant fifteen of those lookups per player, ten times a second. A config edit still lands within one render pass, same as before.

## Colour passes check for their marker first

`applyColors` ran five transforms whatever the input looked like. Gradients need `</#` somewhere in the string, tagged hex needs `<`, and every hex form contains `#`; when the character isn't there the regex can't match, so the pass gets skipped and no Matcher is built. A line like `&7ᴘɪɴɢ: &f25ms` skips three of them now.

## Dropping the second colorize

`applyLineSpigot` was running `ColorUtils.toComponent` over text the caller had already colorized. That finished string carries `§` codes, which means the early-out in `applyColors` couldn't fire and the whole pipeline ran again on every changed line. The suffix went through `colorize("")` too. Both calls are gone, and `ColorUtilsTest` now asserts that a second pass over finished text changes nothing, checked against gradients, hex, small caps, emoji and unicode escapes.

## Holding the Bukkit handles

`board.getObjective("sidebar")` allocates a new `CraftObjective` on every call, and `getTeam("sb_" + i)` ran in three separate loops per player. The objective and the fifteen team handles are held per player now, dropped by the same `invalidatePlayer` and `clearCacheSpigot` paths that already clear the line cache. Should another plugin unregister one of them underneath us, the render throws `IllegalStateException`, which is caught and rebuilds the board.

Scores depend on nothing but the line count, so `setScore` and `resetScores` run when that count moves instead of every pass. A slot that goes missing still forces a full resync, which is what kept the old code self-healing.

## Number hiding stops rediscovering itself

`ScoreboardNumberHider` cached its method lookups but not the packet sender, so twice a second per player it walked the whole `ServerPlayer` hierarchy calling `getDeclaredMethods()`. That route is resolved once per handle class now, stored as a field and method pair and bound to a target per send.

It was also re-applying the blank number format to the NMS objective on every resend. That makes the server broadcast an objective packet of its own on top of the one the plugin sends by hand, so it now happens once per objective, cleared whenever a board gets rebuilt.

## Two more from the same profile

`FeatureManager.isEnabled` used `computeIfAbsent` with a lambda that captures `this`, so every call allocated one even when the cache already had the answer; it reads the map first now. The starkest case was `CrateVisualManager`'s preview task, where the two gate checks in front of `animatePreviews()` cost something like fifteen times the animation they guard. That gate is sampled once a second rather than every other tick.

`/playerwipe` tab completion ran `SELECT username FROM players` on the main thread on every keystroke, and the profile caught the server thread parked in `Object.wait()` inside the database lock. Stored names come from a snapshot refreshed off-thread with a sixty second TTL. One visible difference: the first completion after a restart lists online players only, until that load returns.

## Notes

No config keys added, no messages changed, nothing touched in the schema or in `plugin.yml`. `getLines` and `alignSidebarIconColumn` are shared with the Folia render path, so it picks up the same reduction in config reads.

Suite is green at 350 tests, with two new ones in `ColorUtilsTest`: the second-pass check above, and a gradient expansion test that pins down the behaviour the new marker guards have to preserve.
