### PR TITLE
feat(rtp): queue players by walking into a cuboid (#256)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -309,6 +309,11 @@ QUEUE:
   # How far the matched players are scattered around the shared location, in blocks.
   # 0 drops the whole group on the exact same block
   SPREAD-RADIUS: 16
+  # Cuboid that feeds the queue on its own. Standing anywhere inside it puts a player in the
+  # queue without typing /rtpq, and walking back out takes them off it again. Leave empty to
+  # keep the command as the only way in. Bind it in game with
+  # /cuboid bind <cuboid> rtp-queue true
+  CUBOID: ''
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -319,12 +324,18 @@ QUEUE:
 | `QUEUE.MATCH-SIZE` | `int` | `2` - `32` | `2` | How many players have to be waiting before a match fires. Values below 2 are read as 2 and values above 32 are read as 32. |
 | `QUEUE.WORLD` | `string` | Any RTP world name or menu id | `world` | Where matched groups are sent. The name is resolved the same way `/rtp <world>` resolves it, and the world needs its own `WORLD-SETTINGS` entry. |
 | `QUEUE.SPREAD-RADIUS` | `int` | `0` - `512` | `16` | How far apart the group is scattered around the shared location. Each player after the first gets their own safe-location search inside this radius, and `0` drops everyone on the exact same block. |
+| `QUEUE.CUBOID` | `string` | Any cuboid name | `''` | A region that queues players by itself. Anyone standing inside is put on the queue about a second after walking in, and taken back off it on the way out. Leave it empty and `/rtpq` stays the only way in. `/cuboid bind <cuboid> rtp-queue true` writes the name here for you. |
 | `QUEUE.MESSAGES.*` | `string` | Any coloured text | see below | Player feedback for joining, leaving, and being matched. |
 
 The queue deliberately ignores RTP cooldowns, playtime requirements and the `PLAYERS-IN-RTP`
 slot limit, the same way the respawn teleport does, because a match has to move everybody at
 once. It also skips the stand-still countdown: one player stepping sideways would otherwise
 cancel their half of the match and leave the rest alone in the wilderness.
+
+The cuboid only takes back out the players it queued itself, so somebody who ran `/rtpq` before
+walking through keeps their place. Give it a region of its own rather than reusing
+`RTP-ZONE.CUBOID` from `config.yml`: that one runs a countdown and sends every player somewhere
+different, which is the opposite of what a match is for.
 
 ### 3. Practical Setup Example
 
@@ -335,6 +346,8 @@ QUEUE:
   MATCH-SIZE: 3
   WORLD: world_nether
   SPREAD-RADIUS: 30
+  # Players queue by walking into the pit at spawn instead of typing anything
+  CUBOID: rtp_pit
 ```
 
 ---

--- a/docs/wiki/Cuboids-and-Portals.md
+++ b/docs/wiki/Cuboids-and-Portals.md
@@ -75,7 +75,7 @@ the cuboid spawn point is the fallback everything else uses.
 Cuboids can be bound to different server systems to enforce special features or protections:
 
 ```bash
-/cuboid bind <cuboid_name> <spawn|shard|rtp-zone> <true|false>
+/cuboid bind <cuboid_name> <spawn|shard|rtp-zone|rtp-queue> <true|false>
 ```
 
 ### Feature Binds Explained:
@@ -93,6 +93,14 @@ Cuboids can be bound to different server systems to enforce special features or 
 3. **`rtp-zone` Bind**:
    - Defines the exact region where `/rtp` (Random Teleport) will pick safe destination locations.
    *Command*: `/cuboid bind wilderness_bounds rtp-zone true`
+
+4. **`rtp-queue` Bind**:
+   - Puts everyone standing in the region on the RTP matchmaking queue without them typing
+     `/rtpq`, and takes them off again when they walk out. Once enough of them are waiting the
+     whole group is dropped at one shared random location, so a fight starts where they land.
+   - Writes the region name to `QUEUE.CUBOID` in `rtp.yml`, where the match size, destination
+     world and spread radius live.
+   *Command*: `/cuboid bind rtp_pit rtp-queue true`
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
@@ -194,7 +194,7 @@ public class CuboidCommand implements CommandExecutor {
     private void bindCuboidSystem(Player player, String[] args) {
         if (args.length < 4) {
             player.sendMessage(ColorUtils.toComponent(
-                    "&cUsage: /cuboid bind <cuboid> <spawn|shard|rtp-zone> <true|false>"
+                    "&cUsage: /cuboid bind <cuboid> <spawn|shard|rtp-zone|rtp-queue> <true|false>"
             ));
             return;
         }
@@ -208,7 +208,9 @@ public class CuboidCommand implements CommandExecutor {
 
         String role = normalizeRole(args[2]);
         if (role == null) {
-            player.sendMessage(ColorUtils.toComponent("&cUnknown role. Use &fspawn&c, &fshard&c, or &frtp-zone&c."));
+            player.sendMessage(ColorUtils.toComponent(
+                    "&cUnknown role. Use &fspawn&c, &fshard&c, &frtp-zone&c, or &frtp-queue&c."
+            ));
             return;
         }
 
@@ -251,14 +253,19 @@ public class CuboidCommand implements CommandExecutor {
                 config.set("AFK-SYSTEM.AFK-CUBOID-NAME", afkBinds.isEmpty() ? "" : afkBinds.get(0));
             }
             case "rtp-zone" -> config.set("RTP-ZONE.CUBOID", enabled ? cuboidName : "");
+            // The matchmaking cuboid is a queue setting rather than a world setting, so it lives
+            // in rtp.yml next to the rest of QUEUE and is saved from there.
+            case "rtp-queue" -> plugin.getConfigManager().getRtp().set("QUEUE.CUBOID", enabled ? cuboidName : "");
             default -> {
                 player.sendMessage(ColorUtils.toComponent("&cUnknown role."));
                 return;
             }
         }
 
-        if (!plugin.getConfigManager().saveConfig()) {
-            player.sendMessage(ColorUtils.toComponent("&cFailed to save config.yml."));
+        boolean queueRole = "rtp-queue".equals(role);
+        String file = queueRole ? "rtp.yml" : "config.yml";
+        if (!(queueRole ? plugin.getConfigManager().saveRtp() : plugin.getConfigManager().saveConfig())) {
+            player.sendMessage(ColorUtils.toComponent("&cFailed to save " + file + "."));
             return;
         }
         plugin.reloadAllPluginConfigurations();
@@ -321,11 +328,12 @@ public class CuboidCommand implements CommandExecutor {
             case "spawn" -> "spawn";
             case "shard", "shards" -> "shard";
             case "rtp-zone", "rtpzone", "rtp_zone" -> "rtp-zone";
+            case "rtp-queue", "rtpqueue", "rtp_queue", "rtpq" -> "rtp-queue";
             default -> null;
         };
     }
 
     private void sendUsage(CommandSender sender) {
-        sender.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid <wand|create <name>|delete <name>|list|setspawn <name>|delspawn <name>|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>"));
+        sender.sendMessage(ColorUtils.toComponent("&cUsage: /cuboid <wand|create <name>|delete <name>|list|setspawn <name>|delspawn <name>|bind <cuboid> <spawn|shard|rtp-zone|rtp-queue> <true|false>|reload>"));
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -2168,6 +2168,7 @@ public class ConfigManager {
     public boolean saveFfa() { return save("ffa.yml", ffa); }
     public boolean saveCrates() { return save("crates.yml", crates); }
     public boolean saveShop() { return save("shop.yml", shop); }
+    public boolean saveRtp() { return save("rtp.yml", rtp); }
     public boolean saveMenus() { return save("menus.yml", menus); }
     public boolean saveAuctionHouse() { return save("auction-house.yml", auctionHouse); }
     public boolean saveDatabase() { return save("database.yml", database); }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPQueueManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPQueueManager.java
@@ -11,7 +11,9 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Matchmaking in front of RTP. Players run /rtpq to wait for other players, and once enough of
@@ -23,6 +25,10 @@ import java.util.UUID;
  * match is never blocked by RTP cooldowns, playtime requirements, or the RTP slot queue. The
  * waiting list only lives in memory, so leaving the server or reloading the config drops the
  * player from it.
+ *
+ * <p>A server can skip the command entirely by naming a cuboid in {@code QUEUE.CUBOID}. Players
+ * standing inside it are queued a second after they walk in and taken back off the queue when
+ * they walk out, so a group forms by gathering in one room instead of by typing.
  */
 public class RTPQueueManager {
 
@@ -34,6 +40,7 @@ public class RTPQueueManager {
 
     private final UltimateDonutSmp plugin;
     private final LinkedHashSet<UUID> waiting = new LinkedHashSet<>();
+    private final Set<UUID> zoneJoined = ConcurrentHashMap.newKeySet();
 
     public RTPQueueManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -72,6 +79,27 @@ public class RTPQueueManager {
         return plugin.getRtpManager().resolveWorldSelector(configured);
     }
 
+    /**
+     * Name of the cuboid that queues players by standing in it, or null when the server has not
+     * set one and {@code /rtpq} is the only way in.
+     */
+    public String getCuboidName() {
+        FileConfiguration rtp = rtpConfig();
+        String configured = rtp == null ? null : rtp.getString("QUEUE.CUBOID", "");
+        return configured == null || configured.isBlank() ? null : configured;
+    }
+
+    /**
+     * Whether the per-second cuboid sweep has anything to do, so the task can skip walking the
+     * whole player list on servers that never set a queue cuboid.
+     */
+    public boolean isZoneActive() {
+        return plugin != null
+                && plugin.getCuboidManager() != null
+                && getCuboidName() != null
+                && isEnabled();
+    }
+
     public boolean isInQueue(UUID playerId) {
         if (playerId == null) {
             return false;
@@ -104,6 +132,7 @@ public class RTPQueueManager {
     }
 
     public void clear() {
+        zoneJoined.clear();
         synchronized (waiting) {
             waiting.clear();
         }
@@ -115,34 +144,50 @@ public class RTPQueueManager {
      * @return true when the player is waiting in the queue once this returns
      */
     public boolean join(Player player) {
+        return join(player, true);
+    }
+
+    /**
+     * @param notifyRefusal false for the cuboid join, which would otherwise repeat the same
+     *                      refusal once a second at a player who is only standing there
+     */
+    private boolean join(Player player, boolean notifyRefusal) {
         if (player == null) {
             return false;
         }
 
         if (!isEnabled()) {
-            sendMessage(player, "DISABLED", "&cThe RTP queue is currently disabled.");
+            if (notifyRefusal) {
+                sendMessage(player, "DISABLED", "&cThe RTP queue is currently disabled.");
+            }
             return false;
         }
 
         UUID playerId = player.getUniqueId();
         if (isInQueue(playerId)) {
-            sendMessage(
-                    player,
-                    "ALREADY-QUEUED",
-                    "&cYou are already in the RTP queue at position #{position}.",
-                    "{position}", String.valueOf(getQueuePosition(playerId))
-            );
+            if (notifyRefusal) {
+                sendMessage(
+                        player,
+                        "ALREADY-QUEUED",
+                        "&cYou are already in the RTP queue at position #{position}.",
+                        "{position}", String.valueOf(getQueuePosition(playerId))
+                );
+            }
             return false;
         }
 
         if (getSearchSettings() == null) {
-            sendMessage(player, "UNAVAILABLE", "&cThe RTP queue is not available right now.");
+            if (notifyRefusal) {
+                sendMessage(player, "UNAVAILABLE", "&cThe RTP queue is not available right now.");
+            }
             return false;
         }
 
         if (plugin.getRtpManager().hasActiveRtpFlow(playerId)
                 || plugin.getTeleportManager().hasPendingType(playerId, "RTP")) {
-            sendMessage(player, "BUSY", "&cFinish the teleport you already started before joining the RTP queue.");
+            if (notifyRefusal) {
+                sendMessage(player, "BUSY", "&cFinish the teleport you already started before joining the RTP queue.");
+            }
             return false;
         }
 
@@ -172,6 +217,43 @@ public class RTPQueueManager {
 
         startMatchIfReady();
         return true;
+    }
+
+    /**
+     * Queues a player standing in {@code QUEUE.CUBOID} and takes them off again once they walk
+     * out. Only the players the cuboid put there are pulled back out by it, so somebody who ran
+     * {@code /rtpq} elsewhere keeps their place after crossing the region.
+     */
+    public void tickZone(Player player) {
+        if (player == null) {
+            return;
+        }
+
+        UUID playerId = player.getUniqueId();
+        String cuboidName = getCuboidName();
+        if (cuboidName == null || !isEnabled() || plugin.getCuboidManager() == null) {
+            zoneJoined.remove(playerId);
+            return;
+        }
+
+        CuboidManager.Cuboid cuboid = plugin.getCuboidManager().getCuboid(cuboidName);
+        if (cuboid == null) {
+            zoneJoined.remove(playerId);
+            return;
+        }
+
+        if (cuboid.contains(player.getLocation())) {
+            if (!isInQueue(playerId) && join(player, false)) {
+                zoneJoined.add(playerId);
+            }
+            return;
+        }
+
+        // A matched player has already been dropped from the waiting list and teleported out of
+        // the region, so the marker goes without a second "you have left the queue".
+        if (zoneJoined.remove(playerId) && isInQueue(playerId)) {
+            leave(player);
+        }
     }
 
     /**
@@ -206,6 +288,7 @@ public class RTPQueueManager {
      * Drops a player who has disconnected, without telling the rest of the queue they left.
      */
     public void handleQuit(UUID playerId) {
+        zoneJoined.remove(playerId);
         remove(playerId);
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/RTPZoneTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/RTPZoneTask.java
@@ -3,6 +3,11 @@ package com.bx.ultimateDonutSmp.tasks;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.entity.Player;
 
+/**
+ * The once-a-second sweep behind both RTP cuboids: the countdown zone that teleports whoever
+ * stands still in it, and the matchmaking cuboid that puts whoever walks in on the RTP queue.
+ * They share one pass over the player list rather than running a timer each.
+ */
 public class RTPZoneTask implements Runnable {
 
     private final UltimateDonutSmp plugin;
@@ -13,10 +18,20 @@ public class RTPZoneTask implements Runnable {
 
     @Override
     public void run() {
-        if (plugin.getRtpZoneManager() == null || !plugin.getRtpZoneManager().isEnabled()) {
+        boolean countdownZone = plugin.getRtpZoneManager() != null && plugin.getRtpZoneManager().isEnabled();
+        boolean queueZone = plugin.getRtpQueueManager() != null && plugin.getRtpQueueManager().isZoneActive();
+        if (!countdownZone && !queueZone) {
             return;
         }
-        plugin.getSpigotScheduler().forEachOnlinePlayer((Player player) -> plugin.getRtpZoneManager().tick(player));
+
+        plugin.getSpigotScheduler().forEachOnlinePlayer((Player player) -> {
+            if (countdownZone) {
+                plugin.getRtpZoneManager().tick(player);
+            }
+            if (queueZone) {
+                plugin.getRtpQueueManager().tickZone(player);
+            }
+        });
     }
 
     public static void start(UltimateDonutSmp plugin) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -645,7 +645,7 @@ commands:
     permission-message: "&cYou do not have permission to use /clearlag."
   cuboid:
     description: Manage cuboid regions
-    usage: /cuboid <wand|create|delete|list|setspawn|delspawn|bind <cuboid> <spawn|shard|rtp-zone> <true|false>|reload>
+    usage: /cuboid <wand|create|delete|list|setspawn|delspawn|bind <cuboid> <spawn|shard|rtp-zone|rtp-queue> <true|false>|reload>
     permission: ultimatedonutsmp.command.cuboid
     permission-message: "&cYou do not have permission to use /cuboid."
   setwarp:

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -82,6 +82,11 @@ QUEUE:
   # How far the matched players are scattered around the shared location, in blocks.
   # 0 drops the whole group on the exact same block
   SPREAD-RADIUS: 16
+  # Cuboid that feeds the queue on its own. Standing anywhere inside it puts a player in the
+  # queue without typing /rtpq, and walking back out takes them off it again. Leave empty to
+  # keep the command as the only way in. Bind it in game with
+  # /cuboid bind <cuboid> rtp-queue true
+  CUBOID: ''
   # User feedback for the matchmaking queue
   MESSAGES:
     DISABLED: '&cThe RTP queue is currently disabled.'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPQueueManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPQueueManagerTest.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -16,10 +17,13 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RTPQueueManagerTest {
@@ -100,6 +104,7 @@ class RTPQueueManagerTest {
         setField(UltimateDonutSmp.class, plugin, "featureManager", new FeatureManager(plugin));
         setField(UltimateDonutSmp.class, plugin, "teleportManager", new TeleportManager(plugin));
         setField(UltimateDonutSmp.class, plugin, "rtpManager", new RTPManager(plugin));
+        setField(UltimateDonutSmp.class, plugin, "cuboidManager", new CuboidManager(plugin));
 
         RTPQueueManager queueManager = new RTPQueueManager(plugin);
         setField(UltimateDonutSmp.class, plugin, "rtpQueueManager", queueManager);
@@ -113,6 +118,10 @@ class RTPQueueManagerTest {
     }
 
     private Player createMockPlayer(UUID uuid, String name) {
+        return createMockPlayer(uuid, name, () -> null);
+    }
+
+    private Player createMockPlayer(UUID uuid, String name, Supplier<Location> standingAt) {
         return (Player) Proxy.newProxyInstance(
                 Player.class.getClassLoader(),
                 new Class<?>[]{Player.class},
@@ -121,9 +130,24 @@ class RTPQueueManagerTest {
                     case "getName" -> name;
                     case "isOnline" -> true;
                     case "hasPermission" -> false;
+                    case "getLocation" -> standingAt.get();
                     default -> null;
                 }
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void registerCuboid(UltimateDonutSmp plugin, String name) throws Exception {
+        Field cuboidsField = CuboidManager.class.getDeclaredField("cuboids");
+        cuboidsField.setAccessible(true);
+        ((Map<String, CuboidManager.Cuboid>) cuboidsField.get(plugin.getCuboidManager()))
+                .put(name, new CuboidManager.Cuboid("world", 0, 0, 0, 10, 10, 10));
+    }
+
+    private UltimateDonutSmp pluginOf(RTPQueueManager queueManager) throws Exception {
+        Field pluginField = RTPQueueManager.class.getDeclaredField("plugin");
+        pluginField.setAccessible(true);
+        return (UltimateDonutSmp) pluginField.get(queueManager);
     }
 
     @Test
@@ -232,6 +256,69 @@ class RTPQueueManagerTest {
 
         assertFalse(queueManager.join(createMockPlayer(UUID.randomUUID(), "First")));
         assertEquals(0, queueManager.getQueueSize());
+    }
+
+    @Test
+    void cuboidQueuesWhoeverStandsInItAndDropsThemOnTheWayOut() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(4);
+        rtpConfig.set("QUEUE.CUBOID", "rtpqueue");
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+        registerCuboid(pluginOf(queueManager), "rtpqueue");
+
+        UUID playerId = UUID.randomUUID();
+        Location[] standingAt = {new Location(mockWorld, 5, 5, 5)};
+        Player player = createMockPlayer(playerId, "First", () -> standingAt[0]);
+
+        assertTrue(queueManager.isZoneActive());
+        queueManager.tickZone(player);
+        assertTrue(queueManager.isInQueue(playerId));
+
+        queueManager.tickZone(player);
+        assertEquals(1, queueManager.getQueueSize());
+
+        standingAt[0] = new Location(mockWorld, 500, 5, 5);
+        queueManager.tickZone(player);
+        assertFalse(queueManager.isInQueue(playerId));
+    }
+
+    @Test
+    void cuboidLeavesPlayersWhoQueuedWithTheCommandWhereTheyAre() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(4);
+        rtpConfig.set("QUEUE.CUBOID", "rtpqueue");
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+        registerCuboid(pluginOf(queueManager), "rtpqueue");
+
+        UUID playerId = UUID.randomUUID();
+        Location[] standingAt = {new Location(mockWorld, 500, 5, 5)};
+        Player player = createMockPlayer(playerId, "First", () -> standingAt[0]);
+
+        assertTrue(queueManager.join(player));
+
+        standingAt[0] = new Location(mockWorld, 5, 5, 5);
+        queueManager.tickZone(player);
+        standingAt[0] = new Location(mockWorld, 500, 5, 5);
+        queueManager.tickZone(player);
+
+        assertTrue(queueManager.isInQueue(playerId));
+    }
+
+    @Test
+    void cuboidSweepStaysOffWithoutARegionBehindIt() throws Exception {
+        YamlConfiguration rtpConfig = rtpConfig(4);
+        RTPQueueManager queueManager = createQueueManager(rtpConfig);
+
+        UUID playerId = UUID.randomUUID();
+        Player player = createMockPlayer(playerId, "First", () -> new Location(mockWorld, 5, 5, 5));
+
+        assertNull(queueManager.getCuboidName());
+        assertFalse(queueManager.isZoneActive());
+        queueManager.tickZone(player);
+        assertFalse(queueManager.isInQueue(playerId));
+
+        rtpConfig.set("QUEUE.CUBOID", "missing");
+        assertTrue(queueManager.isZoneActive());
+        queueManager.tickZone(player);
+        assertFalse(queueManager.isInQueue(playerId));
     }
 
     @Test


### PR DESCRIPTION
Closes #256

Standing in a region now puts a player on the RTP matchmaking queue. The queue itself is not new: it already pulled a group together and dropped them at one shared random spot, but the only way in was typing `/rtpq`. Point `QUEUE.CUBOID` at a cuboid and the sweep queues anyone who walks into it about a second later, so a server can dig a pit at spawn and let players collect there instead of arranging it in chat.

## The cuboid sweep

`RTPQueueManager.tickZone` runs once a second per online player and does two things: it queues whoever is inside the region, and it drops whoever it queued earlier and has since walked out. That second half is deliberately narrow. It keeps a set of the players the region put on the queue, so somebody who typed `/rtpq` over in the shop and then cut through the pit on their way to spawn keeps their place instead of losing it to a region they never meant to use.

Joining from the region reuses `join` with the refusals silenced. Otherwise a player who stands there with an RTP search already running eats "finish the teleport you already started" once a second until they move.

## Where it ticks

`RTPZoneTask` already walked the player list every second for the countdown zone, so the queue sweep rides along in the same pass rather than starting a second timer. Each half checks its own toggle, and the task still bails out immediately when neither cuboid is set.

## /cuboid bind rtp-queue

`/cuboid bind <cuboid> rtp-queue true` writes the name into `QUEUE.CUBOID`, the same way the `rtp-zone` role writes `RTP-ZONE.CUBOID`. That key sits in `rtp.yml` rather than `config.yml` because the rest of the queue settings do, so `ConfigManager` picked up a `saveRtp()` alongside the savers it already has for the other files.

## Notes

`QUEUE.CUBOID` defaults to `''`. Nothing changes on a server that leaves it alone, and `isZoneActive()` keeps the sweep switched off there rather than walking the player list for nothing. A key still pointing at a cuboid somebody deleted behaves the way the RTP zone already does with one: nothing happens.

Worth giving it a region of its own instead of reusing `RTP-ZONE.CUBOID`. That one counts down and sends every player somewhere separate, which would tear a match apart before it started.

Three tests in `RTPQueueManagerTest` cover the region queueing a player and dropping them on the way out, the `/rtpq` player who walks through and keeps their place, and the sweep sitting still when the key is empty or names a cuboid that does not exist. Full suite is 399 green. `docs/wiki/Config-rtp.yml.md` and `docs/wiki/Cuboids-and-Portals.md` got the new key and the new bind role.
