### PR TITLE
feat(rtp): match players into a shared random teleport with /rtpq (#234)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -22,6 +22,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/spawn` | `/spawn` | None | Teleport to server spawn | `ultimatedonutsmp.command.spawn` |
 | `/afk` | `/afk` | None | Teleport to or enter AFK reward zone | `ultimatedonutsmp.command.afk` |
 | `/rtp` | `/rtp [world]` | None | Random teleport into the wilderness | `ultimatedonutsmp.command.rtp` |
+| `/rtpq` | `/rtpq [join\|leave]` | `/rtpqueue` | Queue up to be random teleported into the wilderness together with other waiting players | `ultimatedonutsmp.command.rtpq` |
 | `/balance` | `/balance [player]` | `/bal`, `/money` | Check money balance | `ultimatedonutsmp.command.balance` |
 | `/pay` | `/pay <player> <amount>` | None | Pay money to another player | `ultimatedonutsmp.command.pay` |
 | `/shards` | `/shards [player]` | None | Check shard balance | `ultimatedonutsmp.command.shards` |

--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -292,6 +292,103 @@ The `{cooldown}` placeholder in the RTP menu shows the viewing player their own 
 
 ---
 
+## Section: `QUEUE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Matchmaking queue in front of RTP. Players run /rtpq to wait for other players, and the whole
+# group is dropped at one shared random location instead of at a random location each
+QUEUE:
+  # Enable or disable the RTP matchmaking queue and the /rtpq command (true / false)
+  ENABLED: true
+  # How many players have to be waiting before the group is teleported
+  MATCH-SIZE: 2
+  # World the matched group is teleported into
+  WORLD: world
+  # How far the matched players are scattered around the shared location, in blocks.
+  # 0 drops the whole group on the exact same block
+  SPREAD-RADIUS: 16
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `QUEUE.ENABLED` | `bool` | `true`, `false` | `true` | Turns the matchmaking queue and the `/rtpq` command on or off. The queue also follows the global `ENABLED` toggle above, so switching RTP off switches the queue off with it. |
+| `QUEUE.MATCH-SIZE` | `int` | `2` - `32` | `2` | How many players have to be waiting before a match fires. Values below 2 are read as 2 and values above 32 are read as 32. |
+| `QUEUE.WORLD` | `string` | Any RTP world name or menu id | `world` | Where matched groups are sent. The name is resolved the same way `/rtp <world>` resolves it, and the world needs its own `WORLD-SETTINGS` entry. |
+| `QUEUE.SPREAD-RADIUS` | `int` | `0` - `512` | `16` | How far apart the group is scattered around the shared location. Each player after the first gets their own safe-location search inside this radius, and `0` drops everyone on the exact same block. |
+| `QUEUE.MESSAGES.*` | `string` | Any coloured text | see below | Player feedback for joining, leaving, and being matched. |
+
+The queue deliberately ignores RTP cooldowns, playtime requirements and the `PLAYERS-IN-RTP`
+slot limit, the same way the respawn teleport does, because a match has to move everybody at
+once. It also skips the stand-still countdown: one player stepping sideways would otherwise
+cancel their half of the match and leave the rest alone in the wilderness.
+
+### 3. Practical Setup Example
+
+```yaml
+QUEUE:
+  ENABLED: true
+  # Three players per match, dropped within 30 blocks of each other in the nether
+  MATCH-SIZE: 3
+  WORLD: world_nether
+  SPREAD-RADIUS: 30
+```
+
+---
+
+## Section: `QUEUE.MESSAGES`
+
+### 1. Commented Setup Code Example
+
+```yaml
+  # User feedback for the matchmaking queue
+  MESSAGES:
+    DISABLED: '&cThe RTP queue is currently disabled.'
+    UNAVAILABLE: '&cThe RTP queue is not available right now.'
+    BUSY: '&cFinish the teleport you already started before joining the RTP queue.'
+    JOINED: '&e[RTP Queue] &fYou have joined the queue. Waiting for another player... &7({waiting}/{needed})'
+    PLAYER-JOINED: '&e[RTP Queue] &f{player} has joined the queue. &7({waiting}/{needed})'
+    ALREADY-QUEUED: '&cYou are already in the RTP queue at position #{position}.'
+    LEFT: '&e[RTP Queue] &fYou have left the queue.'
+    PLAYER-LEFT: '&e[RTP Queue] &f{player} has left the queue. &7({waiting}/{needed})'
+    NOT-QUEUED: '&cYou are not in the RTP queue.'
+    MATCH-FOUND: '&a[RTP Queue] &fMatch found! Teleporting you to the same area...'
+    MATCH-FAILED: '&c[RTP Queue] &fNo safe location was found for the match, so you are back in the queue.'
+    MATCH-ABANDONED: '&c[RTP Queue] &fThe other players left before the match started, so you are back in the queue.'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Placeholders | Shown When |
+| :--- | :--- | :--- |
+| `DISABLED` | none | `/rtpq` is used while `QUEUE.ENABLED` is `false`. |
+| `UNAVAILABLE` | none | `QUEUE.WORLD` does not resolve to a world with `WORLD-SETTINGS`. |
+| `BUSY` | none | The player already has an RTP search or teleport running. |
+| `JOINED` | `{waiting}`, `{needed}` | The player joins the queue. |
+| `PLAYER-JOINED` | `{player}`, `{waiting}`, `{needed}` | Sent to everyone already waiting when somebody else joins. |
+| `ALREADY-QUEUED` | `{position}` | The player runs `/rtpq` while already waiting. |
+| `LEFT` | none | The player runs `/rtpq leave`. |
+| `PLAYER-LEFT` | `{player}`, `{waiting}`, `{needed}` | Sent to everyone still waiting when somebody leaves. |
+| `NOT-QUEUED` | none | `/rtpq leave` is used by a player who is not in the queue. |
+| `MATCH-FOUND` | none | The queue fills and the search for the shared location starts. |
+| `MATCH-FAILED` | none | No safe location was found, and the group goes back into the queue. |
+| `MATCH-ABANDONED` | none | Too many of the matched players disconnected before the teleport. |
+
+Setting any message to an empty string silences it without disabling the behaviour behind it.
+
+### 3. Practical Setup Example
+
+```yaml
+  MESSAGES:
+    JOINED: '&b&lPVP QUEUE &8» &fWaiting for an opponent &7({waiting}/{needed})'
+    MATCH-FOUND: '&b&lPVP QUEUE &8» &fOpponent found, good luck!'
+```
+
+---
+
 ## Section: `MESSAGES`
 
 ### 1. Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -88,6 +88,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private TeleportManager teleportManager;
     private RTPManager rtpManager;
     private RTPZoneManager rtpZoneManager;
+    private RTPQueueManager rtpQueueManager;
     private FirstJoinSpawnManager firstJoinSpawnManager;
     private RespawnRtpManager respawnRtpManager;
     private PortalManager portalManager;
@@ -265,6 +266,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         teleportManager = new TeleportManager(this);
         rtpManager = new RTPManager(this);
         rtpZoneManager = new RTPZoneManager(this);
+        rtpQueueManager = new RTPQueueManager(this);
         firstJoinSpawnManager = new FirstJoinSpawnManager(this);
         respawnRtpManager = new RespawnRtpManager(this);
         portalManager = new PortalManager(this);
@@ -662,6 +664,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
         // RTP
         setExecutor("rtp", new RTPCommand(this), FeatureManager.Feature.RTP);
+        setExecutor("rtpq", new RTPQueueCommand(this), FeatureManager.Feature.RTP);
 
         // Stats / Leaderboard
         setExecutor("stats", new StatsCommand(this), FeatureManager.Feature.STATS);
@@ -1057,6 +1060,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         billfordManager.load();
         rtpManager.reload();
+        rtpQueueManager.reload();
         portalManager.loadAll();
         crateManager.reload();
         crateVisualManager.reload();
@@ -1352,6 +1356,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public RTPZoneManager getRtpZoneManager() {
         return rtpZoneManager;
+    }
+
+    public RTPQueueManager getRtpQueueManager() {
+        return rtpQueueManager;
     }
 
     public FirstJoinSpawnManager getFirstJoinSpawnManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/RTPQueueCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/RTPQueueCommand.java
@@ -1,0 +1,52 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Locale;
+
+public class RTPQueueCommand implements CommandExecutor, TabCompleter {
+
+    private static final List<String> SUBCOMMANDS = List.of("join", "leave");
+
+    private final UltimateDonutSmp plugin;
+
+    public RTPQueueCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Player only.");
+            return true;
+        }
+
+        if (!plugin.getConfigManager().isCommandEnabled("RTP")) {
+            player.sendMessage(ColorUtils.toComponent("&cRTP command is currently disabled."));
+            return true;
+        }
+
+        String subcommand = args.length == 0 ? "join" : args[0].toLowerCase(Locale.ROOT);
+        switch (subcommand) {
+            case "leave", "quit" -> plugin.getRtpQueueManager().leave(player);
+            default -> plugin.getRtpQueueManager().join(player);
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length != 1) {
+            return List.of();
+        }
+        String prefix = args[0].toLowerCase(Locale.ROOT);
+        return SUBCOMMANDS.stream().filter(option -> option.startsWith(prefix)).toList();
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -402,6 +402,9 @@ public class PlayerJoinQuitListener implements Listener {
         plugin.getShardManager().clearBoosterCache(player.getUniqueId());
         plugin.getRtpZoneManager().clearState(player);
         plugin.getRtpManager().clearSearch(player.getUniqueId());
+        if (plugin.getRtpQueueManager() != null) {
+            plugin.getRtpQueueManager().handleQuit(player.getUniqueId());
+        }
         plugin.getPortalManager().clearPlayerState(player.getUniqueId());
         plugin.getPortalManager().refreshHologramsSoon();
         plugin.getCrateManager().clearSession(player.getUniqueId());

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -1301,6 +1301,13 @@ public class RTPManager {
     private void startSearch(Player player, String worldName, SearchSettings settings) {
         clearSearch(player.getUniqueId());
 
+        // A normal RTP replaces whatever the matchmaking queue had lined up, so the player
+        // does not get pulled to a meeting point they have already teleported away from.
+        if (plugin.getRtpQueueManager() != null
+                && plugin.getRtpQueueManager().isInQueue(player.getUniqueId())) {
+            plugin.getRtpQueueManager().leave(player);
+        }
+
         Location preCached = pollPreCachedLocation(worldName);
         if (preCached != null) {
             SoundUtils.play(player, plugin.getConfigManager().getSound("RTP.SEARCH-START"));
@@ -2518,7 +2525,7 @@ public class RTPManager {
         return activeSearches.containsKey(playerId) || activeDirectSearches.containsKey(playerId);
     }
 
-    private boolean hasActiveRtpFlow(UUID playerId) {
+    public boolean hasActiveRtpFlow(UUID playerId) {
         return activeSearches.containsKey(playerId)
                 || activeResultTasks.containsKey(playerId)
                 || activeDirectSearches.containsKey(playerId);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPQueueManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPQueueManager.java
@@ -1,0 +1,408 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Matchmaking in front of RTP. Players run /rtpq to wait for other players, and once enough of
+ * them are waiting the whole group is dropped at one shared random location rather than at a
+ * random location each, which is what /rtp does. Everybody lands within a few blocks of
+ * everybody else, so a fight can start without anyone swapping coordinates first.
+ *
+ * <p>The search reuses the RTP engine through {@link RTPManager#findSafeLocationAsync}, so a
+ * match is never blocked by RTP cooldowns, playtime requirements, or the RTP slot queue. The
+ * waiting list only lives in memory, so leaving the server or reloading the config drops the
+ * player from it.
+ */
+public class RTPQueueManager {
+
+    private static final int DEFAULT_MATCH_SIZE = 2;
+    private static final int MIN_MATCH_SIZE = 2;
+    private static final int MAX_MATCH_SIZE = 32;
+    private static final int DEFAULT_SPREAD_RADIUS = 16;
+    private static final int MAX_SPREAD_RADIUS = 512;
+
+    private final UltimateDonutSmp plugin;
+    private final LinkedHashSet<UUID> waiting = new LinkedHashSet<>();
+
+    public RTPQueueManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void reload() {
+        clear();
+    }
+
+    public boolean isEnabled() {
+        FileConfiguration rtp = rtpConfig();
+        return rtp != null
+                && plugin.getRtpManager() != null
+                && plugin.getRtpManager().isEnabled()
+                && rtp.getBoolean("QUEUE.ENABLED", true);
+    }
+
+    public int getMatchSize() {
+        FileConfiguration rtp = rtpConfig();
+        int configured = rtp == null ? DEFAULT_MATCH_SIZE : rtp.getInt("QUEUE.MATCH-SIZE", DEFAULT_MATCH_SIZE);
+        return Math.max(MIN_MATCH_SIZE, Math.min(MAX_MATCH_SIZE, configured));
+    }
+
+    public int getSpreadRadius() {
+        FileConfiguration rtp = rtpConfig();
+        int configured = rtp == null ? DEFAULT_SPREAD_RADIUS : rtp.getInt("QUEUE.SPREAD-RADIUS", DEFAULT_SPREAD_RADIUS);
+        return Math.max(0, Math.min(MAX_SPREAD_RADIUS, configured));
+    }
+
+    public String getWorldName() {
+        FileConfiguration rtp = rtpConfig();
+        String configured = rtp == null ? null : rtp.getString("QUEUE.WORLD", "world");
+        if (configured == null || configured.isBlank() || plugin.getRtpManager() == null) {
+            return null;
+        }
+        return plugin.getRtpManager().resolveWorldSelector(configured);
+    }
+
+    public boolean isInQueue(UUID playerId) {
+        if (playerId == null) {
+            return false;
+        }
+        synchronized (waiting) {
+            return waiting.contains(playerId);
+        }
+    }
+
+    public int getQueuePosition(UUID playerId) {
+        if (playerId == null) {
+            return -1;
+        }
+        synchronized (waiting) {
+            int position = 1;
+            for (UUID queued : waiting) {
+                if (queued.equals(playerId)) {
+                    return position;
+                }
+                position++;
+            }
+        }
+        return -1;
+    }
+
+    public int getQueueSize() {
+        synchronized (waiting) {
+            return waiting.size();
+        }
+    }
+
+    public void clear() {
+        synchronized (waiting) {
+            waiting.clear();
+        }
+    }
+
+    /**
+     * Puts a player in the waiting list, and starts the match as soon as that fills it.
+     *
+     * @return true when the player is waiting in the queue once this returns
+     */
+    public boolean join(Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        if (!isEnabled()) {
+            sendMessage(player, "DISABLED", "&cThe RTP queue is currently disabled.");
+            return false;
+        }
+
+        UUID playerId = player.getUniqueId();
+        if (isInQueue(playerId)) {
+            sendMessage(
+                    player,
+                    "ALREADY-QUEUED",
+                    "&cYou are already in the RTP queue at position #{position}.",
+                    "{position}", String.valueOf(getQueuePosition(playerId))
+            );
+            return false;
+        }
+
+        if (getSearchSettings() == null) {
+            sendMessage(player, "UNAVAILABLE", "&cThe RTP queue is not available right now.");
+            return false;
+        }
+
+        if (plugin.getRtpManager().hasActiveRtpFlow(playerId)
+                || plugin.getTeleportManager().hasPendingType(playerId, "RTP")) {
+            sendMessage(player, "BUSY", "&cFinish the teleport you already started before joining the RTP queue.");
+            return false;
+        }
+
+        int needed = getMatchSize();
+        int waitingCount;
+        synchronized (waiting) {
+            waiting.add(playerId);
+            waitingCount = waiting.size();
+        }
+
+        broadcastToQueue(
+                playerId,
+                "PLAYER-JOINED",
+                "&e[RTP Queue] &f{player} has joined the queue. &7({waiting}/{needed})",
+                "{player}", player.getName(),
+                "{waiting}", String.valueOf(waitingCount),
+                "{needed}", String.valueOf(needed)
+        );
+        sendMessage(
+                player,
+                "JOINED",
+                "&e[RTP Queue] &fYou have joined the queue. Waiting for another player... &7({waiting}/{needed})",
+                "{waiting}", String.valueOf(waitingCount),
+                "{needed}", String.valueOf(needed)
+        );
+        SoundUtils.play(player, plugin.getConfigManager().getSound("RTP.SEARCH-START"));
+
+        startMatchIfReady();
+        return true;
+    }
+
+    /**
+     * Takes a player back out of the waiting list at their own request.
+     *
+     * @return true when the player was queued and has now been removed
+     */
+    public boolean leave(Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        UUID playerId = player.getUniqueId();
+        if (!remove(playerId)) {
+            sendMessage(player, "NOT-QUEUED", "&cYou are not in the RTP queue.");
+            return false;
+        }
+
+        sendMessage(player, "LEFT", "&e[RTP Queue] &fYou have left the queue.");
+        broadcastToQueue(
+                playerId,
+                "PLAYER-LEFT",
+                "&e[RTP Queue] &f{player} has left the queue. &7({waiting}/{needed})",
+                "{player}", player.getName(),
+                "{waiting}", String.valueOf(getQueueSize()),
+                "{needed}", String.valueOf(getMatchSize())
+        );
+        return true;
+    }
+
+    /**
+     * Drops a player who has disconnected, without telling the rest of the queue they left.
+     */
+    public void handleQuit(UUID playerId) {
+        remove(playerId);
+    }
+
+    public boolean remove(UUID playerId) {
+        if (playerId == null) {
+            return false;
+        }
+        synchronized (waiting) {
+            return waiting.remove(playerId);
+        }
+    }
+
+    /**
+     * Pulls the players for one match off the front of the waiting list, longest wait first,
+     * and leaves the list untouched while it is still too short to fill a match.
+     */
+    List<UUID> pollMatchParty() {
+        int needed = getMatchSize();
+        synchronized (waiting) {
+            if (waiting.size() < needed) {
+                return List.of();
+            }
+            List<UUID> party = new ArrayList<>(needed);
+            for (UUID queued : waiting) {
+                party.add(queued);
+                if (party.size() == needed) {
+                    break;
+                }
+            }
+            waiting.removeAll(party);
+            return party;
+        }
+    }
+
+    private void startMatchIfReady() {
+        List<UUID> party = pollMatchParty();
+        if (party.isEmpty()) {
+            return;
+        }
+
+        List<Player> matched = onlinePlayers(party);
+        if (matched.size() < MIN_MATCH_SIZE) {
+            requeue(
+                    matched,
+                    "MATCH-ABANDONED",
+                    "&c[RTP Queue] &fThe other players left before the match started, so you are back in the queue."
+            );
+            return;
+        }
+
+        RTPManager.SearchSettings settings = getSearchSettings();
+        if (settings == null) {
+            requeue(matched, "UNAVAILABLE", "&cThe RTP queue is not available right now.");
+            return;
+        }
+
+        for (Player player : matched) {
+            sendMessage(player, "MATCH-FOUND", "&a[RTP Queue] &fMatch found! Teleporting you to the same area...");
+            SoundUtils.play(player, plugin.getConfigManager().getSound("RTP.SEARCH-FOUND"));
+        }
+
+        plugin.getRtpManager().findSafeLocationAsync(settings).whenComplete((meetingPoint, throwable) -> {
+            if (throwable != null || meetingPoint == null) {
+                requeue(
+                        matched,
+                        "MATCH-FAILED",
+                        "&c[RTP Queue] &fNo safe location was found for the match, so you are back in the queue."
+                );
+                return;
+            }
+            teleportParty(matched, meetingPoint, settings);
+        });
+    }
+
+    /**
+     * Sends the whole party to the meeting point. Everybody after the first gets their own
+     * search within SPREAD-RADIUS of it, so the group lands together without stacking up on a
+     * single block, and anybody the spread search cannot place lands on the point itself.
+     *
+     * <p>The teleports deliberately skip the usual RTP stand-still countdown: one player moving
+     * would otherwise cancel their half of the match and strand the rest out in the wild alone.
+     */
+    private void teleportParty(List<Player> matched, Location meetingPoint, RTPManager.SearchSettings settings) {
+        int spreadRadius = getSpreadRadius();
+        for (int index = 0; index < matched.size(); index++) {
+            Player player = matched.get(index);
+            if (index == 0 || spreadRadius <= 0) {
+                teleport(player, meetingPoint);
+                continue;
+            }
+
+            RTPManager.SearchSettings spread = new RTPManager.SearchSettings(
+                    settings.worldName(),
+                    0,
+                    spreadRadius,
+                    meetingPoint.getBlockX(),
+                    meetingPoint.getBlockZ(),
+                    settings.maxAttempts(),
+                    settings.maxChunkSamples(),
+                    settings.attemptIntervalTicks()
+            );
+            plugin.getRtpManager().findSafeLocationAsync(spread).whenComplete((nearby, throwable) ->
+                    teleport(player, throwable == null && nearby != null ? nearby : meetingPoint));
+        }
+    }
+
+    private void teleport(Player player, Location destination) {
+        plugin.getSpigotScheduler().runEntity(player, () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+            plugin.getSpigotScheduler().teleport(player, destination).thenAccept(success ->
+                    plugin.getSpigotScheduler().runEntity(player, () -> {
+                        if (!player.isOnline()) {
+                            return;
+                        }
+                        if (!Boolean.TRUE.equals(success)) {
+                            sendMessage(
+                                    player,
+                                    "MATCH-FAILED",
+                                    "&c[RTP Queue] &fNo safe location was found for the match, so you are back in the queue."
+                            );
+                            rejoin(player.getUniqueId());
+                            return;
+                        }
+                        SoundUtils.play(player, plugin.getConfigManager().getSound("TELEPORT.SUCCESS"));
+                    }));
+        });
+    }
+
+    private void requeue(List<Player> matched, String messageKey, String fallback) {
+        for (Player player : matched) {
+            if (!player.isOnline()) {
+                continue;
+            }
+            rejoin(player.getUniqueId());
+            sendMessage(player, messageKey, fallback);
+        }
+    }
+
+    private void rejoin(UUID playerId) {
+        synchronized (waiting) {
+            waiting.add(playerId);
+        }
+    }
+
+    private List<Player> onlinePlayers(List<UUID> party) {
+        List<Player> matched = new ArrayList<>(party.size());
+        for (UUID playerId : party) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                matched.add(player);
+            }
+        }
+        return matched;
+    }
+
+    private RTPManager.SearchSettings getSearchSettings() {
+        String worldName = getWorldName();
+        if (worldName == null || worldName.isBlank()) {
+            return null;
+        }
+        return plugin.getRtpManager().getWorldSearchSettings(worldName);
+    }
+
+    private void broadcastToQueue(UUID excluded, String messageKey, String fallback, String... replacements) {
+        List<UUID> queued;
+        synchronized (waiting) {
+            queued = new ArrayList<>(waiting);
+        }
+        for (UUID playerId : queued) {
+            if (playerId.equals(excluded)) {
+                continue;
+            }
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                sendMessage(player, messageKey, fallback, replacements);
+            }
+        }
+    }
+
+    private void sendMessage(Player player, String messageKey, String fallback, String... replacements) {
+        FileConfiguration rtp = rtpConfig();
+        String message = rtp == null ? fallback : rtp.getString("QUEUE.MESSAGES." + messageKey, fallback);
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        for (int index = 0; index + 1 < replacements.length; index += 2) {
+            message = message.replace(replacements[index], replacements[index + 1]);
+        }
+        player.sendMessage(ColorUtils.toComponent(message));
+    }
+
+    private FileConfiguration rtpConfig() {
+        if (plugin == null || plugin.getConfigManager() == null) {
+            return null;
+        }
+        return plugin.getConfigManager().getRtp();
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1795,6 +1795,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7Benötigte spielzeit: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cDie RTP-Warteschlange ist derzeit deaktiviert."
+        UNAVAILABLE: "&cDie RTP-Warteschlange ist gerade nicht verfügbar."
+        BUSY: "&cBeende erst deinen laufenden Teleport, bevor du der RTP-Warteschlange beitrittst."
+        JOINED: "&e[RTP Queue] &fDu bist der Warteschlange beigetreten. Warte auf weitere Spieler... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} ist der Warteschlange beigetreten. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cDu stehst bereits auf Platz #{position} der RTP-Warteschlange."
+        LEFT: "&e[RTP Queue] &fDu hast die Warteschlange verlassen."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} hat die Warteschlange verlassen. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cDu stehst nicht in der RTP-Warteschlange."
+        MATCH-FOUND: "&a[RTP Queue] &fGegner gefunden! Du wirst in dasselbe Gebiet teleportiert..."
+        MATCH-FAILED: "&c[RTP Queue] &fEs wurde kein sicherer Ort für das Match gefunden, du bist zurück in der Warteschlange."
+        MATCH-ABANDONED: "&c[RTP Queue] &fDie anderen Spieler sind vor dem Start gegangen, du bist zurück in der Warteschlange."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1923,6 +1923,23 @@ CONFIG:
           - '&7Range: &b{min_radius}-{max_radius}'
           - '&7Cooldown: &b{cooldown}s'
           - '&7Required playtime: &b{required_playtime}'
+    QUEUE:
+      MESSAGES:
+        DISABLED: '&cThe RTP queue is currently disabled.'
+        UNAVAILABLE: '&cThe RTP queue is not available right now.'
+        BUSY: '&cFinish the teleport you already started before joining the RTP queue.'
+        JOINED: '&e[RTP Queue] &fYou have joined the queue. Waiting for another player...
+          &7({waiting}/{needed})'
+        PLAYER-JOINED: '&e[RTP Queue] &f{player} has joined the queue. &7({waiting}/{needed})'
+        ALREADY-QUEUED: '&cYou are already in the RTP queue at position #{position}.'
+        LEFT: '&e[RTP Queue] &fYou have left the queue.'
+        PLAYER-LEFT: '&e[RTP Queue] &f{player} has left the queue. &7({waiting}/{needed})'
+        NOT-QUEUED: '&cYou are not in the RTP queue.'
+        MATCH-FOUND: '&a[RTP Queue] &fMatch found! Teleporting you to the same area...'
+        MATCH-FAILED: '&c[RTP Queue] &fNo safe location was found for the match, so
+          you are back in the queue.'
+        MATCH-ABANDONED: '&c[RTP Queue] &fThe other players left before the match
+          started, so you are back in the queue.'
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1660,6 +1660,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7Tiempo de juego requerido: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cLa cola de RTP está desactivada actualmente."
+        UNAVAILABLE: "&cLa cola de RTP no está disponible en este momento."
+        BUSY: "&cTermina el teletransporte que ya has empezado antes de entrar en la cola de RTP."
+        JOINED: "&e[RTP Queue] &fHas entrado en la cola. Esperando a otro jugador... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} ha entrado en la cola. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cYa estás en la cola de RTP en la posición #{position}."
+        LEFT: "&e[RTP Queue] &fHas salido de la cola."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} ha salido de la cola. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cNo estás en la cola de RTP."
+        MATCH-FOUND: "&a[RTP Queue] &f¡Emparejamiento encontrado! Te teletransportamos a la misma zona..."
+        MATCH-FAILED: "&c[RTP Queue] &fNo se encontró un lugar seguro para el encuentro, así que vuelves a la cola."
+        MATCH-ABANDONED: "&c[RTP Queue] &fLos demás jugadores se fueron antes de empezar, así que vuelves a la cola."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1660,6 +1660,20 @@ CONFIG:
           - "&7Portée : &b{min_radius}-{max_radius}"
           - "&7Recharge : &b{cooldown}s"
           - "&7Temps de jeu requis : &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cLa file d'attente RTP est actuellement désactivée."
+        UNAVAILABLE: "&cLa file d'attente RTP n'est pas disponible pour le moment."
+        BUSY: "&cTermine la téléportation déjà en cours avant de rejoindre la file RTP."
+        JOINED: "&e[RTP Queue] &fTu as rejoint la file. En attente d'un autre joueur... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} a rejoint la file. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cTu es déjà dans la file RTP à la position #{position}."
+        LEFT: "&e[RTP Queue] &fTu as quitté la file."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} a quitté la file. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cTu n'es pas dans la file RTP."
+        MATCH-FOUND: "&a[RTP Queue] &fAdversaire trouvé ! Téléportation vers la même zone..."
+        MATCH-FAILED: "&c[RTP Queue] &fAucun endroit sûr n'a été trouvé pour la rencontre, tu retournes dans la file."
+        MATCH-ABANDONED: "&c[RTP Queue] &fLes autres joueurs sont partis avant le début, tu retournes dans la file."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1796,6 +1796,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7Required playtime: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cAntrean RTP sedang dinonaktifkan."
+        UNAVAILABLE: "&cAntrean RTP sedang tidak tersedia."
+        BUSY: "&cSelesaikan dulu teleport yang sedang berjalan sebelum masuk antrean RTP."
+        JOINED: "&e[RTP Queue] &fKamu masuk antrean. Menunggu pemain lain... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} masuk antrean. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cKamu sudah berada di antrean RTP pada posisi #{position}."
+        LEFT: "&e[RTP Queue] &fKamu keluar dari antrean."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} keluar dari antrean. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cKamu tidak sedang berada di antrean RTP."
+        MATCH-FOUND: "&a[RTP Queue] &fLawan ditemukan! Kamu dipindahkan ke area yang sama..."
+        MATCH-FAILED: "&c[RTP Queue] &fTidak ada lokasi aman untuk pertemuan ini, kamu kembali ke antrean."
+        MATCH-ABANDONED: "&c[RTP Queue] &fPemain lain keluar sebelum dimulai, kamu kembali ke antrean."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1660,6 +1660,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7Tempo de jogo requerido: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cA fila de RTP está desativada no momento."
+        UNAVAILABLE: "&cA fila de RTP não está disponível agora."
+        BUSY: "&cTermine o teleporte que você já começou antes de entrar na fila de RTP."
+        JOINED: "&e[RTP Queue] &fVocê entrou na fila. Esperando outro jogador... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} entrou na fila. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cVocê já está na fila de RTP na posição #{position}."
+        LEFT: "&e[RTP Queue] &fVocê saiu da fila."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} saiu da fila. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cVocê não está na fila de RTP."
+        MATCH-FOUND: "&a[RTP Queue] &fEncontramos alguém! Teleportando você para a mesma área..."
+        MATCH-FAILED: "&c[RTP Queue] &fNenhum local seguro foi encontrado para o encontro, então você voltou para a fila."
+        MATCH-ABANDONED: "&c[RTP Queue] &fOs outros jogadores saíram antes de começar, então você voltou para a fila."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1659,6 +1659,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7Требуемое время игры: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cОчередь RTP сейчас отключена."
+        UNAVAILABLE: "&cОчередь RTP сейчас недоступна."
+        BUSY: "&cСначала закончите уже начатую телепортацию, а потом вставайте в очередь RTP."
+        JOINED: "&e[RTP Queue] &fВы встали в очередь. Ждём другого игрока... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} встал в очередь. &7({waiting}/{needed})"
+        ALREADY-QUEUED: "&cВы уже стоите в очереди RTP на позиции #{position}."
+        LEFT: "&e[RTP Queue] &fВы вышли из очереди."
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} вышел из очереди. &7({waiting}/{needed})"
+        NOT-QUEUED: "&cВы не стоите в очереди RTP."
+        MATCH-FOUND: "&a[RTP Queue] &fСоперник найден! Телепортируем вас в одно и то же место..."
+        MATCH-FAILED: "&c[RTP Queue] &fБезопасное место для встречи не нашлось, вы снова в очереди."
+        MATCH-ABANDONED: "&c[RTP Queue] &fОстальные игроки вышли до начала, вы снова в очереди."
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1655,6 +1655,20 @@ CONFIG:
           - "&7Range: &b{min_radius}-{max_radius}"
           - "&7Cooldown: &b{cooldown}s"
           - "&7需要在线时间: &b{required_playtime}"
+    QUEUE:
+      MESSAGES:
+        DISABLED: "&cRTP 队列当前已关闭。"
+        UNAVAILABLE: "&cRTP 队列暂时不可用。"
+        BUSY: "&c请先完成你已经开始的传送，再加入 RTP 队列。"
+        JOINED: "&e[RTP Queue] &f你已加入队列，正在等待其他玩家... &7({waiting}/{needed})"
+        PLAYER-JOINED: "&e[RTP Queue] &f{player} 加入了队列。&7({waiting}/{needed})"
+        ALREADY-QUEUED: "&c你已经在 RTP 队列中，位置为 #{position}。"
+        LEFT: "&e[RTP Queue] &f你已离开队列。"
+        PLAYER-LEFT: "&e[RTP Queue] &f{player} 离开了队列。&7({waiting}/{needed})"
+        NOT-QUEUED: "&c你不在 RTP 队列中。"
+        MATCH-FOUND: "&a[RTP Queue] &f匹配成功！正在把你传送到同一片区域..."
+        MATCH-FAILED: "&c[RTP Queue] &f没有为这次会合找到安全位置，你已回到队列中。"
+        MATCH-ABANDONED: "&c[RTP Queue] &f其他玩家在开始前离开了，你已回到队列中。"
   AMETHYST_TOOLS:
     AMETHYST-TOOLS:
       DRILL:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -113,6 +113,13 @@ commands:
     usage: /rtp [world]
     permission: ultimatedonutsmp.command.rtp
     permission-message: "&cYou do not have permission to use /rtp."
+  rtpq:
+    description: Join the RTP matchmaking queue
+    usage: /rtpq [join|leave]
+    aliases:
+    - rtpqueue
+    permission: ultimatedonutsmp.command.rtpq
+    permission-message: "&cYou do not have permission to use /rtpq."
   shop:
     description: Open the shop
     usage: /shop [reload]
@@ -1203,6 +1210,7 @@ permissions:
       ultimatedonutsmp.command.afk: true
       ultimatedonutsmp.command.setafk: true
       ultimatedonutsmp.command.rtp: true
+      ultimatedonutsmp.command.rtpq: true
       ultimatedonutsmp.command.shop: true
       ultimatedonutsmp.command.orders: true
       ultimatedonutsmp.command.duel: true
@@ -1360,6 +1368,9 @@ permissions:
     default: true
   ultimatedonutsmp.command.rtp:
     description: Access to /rtp command
+    default: true
+  ultimatedonutsmp.command.rtpq:
+    description: Access to /rtpq command
     default: true
   ultimatedonutsmp.command.shop:
     description: Access to /shop command

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -70,6 +70,33 @@ SETTINGS:
       "ultimatedonutsmp.rtp.cooldown.vip+": 10
       "ultimatedonutsmp.rtp.cooldown.vip": 15
 
+# Matchmaking queue in front of RTP. Players run /rtpq to wait for other players, and the whole
+# group is dropped at one shared random location instead of at a random location each
+QUEUE:
+  # Enable or disable the RTP matchmaking queue and the /rtpq command (true / false)
+  ENABLED: true
+  # How many players have to be waiting before the group is teleported
+  MATCH-SIZE: 2
+  # World the matched group is teleported into
+  WORLD: world
+  # How far the matched players are scattered around the shared location, in blocks.
+  # 0 drops the whole group on the exact same block
+  SPREAD-RADIUS: 16
+  # User feedback for the matchmaking queue
+  MESSAGES:
+    DISABLED: '&cThe RTP queue is currently disabled.'
+    UNAVAILABLE: '&cThe RTP queue is not available right now.'
+    BUSY: '&cFinish the teleport you already started before joining the RTP queue.'
+    JOINED: '&e[RTP Queue] &fYou have joined the queue. Waiting for another player... &7({waiting}/{needed})'
+    PLAYER-JOINED: '&e[RTP Queue] &f{player} has joined the queue. &7({waiting}/{needed})'
+    ALREADY-QUEUED: '&cYou are already in the RTP queue at position #{position}.'
+    LEFT: '&e[RTP Queue] &fYou have left the queue.'
+    PLAYER-LEFT: '&e[RTP Queue] &f{player} has left the queue. &7({waiting}/{needed})'
+    NOT-QUEUED: '&cYou are not in the RTP queue.'
+    MATCH-FOUND: '&a[RTP Queue] &fMatch found! Teleporting you to the same area...'
+    MATCH-FAILED: '&c[RTP Queue] &fNo safe location was found for the match, so you are back in the queue.'
+    MATCH-ABANDONED: '&c[RTP Queue] &fThe other players left before the match started, so you are back in the queue.'
+
 # User feedback and status messages
 MESSAGES:
   DISABLED: '&cRTP is currently disabled.'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPQueueManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPQueueManagerTest.java
@@ -1,0 +1,251 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RTPQueueManagerTest {
+
+    private Server originalServer;
+    private org.bukkit.World mockWorld;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalServer = Bukkit.getServer();
+
+        mockWorld = (org.bukkit.World) Proxy.newProxyInstance(
+                org.bukkit.World.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.World.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getName")) {
+                        return "world";
+                    }
+                    if (method.getName().equals("getEnvironment")) {
+                        return org.bukkit.World.Environment.NORMAL;
+                    }
+                    return null;
+                }
+        );
+
+        Server mockServer = (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getWorlds")) {
+                        return List.of(mockWorld);
+                    }
+                    if (method.getName().equals("getWorld")) {
+                        return mockWorld;
+                    }
+                    if (method.getName().equals("getLogger")) {
+                        return java.util.logging.Logger.getLogger("Minecraft");
+                    }
+                    return null;
+                }
+        );
+
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, mockServer);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field serverField = Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, originalServer);
+    }
+
+    private YamlConfiguration rtpConfig(int matchSize) {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        rtpConfig.set("ENABLED", true);
+        rtpConfig.set("QUEUE.ENABLED", true);
+        rtpConfig.set("QUEUE.MATCH-SIZE", matchSize);
+        rtpConfig.set("QUEUE.WORLD", "world");
+        rtpConfig.set("WORLD-SETTINGS.world.MIN-RADIUS", 500);
+        rtpConfig.set("WORLD-SETTINGS.world.MAX-RADIUS", 5000);
+        return rtpConfig;
+    }
+
+    private RTPQueueManager createQueueManager(YamlConfiguration rtpConfig) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        ReflectionFactory reflectionFactory = ReflectionFactory.getReflectionFactory();
+        Constructor<?> newConstructor =
+                reflectionFactory.newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        UltimateDonutSmp plugin = (UltimateDonutSmp) newConstructor.newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        setField(ConfigManager.class, configManager, "rtp", rtpConfig);
+        setField(ConfigManager.class, configManager, "config", new YamlConfiguration());
+        setField(ConfigManager.class, configManager, "sounds", new YamlConfiguration());
+        setField(UltimateDonutSmp.class, plugin, "configManager", configManager);
+        setField(UltimateDonutSmp.class, plugin, "featureManager", new FeatureManager(plugin));
+        setField(UltimateDonutSmp.class, plugin, "teleportManager", new TeleportManager(plugin));
+        setField(UltimateDonutSmp.class, plugin, "rtpManager", new RTPManager(plugin));
+
+        RTPQueueManager queueManager = new RTPQueueManager(plugin);
+        setField(UltimateDonutSmp.class, plugin, "rtpQueueManager", queueManager);
+        return queueManager;
+    }
+
+    private static void setField(Class<?> owner, Object target, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private Player createMockPlayer(UUID uuid, String name) {
+        return (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getUniqueId" -> uuid;
+                    case "getName" -> name;
+                    case "isOnline" -> true;
+                    case "hasPermission" -> false;
+                    default -> null;
+                }
+        );
+    }
+
+    @Test
+    void queueKeepsJoinOrderAndReportsPositions() throws Exception {
+        RTPQueueManager queueManager = createQueueManager(rtpConfig(4));
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        UUID thirdId = UUID.randomUUID();
+
+        assertTrue(queueManager.join(createMockPlayer(firstId, "First")));
+        assertTrue(queueManager.join(createMockPlayer(secondId, "Second")));
+        assertTrue(queueManager.join(createMockPlayer(thirdId, "Third")));
+
+        assertEquals(3, queueManager.getQueueSize());
+        assertEquals(1, queueManager.getQueuePosition(firstId));
+        assertEquals(2, queueManager.getQueuePosition(secondId));
+        assertEquals(3, queueManager.getQueuePosition(thirdId));
+        assertTrue(queueManager.isInQueue(secondId));
+    }
+
+    @Test
+    void joiningTwiceKeepsTheOriginalPlace() throws Exception {
+        RTPQueueManager queueManager = createQueueManager(rtpConfig(4));
+
+        UUID playerId = UUID.randomUUID();
+        Player player = createMockPlayer(playerId, "First");
+
+        assertTrue(queueManager.join(player));
+        assertFalse(queueManager.join(player));
+        assertEquals(1, queueManager.getQueueSize());
+        assertEquals(1, queueManager.getQueuePosition(playerId));
+    }
+
+    @Test
+    void leavingRemovesOnlyThatPlayer() throws Exception {
+        RTPQueueManager queueManager = createQueueManager(rtpConfig(4));
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        Player first = createMockPlayer(firstId, "First");
+
+        queueManager.join(first);
+        queueManager.join(createMockPlayer(secondId, "Second"));
+
+        assertTrue(queueManager.leave(first));
+        assertFalse(queueManager.leave(first));
+        assertFalse(queueManager.isInQueue(firstId));
+        assertEquals(1, queueManager.getQueueSize());
+        assertEquals(1, queueManager.getQueuePosition(secondId));
+    }
+
+    @Test
+    void disconnectingDropsPlayerFromTheQueue() throws Exception {
+        RTPQueueManager queueManager = createQueueManager(rtpConfig(4));
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+
+        queueManager.join(createMockPlayer(firstId, "First"));
+        queueManager.join(createMockPlayer(secondId, "Second"));
+        queueManager.handleQuit(firstId);
+
+        assertFalse(queueManager.isInQueue(firstId));
+        assertEquals(1, queueManager.getQueueSize());
+    }
+
+    @Test
+    void matchPartyOnlyDrainsOnceTheQueueIsLongEnough() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(4);
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        UUID thirdId = UUID.randomUUID();
+
+        queueManager.join(createMockPlayer(firstId, "First"));
+        queueManager.join(createMockPlayer(secondId, "Second"));
+        queueManager.join(createMockPlayer(thirdId, "Third"));
+
+        assertTrue(queueManager.pollMatchParty().isEmpty());
+        assertEquals(3, queueManager.getQueueSize());
+
+        rtpConfig.set("QUEUE.MATCH-SIZE", 2);
+        assertEquals(List.of(firstId, secondId), queueManager.pollMatchParty());
+        assertEquals(1, queueManager.getQueueSize());
+        assertEquals(1, queueManager.getQueuePosition(thirdId));
+    }
+
+    @Test
+    void disabledQueueRefusesToJoin() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(2);
+        rtpConfig.set("QUEUE.ENABLED", false);
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+
+        assertFalse(queueManager.isEnabled());
+        assertFalse(queueManager.join(createMockPlayer(UUID.randomUUID(), "First")));
+        assertEquals(0, queueManager.getQueueSize());
+    }
+
+    @Test
+    void queueWithoutWorldSettingsRefusesToJoin() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(2);
+        rtpConfig.set("WORLD-SETTINGS", null);
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+
+        assertFalse(queueManager.join(createMockPlayer(UUID.randomUUID(), "First")));
+        assertEquals(0, queueManager.getQueueSize());
+    }
+
+    @Test
+    void matchSizeAndSpreadRadiusStayInsideTheirLimits() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(1);
+        rtpConfig.set("QUEUE.SPREAD-RADIUS", -5);
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+
+        assertEquals(2, queueManager.getMatchSize());
+        assertEquals(0, queueManager.getSpreadRadius());
+
+        rtpConfig.set("QUEUE.MATCH-SIZE", 999);
+        rtpConfig.set("QUEUE.SPREAD-RADIUS", 9999);
+        assertEquals(32, queueManager.getMatchSize());
+        assertEquals(512, queueManager.getSpreadRadius());
+    }
+}


### PR DESCRIPTION
Closes #234

Two players who want to fight each other out in the wild currently have to `/rtp` separately and then shout coordinates in chat, which usually ends with one of them walking a few thousand blocks. `/rtpq` puts you in a waiting list instead, and once that list is long enough everybody in it gets dropped at the same random spot in one go.

## The queue

`RTPQueueManager` keeps the waiting players in memory, longest wait first. `/rtpq` joins, `/rtpq leave` walks back out, and `/rtpqueue` works as an alias so both names from the request do the same thing. Once the list reaches `QUEUE.MATCH-SIZE` the manager pulls that many players off the front, tells them a match was found, and asks the RTP engine for one safe location.

Disconnecting drops you off the list through the existing quit handler, and so does starting an ordinary `/rtp`, since otherwise you would get yanked back to a meeting point minutes after teleporting somewhere else entirely.

## Landing together

Only the first player lands on the exact location that came back. Everybody else gets their own short search inside `QUEUE.SPREAD-RADIUS` blocks of it, which is just `findSafeLocationAsync` again with the centre moved onto the meeting point, so the group arrives close enough to see each other without piling onto a single block. When that short search finds nothing, the player goes to the centre instead.

The teleport skips the usual stand-still countdown on purpose: one player twitching would cancel their half of the match and strand the other one alone in the wilderness, which is a worse trade than losing the anti-abuse window on a teleport that already needs a second person to agree to it. The queue also ignores RTP cooldowns, playtime requirements and the `PLAYERS-IN-RTP` slot limit, the way `RespawnRtpManager` already does, because a match has to move the whole group at once or not at all.

## Notes

- The new config sits under `QUEUE` in `rtp.yml`: `ENABLED`, `MATCH-SIZE` (clamped to 2-32), `WORLD`, `SPREAD-RADIUS` (clamped to 0-512), and twelve message keys, which went into all eight language files.
- `/rtpq` needs `ultimatedonutsmp.command.rtpq`, default true, and sits behind the existing RTP feature toggle, so switching RTP off switches the queue off with it.
- `RTPManager.hasActiveRtpFlow` went from private to public so the queue can turn away a player who already has a search running.
- `RTPQueueManagerTest` covers join order and positions, joining twice, leaving, disconnecting, a match party only draining once the queue is long enough, the disabled and missing-world paths, and both clamps. 358 tests pass.
- `Config-rtp.yml.md` gets `QUEUE` and `QUEUE.MESSAGES` sections, and `Commands-and-Permissions.md` gets the `/rtpq` row.
