### PR TITLE
perf(scoreboard): cache the hex codes, icons and balances the sidebar reuses (#257)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CurrencyManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CurrencyManager.java
@@ -295,8 +295,25 @@ public class CurrencyManager {
                 compactSuffixes,
                 compactDecimalPlaces,
                 groupingSeparator,
-                decimalSeparator
+                decimalSeparator,
+                buildFormat(decimalPlaces, groupingSeparator, decimalSeparator),
+                buildFormat(compactDecimalPlaces, groupingSeparator, decimalSeparator)
         );
+    }
+
+    private DecimalFormat buildFormat(int decimalPlaces, char groupingSeparator, char decimalSeparator) {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
+        symbols.setGroupingSeparator(groupingSeparator);
+        symbols.setDecimalSeparator(decimalSeparator);
+        return new DecimalFormat(pattern(decimalPlaces), symbols);
+    }
+
+    /**
+     * Identity of the definition currently in use for a currency. It changes when the config is
+     * reloaded, so callers can hold formatted values and drop them when this stops matching.
+     */
+    public Object definitionToken(CurrencyType type) {
+        return definition(type);
     }
 
     private String getString(ConfigurationSection section, String key, String fallback) {
@@ -347,20 +364,22 @@ public class CurrencyManager {
         return Math.max(0, Math.min(8, decimalPlaces));
     }
 
-    private final java.util.Map<String, DecimalFormat> formatCache = new java.util.concurrent.ConcurrentHashMap<>();
-
     private String formatNumber(double amount, int decimalPlaces, CurrencyDefinition definition) {
         if (!Double.isFinite(amount)) {
             amount = 0D;
         }
 
-        String key = decimalPlaces + "|" + definition.groupingSeparator() + "|" + definition.decimalSeparator();
-        DecimalFormat format = formatCache.computeIfAbsent(key, k -> {
-            DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
-            symbols.setGroupingSeparator(definition.groupingSeparator());
-            symbols.setDecimalSeparator(definition.decimalSeparator());
-            return new DecimalFormat(pattern(decimalPlaces), symbols);
-        });
+        // Both formats a definition can ask for are built with it. Looking one up used to mean
+        // concatenating a key and allocating a lambda for computeIfAbsent on every call.
+        DecimalFormat format;
+        if (decimalPlaces == definition.decimalPlaces()) {
+            format = definition.amountFormat();
+        } else if (decimalPlaces == definition.compactDecimalPlaces()) {
+            format = definition.compactAmountFormat();
+        } else {
+            format = buildFormat(decimalPlaces, definition.groupingSeparator(), definition.decimalSeparator());
+        }
+
         synchronized (format) {
             return format.format(amount);
         }
@@ -418,6 +437,8 @@ public class CurrencyManager {
             List<String> compactSuffixes,
             int compactDecimalPlaces,
             char groupingSeparator,
-            char decimalSeparator
+            char decimalSeparator,
+            DecimalFormat amountFormat,
+            DecimalFormat compactAmountFormat
     ) {}
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -63,6 +63,14 @@ public class ScoreboardManager {
     private final Map<UUID, Team[]> playerTeams = new ConcurrentHashMap<>();
     private final Map<UUID, Integer> playerLineCounts = new ConcurrentHashMap<>();
 
+    // Formatted balances, and the two sidebar currency icons, held until the value behind them moves.
+    private final Map<UUID, FormattedBalances> balanceCache = new ConcurrentHashMap<>();
+    private Object iconMoneyToken;
+    private Object iconShardsToken;
+    private int iconWidth = -1;
+    private String cachedMoneyIcon;
+    private String cachedShardsIcon;
+
     private int titleIndex = 0;
 
     public ScoreboardManager(UltimateDonutSmp plugin) {
@@ -137,6 +145,7 @@ public class ScoreboardManager {
     }
 
     public void removePlayer(UUID uuid) {
+        balanceCache.remove(uuid);
         if (folia) {
             removePlayerFolia(uuid);
         } else {
@@ -192,6 +201,7 @@ public class ScoreboardManager {
             playerObjectives.clear();
             playerTeams.clear();
             playerLineCounts.clear();
+            balanceCache.clear();
         }
     }
 
@@ -205,6 +215,7 @@ public class ScoreboardManager {
             playerObjectives.remove(uuid);
             playerTeams.remove(uuid);
             playerLineCounts.remove(uuid);
+            balanceCache.remove(uuid);
         }
     }
 
@@ -496,6 +507,7 @@ public class ScoreboardManager {
         playerObjectives.clear();
         playerTeams.clear();
         playerLineCounts.clear();
+        balanceCache.clear();
     }
 
     private void releaseOwnedBoardSpigot(Player player) {
@@ -522,6 +534,7 @@ public class ScoreboardManager {
         playerObjectives.remove(uuid);
         playerTeams.remove(uuid);
         playerLineCounts.remove(uuid);
+        balanceCache.remove(uuid);
         if (numberHider != null) {
             numberHider.forget(uuid);
         }
@@ -533,9 +546,20 @@ public class ScoreboardManager {
     private SidebarSettings readSettings() {
         FileConfiguration scoreboard = plugin.getConfigManager().getScoreboard();
         int iconColumnWidth = Math.max(0, scoreboard.getInt("SCOREBOARD.ICON-COLUMN-WIDTH", 10));
-        // Both currency icons are the same for every line and every player in a pass, and building
-        // one asks CurrencyManager for a definition twice.
         CurrencyManager currency = plugin.getCurrencyManager();
+        Object moneyToken = currency.definitionToken(CurrencyManager.CurrencyType.MONEY);
+        Object shardsToken = currency.definitionToken(CurrencyManager.CurrencyType.SHARDS);
+
+        // An icon only moves when the currency symbol, its colour, or the column width changes.
+        // Rebuilding it every pass meant walking the string for its pixel width every pass.
+        if (moneyToken != iconMoneyToken || shardsToken != iconShardsToken || iconColumnWidth != iconWidth) {
+            cachedMoneyIcon = sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.MONEY, iconColumnWidth);
+            cachedShardsIcon = sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.SHARDS, iconColumnWidth);
+            iconMoneyToken = moneyToken;
+            iconShardsToken = shardsToken;
+            iconWidth = iconColumnWidth;
+        }
+
         return new SidebarSettings(
                 isEnabled(),
                 scoreboard.getStringList("SCOREBOARD.TITLE"),
@@ -546,8 +570,10 @@ public class ScoreboardManager {
                 iconColumnWidth,
                 scoreboard.getBoolean("SCOREBOARD.ALIGN-ICON-COLUMN", true),
                 scoreboard.getBoolean("SCOREBOARD.HIDE-NUMBERS", true),
-                sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.MONEY, iconColumnWidth),
-                sidebarCurrencyIcon(currency, CurrencyManager.CurrencyType.SHARDS, iconColumnWidth)
+                cachedMoneyIcon,
+                cachedShardsIcon,
+                moneyToken,
+                shardsToken
         );
     }
 
@@ -568,14 +594,33 @@ public class ScoreboardManager {
         boolean hasBooster = plugin.getShardManager().hasBooster(player.getUniqueId());
         boolean showShardCuboid = plugin.getShardManager().shouldShowShardCuboidLine(player.getUniqueId());
 
-        // The player's balances read the same for every line of this pass, so format them once
-        // rather than once per line.
+        // Formatting a balance runs it through DecimalFormat, and the result only moves when the
+        // balance does. Hold the last one per player and reuse it until the amount or the currency
+        // config changes underneath it.
         PlayerData data = plugin.getPlayerDataManager().get(player);
-        CurrencyManager currencyManager = plugin.getCurrencyManager();
-        String moneyShort = currencyManager.formatCompactAmount(
-                CurrencyManager.CurrencyType.MONEY, data != null ? data.getMoney() : 0D);
-        String shardsShort = currencyManager.formatCompactAmount(
-                CurrencyManager.CurrencyType.SHARDS, data != null ? data.getShards() : 0L);
+        double money = data != null ? data.getMoney() : 0D;
+        long shards = data != null ? data.getShards() : 0L;
+
+        UUID uuid = player.getUniqueId();
+        FormattedBalances balances = balanceCache.get(uuid);
+        if (balances == null
+                || balances.moneyToken() != settings.moneyToken()
+                || balances.shardsToken() != settings.shardsToken()
+                || Double.compare(balances.money(), money) != 0
+                || balances.shards() != shards) {
+            CurrencyManager currencyManager = plugin.getCurrencyManager();
+            balances = new FormattedBalances(
+                    settings.moneyToken(),
+                    settings.shardsToken(),
+                    money,
+                    shards,
+                    currencyManager.formatCompactAmount(CurrencyManager.CurrencyType.MONEY, money),
+                    currencyManager.formatCompactAmount(CurrencyManager.CurrencyType.SHARDS, shards)
+            );
+            balanceCache.put(uuid, balances);
+        }
+        String moneyShort = balances.moneyText();
+        String shardsShort = balances.shardsText();
 
         for (String line : settings.lines()) {
             String resolved = resolveConfiguredLine(
@@ -847,7 +892,20 @@ public class ScoreboardManager {
             boolean alignIconColumn,
             boolean hideNumbers,
             String moneyIcon,
-            String shardsIcon
+            String shardsIcon,
+            Object moneyToken,
+            Object shardsToken
+    ) {
+    }
+
+    /** A player's balances as they were last formatted, with the currency definitions behind them. */
+    private record FormattedBalances(
+            Object moneyToken,
+            Object shardsToken,
+            double money,
+            long shards,
+            String moneyText,
+            String shardsText
     ) {
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShardManager.java
@@ -187,6 +187,9 @@ public class ShardManager {
     private final Map<UUID, Map<String, ShardCuboidProgress>> cuboidProgress = new HashMap<>();
     private final Map<UUID, Integer> pendingMovementBlocks = new HashMap<>();
     private final Map<UUID, String> lastMatchedCuboid = new HashMap<>();
+    private static final ShardCuboidHudState EMPTY_HUD_STATE =
+            new ShardCuboidHudState("none", "outside", "-", 0, false);
+
     private final Map<UUID, ShardCuboidHudState> hudStates = new HashMap<>();
     private final Map<UUID, Map<UUID, Long>> killRewardCooldowns = new ConcurrentHashMap<>();
 
@@ -594,7 +597,9 @@ public class ShardManager {
     }
 
     public ShardCuboidHudState getHudState(UUID uuid) {
-        return hudStates.getOrDefault(uuid, new ShardCuboidHudState("none", "outside", "-", 0, false));
+        // getOrDefault evaluates its fallback whether or not the key is present, and this runs once
+        // per player per sidebar pass. The fallback never varies, so share one.
+        return hudStates.getOrDefault(uuid, EMPTY_HUD_STATE);
     }
 
     public boolean shouldShowShardCuboidLine(UUID uuid) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
@@ -292,13 +292,16 @@ public class ColorUtils {
     }
 
     private static String toLegacyHex(String hex) {
-        return String.valueOf(SECTION_CHAR) + "x"
-                + SECTION_CHAR + String.valueOf(hex.charAt(0))
-                + SECTION_CHAR + String.valueOf(hex.charAt(1))
-                + SECTION_CHAR + String.valueOf(hex.charAt(2))
-                + SECTION_CHAR + String.valueOf(hex.charAt(3))
-                + SECTION_CHAR + String.valueOf(hex.charAt(4))
-                + SECTION_CHAR + String.valueOf(hex.charAt(5));
+        // The result is always fourteen characters. Chaining concatenations built a dozen throwaway
+        // strings per colour code, and the sidebar runs this for every line of every player.
+        char[] out = new char[14];
+        out[0] = SECTION_CHAR;
+        out[1] = 'x';
+        for (int i = 0; i < 6; i++) {
+            out[2 + i * 2] = SECTION_CHAR;
+            out[3 + i * 2] = hex.charAt(i);
+        }
+        return new String(out);
     }
 
     private static final Pattern UNICODE_ESCAPE_PATTERN = Pattern.compile("\\\\u([0-9A-Fa-f]{4})");

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ShardHudStateFallbackTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ShardHudStateFallbackTest.java
@@ -1,0 +1,70 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ShardHudStateFallbackTest {
+
+    @SuppressWarnings("unchecked")
+    private ShardManager managerWith(Map<UUID, ShardManager.ShardCuboidHudState> states) throws Exception {
+        // The real constructor needs a live server; getHudState only reads the map.
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> managerConstructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(ShardManager.class, objectConstructor);
+        ShardManager manager = (ShardManager) managerConstructor.newInstance();
+
+        Field hudStates = ShardManager.class.getDeclaredField("hudStates");
+        hudStates.setAccessible(true);
+        hudStates.set(manager, states);
+        return manager;
+    }
+
+    @Test
+    void reusesOneFallbackForPlayersWithoutState() throws Exception {
+        ShardManager manager = managerWith(new HashMap<>());
+
+        ShardManager.ShardCuboidHudState first = manager.getHudState(UUID.randomUUID());
+        ShardManager.ShardCuboidHudState second = manager.getHudState(UUID.randomUUID());
+
+        // The sidebar asks once per player per pass, so the fallback must not be rebuilt each time.
+        assertSame(first, second);
+    }
+
+    @Test
+    void fallbackKeepsItsValues() throws Exception {
+        ShardManager manager = managerWith(new HashMap<>());
+        ShardManager.ShardCuboidHudState state = manager.getHudState(UUID.randomUUID());
+
+        assertEquals("none", state.cuboidName());
+        assertEquals("outside", state.status());
+        assertEquals("-", state.display());
+        assertEquals(0, state.remainingSeconds());
+        assertFalse(state.visible());
+    }
+
+    @Test
+    void stillReturnsTheStoredStateWhenThereIsOne() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        ShardManager.ShardCuboidHudState stored =
+                new ShardManager.ShardCuboidHudState("mine", "inside", "42s", 42, true);
+        Map<UUID, ShardManager.ShardCuboidHudState> states = new HashMap<>();
+        states.put(uuid, stored);
+
+        ShardManager manager = managerWith(states);
+
+        assertSame(stored, manager.getHudState(uuid));
+        assertEquals(true, manager.shouldShowShardCuboidLine(uuid));
+        assertFalse(manager.shouldShowShardCuboidLine(UUID.randomUUID()));
+    }
+}


### PR DESCRIPTION
Closes #257

Third pass over the sidebar, after #237 and #254. This one came out of the raw `.sparkprofile` rather than a copied excerpt, so the whole tree was readable and the parts that had been collapsed before are finally accounted for. Four things were still being recomputed every pass that never change between passes. Nothing here alters what ends up on screen.

## Building the legacy hex code

`toLegacyHex` turns `RRGGBB` into `§x§R§R§G§G§B§B` and did it by chaining `String.valueOf` and `+` twelve times, every one of them going through invokedynamic string concat. It cost 880 ms of the capture, 450 ms of that in the concat machinery alone, which made it the largest single piece inside `applyColors`, ahead of the regex work.

The result is always fourteen characters, so it now writes them into a `char[]` and wraps that once. The eight exact-output assertions already in `ColorUtilsTest` pin the result, including the gradient case that runs this per character.

## The two sidebar currency icons

#254 pulled the icons out of the per-line loop into `readSettings`, which was the right move, but they were still rebuilt from scratch on every pass, and `paddedSidebarIcon` walks the string a character at a time to measure its pixel width. `readSettings` had grown to 1,880 ms with 840 ms of that in the icons.

They are held now and rebuilt only when something behind them moves: the currency definition changing identity, or `SCOREBOARD.ICON-COLUMN-WIDTH` changing. `CurrencyManager` exposes `definitionToken(type)` for that, which is just the cached definition instance, so a config reload swaps it and the icons rebuild on the next pass without anything having to remember to clear them.

## Picking a DecimalFormat

`formatNumber` already cached the `DecimalFormat`, but reached it by concatenating a key string and calling `computeIfAbsent` with a capturing lambda, so every call allocated a key and a lambda before finding an object that was already sitting there. Same shape as the `FeatureManager` cache #254 fixed, worth roughly 390 ms here.

A definition only ever asks for two of them, one at `DECIMAL-PLACES` and one at `COMPACT-DECIMAL-PLACES`, so both are built alongside the definition and picked with an int comparison. Any other value still gets one built on the spot, which nothing currently does.

## Formatted balances

That left `DecimalFormat.format` itself at 1,070 ms, running twice per player per pass. The output only moves when the balance moves, so each player's pair of formatted strings is kept alongside the amounts they came from and the currency definitions they were formatted with. A changed balance or a reloaded config misses and reformats; everything else reuses. The entry is dropped by the same paths that already clear a player's line and title state, plus `removePlayer` so the Folia side is covered too.

## Allocating a fallback that never varies

`ShardManager.getHudState` ended with:

```java
return hudStates.getOrDefault(uuid, new ShardCuboidHudState("none", "outside", "-", 0, false));
```

`getOrDefault` evaluates its second argument before the call, so that object was built whether or not the player had an entry. `shouldShowShardCuboidLine` runs once per player per pass from `getLines`, and three more accessors go through the same method, which added up to 440 ms of pure allocation. It is a constant now.

## Notes

No config keys, no message keys, no schema, nothing in `plugin.yml`. One behaviour detail: a currency config edit already needed a reload as of #254, and now the sidebar icons and any balance already on screen follow the same rule, refreshing on the pass after the reload rather than mid-pass.

Two things were left out on purpose. `colorize` spends 1,320 ms in `PlaceholderAPI.setPlaceholders`, and 1,240 ms of that is this plugin's own `EconomyExpansion.onRequest`, reached back through PAPI for values the sidebar already holds. Short-circuiting it would recover most of that, but it changes where the numbers come from and which expansions get a say, so it is BeestoXd's call rather than a cache. `transformAllCaps` and its five regex passes cost another 1,000 ms, and rewriting those would shift when `BALANCE` renders as `Balance`, which is visible on screen.

Suite is green at 399 tests, three of them new: the shard fallback is the same instance across calls, it keeps its five values, and a player who does have a stored state still gets it.
