### PR TITLE
feat(cuboids): set the spawn point of a cuboid (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/crate` | - | `/crate <create\|delete\|type\|open\|keys\|reload\|key\|take\|set\|keyall\|add\|edit\|remove\|bind\|unbind\|info>` | `ultimatedonutsmp.command.crate` |
 | `/crates` | - | `/crates` | `ultimatedonutsmp.command.crates` |
 | `/create` | - | `/create <invite\|friends> <player> [map]` | `ultimatedonutsmp.command.create` |
-| `/cuboid` | - | `/cuboid <wand\|create\|delete\|list\|bind <cuboid> <spawn\|shard\|rtp-zone> <true\|false>\|reload>` | `ultimatedonutsmp.command.cuboid` |
+| `/cuboid` | - | `/cuboid <wand\|create\|delete\|list\|setspawn\|delspawn\|bind <cuboid> <spawn\|shard\|rtp-zone> <true\|false>\|reload>` | `ultimatedonutsmp.command.cuboid` |
 | `/delhome` | - | `/delhome <name>` | `ultimatedonutsmp.command.delhome` |
 | `/delwarp` | - | `/delwarp <name>` | `ultimatedonutsmp.command.delwarp` |
 | `/discord` | - | `/discord` | `ultimatedonutsmp.command.discord` |

--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -87,7 +87,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 
 | Command | Usage Syntax | Description | Permission Node |
 | :--- | :--- | :--- | :--- |
-| `/cuboid` | `/cuboid <wand\|create <name>\|delete <name>\|list\|bind ...>` | Region selection & feature binding | `ultimatedonutsmp.admin.cuboid` |
+| `/cuboid` | `/cuboid <wand\|create <name>\|delete <name>\|list\|setspawn <name>\|delspawn <name>\|bind ...>` | Region selection & feature binding | `ultimatedonutsmp.admin.cuboid` |
 | `/portal` | `/portal <create\|delete\|list\|setcuboid\|setdestination>` | Custom portal trigger setup | `ultimatedonutsmp.admin.portal` |
 | `/arena` | `/arena <create\|delete\|setpos1\|setpos2\|setreturn\|enable>` | Duel arena setup and configuration | `ultimatedonutsmp.admin.arena` |
 | `/ffaarena` | `/ffaarena <create\|delete\|setpos\|enable>` | Instanced FFA arena management | `ultimatedonutsmp.admin.ffaarena` |

--- a/docs/wiki/Cuboids-and-Portals.md
+++ b/docs/wiki/Cuboids-and-Portals.md
@@ -31,6 +31,43 @@ To view all defined cuboids:
 /cuboid list
 ```
 
+### 3. Choosing Where Players Land
+
+Anything that teleports a player into a cuboid — `/spawn`, a spawn or AFK menu area, the shard AFK
+zone — normally aims for the middle of the region and looks downwards for the first block that is
+safe to stand on. On a hand-built spawn that is rarely the spot you want, and players always arrive
+facing the same direction.
+
+Stand exactly where players should appear, look the way they should be facing, and save it:
+
+```bash
+/cuboid setspawn <name>
+```
+
+*Example*: `/cuboid setspawn spawn_zone`
+
+The position has to be inside the cuboid, otherwise players would land outside the protection the
+region gives them. Your facing is stored along with the coordinates.
+
+To go back to the automatic middle-of-the-region spot:
+
+```bash
+/cuboid delspawn <name>
+```
+
+Saved points live under `CUBOID-SPAWNS` in `config.yml`, keyed by cuboid name:
+
+```yaml
+CUBOID-SPAWNS:
+  spawn_zone: world,128.5,71.0,-64.5,90.0,0.0
+```
+
+Deleting a cuboid removes its spawn point too, and redefining one with the wand clears the old point
+if the new corners no longer cover it.
+
+If a spawn menu area has its own `LOCATION` in `menus.yml`, that still wins for that menu button —
+the cuboid spawn point is the fallback everything else uses.
+
 ---
 
 ## Binding Cuboids to Systems (`/cuboid bind`)

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
@@ -56,6 +56,8 @@ public class CuboidCommand implements CommandExecutor {
             case "delete" -> deleteCuboid(player, args);
             case "list" -> listCuboids(player);
             case "bind", "system" -> bindCuboidSystem(player, args);
+            case "setspawn" -> setCuboidSpawn(player, args);
+            case "delspawn" -> deleteCuboidSpawn(player, args);
             default -> sendUsage(player);
         }
         return true;
@@ -98,6 +100,70 @@ public class CuboidCommand implements CommandExecutor {
         Location[] selection = plugin.getCuboidManager().getSelection(player.getUniqueId());
         plugin.getCuboidManager().addCuboid(args[1], selection[0], selection[1]);
         player.sendMessage(ColorUtils.toComponent("&aCuboid &b" + args[1] + " &ahas been created."));
+
+        if (plugin.getCuboidManager().dropSpawnOutsideBounds(args[1]) && plugin.getConfigManager().saveConfig()) {
+            plugin.reloadAllPluginConfigurations();
+            player.sendMessage(ColorUtils.toComponent(
+                    "&7Its old spawn point was outside the new corners, so it has been cleared."
+            ));
+        }
+    }
+
+    private void setCuboidSpawn(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid setspawn <name>"));
+            return;
+        }
+
+        String cuboidName = args[1].toLowerCase();
+        var cuboid = plugin.getCuboidManager().getCuboid(cuboidName);
+        if (cuboid == null) {
+            player.sendMessage(ColorUtils.toComponent("&cCuboid not found: &f" + args[1]));
+            return;
+        }
+
+        Location location = player.getLocation();
+        if (!cuboid.contains(location)) {
+            player.sendMessage(ColorUtils.toComponent(
+                    "&cStand inside &b" + cuboidName + " &cfirst. &7Its spawn point has to be within the region."
+            ));
+            return;
+        }
+
+        plugin.getCuboidManager().setCuboidSpawn(cuboidName, location);
+        if (!plugin.getConfigManager().saveConfig()) {
+            player.sendMessage(ColorUtils.toComponent("&cFailed to save config.yml."));
+            return;
+        }
+        plugin.reloadAllPluginConfigurations();
+        player.sendMessage(ColorUtils.toComponent(
+                "&aCuboid &b" + cuboidName + " &anow spawns players where you are standing. &7(X: &f"
+                        + String.format("%.1f", location.getX()) + "&7, Y: &f"
+                        + String.format("%.1f", location.getY()) + "&7, Z: &f"
+                        + String.format("%.1f", location.getZ()) + "&7)"
+        ));
+    }
+
+    private void deleteCuboidSpawn(Player player, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid delspawn <name>"));
+            return;
+        }
+
+        String cuboidName = args[1].toLowerCase();
+        if (!plugin.getCuboidManager().clearCuboidSpawn(cuboidName)) {
+            player.sendMessage(ColorUtils.toComponent("&cCuboid &b" + args[1] + " &chas no spawn point saved."));
+            return;
+        }
+
+        if (!plugin.getConfigManager().saveConfig()) {
+            player.sendMessage(ColorUtils.toComponent("&cFailed to save config.yml."));
+            return;
+        }
+        plugin.reloadAllPluginConfigurations();
+        player.sendMessage(ColorUtils.toComponent(
+                "&aSpawn point for &b" + cuboidName + " &aremoved. &7Players land near the middle of the region again."
+        ));
     }
 
     private void deleteCuboid(Player player, String[] args) {
@@ -210,6 +276,7 @@ public class CuboidCommand implements CommandExecutor {
 
     private void clearDeletedCuboidReferences(String cuboidName) {
         FileConfiguration config = plugin.getConfigManager().getConfig();
+        plugin.getCuboidManager().clearCuboidSpawn(cuboidName);
         updateBindList(config, "CUBOID-BINDS.SPAWN", cuboidName, false);
         updateBindList(config, "CUBOID-BINDS.AFK", cuboidName, false);
 
@@ -259,6 +326,6 @@ public class CuboidCommand implements CommandExecutor {
     }
 
     private void sendUsage(CommandSender sender) {
-        sender.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid <wand|create <name>|delete <name>|list|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>"));
+        sender.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid <wand|create <name>|delete <name>|list|setspawn <name>|delspawn <name>|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>"));
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CuboidManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CuboidManager.java
@@ -1,11 +1,13 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.LocationUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -17,18 +19,14 @@ public class CuboidManager {
 
     public record Cuboid(String world, int x1, int y1, int z1, int x2, int y2, int z2) {
         public boolean contains(Location loc) {
-            if (loc.getWorld() == null || !loc.getWorld().getName().equalsIgnoreCase(world)) {
+            if (loc.getWorld() == null) {
                 return false;
             }
-
-            int x = loc.getBlockX();
-            int y = loc.getBlockY();
-            int z = loc.getBlockZ();
-            return x >= Math.min(x1, x2) && x <= Math.max(x1, x2)
-                    && y >= Math.min(y1, y2) && y <= Math.max(y1, y2)
-                    && z >= Math.min(z1, z2) && z <= Math.max(z1, z2);
+            return isInside(this, loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
         }
     }
+
+    private static final String SPAWN_SECTION = "CUBOID-SPAWNS";
 
     private final UltimateDonutSmp plugin;
     private final Map<String, Cuboid> cuboids = new HashMap<>();
@@ -129,10 +127,100 @@ public class CuboidManager {
         return new Location(world, centerX, centerY, centerZ);
     }
 
+    /**
+     * The spawn point an admin saved with /cuboid setspawn, or null when there is none. A point that
+     * no longer sits inside the region counts as none, so redefining a cuboid can never leave players
+     * landing outside it.
+     */
+    public Location getCuboidSpawn(String name) {
+        Cuboid cuboid = getCuboid(name);
+        if (cuboid == null) {
+            return null;
+        }
+
+        String serialized = plugin.getConfigManager().getConfig().getString(spawnPath(name));
+        if (!spawnFitsCuboid(cuboid, serialized)) {
+            return null;
+        }
+        return LocationUtils.parse(serialized);
+    }
+
+    public void setCuboidSpawn(String name, Location location) {
+        plugin.getConfigManager().getConfig().set(spawnPath(name), LocationUtils.serialize(location));
+    }
+
+    public boolean clearCuboidSpawn(String name) {
+        String path = spawnPath(name);
+        FileConfiguration config = plugin.getConfigManager().getConfig();
+        if (config.getString(path) == null) {
+            return false;
+        }
+        config.set(path, null);
+        return true;
+    }
+
+    /**
+     * Drops a saved spawn point that the region no longer covers. Recreating a cuboid under a name
+     * that already had one is the way that happens.
+     */
+    public boolean dropSpawnOutsideBounds(String name) {
+        String serialized = plugin.getConfigManager().getConfig().getString(spawnPath(name));
+        if (serialized == null || serialized.isBlank() || spawnFitsCuboid(getCuboid(name), serialized)) {
+            return false;
+        }
+        return clearCuboidSpawn(name);
+    }
+
+    static String spawnPath(String name) {
+        return SPAWN_SECTION + "." + (name == null ? "" : name.toLowerCase());
+    }
+
+    /**
+     * Bounds check on a serialized location, so a stored spawn can be judged without the world being
+     * loaded. Only the feet block has to be inside, matching how the automatic teleport spot is picked.
+     */
+    static boolean spawnFitsCuboid(Cuboid cuboid, String serialized) {
+        if (cuboid == null || serialized == null || serialized.isBlank()) {
+            return false;
+        }
+
+        String[] parts = serialized.split(",");
+        if (parts.length < 4) {
+            return false;
+        }
+
+        try {
+            return isInside(
+                    cuboid,
+                    parts[0].trim(),
+                    (int) Math.floor(Double.parseDouble(parts[1].trim())),
+                    (int) Math.floor(Double.parseDouble(parts[2].trim())),
+                    (int) Math.floor(Double.parseDouble(parts[3].trim()))
+            );
+        } catch (NumberFormatException exception) {
+            return false;
+        }
+    }
+
+    static boolean isInside(Cuboid cuboid, String worldName, int x, int y, int z) {
+        if (cuboid == null || worldName == null || !worldName.equalsIgnoreCase(cuboid.world())) {
+            return false;
+        }
+
+        return x >= Math.min(cuboid.x1(), cuboid.x2()) && x <= Math.max(cuboid.x1(), cuboid.x2())
+                && y >= Math.min(cuboid.y1(), cuboid.y2()) && y <= Math.max(cuboid.y1(), cuboid.y2())
+                && z >= Math.min(cuboid.z1(), cuboid.z2()) && z <= Math.max(cuboid.z1(), cuboid.z2());
+    }
+
     public Location getCuboidTeleportLocation(String name) {
         Cuboid cuboid = getCuboid(name);
         if (cuboid == null) {
             return null;
+        }
+
+        Location savedSpawn = getCuboidSpawn(name);
+        if (savedSpawn != null) {
+            return savedSpawn;
         }
 
         World world = Bukkit.getWorld(cuboid.world());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -638,7 +638,7 @@ commands:
     permission-message: "&cYou do not have permission to use /clearlag."
   cuboid:
     description: Manage cuboid regions
-    usage: /cuboid <wand|create|delete|list|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>
+    usage: /cuboid <wand|create|delete|list|setspawn|delspawn|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>
     permission: ultimatedonutsmp.command.cuboid
     permission-message: "&cYou do not have permission to use /cuboid."
   setwarp:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/CuboidSpawnPointTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/CuboidSpawnPointTest.java
@@ -1,0 +1,77 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.managers.CuboidManager.Cuboid;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CuboidSpawnPointTest {
+
+    private static final Cuboid SPAWN_ZONE = new Cuboid("world", 10, 60, 10, -10, 80, -10);
+
+    @Test
+    void aPointWithinTheCornersBelongsToTheCuboid() {
+        assertTrue(CuboidManager.isInside(SPAWN_ZONE, "world", 0, 70, 0));
+        assertTrue(CuboidManager.isInside(SPAWN_ZONE, "world", -10, 60, 10));
+        assertTrue(CuboidManager.isInside(SPAWN_ZONE, "world", 10, 80, -10));
+    }
+
+    @Test
+    void theCornersAreReadInEitherOrder() {
+        Cuboid flipped = new Cuboid("world", -10, 80, -10, 10, 60, 10);
+        assertTrue(CuboidManager.isInside(flipped, "world", 0, 70, 0));
+        assertFalse(CuboidManager.isInside(flipped, "world", 0, 59, 0));
+    }
+
+    @Test
+    void aPointOutsideTheCornersOrInAnotherWorldDoesNot() {
+        assertFalse(CuboidManager.isInside(SPAWN_ZONE, "world", 11, 70, 0));
+        assertFalse(CuboidManager.isInside(SPAWN_ZONE, "world", 0, 81, 0));
+        assertFalse(CuboidManager.isInside(SPAWN_ZONE, "world_nether", 0, 70, 0));
+        assertFalse(CuboidManager.isInside(SPAWN_ZONE, null, 0, 70, 0));
+        assertFalse(CuboidManager.isInside(null, "world", 0, 70, 0));
+    }
+
+    @Test
+    void worldNamesAreMatchedWithoutRegardForCase() {
+        assertTrue(CuboidManager.isInside(SPAWN_ZONE, "WORLD", 0, 70, 0));
+    }
+
+    @Test
+    void aSavedSpawnIsJudgedByTheBlockItStandsOn() {
+        assertTrue(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,0.5,70.0,0.5,90.0,0.0"));
+        assertTrue(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,10.9,60.0,10.9,0.0,0.0"));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,11.0,70.0,0.5,0.0,0.0"));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,-10.5,70.0,0.5,0.0,0.0"));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world_nether,0.5,70.0,0.5,0.0,0.0"));
+    }
+
+    @Test
+    void anUnreadableSavedSpawnCountsAsNoSpawnAtAll() {
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, null));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, ""));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,0.5,70.0"));
+        assertFalse(CuboidManager.spawnFitsCuboid(SPAWN_ZONE, "world,here,70.0,0.5"));
+        assertFalse(CuboidManager.spawnFitsCuboid(null, "world,0.5,70.0,0.5,0.0,0.0"));
+    }
+
+    @Test
+    void spawnPointsAreStoredUnderTheLowercaseCuboidName() {
+        assertEquals("CUBOID-SPAWNS.spawn_zone", CuboidManager.spawnPath("Spawn_Zone"));
+        assertEquals("CUBOID-SPAWNS.spawn_zone", CuboidManager.spawnPath("spawn_zone"));
+    }
+
+    @Test
+    void pluginMetadataAdvertisesBothSubcommands() {
+        YamlConfiguration pluginYaml = YamlConfiguration.loadConfiguration(new File("src/main/resources/plugin.yml"));
+
+        String usage = pluginYaml.getString("commands.cuboid.usage", "");
+        assertTrue(usage.contains("setspawn"), "usage should mention setspawn: " + usage);
+        assertTrue(usage.contains("delspawn"), "usage should mention delspawn: " + usage);
+    }
+}


### PR DESCRIPTION
Closes #244

Cuboids had no spawn point of their own. Anything that teleported a player into one (`/spawn`, a spawn or AFK menu button, the shard AFK zone) aimed at the middle of the region and searched downwards for the first block safe to stand on, so on a hand-built spawn players tended to land on a roof, or in whatever corner the scan stopped in, always facing yaw 0. `/cuboid setspawn <name>` saves where the admin is standing instead, facing included.

## The command

`/cuboid setspawn <name>` stores the sender's exact position under `CUBOID-SPAWNS.<name>` in `config.yml`, using the same format as every other saved location in the plugin, so yaw and pitch come along with it. The position has to be inside the cuboid. A point outside would drop players beyond the protection and flight rules the region exists to give them, so the command refuses and says why instead of saving something that quietly misbehaves later.

`/cuboid delspawn <name>` clears it and hands the region back to the automatic search.

## Where it takes effect

`CuboidManager.getCuboidTeleportLocation` was already the one place every cuboid teleport went through, so the saved point slots in at the front of it and everything downstream picks it up with no other changes: the spawn and AFK menu areas in `SpawnManager`, `resolveBoundCuboidDestination`, and `ShardManager`'s AFK teleport.

A per-area `LOCATION` in `menus.yml` still wins over the cuboid spawn point. That override is admin-authored and more specific, and `SpawnManager` already read it first.

## Keeping the point honest

The bounds check runs when the point is read, not only when somebody writes it, so a stale point can never send anybody outside the region. Recreating a cuboid with the wand runs that check straight away and drops the old point if the new corners no longer cover it, with a line in chat so the admin knows it went. Deleting a cuboid takes its spawn point along with the bind lists `clearDeletedCuboidReferences` already cleaned up.

That check reads the stored string directly instead of going through Bukkit, so an unloaded world counts as "cannot tell" and leaves the saved point alone rather than throwing it away.

## Notes

- Servers that never run the command see no change at all; with nothing saved, `getCuboidTeleportLocation` behaves as it did before.
- `CUBOID-SPAWNS` is not in the bundled `config.yml`. Its keys are live cuboid names, so there is no default tree to ship and nothing for the config merger to put back, and the section appears the first time somebody saves a spawn point.
- The saved point still passes through `SpawnManager.makeSafeDestination` like every other destination, so a world that changes under it will not put anyone inside lava.
- `Cuboid.contains` and the new bounds check now share one implementation rather than carrying two copies of the same maths.
- `docs/wiki/Cuboids-and-Portals.md` gained a section on choosing where players land, and the `/cuboid` usage line in `plugin.yml`, `README.md` and the commands page lists both subcommands.
- `CuboidSpawnPointTest` covers the bounds maths, corner ordering either way round, block flooring on negative coordinates, unreadable stored values, and the usage line. Suite is 375 tests, all green.
