### PR TITLE
feat(punishments): wipe a banned player when the offence asks for it (#235)

### DIFF
--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -165,3 +165,32 @@ Punishments, IP history, and freeze or staff-mode state survive a wipe, so a ban
 and alt tracking still works. Spawners they placed are left standing as well, since those are blocks
 in the world rather than stored progress. There is no undo, so take a database backup first if the
 account matters.
+
+### Wiping On A Ban (`offenses.yml`)
+
+A wipe can also ride along with a punishment instead of being a second command. Each preset in
+`offenses.yml` takes an optional `wipe` flag, and when `/offend` issues that offense the account is
+cleared straight after the kick:
+
+```yaml
+offenses:
+  duping:
+    name: "Item Duping"
+    type: BAN
+    wipe: true
+    durations:
+      - "3d"
+      - "perm"
+```
+
+The flag defaults to `false`, so nothing changes on a preset that does not mention it, and it is
+read under any casing, so `wipe`, `WIPE` and `Wipe` all work.
+
+It only fires on a real ban. A `MUTE`, `WARN` or `KICK` preset ignores it, and so does a tier of
+`0s`, since that tier is issued as a warning rather than a ban. Staff running the command see the
+number of records removed underneath the usual punishment confirmation.
+
+The wipe itself is the same one `/playerwipe` performs, down to what survives it, and it cannot be
+undone either. Turning it on for an offense your team hands out often is a good way to delete a lot
+of accounts you meant to keep, so it suits things like duping or botting rather than a first-strike
+chat rule.

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.OffenseManager;
+import com.bx.ultimateDonutSmp.managers.PlayerWipeManager;
 import com.bx.ultimateDonutSmp.managers.PunishmentManager;
 import com.bx.ultimateDonutSmp.models.PunishmentQuery;
 import com.bx.ultimateDonutSmp.models.PunishmentRecord;
@@ -121,6 +122,10 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
 
         String durationDisplay = expiresAt == null ? "Permanent" : NumberUtils.formatCountdown(Math.max(0L, (expiresAt - System.currentTimeMillis()) / 1000L));
         sendMessage(sender, "&aSuccessfully issued &f" + type.name() + " &apunishment to &b" + target.name() + "&a! [Duration: &f" + durationDisplay + "&a, Reason: &f" + reasonDisplay + "&a]");
+
+        if (ruleOpt.isPresent() && ruleOpt.get().wipe() && isBan(type)) {
+            wipeTarget(sender, target);
+        }
         return true;
     }
 
@@ -151,6 +156,41 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
         }
 
         return Collections.emptyList();
+    }
+
+    private static boolean isBan(PunishmentType type) {
+        return type == PunishmentType.BAN || type == PunishmentType.BLACKLIST;
+    }
+
+    /**
+     * Runs the wipe an offense asked for. It happens after the kick has already gone out, so the
+     * save the quit handler makes on the way out cannot put the old totals back over the rows the
+     * wipe is deleting.
+     */
+    private void wipeTarget(CommandSender sender, ResolvedTarget target) {
+        PlayerWipeManager wipeManager = plugin.getPlayerWipeManager();
+        if (wipeManager == null) {
+            return;
+        }
+
+        PlayerWipeManager.WipeResult result = wipeManager.wipe(
+                new PlayerWipeManager.Target(target.uuid(), target.name()),
+                resolveActor(sender).name()
+        );
+
+        if (result.busy()) {
+            sendMessage(sender, "&cCould not wipe &f" + target.name() + "&c: a player wipe is already running.");
+            return;
+        }
+        if (!result.success()) {
+            String error = result.errorMessage() == null || result.errorMessage().isBlank()
+                    ? "unknown error"
+                    : result.errorMessage();
+            sendMessage(sender, "&cCould not wipe &f" + target.name() + "&c: &f" + error);
+            return;
+        }
+
+        sendMessage(sender, "&aWiped &f" + target.name() + "&a. Records removed: &f" + result.counts().total() + "&a.");
     }
 
     private void applyRuntimeEffect(PunishmentType type, Player onlineTarget, PunishmentRecord record) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/OffenseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/OffenseManager.java
@@ -19,6 +19,7 @@ public class OffenseManager {
             String key,
             String name,
             PunishmentType type,
+            boolean wipe,
             List<String> durations
     ) {
         public String getDurationForTier(int tierIndex) {
@@ -59,23 +60,48 @@ public class OffenseManager {
             ConfigurationSection offenseSec = section.getConfigurationSection(key);
             if (offenseSec == null) continue;
 
-            String name = offenseSec.getString("name", key);
-            String typeStr = offenseSec.getString("type", "BAN").toUpperCase(Locale.ROOT);
-            PunishmentType type;
-            try {
-                type = PunishmentType.valueOf(typeStr);
-            } catch (IllegalArgumentException e) {
-                type = PunishmentType.BAN;
-            }
-
-            List<String> durations = offenseSec.getStringList("durations");
-            if (durations.isEmpty() && offenseSec.isString("durations")) {
-                durations = Collections.singletonList(offenseSec.getString("durations"));
-            }
-
-            OffenseRule rule = new OffenseRule(key.toLowerCase(Locale.ROOT), name, type, durations);
-            offenses.put(key.toLowerCase(Locale.ROOT), rule);
+            offenses.put(key.toLowerCase(Locale.ROOT), parseRule(key, offenseSec));
         }
+    }
+
+    static OffenseRule parseRule(String key, ConfigurationSection offenseSec) {
+        String name = offenseSec.getString("name", key);
+        String typeStr = offenseSec.getString("type", "BAN").toUpperCase(Locale.ROOT);
+        PunishmentType type;
+        try {
+            type = PunishmentType.valueOf(typeStr);
+        } catch (IllegalArgumentException e) {
+            type = PunishmentType.BAN;
+        }
+
+        List<String> durations = offenseSec.getStringList("durations");
+        if (durations.isEmpty() && offenseSec.isString("durations")) {
+            durations = Collections.singletonList(offenseSec.getString("durations"));
+        }
+
+        return new OffenseRule(key.toLowerCase(Locale.ROOT), name, type, readWipeFlag(offenseSec), durations);
+    }
+
+    /**
+     * Reads the wipe flag under any casing, since the rest of the file is lower case and admins
+     * reasonably write it as WIPE. A quoted "true" counts as well, so a stray pair of quotes does
+     * not silently turn the flag off.
+     */
+    private static boolean readWipeFlag(ConfigurationSection offenseSec) {
+        for (String key : offenseSec.getKeys(false)) {
+            if (!key.equalsIgnoreCase("wipe")) {
+                continue;
+            }
+            Object raw = offenseSec.get(key);
+            if (raw instanceof Boolean flag) {
+                return flag;
+            }
+            if (raw instanceof String text) {
+                return Boolean.parseBoolean(text.trim());
+            }
+            return false;
+        }
+        return false;
     }
 
     public Optional<OffenseRule> getOffenseRule(String key) {

--- a/src/main/resources/offenses.yml
+++ b/src/main/resources/offenses.yml
@@ -3,10 +3,17 @@
 #   <key>:
 #     name: "Display Name"
 #     type: BAN | MUTE | WARN | KICK
+#     wipe: false  # optional, defaults to false
 #     durations:
 #       - "30d"  # 1st offense
 #       - "60d"  # 2nd offense
 #       - "perm" # 3rd offense (and beyond)
+#
+# wipe only fires when the offense actually bans someone. It clears their stats, balance, homes,
+# ender chest, crate keys, auctions, orders and the rest of their progress, the same thing
+# /playerwipe does, and there is no undo. Their punishment history, IP history and any spawners
+# they placed are kept. A tier of "0s" is issued as a warning rather than a ban, so it does not
+# wipe, and neither do MUTE, WARN or KICK offenses.
 
 offenses:
   advertising:

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/OffendWipeGateTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/OffendWipeGateTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The wipe flag in offenses.yml is only meant to fire on a ban, so a preset that mutes or warns
+ * keeps the account even with the flag turned on.
+ */
+class OffendWipeGateTest {
+
+    @Test
+    void bansAndBlacklistsWipe() throws Exception {
+        assertTrue(isBan(PunishmentType.BAN));
+        assertTrue(isBan(PunishmentType.BLACKLIST));
+    }
+
+    @Test
+    void lesserPunishmentsDoNotWipe() throws Exception {
+        assertFalse(isBan(PunishmentType.MUTE));
+        assertFalse(isBan(PunishmentType.KICK));
+        assertFalse(isBan(PunishmentType.WARN), "a 0s tier is issued as a warning and must keep the account");
+    }
+
+    private boolean isBan(PunishmentType type) throws Exception {
+        Method method = OffendCommand.class.getDeclaredMethod("isBan", PunishmentType.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, type);
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/OffenseManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/OffenseManagerTest.java
@@ -1,0 +1,115 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OffenseManagerTest {
+
+    @Test
+    void parsesNameTypeAndDurations() throws Exception {
+        OffenseManager.OffenseRule rule = parse("""
+                duping:
+                  name: "Item Duping"
+                  type: BAN
+                  durations:
+                    - "3d"
+                    - "perm"
+                """, "duping");
+
+        assertEquals("duping", rule.key());
+        assertEquals("Item Duping", rule.name());
+        assertEquals(PunishmentType.BAN, rule.type());
+        assertEquals("3d", rule.getDurationForTier(0));
+        assertEquals("perm", rule.getDurationForTier(7));
+    }
+
+    @Test
+    void offenseWithoutWipeKeyDoesNotWipe() throws Exception {
+        assertFalse(parse("""
+                duping:
+                  name: "Item Duping"
+                  type: BAN
+                  durations:
+                    - "3d"
+                """, "duping").wipe());
+    }
+
+    @Test
+    void wipeFlagIsReadUnderAnyCasing() throws Exception {
+        for (String key : new String[]{"wipe", "WIPE", "Wipe"}) {
+            assertTrue(parse("""
+                    botting:
+                      name: "Botting"
+                      type: BAN
+                      %s: true
+                      durations:
+                        - "perm"
+                    """.formatted(key), "botting").wipe(), key + " should enable the wipe");
+        }
+    }
+
+    @Test
+    void quotedWipeValueStillCounts() throws Exception {
+        assertTrue(parse("""
+                botting:
+                  name: "Botting"
+                  type: BAN
+                  wipe: "true"
+                  durations:
+                    - "perm"
+                """, "botting").wipe());
+
+        assertFalse(parse("""
+                botting:
+                  name: "Botting"
+                  type: BAN
+                  wipe: "false"
+                  durations:
+                    - "perm"
+                """, "botting").wipe());
+    }
+
+    @Test
+    void unknownTypeFallsBackToBan() throws Exception {
+        assertEquals(PunishmentType.BAN, parse("""
+                mystery:
+                  name: "Mystery"
+                  type: SOMETHING-ELSE
+                  durations:
+                    - "1d"
+                """, "mystery").type());
+    }
+
+    @Test
+    void bundledOffensesParseAndNoneWipeByDefault() {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new File("src/main/resources/offenses.yml"));
+        ConfigurationSection offenses = config.getConfigurationSection("offenses");
+        assertNotNull(offenses, "offenses.yml should contain an offenses section");
+
+        for (String key : offenses.getKeys(false)) {
+            ConfigurationSection section = offenses.getConfigurationSection(key);
+            assertNotNull(section, key + " should be a section");
+            OffenseManager.OffenseRule rule = OffenseManager.parseRule(key, section);
+            assertFalse(rule.wipe(), key + " must not wipe out of the box");
+            assertNotNull(rule.type(), key + " should resolve a punishment type");
+        }
+    }
+
+    private OffenseManager.OffenseRule parse(String yaml, String key) throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(new StringReader(yaml));
+        ConfigurationSection section = config.getConfigurationSection(key);
+        assertNotNull(section, "test yaml should define " + key);
+        return OffenseManager.parseRule(key, section);
+    }
+}


### PR DESCRIPTION
Closes #235

Banning a duper and then wiping their account took two commands and a second lookup of the name. `offenses.yml` now carries a `wipe` flag per preset, and `/offend` clears the account itself once the ban has gone out.

## The flag

Each offense picks it up next to `name`, `type` and `durations`:

```yaml
duping:
  name: "Item Duping"
  type: BAN
  wipe: true
  durations:
    - "3d"
    - "perm"
```

It defaults to false, so every bundled preset behaves as it did before, and a test walks the whole bundled file to keep it that way. The request wrote it as `WIPE` while the rest of the file is lower case, so the key matches under any casing, and a quoted `"true"` counts as well. Both bits of leniency earn their few lines: a typo on this particular flag costs someone their account.

## Only on a ban

`isBan` gates it to `BAN` and `BLACKLIST`. A `MUTE` or `WARN` preset keeps the account even with the flag turned on, and so does a tier of `0s`, since `OffendCommand` already downgrades that tier to a warning before any of this runs.

## Ordering

The wipe fires after `applyRuntimeEffect` has kicked them. `kickPlayer` fires `PlayerQuitEvent` synchronously and the quit handler saves and unloads their `PlayerData`, so a wipe running first would have that save write the old totals straight back over rows the transaction had just cleared.

Nothing new happens on the database side. It calls `PlayerWipeManager.wipe`, the same path `/playerwipe confirm` takes, so what survives a wipe is unchanged and it's still one transaction of per-UUID deletes.

## Notes

- Staff see the record count underneath the usual punishment confirmation, and a busy or failed wipe reports the reason rather than going quiet.
- No new message keys, so no language file changed. The lines match the hardcoded English that `/playerwipe` and `/offend` already send.
- Parsing moved into a package-private `OffenseManager.parseRule` so it can be tested without a plugin instance. Two new test classes, `OffenseManagerTest` and `OffendWipeGateTest`; suite is at 391.
- `docs/wiki/Staff-and-Security.md` has a new section under the `/playerwipe` write-up.
