### PR TITLE
fix(menus): repair mis-cased placeholder names left in existing configs (#243)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -64,6 +64,7 @@ public class ConfigManager {
     private static final DateTimeFormatter BACKUP_TIMESTAMP_FORMAT =
             DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS");
     private static final String SETUP_COMMENT_PREFIX = "# UDS setup:";
+    private static final Map<String, String> MISCASED_PLACEHOLDERS = createMiscasedPlaceholders();
 
     private final UltimateDonutSmp plugin;
     private final Set<String> invalidConfigurations = new HashSet<>();
@@ -223,7 +224,8 @@ public class ConfigManager {
         }
 
         int mergedPaths = mergeBundledDefaults(name, currentText.lines(), current, bundledDefault);
-        if (mergedPaths == 0) {
+        int repairedLines = repairMiscasedPlaceholders(name, currentText.lines());
+        if (mergedPaths == 0 && repairedLines == 0) {
             return result;
         }
 
@@ -237,7 +239,13 @@ public class ConfigManager {
             }
             writeTextFileAtomically(targetFile, currentText);
             result.updated = true;
-            plugin.getLogger().info("Added " + mergedPaths + " missing bundled default path(s) to " + name + ".");
+            if (mergedPaths > 0) {
+                plugin.getLogger().info("Added " + mergedPaths + " missing bundled default path(s) to " + name + ".");
+            }
+            if (repairedLines > 0) {
+                plugin.getLogger().info("Repaired " + repairedLines
+                        + " mis-cased placeholder line(s) in " + name + ".");
+            }
         } catch (IOException | InvalidConfigurationException e) {
             result.skipped = true;
             plugin.getLogger().log(Level.WARNING, "Failed to save synced configuration " + targetFile.getPath(), e);
@@ -1250,6 +1258,60 @@ public class ConfigManager {
             index++;
         }
         return line.substring(0, index);
+    }
+
+    /**
+     * A July 2026 casing pass over the bundled text upper-cased the "x" inside placeholder names as
+     * well, so menus.yml and the language files briefly shipped tokens like {neXt_multiplier}. The
+     * bundled copies were corrected a week later, but the merge below only ever adds missing paths,
+     * so a config written during that window keeps the broken spelling and the menu prints it as raw
+     * text. Nothing in the plugin has ever read these spellings, which is what makes rewriting them
+     * safe rather than an edit to an admin's own wording.
+     */
+    private int repairMiscasedPlaceholders(String resourceName, List<String> lines) {
+        if (!isPlaceholderRepairTarget(resourceName)) {
+            return 0;
+        }
+
+        int repaired = 0;
+        for (int index = 0; index < lines.size(); index++) {
+            String line = lines.get(index);
+            String updated = line;
+            for (Map.Entry<String, String> placeholder : MISCASED_PLACEHOLDERS.entrySet()) {
+                updated = updated.replace(placeholder.getKey(), placeholder.getValue());
+            }
+            if (!updated.equals(line)) {
+                lines.set(index, updated);
+                repaired++;
+            }
+        }
+        return repaired;
+    }
+
+    private boolean isPlaceholderRepairTarget(String resourceName) {
+        return resourceName != null
+                && ("menus.yml".equals(resourceName) || resourceName.startsWith("languages/"));
+    }
+
+    private static Map<String, String> createMiscasedPlaceholders() {
+        Map<String, String> placeholders = new LinkedHashMap<>();
+        placeholders.put("{conteXt}", "{context}");
+        placeholders.put("{eXpires_at}", "{expires_at}");
+        placeholders.put("{eXpires}", "{expires}");
+        placeholders.put("{maX_attempts}", "{max_attempts}");
+        placeholders.put("{maX_formatted}", "{max_formatted}");
+        placeholders.put("{maX_members}", "{max_members}");
+        placeholders.put("{maX_page}", "{max_page}");
+        placeholders.put("{maX_radius}", "{max_radius}");
+        placeholders.put("{maX_samples}", "{max_samples}");
+        placeholders.put("{maX}", "{max}");
+        placeholders.put("{neXt_goal}", "{next_goal}");
+        placeholders.put("{neXt_multiplier}", "{next_multiplier}");
+        placeholders.put("{neXt_page}", "{next_page}");
+        placeholders.put("{neXt_rotation}", "{next_rotation}");
+        placeholders.put("{prefiX}", "{prefix}");
+        placeholders.put("{X}", "{x}");
+        return placeholders;
     }
 
     private int mergeBundledDefaults(
@@ -2310,7 +2372,8 @@ public class ConfigManager {
                 current,
                 defaults
         );
-        if (mergedPaths == 0) {
+        int repairedLines = repairMiscasedPlaceholders(name, currentText.lines());
+        if (mergedPaths == 0 && repairedLines == 0) {
             return true;
         }
 
@@ -2322,7 +2385,13 @@ public class ConfigManager {
                 return false;
             }
             writeTextFileAtomically(targetFile, currentText);
-            plugin.getLogger().info("Added " + mergedPaths + " missing generated default path(s) to " + name + ".");
+            if (mergedPaths > 0) {
+                plugin.getLogger().info("Added " + mergedPaths + " missing generated default path(s) to " + name + ".");
+            }
+            if (repairedLines > 0) {
+                plugin.getLogger().info("Repaired " + repairedLines
+                        + " mis-cased placeholder line(s) in " + name + ".");
+            }
             return true;
         } catch (IOException | InvalidConfigurationException e) {
             plugin.getLogger().log(Level.WARNING,

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -425,6 +425,120 @@ class ConfigManagerTest {
         assertTrue(currentLines.contains("      epic: 10"));
     }
 
+    @Test
+    void repairsMiscasedPlaceholdersLeftInExistingMenus() throws Exception {
+        List<String> currentLines = lines(
+                "SELL-MENU:",
+                "  ORES-BUTTON:",
+                "    LORE:",
+                "    - '&7Progress to &f{neXt_multiplier}'",
+                "    - '{porcentage_level} &#6BF18D{porcentage}%'",
+                "PROGRESS-MENU:",
+                "  WORKING-BUTTON:",
+                "    LORE:",
+                "    - '&7{current_earned}/{neXt_goal}'",
+                "SPAWNER-STORAGE-MENU:",
+                "  NEXT-PAGE:",
+                "    LORE:",
+                "    - '&7Go to page &f{neXt_page}&7.' # admin note",
+                "    - '&7Location: &f{world} ({X}, {y}, {z})'"
+        );
+
+        int repaired = repairMiscasedPlaceholders("menus.yml", currentLines);
+        YamlConfiguration merged = yaml(currentLines);
+
+        assertEquals(4, repaired);
+        assertEquals(
+                List.of("&7Progress to &f{next_multiplier}", "{porcentage_level} &#6BF18D{porcentage}%"),
+                merged.getStringList("SELL-MENU.ORES-BUTTON.LORE")
+        );
+        assertEquals(
+                List.of("&7{current_earned}/{next_goal}"),
+                merged.getStringList("PROGRESS-MENU.WORKING-BUTTON.LORE")
+        );
+        assertEquals(
+                List.of("&7Go to page &f{next_page}&7.", "&7Location: &f{world} ({x}, {y}, {z})"),
+                merged.getStringList("SPAWNER-STORAGE-MENU.NEXT-PAGE.LORE")
+        );
+        assertTrue(currentLines.contains("    - '&7Go to page &f{next_page}&7.' # admin note"));
+    }
+
+    @Test
+    void repairsMiscasedPlaceholdersInGeneratedLanguageFiles() throws Exception {
+        List<String> currentLines = lines(
+                "MENUS:",
+                "  SELL-MENU:",
+                "    ORES-BUTTON:",
+                "      LORE:",
+                "      - '&7Progress to &f{neXt_multiplier}'"
+        );
+
+        int repaired = repairMiscasedPlaceholders("languages/id_ID.yml", currentLines);
+
+        assertEquals(1, repaired);
+        assertEquals(
+                List.of("&7Progress to &f{next_multiplier}"),
+                yaml(currentLines).getStringList("MENUS.SELL-MENU.ORES-BUTTON.LORE")
+        );
+    }
+
+    @Test
+    void repairMiscasedPlaceholdersLeavesCleanFilesAndOtherConfigsAlone() throws Exception {
+        List<String> cleanMenus = lines(
+                "SELL-MENU:",
+                "  ORES-BUTTON:",
+                "    LORE:",
+                "    - '&7Progress to &f{next_multiplier}'"
+        );
+        List<String> cleanBefore = new ArrayList<>(cleanMenus);
+
+        assertEquals(0, repairMiscasedPlaceholders("menus.yml", cleanMenus));
+        assertEquals(cleanBefore, cleanMenus);
+
+        List<String> otherConfig = lines(
+                "SETTINGS:",
+                "  TEXT: '&7Page {neXt_page}'"
+        );
+        List<String> otherBefore = new ArrayList<>(otherConfig);
+
+        assertEquals(0, repairMiscasedPlaceholders("config.yml", otherConfig));
+        assertEquals(otherBefore, otherConfig);
+    }
+
+    @Test
+    void bundledMenusAndLanguagesShipNoMiscasedPlaceholders() throws Exception {
+        List<Path> targets = new ArrayList<>();
+        targets.add(Path.of("src/main/resources/menus.yml"));
+        try (Stream<Path> paths = Files.list(Path.of("src/main/resources/languages"))) {
+            paths.filter(ConfigManagerTest::isYamlResource).forEach(targets::add);
+        }
+
+        for (Path target : targets) {
+            String fileName = target.getFileName().toString();
+            String resourceName = "menus.yml".equals(fileName) ? fileName : "languages/" + fileName;
+            List<String> fileLines = new ArrayList<>(Files.readAllLines(target, StandardCharsets.UTF_8));
+
+            assertEquals(
+                    0,
+                    repairMiscasedPlaceholders(resourceName, fileLines),
+                    () -> "Mis-cased placeholder names shipped in " + target
+            );
+        }
+    }
+
+    private static int repairMiscasedPlaceholders(
+            String resourceName,
+            List<String> lines
+    ) throws Exception {
+        Method method = ConfigManager.class.getDeclaredMethod(
+                "repairMiscasedPlaceholders",
+                String.class,
+                List.class
+        );
+        method.setAccessible(true);
+        return (int) method.invoke(new ConfigManager(null), resourceName, lines);
+    }
+
     private static int mergeBundledDefaults(
             String resourceName,
             List<String> currentLines,


### PR DESCRIPTION
Closes #243

Hovering a category button in `/sell` printed `{next_multiplier}` as literal text instead of the multiplier the player is working towards. Zoom into the reporter's screenshot and the reason shows up: the token in their `menus.yml` reads `{neXt_multiplier}`, capital X. A casing pass over the bundled text on 14 July upper-cased the `x` inside placeholder names along with the prose around them, and although `ec72be9a` corrected the bundled copies eight days later, the config sync only inserts paths that are missing. It never touches a value that already exists. So any server that generated its `menus.yml` during that window keeps the dead token forever, and resetting the file is the only way out today, which is what the reporter kept doing.

## The repair

`ConfigManager` rewrites the known-bad spellings inside the same line-preserving sync that adds missing defaults, so it runs on startup and on `/uds reload` and leaves admin comments and formatting alone. The sync backs the file up first, the same as any other write it makes.

Sixteen tokens shipped mis-cased, not only the one in the report: `{neXt_multiplier}`, `{neXt_goal}`, `{neXt_page}`, `{neXt_rotation}`, `{maX}`, `{maX_page}`, `{maX_radius}`, `{maX_members}`, `{maX_samples}`, `{maX_attempts}`, `{maX_formatted}`, `{eXpires}`, `{eXpires_at}`, `{conteXt}`, `{prefiX}` and `{X}`. Nothing in the plugin has ever read any of them, which is what makes the rewrite safe: it corrects text the plugin itself shipped rather than editing wording an admin chose. Scope is `menus.yml` and the generated `languages/*.yml` files, since the casing pass touched nothing else.

## Notes

- Running the repair over the real `menus.yml` from `0231fba0` fixes 18 lines and leaves zero mis-cased tokens behind. A second pass changes nothing, so reloads neither churn the file nor pile up backups.
- Four new tests in `ConfigManagerTest`. One of them is a guard that scans the bundled `menus.yml` plus all eight language files and fails if any of these spellings come back. 362 tests pass.
- `PunishmentItemRenderer` still carries a hand-added `{eXpires_at}` line from an earlier one-off patch. It stays: it costs nothing, and it still covers a file the repair cannot rewrite, such as one with broken YAML.
