### PR TITLE
docs(cuboids): say what the rtp-zone bind actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/crate` | - | `/crate <create\|delete\|type\|open\|keys\|reload\|key\|take\|set\|keyall\|add\|edit\|remove\|bind\|unbind\|info>` | `ultimatedonutsmp.command.crate` |
 | `/crates` | - | `/crates` | `ultimatedonutsmp.command.crates` |
 | `/create` | - | `/create <invite\|friends> <player> [map]` | `ultimatedonutsmp.command.create` |
-| `/cuboid` | - | `/cuboid <wand\|create\|delete\|list\|setspawn\|delspawn\|bind <cuboid> <spawn\|shard\|rtp-zone> <true\|false>\|reload>` | `ultimatedonutsmp.command.cuboid` |
+| `/cuboid` | - | `/cuboid <wand\|create\|delete\|list\|setspawn\|delspawn\|bind <cuboid> <spawn\|shard\|rtp-zone\|rtp-queue> <true\|false>\|reload>` | `ultimatedonutsmp.command.cuboid` |
 | `/delhome` | - | `/delhome <name>` | `ultimatedonutsmp.command.delhome` |
 | `/delwarp` | - | `/delwarp <name>` | `ultimatedonutsmp.command.delwarp` |
 | `/discord` | - | `/discord` | `ultimatedonutsmp.command.discord` |

--- a/docs/wiki/Cuboids-and-Portals.md
+++ b/docs/wiki/Cuboids-and-Portals.md
@@ -91,8 +91,15 @@ Cuboids can be bound to different server systems to enforce special features or 
    *Command*: `/cuboid bind shard_arena shard true`
 
 3. **`rtp-zone` Bind**:
-   - Defines the exact region where `/rtp` (Random Teleport) will pick safe destination locations.
-   *Command*: `/cuboid bind wilderness_bounds rtp-zone true`
+   - Marks a region players stand *in*, not a region they get sent to. Anyone inside it sees the
+     `RTP-ZONE.EVERY` countdown on their screen, and when it reaches zero they are teleported to a
+     random location drawn from the `RTP-ZONE.WORLD` centre and radius settings. Walking back out
+     before the count finishes cancels it.
+   - Each player runs their own countdown and lands somewhere of their own, so a group standing in
+     the region is scattered rather than kept together. Use the `rtp-queue` bind below for that.
+   - Writes the region name to `RTP-ZONE.CUBOID` in `config.yml`, where the countdown length, the
+     titles and the destination world live. `RTP-ZONE.ENABLED` has to be on as well.
+   *Command*: `/cuboid bind rtp_pad rtp-zone true`
 
 4. **`rtp-queue` Bind**:
    - Puts everyone standing in the region on the RTP matchmaking queue without them typing


### PR DESCRIPTION
The wiki said the `rtp-zone` bind "defines the exact region where `/rtp` will pick safe destination locations", which describes a boundary players get thrown into. It works the other way round. `RTP-ZONE.CUBOID` is the region players walk into: standing there starts the `RTP-ZONE.EVERY` countdown with the configured title on screen, at zero the plugin drops them at a random spot taken from the `RTP-ZONE.WORLD` centre and radius keys, and stepping back out cancels the count and sends `CANCELLED-MESSAGE`. None of it decides where `/rtp` lands anyone.

Read literally, the old line tells an admin to draw the region around the wilderness border, which does nothing except make sure nobody ever stands in it.

## The rewritten bullet

It now says what the region is and what the countdown does, then the part the old line hid: every player inside runs their own timer and lands somewhere of their own, so a group standing together gets scattered. That is worth spelling out since #259, because the `rtp-queue` bind sitting directly below it is the one that keeps a group together, and the bullet now points at it. The last line names `RTP-ZONE.CUBOID` and `RTP-ZONE.ENABLED` so there is somewhere to go next.

The example command went from `wilderness_bounds` to `rtp_pad`. That old name only makes sense under the wrong reading.

## Notes

`docs/wiki/Config-config.yml.md` has no `RTP-ZONE` section at all, and the one in `docs/wiki/Configuration-Reference.md` is generated boilerplate along the lines of "Configures `CUBOID` for `RTP-ZONE`". Neither repeats the wrong claim, so I left both alone. That boilerplate is vague rather than wrong, and rewriting the whole table is a different job.

The `/cuboid` row in `README.md` still listed `<spawn|shard|rtp-zone>` and had missed the `rtp-queue` role from #259, so that line is fixed here too.

No code changed. Suite is 407 green.
