### PR TITLE
feat(worth): rotate a farming meta that boosts one item at a time (#246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/leave` | - | `/leave` | `ultimatedonutsmp.command.leave` |
 | `/logs` | - | `/logs` | `ultimatedonutsmp.command.logs` |
 | `/maintenance` | - | `/maintenance <on\|off\|status\|setlobby [server]>` | `ultimatedonutsmp.command.maintenance` |
+| `/meta` | `/farmingmeta` | `/meta` | `ultimatedonutsmp.command.meta` |
 | `/msg` | `/message`, `/tell`, `/whisper`, `/w` | `/msg <player> <message>` | `ultimatedonutsmp.command.msg` |
 | `/mute` | - | `/mute <player> [reason]` | `ultimatedonutsmp.command.mute` |
 | `/nightvision` | `/nv` | `/nightvision` | `ultimatedonutsmp.command.nightvision` |

--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -37,6 +37,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/sellmultiplier` | `/sellmultiplier [category]` | None | Open sell multiplier menu | `ultimatedonutsmp.command.sellmulti` |
 | `/sellprogress` | `/sellprogress [category]` | None | Open sell multiplier progress menu | `ultimatedonutsmp.command.sellprogress` |
 | `/worth` | `/worth [hand]` | `/prices` | Check worth of held item or open price catalog | `ultimatedonutsmp.command.worth` |
+| `/meta` | `/meta` | `/farmingmeta` | Show the item that is currently the farming meta | `ultimatedonutsmp.command.meta` |
 | `/auctionhouse`| `/auctionhouse [sell\|my\|claims]`| `/ah` | Open Auction House marketplace | `ultimatedonutsmp.command.auctionhouse` |
 | `/orders` | `/orders [my\|collect]` | None | Open buy/sell Orders board | `ultimatedonutsmp.command.orders` |
 | `/enderchest` | `/enderchest` | `/ec` | Open custom Ender Chest | `ultimatedonutsmp.command.enderchest` |

--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -1233,6 +1233,12 @@ WORTH:
   RELOADED: '&aWorth config reloaded.'
   # The text or value for No Admin Permission. Available options: Any valid string text
   NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+  # The text or value for Meta Current. Available options: Any valid string text
+  META-CURRENT: '&b{item} &fis the farming meta at &a{multiplier}x&f and sells for &a{price_formatted}&f, up from &7{base_formatted}&f. Next rotation in &e{countdown}&f.'
+  # The text or value for Meta Inactive. Available options: Any valid string text
+  META-INACTIVE: '&cNo farming meta is running right now.'
+  # The text or value for Meta Rotated. Available options: Any valid string text
+  META-ROTATED: '&b{item} &fis the new farming meta at &a{multiplier}x&f and now sells for &a{price_formatted}&f. Next rotation in &e{countdown}&f.'
 # Configuration section for Bounty.
 ```
 
@@ -1246,6 +1252,9 @@ WORTH:
 | `WORTH.CONTAINER-BREAKDOWN` | `str` | Any string text | `'&7Base: &f${base} &8| &7Contents: &...'` | Configures the technical `CONTAINER-BREAKDOWN` parameter for `WORTH.CONTAINER-BREAKDOWN` in `messages.yml`. |
 | `WORTH.RELOADED` | `str` | Any string text | `'&aWorth config reloaded.'` | Configures the technical `RELOADED` parameter for `WORTH.RELOADED` in `messages.yml`. |
 | `WORTH.NO-ADMIN-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rel...'` | Configures the technical `NO-ADMIN-PERMISSION` parameter for `WORTH.NO-ADMIN-PERMISSION` in `messages.yml`. |
+| `WORTH.META-CURRENT` | `str` | Any string text | `'&b{item} &fis the farming meta at &a{mult...'` | Answer to `/meta` while a rotation is running. Supports `{item}`, `{multiplier}`, `{base}`, `{base_formatted}`, `{price}`, `{price_formatted}`, and `{countdown}`. |
+| `WORTH.META-INACTIVE` | `str` | Any string text | `'&cNo farming meta is running right now.'` | Answer to `/meta` when `META.ENABLED` is off in `worth.yml` or no configured item has a price. |
+| `WORTH.META-ROTATED` | `str` | Any string text | `'&b{item} &fis the new farming meta at &a{mult...'` | Broadcast when the meta moves to the next item, unless `META.ANNOUNCE_ON_ROTATE` is off. Supports the same placeholders as `WORTH.META-CURRENT`. |
 
 ### 3. Practical Setup Example
 
@@ -1263,6 +1272,12 @@ WORTH:
   RELOADED: '&aWorth config reloaded.'
   # The text or value for No Admin Permission. Available options: Any valid string text
   NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+  # The text or value for Meta Current. Available options: Any valid string text
+  META-CURRENT: '&b{item} &fis the farming meta at &a{multiplier}x&f and sells for &a{price_formatted}&f, up from &7{base_formatted}&f. Next rotation in &e{countdown}&f.'
+  # The text or value for Meta Inactive. Available options: Any valid string text
+  META-INACTIVE: '&cNo farming meta is running right now.'
+  # The text or value for Meta Rotated. Available options: Any valid string text
+  META-ROTATED: '&b{item} &fis the new farming meta at &a{multiplier}x&f and now sells for &a{price_formatted}&f. Next rotation in &e{countdown}&f.'
 # Configuration section for Bounty.
 ```
 

--- a/docs/wiki/Config-worth.yml.md
+++ b/docs/wiki/Config-worth.yml.md
@@ -160,6 +160,71 @@ BROWSER:
 
 ---
 
+## Section: `META`
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Configuration section for Meta.
+META:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: false
+  # The decimal value for Multiplier. Available options: Any decimal number
+  MULTIPLIER: 1.15
+  # The numerical value for Interval Days. Available options: Any valid integer
+  INTERVAL_DAYS: 14
+  # The numerical value for Interval Hours. Available options: Any valid integer
+  INTERVAL_HOURS: 0
+  # Determines whether Announce On Rotate is enabled or disabled. Available options: true, false
+  ANNOUNCE_ON_ROTATE: true
+  # The items that take turns being the meta, in rotation order. Every entry needs a price
+  # under TYPE or it is skipped. Available options: Any valid material name
+  ITEMS:
+  - KELP
+  - IRON_INGOT
+  - OAK_LOG
+  - COBBLESTONE
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `META.ENABLED` | `bool` | `true`, `false` | `false` | Turns the farming meta rotation on. While it is off every item keeps the price set under `TYPE`, so updating the plugin never changes an existing economy on its own. |
+| `META.MULTIPLIER` | `dec` | Any decimal number above zero | `1.15` | What the meta item's `TYPE` price is multiplied by. `1.15` means the meta item sells for 15% more; anything at or below zero falls back to no boost. |
+| `META.INTERVAL_DAYS` | `int` | Any whole number | `14` | Days between rotations. Added to `INTERVAL_HOURS`; if both are zero the rotation falls back to 14 days. |
+| `META.INTERVAL_HOURS` | `int` | Any whole number | `0` | Hours between rotations, on top of `INTERVAL_DAYS`. |
+| `META.ANNOUNCE_ON_ROTATE` | `bool` | `true`, `false` | `true` | Broadcasts `MESSAGES.WORTH.META-ROTATED` when the meta changes. Players who turned server broadcasts off in `/settings` do not receive it. |
+| `META.ITEMS` | `list` | List of material names | `[KELP, IRON_INGOT, OAK_LOG, COBBLESTONE]` | The rotation, walked in order and looped. Names that no item matches, duplicates, and items with no price under `TYPE` are skipped. |
+
+### 3. Practical Setup Example
+
+A weekly rotation over four crops with a 20% bonus and no broadcast:
+
+```yaml
+META:
+  ENABLED: true
+  MULTIPLIER: 1.2
+  INTERVAL_DAYS: 7
+  INTERVAL_HOURS: 0
+  ANNOUNCE_ON_ROTATE: false
+  ITEMS:
+  - KELP
+  - SUGAR_CANE
+  - PUMPKIN
+  - CACTUS
+```
+
+The boost reaches every price the item has: `/worth`, the price catalog, the worth lore on the item, `/sell`
+and the sell menus, and spawner auto-sell. `/meta` shows which item holds it, what it is worth with and
+without the bonus, and how long the rotation has left.
+
+The current item and the countdown live in `farming-meta-data.yml` in the plugin folder, so a restart
+picks the rotation up where it left off rather than starting the clock again. Editing this section takes
+effect after `/worth reload`.
+
+---
+
 ## Section: `TYPE`
 
 ### 1. Commented Setup Code Example

--- a/docs/wiki/Economy-and-Marketplaces.md
+++ b/docs/wiki/Economy-and-Marketplaces.md
@@ -44,6 +44,18 @@ Items placed this way are stored whole, so enchantments, potion data, firework f
 - `/worth`: Opens the full price catalog GUI displaying buy/sell values for every item.
 - `/worth hand`: Checks the sell price of the item currently held in hand.
 
+### 4. Farming Meta Rotation (`/meta`)
+One item from a configured list is the farming meta at any time. It keeps its normal `worth.yml` price
+as a base and sells for a multiple of it, so the item worth farming changes every few weeks without
+anyone editing prices by hand.
+- `/meta` (Alias: `/farmingmeta`): Shows the current meta item, its multiplier, what it sells for now
+  compared to its usual price, and how long is left before the rotation moves on.
+- The boost applies everywhere a price is shown or paid: `/worth`, the price catalog, the worth lore on
+  items, `/sell` and the sell menus, and spawner auto-sell.
+- Rotation is off until `META.ENABLED` is turned on in `worth.yml`, so updating the plugin never moves
+  prices on its own.
+- The countdown is stored in `farming-meta-data.yml`, so restarts do not reset it.
+
 ---
 
 ## Marketplaces

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -70,6 +70,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private AFKManager afkManager;
     private HoverStatsManager hoverStatsManager;
     private WorthManager worthManager;
+    private FarmingMetaManager farmingMetaManager;
     private MoneyNametagManager moneyNametagManager;
     private ShopManager shopManager;
     private OrdersManager ordersManager;
@@ -203,6 +204,8 @@ public final class UltimateDonutSmp extends JavaPlugin {
         afkManager = new AFKManager(this);
         hoverStatsManager = new HoverStatsManager(this);
         worthManager = new WorthManager(this);
+        farmingMetaManager = new FarmingMetaManager(this);
+        farmingMetaManager.load();
         moneyNametagManager = new MoneyNametagManager(this);
         shopManager = new ShopManager(this);
         filterManager = new FilterManager(this);
@@ -295,6 +298,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         AFKCheckTask.start(this);
         LunarTeammatesTask.start(this);
         BillfordTask.start(this); // Billford trade rotation check (every 30 s)
+        FarmingMetaTask.start(this); // farming meta rotation check (every 30 s)
         OrdersExpiryTask.start(this);
         AuctionHouseExpiryTask.start(this);
         AuctionOrderBotTask.start(this);
@@ -661,6 +665,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("topsell", sellStatsCmd, FeatureManager.Feature.SELL);
         setTabCompleter("topsell", sellStatsCmd);
         setExecutor("worth", new WorthCommand(this), FeatureManager.Feature.SELL, FeatureManager.Feature.WORTH);
+        setExecutor("meta", new MetaCommand(this), FeatureManager.Feature.SELL, FeatureManager.Feature.WORTH);
 
         // RTP
         setExecutor("rtp", new RTPCommand(this), FeatureManager.Feature.RTP);
@@ -1049,6 +1054,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         warpManager.loadAll();
         spawnManager.load();
         worthManager.reload();
+        farmingMetaManager.load();
         moneyNametagManager.reload();
         shopManager.reload();
         ordersManager.reload();
@@ -1276,6 +1282,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public WorthManager getWorthManager() {
         return worthManager;
+    }
+
+    public FarmingMetaManager getFarmingMetaManager() {
+        return farmingMetaManager;
     }
 
     public MoneyNametagManager getMoneyNametagManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/MetaCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/MetaCommand.java
@@ -1,0 +1,32 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.FarmingMetaManager;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class MetaCommand implements CommandExecutor {
+
+    private final UltimateDonutSmp plugin;
+
+    public MetaCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        FarmingMetaManager farmingMetaManager = plugin.getFarmingMetaManager();
+
+        if (!farmingMetaManager.isActive()) {
+            sender.sendMessage(ColorUtils.toComponent(
+                    plugin.getConfigManager().getMessage("WORTH.META-INACTIVE")));
+            return true;
+        }
+
+        sender.sendMessage(ColorUtils.toComponent(
+                farmingMetaManager.formatMetaMessage("WORTH.META-CURRENT")));
+        return true;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -462,7 +462,7 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
             case "economy" -> List.of(
                     "balance", "pay", "addmoney", "removemoney", "setmoney", "shards", "shardpay",
                     "addshards", "removeshards", "setshards",
-                    "shop", "sell", "sellhand", "sellall", "sellhistory", "worth"
+                    "shop", "sell", "sellhand", "sellall", "sellhistory", "worth", "meta"
             );
             case "market" -> List.of(
                     "auctionhouse", "orders", "billford", "bounty", "crate", "crates", "keys", "spawner"

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/WorthCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/WorthCommand.java
@@ -52,6 +52,7 @@ public class WorthCommand implements CommandExecutor {
 
             plugin.getConfigManager().reloadWorth();
             plugin.getWorthManager().reload();
+            plugin.getFarmingMetaManager().load();
             sendMessage(sender, plugin.getConfigManager().getMessages().getString(
                     "WORTH.RELOADED",
                     "&aWorth config reloaded."

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FarmingMetaManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FarmingMetaManager.java
@@ -1,0 +1,234 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
+
+/**
+ * Keeps one item from the configured rotation marked as the farming meta. The meta item keeps
+ * its normal worth.yml price as a base and sells for a multiple of it until the rotation moves
+ * on to the next item.
+ */
+public class FarmingMetaManager {
+
+    private final UltimateDonutSmp plugin;
+
+    private File dataFile;
+    private YamlConfiguration dataConfig;
+
+    // worth is resolved from packet and region threads, so the rotation has to be visible
+    // to them the moment the timer thread moves it
+    private volatile Material currentItem;
+    private volatile long nextRotationMillis;
+
+    public FarmingMetaManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        dataFile = new File(plugin.getDataFolder(), "farming-meta-data.yml");
+        dataConfig = dataFile.exists()
+                ? YamlConfiguration.loadConfiguration(dataFile)
+                : new YamlConfiguration();
+
+        List<Material> items = getRotationItems();
+        currentItem = resolveCurrentItem(dataConfig.getString("current-item"), items);
+
+        long persisted = dataConfig.getLong("next-rotation-millis", -1L);
+        if (persisted > 0L) {
+            nextRotationMillis = persisted;
+            return;
+        }
+
+        nextRotationMillis = System.currentTimeMillis() + getRotationIntervalMillis();
+        // the countdown has to survive restarts, otherwise a server that reboots daily never
+        // reaches the end of a two week rotation. It only starts once the rotation is switched
+        // on, so turning it on later does not begin with an overdue rotation.
+        if (isEnabled() && currentItem != null) {
+            save();
+        }
+    }
+
+    public boolean isEnabled() {
+        return plugin.getConfigManager().getWorth().getBoolean("META.ENABLED", false);
+    }
+
+    public boolean isActive() {
+        return isEnabled() && currentItem != null;
+    }
+
+    public Material getCurrentItem() {
+        return isEnabled() ? currentItem : null;
+    }
+
+    public double getMultiplier() {
+        double configured = plugin.getConfigManager().getWorth().getDouble("META.MULTIPLIER", 1.15D);
+        if (!Double.isFinite(configured) || configured <= 0D) {
+            return 1.0D;
+        }
+        return configured;
+    }
+
+    /**
+     * The factor to apply to a worth price. This runs for every item a player looks at or sells,
+     * so it answers with a plain field comparison before it reads any configuration.
+     */
+    public double getMultiplierFor(Material material) {
+        if (material == null || material != currentItem) {
+            return 1.0D;
+        }
+        if (!isEnabled()) {
+            return 1.0D;
+        }
+        return getMultiplier();
+    }
+
+    public boolean isTimeToRotate() {
+        return isActive() && System.currentTimeMillis() >= nextRotationMillis;
+    }
+
+    public void rotate() {
+        List<Material> items = getRotationItems();
+        if (items.isEmpty()) {
+            return;
+        }
+
+        int currentIndex = items.indexOf(currentItem);
+        currentItem = items.get((currentIndex + 1) % items.size());
+        nextRotationMillis = System.currentTimeMillis() + getRotationIntervalMillis();
+        save();
+
+        // browser prices are cached per item, so they have to be rebuilt against the new meta
+        plugin.getWorthManager().reload();
+
+        announceRotation();
+    }
+
+    public long getRemainingSeconds() {
+        return Math.max(0L, (nextRotationMillis - System.currentTimeMillis()) / 1000L);
+    }
+
+    public String getFormattedCountdown() {
+        return NumberUtils.formatTimeLong(getRemainingSeconds());
+    }
+
+    /**
+     * The rotation in configuration order, without duplicates and without items that have no
+     * price to multiply.
+     */
+    public List<Material> getRotationItems() {
+        List<Material> items = new ArrayList<>();
+        WorthManager worthManager = plugin.getWorthManager();
+
+        for (String configured : plugin.getConfigManager().getWorth().getStringList("META.ITEMS")) {
+            Material material = parseRotationItem(configured);
+            if (material == null || material.isAir() || items.contains(material)) {
+                continue;
+            }
+            if (worthManager != null && worthManager.getBaseWorth(material) <= 0D) {
+                continue;
+            }
+            items.add(material);
+        }
+
+        return items;
+    }
+
+    private Material resolveCurrentItem(String persisted, List<Material> items) {
+        if (items.isEmpty()) {
+            return null;
+        }
+
+        Material stored = parseRotationItem(persisted);
+        return stored != null && items.contains(stored) ? stored : items.get(0);
+    }
+
+    static Material parseRotationItem(String configured) {
+        if (configured == null || configured.isBlank()) {
+            return null;
+        }
+
+        String name = configured.trim();
+        int namespace = name.indexOf(':');
+        if (namespace >= 0) {
+            name = name.substring(namespace + 1);
+        }
+
+        return Material.getMaterial(name.toUpperCase(Locale.US).replace(' ', '_'));
+    }
+
+    /**
+     * Fills a message with the meta item, what it is worth before and after the multiplier, and
+     * how long the rotation has left.
+     */
+    public String formatMetaMessage(String messagePath) {
+        WorthManager worthManager = plugin.getWorthManager();
+        double baseWorth = worthManager.getBaseWorth(currentItem);
+        double metaWorth = worthManager.getWorth(currentItem);
+
+        return plugin.getConfigManager().getMessage(
+                messagePath,
+                "{item}", worthManager.prettifyMaterial(currentItem),
+                "{multiplier}", NumberUtils.format(getMultiplier()),
+                "{base}", NumberUtils.format(baseWorth),
+                "{base_formatted}", plugin.getCurrencyManager().formatMoney(baseWorth),
+                "{price}", NumberUtils.format(metaWorth),
+                "{price_formatted}", plugin.getCurrencyManager().formatMoney(metaWorth),
+                "{countdown}", getFormattedCountdown()
+        );
+    }
+
+    private void announceRotation() {
+        if (!plugin.getConfigManager().getWorth().getBoolean("META.ANNOUNCE_ON_ROTATE", true)) {
+            return;
+        }
+
+        String message = formatMetaMessage("WORTH.META-ROTATED");
+
+        Bukkit.getOnlinePlayers().forEach(player -> {
+            if (!PlayerSettingUtils.notificationEnabled(
+                    plugin,
+                    player,
+                    PlayerSettingUtils.NotificationChannel.SERVER_BROADCAST
+            )) {
+                return;
+            }
+            player.sendMessage(ColorUtils.toComponent(message));
+        });
+    }
+
+    private void save() {
+        if (dataConfig == null || dataFile == null) {
+            return;
+        }
+
+        dataConfig.set("current-item", currentItem == null ? null : currentItem.name());
+        dataConfig.set("next-rotation-millis", nextRotationMillis);
+
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to save farming-meta-data.yml", e);
+        }
+    }
+
+    private long getRotationIntervalMillis() {
+        int days = Math.max(0, plugin.getConfigManager().getWorth().getInt("META.INTERVAL_DAYS", 14));
+        int hours = Math.max(0, plugin.getConfigManager().getWorth().getInt("META.INTERVAL_HOURS", 0));
+
+        Duration interval = Duration.ofDays(days).plusHours(hours);
+        return interval.isZero() ? Duration.ofDays(14).toMillis() : interval.toMillis();
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -227,7 +227,7 @@ public class FeatureManager {
             case "auctionhouse" -> new Feature[]{Feature.AUCTION_HOUSE};
             case "enderchest", "ecsee" -> new Feature[]{Feature.ENDER_CHEST};
             case "sell", "sellhand", "sellall", "sellhistory" -> new Feature[]{Feature.SELL};
-            case "worth" -> new Feature[]{Feature.SELL, Feature.WORTH};
+            case "worth", "meta" -> new Feature[]{Feature.SELL, Feature.WORTH};
             case "rtp" -> new Feature[]{Feature.RTP};
             case "stats", "ping", "playtime" -> new Feature[]{Feature.STATS};
             case "leaderboard" -> new Feature[]{Feature.LEADERBOARDS};

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
@@ -173,6 +173,16 @@ public class WorthManager {
         return getWorth(new ItemStack(material));
     }
 
+    // the price before the farming meta multiplier, for callers that need to show both
+    public double getBaseWorth(Material material) {
+        if (material == null || material.isAir()) {
+            return -1;
+        }
+
+        DirectWorthData data = resolveBaseDirectWorth(new ItemStack(material));
+        return data == null ? -1 : data.worth();
+    }
+
     public double getWorth(ItemStack item) {
         DirectWorthData data = resolveDirectWorth(item);
         return data == null ? -1 : data.worth();
@@ -286,7 +296,12 @@ public class WorthManager {
                     continue;
                 }
 
-                entries.add(new WorthBrowserEntry(material, categoryKey, unitWorth, key));
+                entries.add(new WorthBrowserEntry(
+                        material,
+                        categoryKey,
+                        unitWorth * getMetaMultiplier(material),
+                        key
+                ));
             }
         }
 
@@ -877,6 +892,35 @@ public class WorthManager {
     }
 
     private DirectWorthData resolveDirectWorth(ItemStack item) {
+        return applyMetaMultiplier(item == null ? null : item.getType(), resolveBaseDirectWorth(item));
+    }
+
+    // the cache holds base prices, so the meta multiplier is applied on the way out and a
+    // rotation never leaves a stale price behind in it
+    private DirectWorthData applyMetaMultiplier(Material material, DirectWorthData data) {
+        if (data == null) {
+            return null;
+        }
+
+        double multiplier = getMetaMultiplier(material);
+        if (multiplier == 1.0D) {
+            return data;
+        }
+
+        return new DirectWorthData(
+                data.worth() * multiplier,
+                data.sourceKey(),
+                data.categoryKey(),
+                data.resolutionType()
+        );
+    }
+
+    private double getMetaMultiplier(Material material) {
+        FarmingMetaManager farmingMetaManager = plugin.getFarmingMetaManager();
+        return farmingMetaManager == null ? 1.0D : farmingMetaManager.getMultiplierFor(material);
+    }
+
+    private DirectWorthData resolveBaseDirectWorth(ItemStack item) {
         if (item == null || item.getType().isAir()) {
             return null;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/FarmingMetaTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/FarmingMetaTask.java
@@ -1,0 +1,31 @@
+package com.bx.ultimateDonutSmp.tasks;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+
+/**
+ * Checks every 30 seconds whether the farming meta rotation timer has expired and, if so,
+ * moves the meta on to the next item in the rotation.
+ */
+public class FarmingMetaTask implements Runnable {
+
+    private final UltimateDonutSmp plugin;
+
+    private FarmingMetaTask(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public static void start(UltimateDonutSmp plugin) {
+        // 600 ticks = 30 seconds; first check after 30 s as well
+        plugin.getSpigotScheduler().runGlobalTimer(new FarmingMetaTask(plugin), 600L, 600L);
+    }
+
+    @Override
+    public void run() {
+        if (!plugin.getFeatureManager().isEnabled(com.bx.ultimateDonutSmp.managers.FeatureManager.Feature.WORTH)) {
+            return;
+        }
+        if (plugin.getFarmingMetaManager().isTimeToRotate()) {
+            plugin.getFarmingMetaManager().rotate();
+        }
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2553,6 +2553,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fist gerade das Farm-Meta mit &a{multiplier}x&f und verkauft sich für &a{price_formatted}&f statt &7{base_formatted}&f. Nächster Wechsel in &e{countdown}&f."
+    META-INACTIVE: "&cGerade läuft kein Farm-Meta."
+    META-ROTATED: "&b{item} &fist das neue Farm-Meta mit &a{multiplier}x&f und verkauft sich jetzt für &a{price_formatted}&f. Nächster Wechsel in &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player}!"
     INCREASED: "&aThe bounty for {player} has been increased by ${price}!"

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2753,6 +2753,11 @@ MESSAGES:
     CONTAINER-BREAKDOWN: '&7Base: &f${base} &8| &7contents: &f${contents}'
     RELOADED: '&aWorth config reloaded.'
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: '&b{item} &fis the farming meta at &a{multiplier}x&f and sells for
+      &a{price_formatted}&f, up from &7{base_formatted}&f. Next rotation in &e{countdown}&f.'
+    META-INACTIVE: '&cNo farming meta is running right now.'
+    META-ROTATED: '&b{item} &fis the new farming meta at &a{multiplier}x&f and now
+      sells for &a{price_formatted}&f. Next rotation in &e{countdown}&f.'
   BOUNTY:
     NEW: '&aA new bounty of ${price} has been placed on {player}!'
     INCREASED: '&aThe bounty for {player} has been increased by ${price}!'

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2418,6 +2418,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fes el meta de farmeo con &a{multiplier}x&f y se vende por &a{price_formatted}&f en lugar de &7{base_formatted}&f. Próxima rotación en &e{countdown}&f."
+    META-INACTIVE: "&cAhora mismo no hay ningún meta de farmeo activo."
+    META-ROTATED: "&b{item} &fes el nuevo meta de farmeo con &a{multiplier}x&f y ahora se vende por &a{price_formatted}&f. Próxima rotación en &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player}!"
     INCREASED: "&aThe bounty for {player} has been increased by ${price}!"

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2418,6 +2418,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base : &f${base} &8| &7contents : &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fest le méta de farm à &a{multiplier}x&f et se vend &a{price_formatted}&f au lieu de &7{base_formatted}&f. Prochaine rotation dans &e{countdown}&f."
+    META-INACTIVE: "&cAucun méta de farm n'est en cours."
+    META-ROTATED: "&b{item} &fest le nouveau méta de farm à &a{multiplier}x&f et se vend maintenant &a{price_formatted}&f. Prochaine rotation dans &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player} !"
     INCREASED: "&aThe bounty for {player} has been increased by ${price} !"

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2553,6 +2553,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fadalah meta farming saat ini dengan &a{multiplier}x&f dan terjual seharga &a{price_formatted}&f, naik dari &7{base_formatted}&f. Rotasi berikutnya dalam &e{countdown}&f."
+    META-INACTIVE: "&cTidak ada meta farming yang sedang berjalan."
+    META-ROTATED: "&b{item} &fadalah meta farming yang baru dengan &a{multiplier}x&f dan sekarang terjual seharga &a{price_formatted}&f. Rotasi berikutnya dalam &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} dan on {player}!"
     INCREASED: "&aThe bounty for {player} dan been increased by ${price}!"

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2419,6 +2419,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fé o meta de farm com &a{multiplier}x&f e vende por &a{price_formatted}&f em vez de &7{base_formatted}&f. Próxima rotação em &e{countdown}&f."
+    META-INACTIVE: "&cNenhum meta de farm está ativo no momento."
+    META-ROTATED: "&b{item} &fé o novo meta de farm com &a{multiplier}x&f e agora vende por &a{price_formatted}&f. Próxima rotação em &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player}!"
     INCREASED: "&aThe bounty for {player} has been increased by ${price}!"

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2416,6 +2416,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded."
     NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+    META-CURRENT: "&b{item} &fсейчас в мете фарма с множителем &a{multiplier}x&f и продаётся за &a{price_formatted}&f вместо &7{base_formatted}&f. Следующая смена через &e{countdown}&f."
+    META-INACTIVE: "&cСейчас мета фарма не запущена."
+    META-ROTATED: "&b{item} &fтеперь в мете фарма с множителем &a{multiplier}x&f и продаётся за &a{price_formatted}&f. Следующая смена через &e{countdown}&f."
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player}!"
     INCREASED: "&aThe bounty for {player} has been increased by ${price}!"

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2410,6 +2410,9 @@ MESSAGES:
     CONTAINER-BREAKDOWN: "&7Base: &f${base} &8| &7contents: &f${contents}"
     RELOADED: "&aWorth config reloaded。"
     NO-ADMIN-PERMISSION: "&cYou do not have permission to reload worth settings。"
+    META-CURRENT: "&b{item} &f是当前的农场热门物品，倍率 &a{multiplier}x&f，售价 &a{price_formatted}&f，原价 &7{base_formatted}&f。下次轮换还有 &e{countdown}&f。"
+    META-INACTIVE: "&c当前没有正在进行的农场热门轮换。"
+    META-ROTATED: "&b{item} &f成为新的农场热门物品，倍率 &a{multiplier}x&f，现在售价 &a{price_formatted}&f。下次轮换还有 &e{countdown}&f。"
   BOUNTY:
     NEW: "&aA new bounty of ${price} has been placed on {player}！"
     INCREASED: "&aThe bounty for {player} has been increased by ${price}！"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -455,6 +455,12 @@ WORTH:
   RELOADED: '&aWorth config reloaded.'
   # The text or value for No Admin Permission. Available options: Any valid string text
   NO-ADMIN-PERMISSION: '&cYou do not have permission to reload worth settings.'
+  # The text or value for Meta Current. Available options: Any valid string text
+  META-CURRENT: '&b{item} &fis the farming meta at &a{multiplier}x&f and sells for &a{price_formatted}&f, up from &7{base_formatted}&f. Next rotation in &e{countdown}&f.'
+  # The text or value for Meta Inactive. Available options: Any valid string text
+  META-INACTIVE: '&cNo farming meta is running right now.'
+  # The text or value for Meta Rotated. Available options: Any valid string text
+  META-ROTATED: '&b{item} &fis the new farming meta at &a{multiplier}x&f and now sells for &a{price_formatted}&f. Next rotation in &e{countdown}&f.'
 # Configuration section for Bounty.
 BOUNTY:
   # The text or value for New. Available options: Any valid string text

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -240,6 +240,13 @@ commands:
     - prices
     permission: ultimatedonutsmp.command.worth
     permission-message: "&cYou do not have permission to use /worth."
+  meta:
+    description: Show the item that is currently the farming meta
+    usage: /meta
+    aliases:
+    - farmingmeta
+    permission: ultimatedonutsmp.command.meta
+    permission-message: "&cYou do not have permission to use /meta."
   balance:
     description: Check balance
     usage: /balance [player]
@@ -1231,6 +1238,7 @@ permissions:
       ultimatedonutsmp.command.sellhistory: true
       ultimatedonutsmp.command.topsell: true
       ultimatedonutsmp.command.worth: true
+      ultimatedonutsmp.command.meta: true
       ultimatedonutsmp.command.balance: true
       ultimatedonutsmp.command.pay: true
       ultimatedonutsmp.command.addmoney: true
@@ -1431,6 +1439,9 @@ permissions:
     default: op
   ultimatedonutsmp.command.worth:
     description: Access to /worth command
+    default: true
+  ultimatedonutsmp.command.meta:
+    description: Access to /meta command
     default: true
   ultimatedonutsmp.command.balance:
     description: Access to /balance command

--- a/src/main/resources/worth.yml
+++ b/src/main/resources/worth.yml
@@ -42,6 +42,25 @@ BROWSER:
     - '&7Stack x{stack_size}: {stack_price_compact}'
     - ''
     - '&eClick to send the unit price in chat'
+# Configuration section for Meta.
+META:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: false
+  # The decimal value for Multiplier. Available options: Any decimal number
+  MULTIPLIER: 1.15
+  # The numerical value for Interval Days. Available options: Any valid integer
+  INTERVAL_DAYS: 14
+  # The numerical value for Interval Hours. Available options: Any valid integer
+  INTERVAL_HOURS: 0
+  # Determines whether Announce On Rotate is enabled or disabled. Available options: true, false
+  ANNOUNCE_ON_ROTATE: true
+  # The items that take turns being the meta, in rotation order. Every entry needs a price
+  # under TYPE or it is skipped. Available options: Any valid material name
+  ITEMS:
+  - KELP
+  - IRON_INGOT
+  - OAK_LOG
+  - COBBLESTONE
 TYPE:
   # Configuration section for Crops.
   CROPS:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/FarmingMetaManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/FarmingMetaManagerTest.java
@@ -1,0 +1,234 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FarmingMetaManagerTest {
+
+    @TempDir
+    Path dataFolder;
+
+    @Test
+    void metaItemIsWorthMoreWhileTheRestOfThePricesStayPut() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(metaConfig(1.25D, List.of("KELP", "IRON_INGOT")));
+
+        assertEquals(Material.KELP, plugin.getFarmingMetaManager().getCurrentItem());
+        assertEquals(10.0D, plugin.getWorthManager().getWorth(Material.KELP));
+        assertEquals(8.0D, plugin.getWorthManager().getBaseWorth(Material.KELP));
+        assertEquals(5.0D, plugin.getWorthManager().getWorth(Material.IRON_INGOT));
+    }
+
+    @Test
+    void sellingTheMetaItemPaysTheMultipliedPrice() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(metaConfig(1.25D, List.of("KELP", "IRON_INGOT")));
+
+        List<WorthManager.SellWorthEntry> entries = plugin.getWorthManager()
+                .resolveSellWorthEntries(new org.bukkit.inventory.ItemStack(Material.KELP, 64));
+
+        assertEquals(1, entries.size());
+        assertEquals(640.0D, entries.get(0).totalWorth());
+    }
+
+    @Test
+    void rotationWalksTheListInOrderAndComesBackAround() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(metaConfig(1.25D, List.of("KELP", "IRON_INGOT")));
+        FarmingMetaManager farmingMetaManager = plugin.getFarmingMetaManager();
+
+        farmingMetaManager.rotate();
+
+        assertEquals(Material.IRON_INGOT, farmingMetaManager.getCurrentItem());
+        assertEquals(8.0D, plugin.getWorthManager().getWorth(Material.KELP));
+        assertEquals(6.25D, plugin.getWorthManager().getWorth(Material.IRON_INGOT));
+
+        farmingMetaManager.rotate();
+
+        assertEquals(Material.KELP, farmingMetaManager.getCurrentItem());
+        assertEquals(10.0D, plugin.getWorthManager().getWorth(Material.KELP));
+    }
+
+    @Test
+    void turningTheMetaOffLeavesEveryPriceAlone() throws Exception {
+        YamlConfiguration worthConfig = metaConfig(1.25D, List.of("KELP", "IRON_INGOT"));
+        worthConfig.set("META.ENABLED", false);
+
+        UltimateDonutSmp plugin = createPlugin(worthConfig);
+
+        assertFalse(plugin.getFarmingMetaManager().isActive());
+        assertNull(plugin.getFarmingMetaManager().getCurrentItem());
+        assertEquals(8.0D, plugin.getWorthManager().getWorth(Material.KELP));
+    }
+
+    @Test
+    void itemsWithoutAPriceNeverBecomeTheMeta() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(
+                metaConfig(1.25D, List.of("KELP", "DIAMOND_BLOCK", "IRON_INGOT")));
+        FarmingMetaManager farmingMetaManager = plugin.getFarmingMetaManager();
+
+        assertEquals(List.of(Material.KELP, Material.IRON_INGOT), farmingMetaManager.getRotationItems());
+
+        farmingMetaManager.rotate();
+
+        assertEquals(Material.IRON_INGOT, farmingMetaManager.getCurrentItem());
+    }
+
+    @Test
+    void theCountdownAndTheCurrentItemSurviveARestart() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(metaConfig(1.25D, List.of("KELP", "IRON_INGOT")));
+        plugin.getFarmingMetaManager().rotate();
+        long remainingBefore = plugin.getFarmingMetaManager().getRemainingSeconds();
+
+        FarmingMetaManager restarted = new FarmingMetaManager(plugin);
+        restarted.load();
+
+        assertEquals(Material.IRON_INGOT, restarted.getCurrentItem());
+        assertTrue(Math.abs(remainingBefore - restarted.getRemainingSeconds()) <= 1L);
+        assertTrue(new File(dataFolder.toFile(), "farming-meta-data.yml").exists());
+    }
+
+    @Test
+    void anItemThatLeavesTheRotationHandsTheMetaBackToTheFirstOne() throws Exception {
+        UltimateDonutSmp plugin = createPlugin(metaConfig(1.25D, List.of("KELP", "IRON_INGOT")));
+        plugin.getFarmingMetaManager().rotate();
+
+        plugin.getConfigManager().getWorth().set("META.ITEMS", List.of("KELP"));
+        FarmingMetaManager restarted = new FarmingMetaManager(plugin);
+        restarted.load();
+
+        assertEquals(Material.KELP, restarted.getCurrentItem());
+    }
+
+    @Test
+    void parsesMaterialNamesWithoutFallingBackToAnUnrelatedItem() {
+        assertEquals(Material.KELP, FarmingMetaManager.parseRotationItem("kelp"));
+        assertEquals(Material.KELP, FarmingMetaManager.parseRotationItem("minecraft:kelp"));
+        assertEquals(Material.IRON_INGOT, FarmingMetaManager.parseRotationItem("iron ingot"));
+        assertNull(FarmingMetaManager.parseRotationItem("not_a_real_item"));
+        assertNull(FarmingMetaManager.parseRotationItem(" "));
+    }
+
+    private YamlConfiguration metaConfig(double multiplier, List<String> items) {
+        YamlConfiguration worthConfig = new YamlConfiguration();
+        worthConfig.set("TYPE.CROPS.KELP", 8.0D);
+        worthConfig.set("TYPE.ORES.IRON_INGOT", 5.0D);
+        worthConfig.set("META.ENABLED", true);
+        worthConfig.set("META.MULTIPLIER", multiplier);
+        worthConfig.set("META.INTERVAL_DAYS", 14);
+        worthConfig.set("META.ANNOUNCE_ON_ROTATE", false);
+        worthConfig.set("META.ITEMS", items);
+        return worthConfig;
+    }
+
+    private UltimateDonutSmp createPlugin(YamlConfiguration worthConfig) throws Exception {
+        setupMockServer();
+
+        sun.reflect.ReflectionFactory reflectionFactory = sun.reflect.ReflectionFactory.getReflectionFactory();
+        UltimateDonutSmp plugin = (UltimateDonutSmp) reflectionFactory
+                .newConstructorForSerialization(UltimateDonutSmp.class, Object.class.getConstructor())
+                .newInstance();
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        setField(ConfigManager.class, configManager, "worth", worthConfig);
+        setField(UltimateDonutSmp.class, plugin, "configManager", configManager);
+        setField(org.bukkit.plugin.java.JavaPlugin.class, plugin, "dataFolder", dataFolder.toFile());
+        setField(org.bukkit.plugin.java.JavaPlugin.class, plugin, "description",
+                new org.bukkit.plugin.PluginDescriptionFile(
+                        "UltimateDonutSmp", "1.0", "com.bx.ultimateDonutSmp.UltimateDonutSmp"));
+
+        WorthManager worthManager = new WorthManager(plugin);
+        setField(UltimateDonutSmp.class, plugin, "worthManager", worthManager);
+
+        FarmingMetaManager farmingMetaManager = new FarmingMetaManager(plugin);
+        setField(UltimateDonutSmp.class, plugin, "farmingMetaManager", farmingMetaManager);
+        farmingMetaManager.load();
+
+        return plugin;
+    }
+
+    private static void setField(Class<?> owner, Object target, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void setupMockServer() throws Exception {
+        Field serverField = org.bukkit.Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+
+        Map<org.bukkit.enchantments.Enchantment, Integer> enchantments = new HashMap<>();
+        org.bukkit.inventory.meta.ItemMeta itemMeta = (org.bukkit.inventory.meta.ItemMeta) Proxy.newProxyInstance(
+                org.bukkit.inventory.meta.ItemMeta.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.inventory.meta.ItemMeta.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getEnchants", "getStoredEnchants" -> enchantments;
+                    case "clone" -> proxy;
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    default -> defaultValue(method);
+                });
+
+        Object itemFactory = Proxy.newProxyInstance(
+                org.bukkit.inventory.ItemFactory.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.inventory.ItemFactory.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getItemMeta" -> itemMeta;
+                    case "hasItemMeta", "isApplicable" -> true;
+                    case "asMetaFor" -> args[0];
+                    case "equals" -> args.length == 2 ? Objects.equals(args[0], args[1]) : proxy == args[0];
+                    default -> defaultValue(method);
+                });
+
+        // Material.isAir() reads the block registry, so every registry lookup has to answer with
+        // something rather than null or org.bukkit.Registry never finishes initialising. The
+        // registry proxy is built on first use because building it needs a server in place.
+        Object[] registry = new Object[1];
+
+        org.bukkit.Server server = (org.bukkit.Server) Proxy.newProxyInstance(
+                org.bukkit.Server.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.Server.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getItemFactory" -> itemFactory;
+                    case "getRegistry" -> {
+                        if (registry[0] == null) {
+                            Class<?> registryClass = Class.forName("org.bukkit.Registry");
+                            registry[0] = Proxy.newProxyInstance(
+                                    registryClass.getClassLoader(),
+                                    new Class<?>[]{registryClass},
+                                    (registryProxy, registryMethod, registryArgs) -> defaultValue(registryMethod));
+                        }
+                        yield registry[0];
+                    }
+                    default -> defaultValue(method);
+                });
+
+        serverField.set(null, server);
+    }
+
+    private static Object defaultValue(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #246

One item out of a configured list is now the farming meta, and it sells for a multiple of its usual `worth.yml` price until the rotation moves on to the next one. Prices under `TYPE` stay exactly where they are; the meta only multiplies what an item is already worth, so a hand-tuned economy is still the base everything runs off.

## Where the boost lands

Every price a player sees or gets paid resolves through the same method, so the multiplier lives there and reaches `/worth`, the price catalog, the worth lore on items, `/sell` and the sell menus, and spawner auto-sell without any of them needing to know it exists. The cache keeps plain prices and the multiplier goes on afterwards, so a rotation can't leave a stale boosted price sitting in it. The catalog is the one exception, since it reads `worth.yml` straight and caches what it builds; rotating drops that cache.

## The rotation

`worth.yml` gained a `META` block: whether it runs, the multiplier, how long a turn lasts in days and hours, whether the change is announced, and the item list. A task checks every 30 seconds whether the turn is up, the same way the Billford trade rotation already does it. The rotation skips names that match nothing, duplicates, and items with no price under `TYPE`, so none of them burns two weeks as a meta nobody can sell.

Current item and deadline live in `farming-meta-data.yml`, so a server that reboots nightly doesn't hand itself a fresh two weeks every morning. That clock only starts once `ENABLED` is on, otherwise switching the feature on months later would fire a rotation on the first tick.

## /meta

Shows which item holds the meta, its multiplier, what it sells for now against its usual price, and how long is left. Alias `/farmingmeta`, permission `ultimatedonutsmp.command.meta`, on by default, gated behind the same feature toggles as `/worth`.

## Notes

`ENABLED` ships as `false`, so updating the plugin moves nobody's prices until an admin asks for it. The bundled list is the four the issue named: kelp, iron, oak logs, cobblestone.

Three keys under `MESSAGES.WORTH` in `messages.yml`, plus all 8 language files. `/worth reload` picks up edits to the `META` block.

`FarmingMetaManagerTest` adds 8 tests: the multiplied price against untouched neighbours, the `/sell` payout, rotation order and wrap-around, unpriced items staying out, the countdown surviving a restart, an item leaving the list mid-rotation, and material name parsing. Suite is at 383, all green.
