### PR TITLE
fix(shop): start the analytics web server on reload and log its state (#238)

### DIFF
--- a/docs/wiki/Config-shop.yml.md
+++ b/docs/wiki/Config-shop.yml.md
@@ -1138,9 +1138,9 @@ SHOP-GUI:
 | `SHOP-GUI.SHOW-AUCTION-PRICE` | `bool` | `true`, `false` | `true` | Configures the technical `SHOW-AUCTION-PRICE` parameter for `SHOP-GUI.SHOW-AUCTION-PRICE` in `shop.yml`. |
 | `SHOP-GUI.ITEM.LORE` | `list` | List of configured items/strings | `['&7Shop price: {shop_price}', ...]` | Tooltip lines shown under every item in the shop menu. Supports `{shop_price}`, `{shop_unit_price}`, `{item}`, and the lines built from the other `SHOP-GUI.ITEM` keys: `{auction_line}`, `{auction_action}`, `{favorite_line}`, `{favorite_action}`. Leave it empty to show no tooltip. |
 | `SHOP-GUI.FAVORITES.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `SHOP-GUI` system. Set to `true` to enable, `false` to disable. |
-| `SHOP-GUI.WEB-SERVER.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `SHOP-GUI` system. Set to `true` to enable, `false` to disable. |
-| `SHOP-GUI.WEB-SERVER.PORT` | `int` | Any valid integer number | `'8080'` | Configures the technical `PORT` parameter for `SHOP-GUI.WEB-SERVER.PORT` in `shop.yml`. |
-| `SHOP-GUI.WEB-SERVER.PUBLIC-URL` | `str` | Any string text | `''` | Configures the technical `PUBLIC-URL` parameter for `SHOP-GUI.WEB-SERVER.PUBLIC-URL` in `shop.yml`. |
+| `SHOP-GUI.WEB-SERVER.ENABLED` | `bool` | `true`, `false` | `false` | Turns the built-in Shop Analytics dashboard on. It ships off, so nothing is listening until you set this to `true`. `/uds reload` applies the change without a restart, and the console line tells you the address it came up on. |
+| `SHOP-GUI.WEB-SERVER.PORT` | `int` | Any valid integer number | `'8080'` | The port the dashboard listens on, so the page lives at `http://localhost:<PORT>/stats`. If that port is already taken the server falls back to `8080`, `8081`, `25580` or `8888` and warns in the console which one it settled on. |
+| `SHOP-GUI.WEB-SERVER.PUBLIC-URL` | `str` | Any string text | `''` | The address `/topsell web` hands out, for when the dashboard sits behind a domain or a reverse proxy. Leave it empty and it uses `http://localhost:<PORT>/stats`. |
 
 ### 3. Practical Setup Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -1114,6 +1114,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
             worthManager.clearWorthDisplay(player);
             worthManager.syncWorthDisplay(player);
         }
+
+        com.bx.ultimateDonutSmp.managers.SellStatsExporter.restartEmbeddedHttpServer(this);
+
         syncCommands();
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SellStatsExporter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SellStatsExporter.java
@@ -28,13 +28,15 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 public class SellStatsExporter {
 
     private static HttpServer activeHttpServer = null;
-    private static int actualBoundPort = 8080;
+    private static ExecutorService activeHttpExecutor = null;
+    private static int actualBoundPort = -1;
 
     private static volatile String cachedHtml = null;
     private static volatile long lastCacheTime = 0;
@@ -75,10 +77,12 @@ public class SellStatsExporter {
 
         boolean enabled = plugin.getConfigManager().getShop().getBoolean("SHOP-GUI.WEB-SERVER.ENABLED", true);
         if (!enabled) {
+            plugin.getLogger().info("Shop Analytics Web Server is off. Set SHOP-GUI.WEB-SERVER.ENABLED to true in shop.yml to turn it on.");
             return;
         }
 
-        int targetPort = plugin.getConfigManager().getShop().getInt("SHOP-GUI.WEB-SERVER.PORT", 8080);
+        int configuredPort = plugin.getConfigManager().getShop().getInt("SHOP-GUI.WEB-SERVER.PORT", 8080);
+        int targetPort = configuredPort;
         int mcPort = plugin.getServer().getPort();
 
         if (targetPort == mcPort) {
@@ -88,9 +92,11 @@ public class SellStatsExporter {
 
         int[] tryPorts = new int[]{targetPort, 8080, 8081, 25580, 8888};
         for (int p : tryPorts) {
+            HttpServer server = null;
+            ExecutorService executor = null;
             try {
-                activeHttpServer = HttpServer.create(new InetSocketAddress(p), 0);
-                activeHttpServer.createContext("/stats", exchange -> {
+                server = HttpServer.create(new InetSocketAddress(p), 0);
+                server.createContext("/stats", exchange -> {
                     try {
                         String path = exchange.getRequestURI().getPath();
                         if ("/stats/reset".equals(path) || "/stats/reset/".equals(path)) {
@@ -114,25 +120,66 @@ public class SellStatsExporter {
                         }
                     } catch (Exception e) {
                         plugin.getLogger().log(Level.WARNING, "Error serving stats web page", e);
+                        sendDashboardFailure(exchange);
+                    } finally {
+                        exchange.close();
                     }
                 });
-                activeHttpServer.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
-                activeHttpServer.start();
+                executor = Executors.newVirtualThreadPerTaskExecutor();
+                server.setExecutor(executor);
+                server.start();
+                activeHttpServer = server;
+                activeHttpExecutor = executor;
                 actualBoundPort = p;
                 plugin.getLogger().info("Shop Analytics Web Server started at http://localhost:" + p + "/stats");
+                if (p != configuredPort) {
+                    plugin.getLogger().warning("Port " + configuredPort + " from shop.yml was busy, so the Shop Analytics Web Server took " + p + " instead. Open http://localhost:" + p + "/stats, or free port " + configuredPort + " and reload.");
+                }
                 return;
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+                closeQuietly(server, executor);
+            }
         }
-        plugin.getLogger().warning("Could not bind Shop Analytics Web Server to any open port.");
+        plugin.getLogger().warning("Could not bind the Shop Analytics Web Server to port " + configuredPort + " or to any fallback port. Pick a free SHOP-GUI.WEB-SERVER.PORT in shop.yml.");
+    }
+
+    public static synchronized void restartEmbeddedHttpServer(UltimateDonutSmp plugin) {
+        stopEmbeddedHttpServer();
+        startEmbeddedHttpServer(plugin);
     }
 
     public static synchronized void stopEmbeddedHttpServer() {
-        if (activeHttpServer != null) {
+        closeQuietly(activeHttpServer, activeHttpExecutor);
+        activeHttpServer = null;
+        activeHttpExecutor = null;
+        actualBoundPort = -1;
+    }
+
+    private static void closeQuietly(HttpServer server, ExecutorService executor) {
+        if (server != null) {
             try {
-                activeHttpServer.stop(0);
+                server.stop(0);
             } catch (Exception ignored) {}
-            activeHttpServer = null;
         }
+        if (executor != null) {
+            try {
+                executor.shutdownNow();
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private static void sendDashboardFailure(HttpExchange exchange) {
+        try {
+            if (exchange.getResponseCode() != -1) {
+                return;
+            }
+            byte[] response = "Shop Analytics could not build the dashboard. Check the server console.".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(500, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        } catch (Exception ignored) {}
     }
 
     public void exportHtml(CommandSender sender) {
@@ -161,7 +208,11 @@ public class SellStatsExporter {
         // First make sure HTML file is generated
         exportHtml(null);
 
-        int port = actualBoundPort > 0 ? actualBoundPort : plugin.getConfigManager().getShop().getInt("SHOP-GUI.WEB-SERVER.PORT", 8080);
+        if (activeHttpServer == null) {
+            sendWebServerOfflineNotice(sender);
+            return;
+        }
+
         String configuredUrl = plugin.getConfigManager().getShop().getString("SHOP-GUI.WEB-SERVER.PUBLIC-URL", "");
         if (configuredUrl != null && (configuredUrl.contains("example.com") || configuredUrl.isBlank())) {
             configuredUrl = "";
@@ -169,7 +220,7 @@ public class SellStatsExporter {
 
         String localWebUrl = (configuredUrl != null && !configuredUrl.isBlank())
                 ? configuredUrl
-                : "http://localhost:" + port + "/stats";
+                : "http://localhost:" + actualBoundPort + "/stats";
 
         if (sender instanceof Player player && player.isOnline()) {
             TextComponent linkMsg = new TextComponent(ColorUtils.toComponent("&a&l[Sell Stats Web] &fOpen live Shop Analytics site: &e&n" + localWebUrl));
@@ -179,6 +230,20 @@ public class SellStatsExporter {
         } else if (sender != null) {
             sender.sendMessage(ColorUtils.toComponent("&a&l[Sell Stats Web] &fLive web site: &e" + localWebUrl + " &7(or open plugins/UltimateDonutSMP/sell-stats.html)"));
         }
+    }
+
+    private void sendWebServerOfflineNotice(CommandSender sender) {
+        if (sender == null) {
+            return;
+        }
+
+        boolean enabled = plugin.getConfigManager().getShop().getBoolean("SHOP-GUI.WEB-SERVER.ENABLED", true);
+        if (enabled) {
+            sender.sendMessage(ColorUtils.toComponent("&c&l[Sell Stats Web] &fThe web server could not claim a port. Check the console, then set a free &eSHOP-GUI.WEB-SERVER.PORT &fin &eshop.yml&f."));
+        } else {
+            sender.sendMessage(ColorUtils.toComponent("&c&l[Sell Stats Web] &fThe web server is switched off. Set &eSHOP-GUI.WEB-SERVER.ENABLED &fto &etrue &fin &eshop.yml&f, then run &e/uds reload&f."));
+        }
+        sender.sendMessage(ColorUtils.toComponent("&7An offline copy is still saved to &eplugins/UltimateDonutSMP/sell-stats.html&7."));
     }
 
     public String generateDashboardHtml() {


### PR DESCRIPTION
Closes #238

Shop Analytics ships with its web server switched off, and nothing in the plugin ever said so. Turning it on in `shop.yml` and running `/uds reload` did nothing either, because the plugin only ever started the server from `onEnable` and `reloadAllPluginConfigurations` never touched it, so the one way to bring it up was a full restart nobody knew they needed. Meanwhile `/topsell web` kept handing out `http://localhost:8080/stats` regardless, since `actualBoundPort` was a static field sitting at 8080 that nothing ever cleared.

## Reload applies the setting now

`reloadAllPluginConfigurations` calls a new `restartEmbeddedHttpServer`, which stops whatever is running and starts again from the current `shop.yml`, so flipping `ENABLED` or changing `PORT` takes effect on `/uds reload`. The stop side also shuts down the virtual-thread executor it used to leak, which starts to matter once a reload can happen any number of times in one session.

## The console says what happened

Silence was most of the problem here, so the log covers the cases it used to skip. A disabled server names the key that turns it on. If the configured port is busy, the warning carries the address it actually landed on, and if nothing is free at all it says which port from `shop.yml` it tried first. The success line was already there.

## /topsell web stops handing out dead links

It checks whether the server is up before printing anything clickable. When it isn't, the admin gets the reason (off in config, or no free port) plus a pointer to `sell-stats.html`, which the plugin writes either way. `PUBLIC-URL` still wins when it's set.

## Notes

Errors inside the `/stats` handler used to log and then leave the exchange hanging open with no status, so the browser just sat there. It now sends a 500 and closes the exchange in a `finally`. The bind loop builds its server into a local and only publishes it after `start()` returns, so a half-created server can't get stranded in `activeHttpServer` and block every later attempt.

This adds no config keys and no language keys; `SHOP-GUI.WEB-SERVER` itself is unchanged. The wiki row for `WEB-SERVER.ENABLED` claimed it was the "Global toggle for `SHOP-GUI` system", which is a copy-paste from the `FAVORITES` row above it, so all three `WEB-SERVER` rows in `docs/wiki/Config-shop.yml.md` now describe what the keys really do. The full suite passes, 350 tests.
