### PR TITLE
fix(combat): start the combat timer on the configured second (#258)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CombatManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CombatManager.java
@@ -92,7 +92,17 @@ public class CombatManager {
     public long getRemainingSeconds(UUID uuid) {
         Long expiry = combatMap.get(uuid);
         if (expiry == null) return 0;
-        return Math.max(0, (expiry - System.currentTimeMillis()) / 1000L);
+        return remainingSeconds(expiry, System.currentTimeMillis());
+    }
+
+    /**
+     * Rounds the leftover millis up, so a tag with 19.95 seconds on it still reads 20. The action
+     * bar draws its first frame a tick after the expiry is stamped, so truncating here opened a
+     * twenty second tag on 19 and finished on a second of 0 while the player was still tagged.
+     */
+    static long remainingSeconds(long expiryMillis, long nowMillis) {
+        long remainingMillis = expiryMillis - nowMillis;
+        return remainingMillis <= 0L ? 0L : (remainingMillis + 999L) / 1000L;
     }
 
     public boolean isEnabled() {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/CombatManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/CombatManagerTest.java
@@ -1,0 +1,41 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CombatManagerTest {
+
+    private static final long TAG_APPLIED = 1_000L;
+    private static final long TWENTY_SECOND_EXPIRY = TAG_APPLIED + 20_000L;
+
+    @Test
+    void twentySecondTagOpensOnTwentyRatherThanNineteen() {
+        assertEquals(20L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 50L));
+        assertEquals(20L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED));
+    }
+
+    @Test
+    void everyLaterFrameDropsByExactlyOne() {
+        assertEquals(19L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 1_050L));
+        assertEquals(18L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 2_050L));
+        assertEquals(1L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 19_050L));
+    }
+
+    @Test
+    void aWholeSecondLeftReadsAsThatSecondAndNotTheOneAbove() {
+        assertEquals(19L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 1_000L));
+        assertEquals(1L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TAG_APPLIED + 19_000L));
+    }
+
+    @Test
+    void aTaggedPlayerIsNeverShownZero() {
+        assertEquals(1L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TWENTY_SECOND_EXPIRY - 1L));
+    }
+
+    @Test
+    void anExpiredTagReadsZero() {
+        assertEquals(0L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TWENTY_SECOND_EXPIRY));
+        assertEquals(0L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TWENTY_SECOND_EXPIRY + 5_000L));
+    }
+}


### PR DESCRIPTION
Closes #258

A twenty second combat tag opened its action bar on 19. The countdown was doing integer division on the milliseconds left, which throws the fraction away, and by the time the first frame draws there is always a fraction to throw away, so every tag lost a second off the top no matter what COOLDOWN was set to.

## Where the second went

`tag()` stamps the expiry at now plus COOLDOWN seconds and then hands the action bar to a repeating task, and that task never runs in the same millisecond. On Paper a zero tick delay means the next tick; on Folia the entity scheduler clamps the delay to a minimum of one tick anyway. So the first draw lands roughly 50ms in with about 19,950ms on the clock, and `19950 / 1000` floors to 19.

The tail had the same problem in reverse. Under a second left rounded down to zero, so the bar sat on `Combat: 0s` for a full second while the player was still tagged and still getting refused `/spawn`.

Rounding up fixes both ends. The tag now opens on whatever number COOLDOWN says and clears while the last frame still reads 1, dropping by exactly one in between.

## Notes

The round-up is `(millis + 999) / 1000`, already the idiom in `HideIdentityPolicy`, `ShardManager`, `SpawnStashManager` and `DuelManager` for their own countdowns; combat was the one place that truncated. How long the tag actually lasts hasn't changed, only the number drawn on it, so command blocking and the logout kill keep their old timing.

I split the arithmetic out into a static `remainingSeconds(expiry, now)` so a test can exercise it without a live server, the same way `CombatListener.shouldTagVictim` already works. Five cases in a new `CombatManagerTest` cover the first frame, the per-second steps, the boundary where a whole second is left, the last fraction reading 1 rather than 0, and an expired tag reading 0. Suite is at 407.
