### PR TITLE
perf(scoreboard): stop rebuilding currency config for every sidebar line (#253)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CurrencyManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CurrencyManager.java
@@ -2,12 +2,15 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CurrencyManager {
 
@@ -54,12 +57,18 @@ public class CurrencyManager {
 
     private final UltimateDonutSmp plugin;
 
+    // Rebuilding a definition costs a dozen config lookups and three list allocations, and the
+    // sidebar asks for one six times per line. The values only move when the config is reloaded.
+    private final Map<CurrencyType, CurrencyDefinition> definitionCache = new ConcurrentHashMap<>();
+    private volatile FileConfiguration definitionSource;
+
     public CurrencyManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
     }
 
     public void reload() {
-        // Values are read live from config so existing reload flow only needs a hook point.
+        definitionCache.clear();
+        definitionSource = null;
     }
 
     public String formatMoney(double amount) {
@@ -230,8 +239,26 @@ public class CurrencyManager {
     }
 
     private CurrencyDefinition definition(CurrencyType type) {
-        ConfigurationSection section = plugin.getConfigManager().getConfig()
-                .getConfigurationSection("CURRENCY." + type.configKey);
+        FileConfiguration config = plugin.getConfigManager().getConfig();
+        // ConfigManager.reload() swaps in a fresh YamlConfiguration, so an identity change means the
+        // file was reloaded without going through reload() above.
+        if (config != definitionSource) {
+            definitionCache.clear();
+            definitionSource = config;
+        }
+
+        CurrencyDefinition cached = definitionCache.get(type);
+        if (cached != null) {
+            return cached;
+        }
+
+        CurrencyDefinition built = readDefinition(config, type);
+        definitionCache.put(type, built);
+        return built;
+    }
+
+    private CurrencyDefinition readDefinition(FileConfiguration config, CurrencyType type) {
+        ConfigurationSection section = config.getConfigurationSection("CURRENCY." + type.configKey);
 
         String singular = getString(section, "SINGULAR", type.defaultSingular);
         String plural = getString(section, "PLURAL", type.defaultPlural);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PingManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PingManager.java
@@ -34,6 +34,10 @@ public final class PingManager implements Listener {
     private final Map<UUID, Long> pendingKeepAlives = new ConcurrentHashMap<>();
     private boolean protocolLibEnabled = false;
 
+    private volatile boolean geyserAbsent;
+    private volatile Method geyserApiMethod;
+    private volatile Method geyserConnectionMethod;
+
     public PingManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
@@ -160,12 +164,26 @@ public final class PingManager implements Listener {
      * Checks GeyserApi via reflection if Geyser is installed on the server.
      */
     private int getGeyserPing(UUID uuid) {
+        // Without Geyser installed this lookup walks the whole plugin classloader graph and builds a
+        // ClassNotFoundException, and it used to run on every ping refresh. The answer cannot change
+        // while the server is up.
+        if (geyserAbsent) {
+            return -1;
+        }
+
         try {
-            Class<?> geyserApiClass = Class.forName("org.geysermc.geyser.api.GeyserApi");
-            Method apiMethod = geyserApiClass.getMethod("api");
+            Method apiMethod = geyserApiMethod;
+            Method connectionMethod = geyserConnectionMethod;
+            if (apiMethod == null || connectionMethod == null) {
+                Class<?> geyserApiClass = Class.forName("org.geysermc.geyser.api.GeyserApi");
+                apiMethod = geyserApiClass.getMethod("api");
+                connectionMethod = geyserApiClass.getMethod("connectionByUuid", UUID.class);
+                geyserApiMethod = apiMethod;
+                geyserConnectionMethod = connectionMethod;
+            }
+
             Object apiInstance = apiMethod.invoke(null);
             if (apiInstance != null) {
-                Method connectionMethod = geyserApiClass.getMethod("connectionByUuid", UUID.class);
                 Object connection = connectionMethod.invoke(apiInstance, uuid);
                 if (connection != null) {
                     Method pingMethod = connection.getClass().getMethod("ping");
@@ -178,8 +196,11 @@ public final class PingManager implements Listener {
                     }
                 }
             }
+        } catch (ClassNotFoundException | NoSuchMethodException | LinkageError absent) {
+            // Geyser is not installed. Stop asking.
+            geyserAbsent = true;
         } catch (Throwable ignored) {
-            // Geyser API not available or player is not a Bedrock player on local Geyser
+            // Geyser is present but this player is not a Bedrock connection, or the call failed.
         }
         return -1;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -100,7 +100,7 @@ public class ScoreboardManager {
     public void applyVisibility(Player player) {
         SidebarSettings settings = readSettings();
         if (folia) {
-            if (!isEnabled()) {
+            if (!settings.enabled()) {
                 releasePlayerFolia(player);
                 return;
             }
@@ -110,7 +110,7 @@ public class ScoreboardManager {
             }
             updateFolia(player, settings);
         } else {
-            if (!isEnabled()) {
+            if (!settings.enabled()) {
                 releaseOwnedBoardSpigot(player);
                 return;
             }
@@ -211,7 +211,7 @@ public class ScoreboardManager {
     // ── Folia Implementations ──────────────────────────────────────────────────
 
     private void setupPlayerFolia(Player player, SidebarSettings settings) {
-        if (!isEnabled()) {
+        if (!settings.enabled()) {
             releasePlayerFolia(player);
             return;
         }
@@ -228,7 +228,7 @@ public class ScoreboardManager {
     }
 
     private void updateFolia(Player player, SidebarSettings settings) {
-        if (!isEnabled()) {
+        if (!settings.enabled()) {
             releasePlayerFolia(player);
             return;
         }
@@ -300,7 +300,7 @@ public class ScoreboardManager {
     // ── Spigot/Paper Implementations ───────────────────────────────────────────
 
     private void setupPlayerSpigot(Player player, SidebarSettings settings) {
-        if (!isEnabled()) {
+        if (!settings.enabled()) {
             releaseOwnedBoardSpigot(player);
             return;
         }
@@ -328,7 +328,7 @@ public class ScoreboardManager {
     }
 
     private void updateSpigot(Player player, SidebarSettings settings) {
-        if (!isEnabled()) {
+        if (!settings.enabled()) {
             releaseOwnedBoardSpigot(player);
             return;
         }
@@ -459,14 +459,22 @@ public class ScoreboardManager {
         // placeholder and colour pipeline on a string that is finished.
         if (text.length() <= 64) {
             team.setPrefix(text);
-            team.setSuffix("");
+            // Prefix and suffix each broadcast a team update of their own, and a short line leaves
+            // the suffix empty every pass after the first.
+            applySuffixSpigot(team, "");
             return;
         }
 
         int split = findSafeSplit(text, 64);
         int end = findSafeSplit(text, split + 64);
         team.setPrefix(text.substring(0, split));
-        team.setSuffix(text.substring(split, end));
+        applySuffixSpigot(team, text.substring(split, end));
+    }
+
+    private void applySuffixSpigot(Team team, String suffix) {
+        if (!suffix.equals(team.getSuffix())) {
+            team.setSuffix(suffix);
+        }
     }
 
     private void hidePlayerSpigot(Player player) {
@@ -524,16 +532,27 @@ public class ScoreboardManager {
     /** Reads every sidebar config value the render needs, once, for a whole update pass. */
     private SidebarSettings readSettings() {
         FileConfiguration scoreboard = plugin.getConfigManager().getScoreboard();
+        int iconColumnWidth = Math.max(0, scoreboard.getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10));
+        // Both currency icons are the same for every line and every player in a pass, and building
+        // one asks CurrencyManager for a definition twice.
+        CurrencyManager currency = plugin.getCurrencyManager();
         return new SidebarSettings(
+                isEnabled(),
                 scoreboard.getStringList("SCOREBOARD.TITLE"),
                 scoreboard.getStringList("SCOREBOARD.LINES"),
                 scoreboard.getString("SCOREBOARD.TEAM"),
                 scoreboard.getString("SCOREBOARD.SHARD-BOOSTER"),
                 scoreboard.getString("SCOREBOARD.SHARD-CUBOID"),
-                Math.max(0, scoreboard.getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10)),
+                iconColumnWidth,
                 scoreboard.getBoolean("SCOREBOARD.ALIGN-ICON-COLUMN", true),
-                scoreboard.getBoolean("SCOREBOARD.HIDE-NUMBERS", true)
+                scoreboard.getBoolean("SCOREBOARD.HIDE-NUMBERS", true),
+                sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.MONEY, iconColumnWidth),
+                sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.SHARDS, iconColumnWidth)
         );
+    }
+
+    private String sidebarCurrencyIcon(CurrencyManager currency, CurrencyManager.CurrencyType type, int columnWidth) {
+        return paddedSidebarIcon(currency.symbolColor(type) + "&l" + currency.symbol(type), columnWidth);
     }
 
     private static boolean hasPlaceholder(String text) {
@@ -549,6 +568,15 @@ public class ScoreboardManager {
         boolean hasBooster = plugin.getShardManager().hasBooster(player.getUniqueId());
         boolean showShardCuboid = plugin.getShardManager().shouldShowShardCuboidLine(player.getUniqueId());
 
+        // The player's balances read the same for every line of this pass, so format them once
+        // rather than once per line.
+        PlayerData data = plugin.getPlayerDataManager().get(player);
+        CurrencyManager currencyManager = plugin.getCurrencyManager();
+        String moneyShort = currencyManager.formatCompactAmount(
+                CurrencyManager.CurrencyType.MONEY, data != null ? data.getMoney() : 0D);
+        String shardsShort = currencyManager.formatCompactAmount(
+                CurrencyManager.CurrencyType.SHARDS, data != null ? data.getShards() : 0L);
+
         for (String line : settings.lines()) {
             String resolved = resolveConfiguredLine(
                     line,
@@ -560,7 +588,7 @@ public class ScoreboardManager {
                     showShardCuboid
             );
             if (resolved != null) {
-                resolved = applySidebarEconomyPlaceholders(resolved, player);
+                resolved = applySidebarEconomyPlaceholders(resolved, moneyShort, shardsShort);
                 lines.add(applySidebarLayoutPlaceholders(resolved, settings));
             }
         }
@@ -594,17 +622,14 @@ public class ScoreboardManager {
         return line;
     }
 
-    private String applySidebarEconomyPlaceholders(String line, Player player) {
+    private String applySidebarEconomyPlaceholders(String line, String moneyShort, String shardsShort) {
         if (line == null || line.isEmpty()) {
             return line == null ? "" : line;
         }
-
-        PlayerData data = plugin.getPlayerDataManager().get(player);
-        double money = data != null ? data.getMoney() : 0D;
-        long shards = data != null ? data.getShards() : 0L;
-        CurrencyManager currencyManager = plugin.getCurrencyManager();
-        String moneyShort = currencyManager.formatCompactAmount(CurrencyManager.CurrencyType.MONEY, money);
-        String shardsShort = currencyManager.formatCompactAmount(CurrencyManager.CurrencyType.SHARDS, shards);
+        // One scan rules out all seven replacements below, and most sidebar lines carry none of them.
+        if (line.indexOf("%economy_") < 0) {
+            return line;
+        }
 
         return line
                 .replace("%economy_nicestMoney%", moneyShort)
@@ -622,16 +647,8 @@ public class ScoreboardManager {
         }
 
         String result = line
-                .replace("{money_icon}", paddedSidebarIcon(
-                        plugin.getCurrencyManager().symbolColor(CurrencyManager.CurrencyType.MONEY)
-                                + "&l"
-                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.MONEY),
-                        settings))
-                .replace("{shards_icon}", paddedSidebarIcon(
-                        plugin.getCurrencyManager().symbolColor(CurrencyManager.CurrencyType.SHARDS)
-                                + "&l"
-                                + plugin.getCurrencyManager().symbol(CurrencyManager.CurrencyType.SHARDS),
-                        settings));
+                .replace("{money_icon}", settings.moneyIcon())
+                .replace("{shards_icon}", settings.shardsIcon());
 
         if (result.indexOf("{sb_icon:") < 0) {
             return result;
@@ -640,14 +657,14 @@ public class ScoreboardManager {
         Matcher matcher = SIDEBAR_ICON_PATTERN.matcher(result);
         StringBuffer buffer = new StringBuffer();
         while (matcher.find()) {
-            matcher.appendReplacement(buffer, Matcher.quoteReplacement(paddedSidebarIcon(matcher.group(1), settings)));
+            matcher.appendReplacement(buffer,
+                    Matcher.quoteReplacement(paddedSidebarIcon(matcher.group(1), settings.iconColumnWidth())));
         }
         matcher.appendTail(buffer);
         return buffer.toString();
     }
 
-    private String paddedSidebarIcon(String icon, SidebarSettings settings) {
-        int columnWidth = settings.iconColumnWidth();
+    private String paddedSidebarIcon(String icon, int columnWidth) {
         int iconWidth = minecraftTextWidth(icon);
         int missingWidth = Math.max(0, columnWidth - iconWidth);
         int spaces = Math.max(1, Math.round(missingWidth / 4F));
@@ -820,6 +837,7 @@ public class ScoreboardManager {
 
     /** The sidebar config as it stood at the start of one update pass. */
     private record SidebarSettings(
+            boolean enabled,
             List<String> titles,
             List<String> lines,
             String teamLine,
@@ -827,7 +845,9 @@ public class ScoreboardManager {
             String shardCuboidLine,
             int iconColumnWidth,
             boolean alignIconColumn,
-            boolean hideNumbers
+            boolean hideNumbers,
+            String moneyIcon,
+            String shardsIcon
     ) {
     }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardEconomyPlaceholderTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ScoreboardEconomyPlaceholderTest.java
@@ -1,0 +1,71 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ScoreboardEconomyPlaceholderTest {
+
+    private static final String MONEY = "1,2K";
+    private static final String SHARDS = "340";
+
+    private String apply(String line) throws Exception {
+        // The real constructor needs a live server; the substitution only reads its arguments.
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> managerConstructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(ScoreboardManager.class, objectConstructor);
+        ScoreboardManager manager = (ScoreboardManager) managerConstructor.newInstance();
+
+        Method apply = ScoreboardManager.class.getDeclaredMethod(
+                "applySidebarEconomyPlaceholders", String.class, String.class, String.class);
+        apply.setAccessible(true);
+
+        return (String) apply.invoke(manager, line, MONEY, SHARDS);
+    }
+
+    @Test
+    void substitutesEveryMoneyToken() throws Exception {
+        assertEquals("&f" + MONEY, apply("&f%economy_nicestMoney%"));
+        assertEquals("&f" + MONEY, apply("&f%economy_money_short%"));
+        assertEquals("&f" + MONEY, apply("&f%economy_money_amount_short%"));
+    }
+
+    @Test
+    void substitutesEveryShardToken() throws Exception {
+        assertEquals("&f" + SHARDS, apply("&f%economy_nicestShards%"));
+        assertEquals("&f" + SHARDS, apply("&f%economy_shards_short%"));
+        assertEquals("&f" + SHARDS, apply("&f%economy_shards_amount_short%"));
+        assertEquals("&f" + SHARDS, apply("&f%economy_shards%"));
+    }
+
+    @Test
+    void substitutesBothOnOneLine() throws Exception {
+        assertEquals(
+                "&aMoney " + MONEY + " &dShards " + SHARDS,
+                apply("&aMoney %economy_money_short% &dShards %economy_shards%")
+        );
+    }
+
+    @Test
+    void leavesLinesWithoutEconomyTokensUntouched() throws Exception {
+        // The early-out skips seven replace scans, so it has to return the line exactly as given,
+        // including lines that carry other placeholders.
+        String plain = "&#00A4FC &fKills &#00A4FC%statistic_player_kills%";
+        assertSame(plain, apply(plain));
+
+        String noPlaceholder = "&7ᴘɪɴɢ: &f25ms";
+        assertSame(noPlaceholder, apply(noPlaceholder));
+    }
+
+    @Test
+    void handlesEmptyAndNullLines() throws Exception {
+        assertEquals("", apply(""));
+        assertEquals("", apply(null));
+    }
+}


### PR DESCRIPTION
Closes #253

Follow-up to #237. That fix cleared the top layer off the sidebar, and the capture underneath showed the same problem one level down: things that hold still for a whole render pass were being rebuilt per line, and in one case on every call. What the plugin does is unchanged; only how often it works it out.

## Caching the currency definitions

`CurrencyManager.definition()` had no cache. One call read seven strings, two ints, a boolean and two separators out of `CURRENCY.<type>`, and `getCompactSuffixes` built two `ArrayList`s and a `List.copyOf` before the record was even constructed. Every accessor went through it, so the sidebar asked six times per line: twice for the balances, four times for the two currency icons. Fifteen lines at ten passes a second works out around 900 rebuilds per player per second.

The definition is cached per currency type now. `reload()` clears it, and the lookup also compares the `FileConfiguration` it was built from against the current one, since `ConfigManager.reload()` swaps in a fresh `YamlConfiguration` rather than mutating the old one. That second check means a reload path that forgets to call `reload()` still cannot serve a stale value. Nothing writes `CURRENCY.*` at runtime, so there is no third way for it to drift.

This helps everywhere currency gets formatted, not only the sidebar.

## Balances and icons move up to the pass

`applySidebarEconomyPlaceholders` formatted the player's money and shards for every line, including the lines with no economy placeholder anywhere in them, then ran seven `String.replace` scans over each. Both strings are the same for every line of a pass, so `getLines` formats them once and hands them down. A line with no `%economy_` in it now returns after a single scan instead of seven.

`applySidebarLayoutPlaceholders` had the same shape with the two currency icons, which is where four of those six `definition()` calls came from, plus a `minecraftTextWidth` walk each. Both icons are global to a pass, so they get built in `readSettings()` and travel in the snapshot.

## Geyser gets looked up once, not on every ping

`getGeyserPing` called `Class.forName("org.geysermc.geyser.api.GeyserApi")` on every refresh and threw the answer away. With no Geyser installed that walks Paper's whole plugin classloader graph and builds a `ClassNotFoundException` with a full stack trace, which was very nearly the entire cost of the ping task.

The resolved methods are kept, and a missing class marks Geyser absent for the session. The catch is split so that only `ClassNotFoundException`, `NoSuchMethodException` and `LinkageError` count as absent. A call that fails because the player is not a Bedrock connection still falls through to the normal path exactly as before.

## Two smaller ones

`SCOREBOARD.ENABLED` joins the `SidebarSettings` snapshot, so the six render paths that were each reading it live now read the value the pass started with. `updateAll` keeps its own live check ahead of building the snapshot, so a server running with the sidebar off does no more work than it does today.

`applyLineSpigot` called `setSuffix("")` on every changed short line even though the suffix was already empty. Prefix and suffix each fire `onTeamChanged → broadcastAll` separately, so that was two team packets where one would do. The suffix only gets written when it actually differs.

## Notes

Nothing added or renamed in config, no message keys, no schema, nothing in `plugin.yml`. Two behaviour details to be aware of: a currency config edit takes effect on reload rather than on the next line rendered, and toggling `SCOREBOARD.ENABLED` applies from the next render pass rather than mid-pass, about a tenth of a second later.

`ColorUtils.colorize()` is deliberately untouched. It is still the largest frame under the render at 367.56%, roughly eight times `getLines()`, but its subtree was not expanded in the capture, so there is no telling whether that is PlaceholderAPI, the five regex passes inside `stripColorCodesAndPlaceholders`, or `normalizeText`. Those want opposite fixes, and the caps handling decides when `BALANCE` renders as `Balance`, which is visible on screen. It gets its own issue once there is a capture that expands the node.

Suite is green at 396 tests. Five of them are new, covering the early-out: every one of the seven tokens still substitutes, a line carrying a non-economy placeholder comes back as the identical instance, and empty and null lines behave as they did.
