### PR TITLE
fix(nametags): show money nametags when protocollib cannot build the packets (#245)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -967,7 +967,7 @@ MONEY-NAMETAGS:
   ENABLED: true
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
   # Available options: Any valid string text
-  FORMAT: '&a${balance}'
+  FORMAT: '&a$ &f{balance}'
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true
@@ -982,7 +982,7 @@ MONEY-NAMETAGS:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `MONEY-NAMETAGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `MONEY-NAMETAGS` system. Set to `false` to take the option out of the game entirely, whatever players picked in `/settings`. |
-| `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a${balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
+| `MONEY-NAMETAGS.FORMAT` | `str` | Any string text | `'&a$ &f{balance}'` | The line drawn under the username. `{balance}` is replaced with the player's balance, and PlaceholderAPI placeholders are resolved against the player who owns the line. |
 | `MONEY-NAMETAGS.SHORT-FORMAT` | `bool` | `true`, `false` | `true` | `true` writes `1.1K`, `1.1M`, `1.1B`, `1.1T` and `1.1Q` where `false` writes them out in full as `1,100,000`. Leaving it on keeps the line narrow once balances run into the billions. |
 | `MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS` | `int` | `1` to `40` | `10` | How often balances are re-read and sent out. It has nothing to do with where the line sits or how it follows a player, since the client draws it as part of the nametag. Lower it if you want balance changes to appear faster. |
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MoneyNametagManager.java
@@ -4,6 +4,7 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.PacketBelowNameRenderer;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
@@ -37,8 +38,7 @@ import java.util.logging.Level;
  *
  * <p>The slot normally shows a raw score, which is an integer and no use for a balance in the
  * billions, so each score carries a fixed number format holding the text to draw instead. That is a
- * packet level feature with no Bukkit API, which is why everything here is sent through
- * ProtocolLib.</p>
+ * packet level feature with no Bukkit API behind it, which is why everything here is a packet.</p>
  *
  * <p>Nothing is written to anybody's real scoreboard. Every packet goes to one viewer, so a player
  * who left the setting off never hears about the objective at all, and the balances a viewer sees
@@ -46,6 +46,11 @@ import java.util.logging.Level;
  *
  * <p>Two things about the slot are the client's rules rather than ours: it only draws within about
  * ten blocks, and a server can only show one objective there at a time.</p>
+ *
+ * <p>ProtocolLib only knows how to build a packet for a Minecraft build it has been taught about,
+ * and on a newer one it cannot assemble these at all. Rather than lose the feature until it catches
+ * up, the first refusal moves everything onto {@link PacketBelowNameRenderer}, which reads the same
+ * packets off the running server.</p>
  */
 public class MoneyNametagManager {
 
@@ -61,13 +66,18 @@ public class MoneyNametagManager {
     private final Map<UUID, Map<UUID, String>> sentText = new ConcurrentHashMap<>();
     /** Viewers whose client has been told the objective exists. */
     private final Set<UUID> installed = ConcurrentHashMap.newKeySet();
+    /** The standby path, used from the moment ProtocolLib cannot build one of these packets. */
+    private final PacketBelowNameRenderer directPackets;
     private ProtocolManager protocolManager;
     private boolean warnedUnsupported;
     /** Set once ProtocolLib proves it cannot build this server's scoreboard packets. */
+    private volatile boolean protocolLibUnusable;
+    /** Set once neither path can build them, which is the only case that loses the feature. */
     private volatile boolean packetsUnsupported;
 
     public MoneyNametagManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
+        this.directPackets = new PacketBelowNameRenderer(plugin, OBJECTIVE);
     }
 
     /** Renders {@code format} for {@code balance}; visible for tests without a running server. */
@@ -205,7 +215,7 @@ public class MoneyNametagManager {
 
     private String currentText(Player target) {
         return render(
-                config().getString("MONEY-NAMETAGS.FORMAT", "&a${balance}"),
+                config().getString("MONEY-NAMETAGS.FORMAT", "&a$ &f{balance}"),
                 plugin.getEconomyManager().getBalance(target),
                 config().getBoolean("MONEY-NAMETAGS.SHORT-FORMAT", true));
     }
@@ -218,37 +228,35 @@ public class MoneyNametagManager {
 
     private boolean sendObjective(Player viewer, int method) {
         ProtocolManager manager = protocolManager();
-        if (manager == null) {
-            return false;
+        if (manager != null && !protocolLibUnusable) {
+            try {
+                PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_OBJECTIVE);
+                packet.getStrings().write(0, OBJECTIVE);
+                packet.getChatComponents().writeSafely(0, WrappedChatComponent.fromText(""));
+                packet.getRenderTypes().writeSafely(0, EnumWrappers.RenderType.INTEGER);
+                packet.getIntegers().write(0, method);
+                emptyEveryOptional(packet);
+                return send(viewer, packet);
+            } catch (RuntimeException | LinkageError error) {
+                switchToDirectPackets("Unable to set up the money nametag objective.", error);
+            }
         }
-        try {
-            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_OBJECTIVE);
-            packet.getStrings().write(0, OBJECTIVE);
-            packet.getChatComponents().writeSafely(0, WrappedChatComponent.fromText(""));
-            packet.getRenderTypes().writeSafely(0, EnumWrappers.RenderType.INTEGER);
-            packet.getIntegers().write(0, method);
-            emptyEveryOptional(packet);
-            return send(viewer, packet);
-        } catch (RuntimeException | LinkageError error) {
-            warnPacketFailure("Unable to set up the money nametag objective.", error);
-            return false;
-        }
+        return directPackets.sendObjective(viewer, method);
     }
 
     private boolean sendDisplaySlot(Player viewer) {
         ProtocolManager manager = protocolManager();
-        if (manager == null) {
-            return false;
+        if (manager != null && !protocolLibUnusable) {
+            try {
+                PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_DISPLAY_OBJECTIVE);
+                packet.getDisplaySlots().write(0, EnumWrappers.DisplaySlot.BELOW_NAME);
+                packet.getStrings().write(0, OBJECTIVE);
+                return send(viewer, packet);
+            } catch (RuntimeException | LinkageError error) {
+                switchToDirectPackets("Unable to place the money nametag under the name.", error);
+            }
         }
-        try {
-            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_DISPLAY_OBJECTIVE);
-            packet.getDisplaySlots().write(0, EnumWrappers.DisplaySlot.BELOW_NAME);
-            packet.getStrings().write(0, OBJECTIVE);
-            return send(viewer, packet);
-        } catch (RuntimeException | LinkageError error) {
-            warnPacketFailure("Unable to place the money nametag under the name.", error);
-            return false;
-        }
+        return directPackets.sendDisplaySlot(viewer);
     }
 
     /**
@@ -257,21 +265,20 @@ public class MoneyNametagManager {
      */
     private boolean sendScore(Player viewer, String targetName, String text) {
         ProtocolManager manager = protocolManager();
-        if (manager == null) {
-            return false;
+        if (manager != null && !protocolLibUnusable) {
+            try {
+                PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_SCORE);
+                packet.getStrings().write(0, targetName);
+                packet.getStrings().write(1, OBJECTIVE);
+                packet.getIntegers().write(0, 0);
+                emptyEveryOptional(packet);
+                writeNumberFormat(packet, WrappedNumberFormat.fixed(WrappedChatComponent.fromLegacyText(text)));
+                return send(viewer, packet);
+            } catch (RuntimeException | LinkageError error) {
+                switchToDirectPackets("Unable to send a money nametag balance.", error);
+            }
         }
-        try {
-            PacketContainer packet = manager.createPacket(PacketType.Play.Server.SCOREBOARD_SCORE);
-            packet.getStrings().write(0, targetName);
-            packet.getStrings().write(1, OBJECTIVE);
-            packet.getIntegers().write(0, 0);
-            emptyEveryOptional(packet);
-            writeNumberFormat(packet, WrappedNumberFormat.fixed(WrappedChatComponent.fromLegacyText(text)));
-            return send(viewer, packet);
-        } catch (RuntimeException | LinkageError error) {
-            warnPacketFailure("Unable to send a money nametag balance.", error);
-            return false;
-        }
+        return directPackets.sendScore(viewer, targetName, text);
     }
 
     /**
@@ -310,29 +317,35 @@ public class MoneyNametagManager {
 
     /**
      * A packet that will not build or send means ProtocolLib does not recognise this server's
-     * scoreboard packets, which nothing short of a ProtocolLib update will change. The feature
-     * turns itself off on the first failure and says so once, in the same plain terms an
-     * unsupported server gets from {@link #isNumberFormatSupported()}. The trace itself is kept at
-     * FINE for anyone debugging it.
+     * scoreboard packets, which nothing short of a ProtocolLib update will change. Everything moves
+     * to the direct path from here, once, and the trace is kept at FINE for anyone debugging it.
+     * Only a server where that path cannot run either loses the feature.
      */
-    private void warnPacketFailure(String message, Throwable error) {
-        if (packetsUnsupported) {
-            plugin.getLogger().log(Level.FINE, message, error);
+    private void switchToDirectPackets(String message, Throwable error) {
+        plugin.getLogger().log(Level.FINE, message, error);
+        if (protocolLibUnusable) {
+            return;
+        }
+        protocolLibUnusable = true;
+        if (directPackets.isUsable()) {
+            plugin.getLogger().info("ProtocolLib cannot build this server's scoreboard packets, so money"
+                    + " nametags will be sent to players directly instead.");
             return;
         }
         packetsUnsupported = true;
-        plugin.getLogger().warning("Money nametags need scoreboard packets that the installed"
-                + " ProtocolLib understands, and it cannot build them on this server. The feature"
-                + " will stay off until ProtocolLib supports this Minecraft build.");
-        plugin.getLogger().log(Level.FINE, message, error);
+        plugin.getLogger().warning("Money nametags need scoreboard packets that neither ProtocolLib nor"
+                + " this server itself can build. The feature will stay off.");
     }
 
     /**
-     * Both reasons the packet path can be unusable, checked together everywhere the feature starts
-     * work. Once either is known the answer cannot change while the server is running.
+     * Every reason the packet path can be unusable, checked together everywhere the feature starts
+     * work. Once these are known the answer cannot change while the server is running.
      */
     private boolean isPacketPathUsable() {
-        return !packetsUnsupported && isNumberFormatSupported();
+        if (packetsUnsupported || (protocolLibUnusable && !directPackets.isUsable())) {
+            return false;
+        }
+        return isNumberFormatSupported();
     }
 
     private boolean send(Player viewer, PacketContainer packet) {
@@ -340,13 +353,8 @@ public class MoneyNametagManager {
         if (manager == null || viewer == null || !viewer.isOnline()) {
             return false;
         }
-        try {
-            manager.sendServerPacket(viewer, packet, false);
-            return true;
-        } catch (RuntimeException | LinkageError error) {
-            warnPacketFailure("Unable to send a money nametag packet.", error);
-            return false;
-        }
+        manager.sendServerPacket(viewer, packet, false);
+        return true;
     }
 
     /**
@@ -354,12 +362,8 @@ public class MoneyNametagManager {
      * showing fits into, so the feature stays off rather than printing a wrong number.
      */
     private boolean isNumberFormatSupported() {
-        try {
-            if (WrappedNumberFormat.isSupported()) {
-                return true;
-            }
-        } catch (RuntimeException | LinkageError ignored) {
-            // Treated the same as an unsupported server below.
+        if (protocolLibNumberFormats() || directPackets.isUsable()) {
+            return true;
         }
         if (!warnedUnsupported) {
             warnedUnsupported = true;
@@ -367,6 +371,14 @@ public class MoneyNametagManager {
                     + " formats (Minecraft 1.20.3 or newer). The feature will stay off.");
         }
         return false;
+    }
+
+    private boolean protocolLibNumberFormats() {
+        try {
+            return !protocolLibUnusable && WrappedNumberFormat.isSupported();
+        } catch (RuntimeException | LinkageError unsupportedServer) {
+            return false;
+        }
     }
 
     private ProtocolManager protocolManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PacketBelowNameRenderer.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PacketBelowNameRenderer.java
@@ -1,0 +1,516 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Criteria;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.Optional;
+import java.util.logging.Level;
+
+/**
+ * Builds the three below-name scoreboard packets out of the server's own classes.
+ *
+ * <p>ProtocolLib assembles these everywhere else in the plugin and is still the first thing tried,
+ * but it can only build a packet for a Minecraft build it has already been taught about. On a
+ * release it has not caught up with, the scoreboard packets refuse to instantiate at all and money
+ * nametags vanish even though nothing about the packets themselves changed. Reading the
+ * constructors off the running server instead survives a version bump on its own.</p>
+ *
+ * <p>The objective these packets carry is registered through the ordinary Bukkit scoreboard API, on
+ * a board no player is ever given, so the server hands over its own class rather than the plugin
+ * guessing at a name that differs between Spigot and Paper. Folia does not allow that API, so there
+ * the objective is built straight from the Mojang-mapped classes Folia always ships.</p>
+ */
+public final class PacketBelowNameRenderer {
+
+    /** The slot index the pre-1.20.2 display packet used for the line under the name. */
+    private static final int LEGACY_BELOW_NAME_SLOT = 2;
+
+    private final UltimateDonutSmp plugin;
+    private final String objectiveName;
+
+    private boolean resolved;
+    private volatile boolean unavailable;
+
+    private Object nmsObjective;
+    private Object belowNameSlot;
+    private Constructor<?> objectivePacket;
+    private Constructor<?> displayPacket;
+    private Constructor<?> scorePacket;
+    private Constructor<?> fixedFormat;
+    private int numberFormatIndex;
+
+    public PacketBelowNameRenderer(UltimateDonutSmp plugin, String objectiveName) {
+        this.plugin = plugin;
+        this.objectiveName = objectiveName;
+    }
+
+    /** Whether this server exposes everything the three packets need. Resolved once, then cached. */
+    public synchronized boolean isUsable() {
+        if (!resolved) {
+            resolved = true;
+            try {
+                resolve();
+            } catch (ReflectiveOperationException | RuntimeException | LinkageError failure) {
+                unavailable = true;
+                plugin.getLogger().log(Level.FINE, "Unable to read this server's scoreboard packets.", failure);
+            }
+        }
+        return !unavailable;
+    }
+
+    public boolean sendObjective(Player viewer, int method) {
+        return isUsable() && send(viewer, () -> build(objectivePacket, method, null));
+    }
+
+    public boolean sendDisplaySlot(Player viewer) {
+        return isUsable() && send(viewer, () -> build(displayPacket, LEGACY_BELOW_NAME_SLOT, belowNameSlot));
+    }
+
+    /** Sends one player's balance as the fixed number format attached to their score. */
+    public boolean sendScore(Player viewer, String owner, String legacyText) {
+        return isUsable() && send(viewer, () -> buildScore(owner, legacyText));
+    }
+
+    /**
+     * Fills a constructor from the handful of values these packets are made of. Which parameter
+     * takes what is decided by its declared type, because the order the objective, the slot and the
+     * mode appear in has changed between releases.
+     */
+    private Object build(Constructor<?> constructor, int number, Object slot) throws ReflectiveOperationException {
+        Class<?>[] parameters = constructor.getParameterTypes();
+        Object[] arguments = new Object[parameters.length];
+        for (int index = 0; index < parameters.length; index++) {
+            Class<?> parameter = parameters[index];
+            if (parameter == String.class) {
+                arguments[index] = objectiveName;
+            } else if (parameter == int.class || parameter == Integer.class) {
+                arguments[index] = number;
+            } else if (slot != null && parameter.isAssignableFrom(slot.getClass())) {
+                arguments[index] = slot;
+            } else if (parameter.isAssignableFrom(nmsObjective.getClass())) {
+                arguments[index] = nmsObjective;
+            } else {
+                throw new NoSuchMethodException(constructor.getDeclaringClass().getName());
+            }
+        }
+        return constructor.newInstance(arguments);
+    }
+
+    private Object buildScore(String owner, String legacyText) throws ReflectiveOperationException {
+        Class<?>[] parameters = scorePacket.getParameterTypes();
+        Object[] arguments = new Object[parameters.length];
+        int strings = 0;
+        int optionals = 0;
+        for (int index = 0; index < parameters.length; index++) {
+            Class<?> parameter = parameters[index];
+            if (parameter == String.class) {
+                arguments[index] = strings++ == 0 ? owner : objectiveName;
+            } else if (parameter == int.class || parameter == Integer.class) {
+                arguments[index] = 0;
+            } else {
+                arguments[index] = optionals++ == numberFormatIndex
+                        ? Optional.of(fixedFormat.newInstance(component(legacyText)))
+                        : Optional.empty();
+            }
+        }
+        return scorePacket.newInstance(arguments);
+    }
+
+    private boolean send(Player viewer, PacketSupplier supplier) {
+        if (viewer == null || !viewer.isOnline()) {
+            return false;
+        }
+        try {
+            Object packet = supplier.get();
+            Object connection = playerConnection(invoke(viewer, "getHandle"));
+            findSender(connection.getClass(), packet).invoke(connection, packet);
+            return true;
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError failure) {
+            unavailable = true;
+            plugin.getLogger().log(Level.FINE, "Unable to send a money nametag packet directly.", failure);
+            return false;
+        }
+    }
+
+    // ── Working out what this server calls things ──────────────────────────────
+
+    private void resolve() throws ReflectiveOperationException {
+        nmsObjective = createObjective();
+        objectivePacket = matchConstructor(
+                "net.minecraft.network.protocol.game.ClientboundSetObjectivePacket",
+                "net.minecraft.network.protocol.game.PacketPlayOutScoreboardObjective",
+                parameters -> takesObjectiveOrName(parameters) && takesNumber(parameters));
+        displayPacket = matchConstructor(
+                "net.minecraft.network.protocol.game.ClientboundSetDisplayObjectivePacket",
+                "net.minecraft.network.protocol.game.PacketPlayOutScoreboardDisplayObjective",
+                this::takesObjectiveOrName);
+        belowNameSlot = readBelowNameSlot(displayPacket);
+        resolveScorePacket();
+    }
+
+    private void resolveScorePacket() throws ReflectiveOperationException {
+        Class<?> type = loadClass(
+                "net.minecraft.network.protocol.game.ClientboundSetScorePacket",
+                "net.minecraft.network.protocol.game.PacketPlayOutScoreboardScore");
+        for (Constructor<?> candidate : type.getDeclaredConstructors()) {
+            int strings = 0;
+            int optionals = 0;
+            boolean number = false;
+            boolean usable = true;
+            for (Class<?> parameter : candidate.getParameterTypes()) {
+                if (parameter == String.class) {
+                    strings++;
+                } else if (parameter == int.class || parameter == Integer.class) {
+                    number = true;
+                } else if (parameter == Optional.class) {
+                    optionals++;
+                } else {
+                    usable = false;
+                    break;
+                }
+            }
+            if (usable && strings >= 2 && number && optionals >= 1) {
+                candidate.setAccessible(true);
+                scorePacket = candidate;
+                numberFormatIndex = numberFormatOptional(type, optionals);
+                fixedFormat = fixedFormatConstructor();
+                return;
+            }
+        }
+        throw new NoSuchMethodException(type.getName());
+    }
+
+    /**
+     * Which of the packet's optional fields holds the number format. The packet carries an optional
+     * display name as well, both are plain {@link Optional} to the constructor, and only the generic
+     * type tells them apart, so the field is picked by what it declares rather than by counting on an
+     * order that is Minecraft's business. Visible for tests, which stand a record in for the packet.
+     */
+    static int numberFormatOptional(Class<?> type, int optionals) {
+        RecordComponent[] components = type.getRecordComponents();
+        if (components != null) {
+            int seen = 0;
+            for (RecordComponent component : components) {
+                if (component.getType() != Optional.class) {
+                    continue;
+                }
+                if (component.getGenericType().getTypeName().contains("NumberFormat")) {
+                    return seen;
+                }
+                seen++;
+            }
+        }
+        return optionals - 1;
+    }
+
+    private Constructor<?> fixedFormatConstructor() throws ReflectiveOperationException {
+        Class<?> type = loadClass("net.minecraft.network.chat.numbers.FixedFormat");
+        Object sample = component("");
+        for (Constructor<?> candidate : type.getDeclaredConstructors()) {
+            Class<?>[] parameters = candidate.getParameterTypes();
+            if (parameters.length == 1 && parameters[0].isAssignableFrom(sample.getClass())) {
+                candidate.setAccessible(true);
+                return candidate;
+            }
+        }
+        throw new NoSuchMethodException(type.getName());
+    }
+
+    /**
+     * The enum constant for the line under the name, read off whichever parameter of the display
+     * packet carries the slot. Nothing is guessed here: an enum with no {@code BELOW_NAME} in it is
+     * not the slot, and a packet with no such parameter falls back to the older integer form.
+     */
+    private Object readBelowNameSlot(Constructor<?> constructor) {
+        for (Class<?> parameter : constructor.getParameterTypes()) {
+            if (!parameter.isEnum()) {
+                continue;
+            }
+            for (Object constant : parameter.getEnumConstants()) {
+                if (constant instanceof Enum<?> value && value.name().equalsIgnoreCase("BELOW_NAME")) {
+                    return constant;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Constructor<?> matchConstructor(String mojang, String spigot, ParameterTest test)
+            throws ReflectiveOperationException {
+        Class<?> type = loadClass(mojang, spigot);
+        for (Constructor<?> candidate : type.getDeclaredConstructors()) {
+            Class<?>[] parameters = candidate.getParameterTypes();
+            if (isBuildable(parameters) && test.matches(parameters)) {
+                candidate.setAccessible(true);
+                return candidate;
+            }
+        }
+        throw new NoSuchMethodException(type.getName());
+    }
+
+    private boolean isBuildable(Class<?>[] parameters) {
+        if (parameters.length == 0) {
+            return false;
+        }
+        for (Class<?> parameter : parameters) {
+            boolean known = parameter == String.class
+                    || parameter == int.class
+                    || parameter == Integer.class
+                    || parameter.isEnum()
+                    || parameter.isAssignableFrom(nmsObjective.getClass());
+            if (!known) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean takesObjectiveOrName(Class<?>[] parameters) {
+        for (Class<?> parameter : parameters) {
+            if (parameter == String.class
+                    || (!parameter.isEnum() && parameter.isAssignableFrom(nmsObjective.getClass()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean takesNumber(Class<?>[] parameters) {
+        for (Class<?> parameter : parameters) {
+            if (parameter == int.class || parameter == Integer.class) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ── The objective the packets are built around ─────────────────────────────
+
+    /**
+     * Registers the objective on a throwaway board and unwraps the server's own object out of it.
+     * That board is never handed to a player, so nothing about it reaches a client except through
+     * the packets above.
+     */
+    private Object createObjective() throws ReflectiveOperationException {
+        try {
+            org.bukkit.scoreboard.ScoreboardManager manager = Bukkit.getScoreboardManager();
+            if (manager != null) {
+                Scoreboard board = manager.getNewScoreboard();
+                Objective objective = board.registerNewObjective(objectiveName, Criteria.DUMMY, "");
+                Object handle = unwrap(objective);
+                if (handle != null) {
+                    return handle;
+                }
+            }
+        } catch (RuntimeException | LinkageError foliaOrOlderServer) {
+            plugin.getLogger().log(Level.FINE,
+                    "Building the money nametag objective directly instead.", foliaOrOlderServer);
+        }
+        return createObjectiveDirectly();
+    }
+
+    private Object unwrap(Objective objective) throws ReflectiveOperationException {
+        for (Class<?> type = objective.getClass(); type != null; type = type.getSuperclass()) {
+            for (Field field : type.getDeclaredFields()) {
+                if (!field.getType().getName().startsWith("net.minecraft")) {
+                    continue;
+                }
+                field.setAccessible(true);
+                Object value = field.get(objective);
+                if (value != null) {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** The Folia path: no Bukkit scoreboards there, so the objective is put together by hand. */
+    private Object createObjectiveDirectly() throws ReflectiveOperationException {
+        Class<?> scoreboardType = loadClass("net.minecraft.world.scores.Scoreboard");
+        Class<?> objectiveType = loadClass("net.minecraft.world.scores.Objective");
+        Object scoreboard = scoreboardType.getDeclaredConstructor().newInstance();
+        Object criteria = staticField("net.minecraft.world.scores.criteria.ObjectiveCriteria", "DUMMY");
+        Object renderType = enumConstant(
+                "net.minecraft.world.scores.criteria.ObjectiveCriteria$RenderType", "INTEGER");
+        Object displayName = component("");
+
+        for (Constructor<?> candidate : objectiveType.getDeclaredConstructors()) {
+            Object[] arguments = objectiveArguments(
+                    candidate.getParameterTypes(), scoreboard, criteria, renderType, displayName);
+            if (arguments != null) {
+                candidate.setAccessible(true);
+                return candidate.newInstance(arguments);
+            }
+        }
+        throw new NoSuchMethodException(objectiveType.getName());
+    }
+
+    private Object[] objectiveArguments(
+            Class<?>[] parameters, Object scoreboard, Object criteria, Object renderType, Object displayName) {
+        Object[] arguments = new Object[parameters.length];
+        boolean named = false;
+        for (int index = 0; index < parameters.length; index++) {
+            Class<?> parameter = parameters[index];
+            if (parameter == String.class) {
+                arguments[index] = objectiveName;
+                named = true;
+            } else if (parameter.isAssignableFrom(scoreboard.getClass())) {
+                arguments[index] = scoreboard;
+            } else if (criteria != null && parameter.isAssignableFrom(criteria.getClass())) {
+                arguments[index] = criteria;
+            } else if (renderType != null && parameter.isAssignableFrom(renderType.getClass())) {
+                arguments[index] = renderType;
+            } else if (parameter.isAssignableFrom(displayName.getClass())) {
+                arguments[index] = displayName;
+            } else if (parameter == boolean.class || parameter == Boolean.class) {
+                arguments[index] = false;
+            } else if (parameter == Optional.class) {
+                arguments[index] = Optional.empty();
+            } else if (parameter.isPrimitive()) {
+                return null;
+            } else {
+                arguments[index] = null;
+            }
+        }
+        return named ? arguments : null;
+    }
+
+    // ── Small reflective helpers ───────────────────────────────────────────────
+
+    /** Turns legacy colour codes into whatever this server's chat component class is. */
+    private Object component(String legacyText) throws ReflectiveOperationException {
+        String text = legacyText == null ? "" : legacyText;
+        Class<?> chatMessage = optionalClass(
+                plugin.getServer().getClass().getPackage().getName() + ".util.CraftChatMessage",
+                "org.bukkit.craftbukkit.util.CraftChatMessage");
+        if (chatMessage != null) {
+            for (Method method : chatMessage.getDeclaredMethods()) {
+                if (!method.getName().equals("fromStringOrNull") || method.getParameterCount() != 1) {
+                    continue;
+                }
+                method.setAccessible(true);
+                Object component = method.invoke(null, text);
+                if (component != null) {
+                    return component;
+                }
+            }
+        }
+        Class<?> componentType = loadClass(
+                "net.minecraft.network.chat.Component", "net.minecraft.network.chat.IChatBaseComponent");
+        return componentType.getMethod("literal", String.class).invoke(null, text);
+    }
+
+    private Object playerConnection(Object handle) throws ReflectiveOperationException {
+        for (Class<?> type = handle.getClass(); type != null; type = type.getSuperclass()) {
+            for (Field field : type.getDeclaredFields()) {
+                if (!field.getType().getName().startsWith("net.minecraft.server.network.")) {
+                    continue;
+                }
+                field.setAccessible(true);
+                Object value = field.get(handle);
+                if (value != null && findSenderOrNull(value.getClass()) != null) {
+                    return value;
+                }
+            }
+        }
+        throw new NoSuchFieldException("player connection");
+    }
+
+    private Method findSender(Class<?> type, Object packet) throws ReflectiveOperationException {
+        Method sender = findSenderOrNull(type);
+        if (sender == null || !sender.getParameterTypes()[0].isAssignableFrom(packet.getClass())) {
+            throw new NoSuchMethodException("send");
+        }
+        return sender;
+    }
+
+    private Method findSenderOrNull(Class<?> type) {
+        for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+            for (Method method : current.getDeclaredMethods()) {
+                String name = method.getName();
+                if (method.getParameterCount() != 1 || (!name.equals("send") && !name.equals("sendPacket"))) {
+                    continue;
+                }
+                if (method.getParameterTypes()[0].getName().endsWith("Packet")) {
+                    method.setAccessible(true);
+                    return method;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Object invoke(Object target, String name) throws ReflectiveOperationException {
+        for (Class<?> type = target.getClass(); type != null; type = type.getSuperclass()) {
+            for (Method method : type.getDeclaredMethods()) {
+                if (method.getParameterCount() == 0 && method.getName().equals(name)) {
+                    method.setAccessible(true);
+                    return method.invoke(target);
+                }
+            }
+        }
+        throw new NoSuchMethodException(name);
+    }
+
+    private Object staticField(String className, String name) throws ReflectiveOperationException {
+        Class<?> type = optionalClass(className);
+        if (type == null) {
+            return null;
+        }
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    private Object enumConstant(String className, String name) {
+        Class<?> type = optionalClass(className);
+        if (type == null || !type.isEnum()) {
+            return null;
+        }
+        for (Object constant : type.getEnumConstants()) {
+            if (constant instanceof Enum<?> value && value.name().equalsIgnoreCase(name)) {
+                return constant;
+            }
+        }
+        return null;
+    }
+
+    private Class<?> loadClass(String... names) throws ClassNotFoundException {
+        Class<?> type = optionalClass(names);
+        if (type == null) {
+            throw new ClassNotFoundException(String.join(", ", names));
+        }
+        return type;
+    }
+
+    private Class<?> optionalClass(String... names) {
+        ClassLoader loader = plugin.getServer().getClass().getClassLoader();
+        for (String name : names) {
+            try {
+                return Class.forName(name, false, loader);
+            } catch (ClassNotFoundException | LinkageError ignored) {
+                // Tried again under the next name this server might use.
+            }
+        }
+        return null;
+    }
+
+    @FunctionalInterface
+    private interface PacketSupplier {
+        Object get() throws ReflectiveOperationException;
+    }
+
+    @FunctionalInterface
+    private interface ParameterTest {
+        boolean matches(Class<?>[] parameters);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -386,7 +386,7 @@ MONEY-NAMETAGS:
   ENABLED: true
   # The text or value for Format. Supports {balance} and PlaceholderAPI placeholders.
   # Available options: Any valid string text
-  FORMAT: '&a${balance}'
+  FORMAT: '&a$ &f{balance}'
   # Determines whether balances are shortened to 1.1K, 1.1M, 1.1B and so on instead of
   # being written out as 1,100,000. Available options: true, false
   SHORT-FORMAT: true

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MoneyNametagConfigurationTest.java
@@ -40,6 +40,12 @@ class MoneyNametagConfigurationTest {
     }
 
     @Test
+    void theShippedFormatPutsAGreenSignInFrontOfAWhiteAmount() {
+        assertEquals("&a$ &f884M", MoneyNametagManager.render("&a$ &f{balance}", 884_000_000D, true));
+        assertEquals("&a$ &f884,000,000", MoneyNametagManager.render("&a$ &f{balance}", 884_000_000D, false));
+    }
+
+    @Test
     void aFormatWithoutThePlaceholderIsLeftAlone() {
         assertEquals("&7Balance hidden", MoneyNametagManager.render("&7Balance hidden", 1_000D, false));
         assertEquals("1,000", MoneyNametagManager.render(null, 1_000D, false));
@@ -52,7 +58,7 @@ class MoneyNametagConfigurationTest {
 
         assertTrue(config.isConfigurationSection("MONEY-NAMETAGS"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.ENABLED"));
-        assertEquals("&a${balance}", config.getString("MONEY-NAMETAGS.FORMAT"));
+        assertEquals("&a$ &f{balance}", config.getString("MONEY-NAMETAGS.FORMAT"));
         assertTrue(config.getBoolean("MONEY-NAMETAGS.SHORT-FORMAT"));
         assertEquals(10, config.getInt("MONEY-NAMETAGS.UPDATE-INTERVAL-TICKS"));
 

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/PacketBelowNameRendererTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/PacketBelowNameRendererTest.java
@@ -1,0 +1,51 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The score packet carries two optionals and the constructor sees both as bare {@link Optional},
+ * so the balance can only be put in the right one by reading what the field declares. These stand a
+ * record in for the packet, in the shapes Minecraft has shipped it in.
+ */
+class PacketBelowNameRendererTest {
+
+    /** Stand-in for a number format, named so the generic type reads the way Minecraft's does. */
+    private interface NumberFormat {
+    }
+
+    private record ScorePacket(String owner, String objectiveName, int score,
+                               Optional<String> display, Optional<NumberFormat> numberFormat) {
+    }
+
+    private record ReorderedScorePacket(String owner, String objectiveName, int score,
+                                        Optional<NumberFormat> numberFormat, Optional<String> display) {
+    }
+
+    private record DisplayOnlyScorePacket(String owner, String objectiveName, int score,
+                                          Optional<String> display) {
+    }
+
+    @Test
+    void theBalanceGoesInTheOptionalThatDeclaresANumberFormat() {
+        assertEquals(1, PacketBelowNameRenderer.numberFormatOptional(ScorePacket.class, 2));
+    }
+
+    @Test
+    void reorderingTheOptionalsMovesTheBalanceWithThem() {
+        assertEquals(0, PacketBelowNameRenderer.numberFormatOptional(ReorderedScorePacket.class, 2));
+    }
+
+    @Test
+    void aPacketWithNoNumberFormatFallsBackToTheLastOptional() {
+        assertEquals(0, PacketBelowNameRenderer.numberFormatOptional(DisplayOnlyScorePacket.class, 1));
+    }
+
+    @Test
+    void aPacketThatIsNotARecordFallsBackToTheLastOptional() {
+        assertEquals(1, PacketBelowNameRenderer.numberFormatOptional(String.class, 2));
+    }
+}


### PR DESCRIPTION
Closes #245

Money nametags have never worked on Minecraft 26.2. Turning the option on in `/settings` saves fine and the menu happily reports it as enabled, but no balance shows up under anyone, because the first packet the feature needs never gets built at all. ProtocolLib can only assemble a packet for a Minecraft version somebody has taught it about, and on 26.2 it throws `IllegalArgumentException: Cannot create instance of class ClientboundSetObjectivePacket` long before we get anywhere near a client. That trace is what #212 was about; the fix there stopped the console spam and made the feature switch itself off quietly, which is why #245 arrives with an empty log box.

Waiting for ProtocolLib is not much of a plan, so the feature now falls back to reading the packets off the server itself.

## The standby path

`PacketBelowNameRenderer` builds the same three packets out of whatever classes the running server actually has: create the objective, put it in the below-name slot, then send a score carrying the balance as a fixed number format. Constructors are matched by the types they declare rather than by position, since the order the objective, the slot and the mode appear in has moved around between releases.

The objective those packets carry comes from an ordinary `registerNewObjective` call on a scoreboard no player is ever given, so the server hands over its own class instead of the plugin hardcoding a name that differs between Spigot and Paper. Folia rejects that API, and there the objective gets assembled by hand from the Mojang-mapped classes Folia always ships.

The one genuinely fiddly bit is the score packet. It carries two optional fields, an optional display name and an optional number format, and a constructor sees both as a bare `Optional`. Put the balance in the wrong one and the line draws nothing at all. The right field gets picked by reading the record component's generic type, which is the same trick the ProtocolLib path already used.

## When it kicks in

Nothing changes on a server where ProtocolLib is happy: it stays the first thing tried, and the direct path never even gets resolved. The first refusal flips `protocolLibUnusable`, logs one INFO line saying where nametags are coming from now, and everything after that goes direct. Only a server where neither can build the packets loses the feature, and that case keeps the warning it had before.

`send` no longer swallows its own exceptions, since the caller has to know a send failed before it can fall back.

## The DonutSMP look

The second half of the report asked for the line to match DonutSMP, which puts a green `$` against a white amount rather than the all-green line we shipped. That is only the format string, so the default moves from `'&a${balance}'` to `'&a$ &f{balance}'`. Config merging leaves keys that already exist alone, so this reaches new installs only and anyone else has to edit the value themselves.

## Notes

- Four tests over the optional-picking logic, using records that stand in for the packet in the shapes Minecraft has shipped it in, plus one over the new default rendering `&a$ &f884M`.
- `MoneyNametagConfigurationTest` and the `MONEY-NAMETAGS` page under `docs/wiki/` follow the new default.
- No config keys added and no language keys touched. 367 tests pass.
- Nothing here goes near `plugin.yml`. ProtocolLib stays a hard `depend`, and the rest of the plugin still uses it.
