### PR TITLE
feat(voicechat): show the consent menu on join and gate the mic (#263)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -50,6 +50,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/ffastats` | `/ffastats [player]` | None | View FFA kill/death/streak stats | `ultimatedonutsmp.command.ffastats` |
 | `/bounty` | `/bounty [place\|list]` | None | Place or view player bounties | `ultimatedonutsmp.command.bounty` |
 | `/leaderboard` | `/leaderboard [type]` | `/lb`, `/top`, `/leaderboards`, `/baltop` | Open leaderboard menus; `/baltop` opens the money leaderboard directly | `ultimatedonutsmp.command.leaderboard` |
+| `/voicechatconsent` | `/voicechatconsent [revoke]` | `/vcconsent`, `/voiceconsent` | Open the voice chat consent menu, or withdraw an answer already given with `revoke` | `ultimatedonutsmp.command.voicechatconsent` |
 
 ---
 

--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1852,3 +1852,54 @@ COMBAT-MANAGER:
 ```
 
 ---
+
+## Section: `VOICE-CHAT`
+
+Shows every player a consent menu before their microphone works. The menu opens on its own the first
+time somebody joins and keeps opening on later joins until they pick an answer, so nobody ends up
+talking in a voice channel without having read the policy first. Once they confirm or decline, the
+prompt stops. `/voicechatconsent` reopens it, and `/voicechatconsent revoke` throws the answer away
+and puts them back at undecided.
+
+The policy wording itself is not here. It lives under `VOICE-CHAT-CONSENT-MENU.INFO-BUTTON.LORE` in
+`menus.yml`, because what your server records and how long you keep it is your own policy to write.
+The bundled text is a starting point, not legal advice; edit it before you rely on it.
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Configuration section for Voice Chat.
+VOICE-CHAT:
+  # Determines whether Prompt On Join is enabled or disabled. Available options: true, false
+  PROMPT-ON-JOIN: true
+  # The number for Prompt Delay Ticks. Available options: Any whole number
+  PROMPT-DELAY-TICKS: 40
+  # Determines whether Mute Until Accepted is enabled or disabled. Available options: true, false
+  MUTE-UNTIL-ACCEPTED: true
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Path | Type | Accepted Values | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `VOICE-CHAT.PROMPT-ON-JOIN` | `boolean` | `true`, `false` | `true` | Opens the menu by itself when an undecided player joins. Turn it off to leave the menu behind `/voicechatconsent` only. The answer is still stored either way. |
+| `VOICE-CHAT.PROMPT-DELAY-TICKS` | `integer` | Any whole number, 20 ticks to the second | `40` | How long to wait after the join before the menu opens. Two seconds keeps it clear of join messages and of any other plugin that moves players around on arrival. |
+| `VOICE-CHAT.MUTE-UNTIL-ACCEPTED` | `boolean` | `true`, `false` | `true` | Drops microphone audio from anyone who has not confirmed. Set it to `false` and the menu becomes a record of who agreed, without stopping anybody talking. Needs Simple Voice Chat installed to have any effect. |
+
+The whole feature answers to the `VOICE_CHAT` toggle in `/features`, so disabling it there stops the
+prompt, the command, and the microphone gate together.
+
+### 3. Practical Setup Example
+
+A server that will not carry a recording of anyone who never agreed to being recorded. The prompt
+waits three seconds so it does not collide with a spawn teleport, and nobody transmits until they
+have confirmed:
+
+```yaml
+VOICE-CHAT:
+  PROMPT-ON-JOIN: true
+  PROMPT-DELAY-TICKS: 60
+  MUTE-UNTIL-ACCEPTED: true
+```
+
+---

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -2324,3 +2324,72 @@ SELLALL-CONFIRM-MENU:
 
 ---
 
+
+## Section: `VOICE-CHAT-CONSENT-MENU`
+
+The consent prompt. It opens on its own when an undecided player joins, and `/voicechatconsent`
+reopens it later. Clicking confirm lets the player transmit on Simple Voice Chat; clicking decline
+records the refusal and leaves their microphone gated. Anything the player is meant to have read
+before agreeing belongs in `INFO-BUTTON.LORE`, and the shipped wording is a starting point rather
+than a policy anyone has cleared for your server.
+
+### 1. Commented Setup Code Example
+
+```yaml
+VOICE-CHAT-CONSENT-MENU:
+  TITLE: '&8Confirm Voice Chat'
+  SIZE: 27
+  INFO-BUTTON:
+    DISPLAY-NAME: '&bVoice Chat Policy'
+    MATERIAL: JUKEBOX
+    SLOT: 13
+    LORE:
+    - '&7Your voice is recorded while you are'
+    - '&7talking in a voice channel.'
+    - ''
+    - '&7Recordings are thrown away unless somebody'
+    - '&7reports you. A reported recording is kept'
+    - '&7as proof for a mute or a ban, and the'
+    - '&7moderation team reviews it.'
+    - ''
+    - '&7You have to be 13 or older to talk.'
+    - ''
+    - '&7Changed your mind later? Run'
+    - '&f/voicechatconsent revoke'
+  CONFIRM-BUTTON:
+    DISPLAY-NAME: '&aConfirm'
+    MATERIAL: LIME_STAINED_GLASS_PANE
+    SLOT: 11
+    LORE:
+    - '&fClick to turn voice chat on'
+  DECLINE-BUTTON:
+    DISPLAY-NAME: '&cDecline'
+    MATERIAL: RED_STAINED_GLASS_PANE
+    SLOT: 15
+    LORE:
+    - '&fVoice chat will stay disabled'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `VOICE-CHAT-CONSENT-MENU.TITLE` | `str` | Any string text | `'&8Confirm Voice Chat'` | Inventory title of the consent prompt. |
+| `VOICE-CHAT-CONSENT-MENU.SIZE` | `int` | Any valid integer number | `'27'` | Inventory size in slots. Keep it a multiple of nine and large enough for the three slots below. |
+| `VOICE-CHAT-CONSENT-MENU.INFO-BUTTON.DISPLAY-NAME` | `str` | Any string text | `'&bVoice Chat Policy'` | Name of the item holding the policy. |
+| `VOICE-CHAT-CONSENT-MENU.INFO-BUTTON.MATERIAL` | `str` | Any string text | `'JUKEBOX'` | Item shown for the policy. Any material name works. |
+| `VOICE-CHAT-CONSENT-MENU.INFO-BUTTON.SLOT` | `int` | Any valid integer number | `'13'` | Slot the policy item sits in. Clicking it does nothing on purpose, so a misclick cannot answer for the player. |
+| `VOICE-CHAT-CONSENT-MENU.INFO-BUTTON.LORE` | `list` | List of configured items/strings | See the example above | The policy itself. Write what your server actually records, how long it keeps it, and who reads it. Add a line pointing at your own privacy page if you have one. |
+| `VOICE-CHAT-CONSENT-MENU.CONFIRM-BUTTON.DISPLAY-NAME` | `str` | Any string text | `'&aConfirm'` | Name of the accept button. |
+| `VOICE-CHAT-CONSENT-MENU.CONFIRM-BUTTON.MATERIAL` | `str` | Any string text | `'LIME_STAINED_GLASS_PANE'` | Item used for the accept button. |
+| `VOICE-CHAT-CONSENT-MENU.CONFIRM-BUTTON.SLOT` | `int` | Any valid integer number | `'11'` | Slot of the accept button. Clicking here records agreement and opens the microphone. |
+| `VOICE-CHAT-CONSENT-MENU.CONFIRM-BUTTON.LORE` | `list` | List of configured items/strings | `['&fClick to turn voice chat on']` | Lore under the accept button. |
+| `VOICE-CHAT-CONSENT-MENU.DECLINE-BUTTON.DISPLAY-NAME` | `str` | Any string text | `'&cDecline'` | Name of the decline button. |
+| `VOICE-CHAT-CONSENT-MENU.DECLINE-BUTTON.MATERIAL` | `str` | Any string text | `'RED_STAINED_GLASS_PANE'` | Item used for the decline button. |
+| `VOICE-CHAT-CONSENT-MENU.DECLINE-BUTTON.SLOT` | `int` | Any valid integer number | `'15'` | Slot of the decline button. Clicking here records the refusal, and the prompt stops appearing on later joins. |
+| `VOICE-CHAT-CONSENT-MENU.DECLINE-BUTTON.LORE` | `list` | List of configured items/strings | `['&fVoice chat will stay disabled']` | Lore under the decline button. |
+
+A player who closes the menu without clicking either button stays undecided, so the prompt comes
+back the next time they join.
+
+---

--- a/docs/wiki/Placeholders-and-Integrations.md
+++ b/docs/wiki/Placeholders-and-Integrations.md
@@ -118,3 +118,4 @@ UltimateDonutSMP seamlessly hooks into the following plugins when installed:
 5. **SkinsRestorer**: Preserves custom player skin textures in GUI menus and head skulls.
 6. **Multiverse-Core**: Inherits world safety flags and spawn points.
 7. **Floodgate (Bedrock)**: Fixes form GUI layouts for Bedrock Geyser players joining from mobile or consoles.
+8. **Simple Voice Chat**: Gates the microphone behind the consent menu. Players who have not accepted the policy can still hear a voice channel, but their microphone audio is dropped before anyone receives it. Without Simple Voice Chat installed the menu still records an answer, it just has nothing to gate.

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
             <id>opencollab-snapshots</id>
             <url>https://repo.opencollab.dev/main/</url>
         </repository>
+        <repository>
+            <id>maxhenkel</id>
+            <url>https://maven.maxhenkel.de/repository/public</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -224,6 +228,12 @@
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
             <version>5.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.maxhenkel.voicechat</groupId>
+            <artifactId>voicechat-api</artifactId>
+            <version>2.6.20</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -110,6 +110,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private SpawnStashManager spawnStashManager;
     private FakePlayerManager fakePlayerManager;
     private HideManager hideManager;
+    private VoiceChatConsentManager voiceChatConsentManager;
     private NetworkStatusManager networkStatusManager;
     private RedisManager redisManager;
     private MaintenanceManager maintenanceManager;
@@ -266,6 +267,8 @@ public final class UltimateDonutSmp extends JavaPlugin {
         tablistManager = new TablistManager(this);
         hideManager = new HideManager(this);
         hideManager.loadAll();
+        voiceChatConsentManager = new VoiceChatConsentManager(this);
+        voiceChatConsentManager.registerVoicechatHook();
         teleportManager = new TeleportManager(this);
         rtpManager = new RTPManager(this);
         rtpZoneManager = new RTPZoneManager(this);
@@ -752,6 +755,8 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
         setExecutor("rules", new RulesCommand(this), FeatureManager.Feature.RULES);
         setExecutor("safety", new SafetyCommand(this), FeatureManager.Feature.SAFETY);
+        setExecutor("voicechatconsent", new VoiceChatConsentCommand(this),
+                FeatureManager.Feature.VOICE_CHAT);
 
         FriendsCommand friendsCommand = new FriendsCommand(this);
         setExecutor("friends", friendsCommand, FeatureManager.Feature.FRIENDS);
@@ -1093,6 +1098,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         spawnStashManager.reload();
         fakePlayerManager.reload();
         hideManager.reload();
+        voiceChatConsentManager.refreshSettings();
         networkStatusManager.reload();
         networkStaffChatManager.reload();
         networkStaffAlertManager.reload();
@@ -1238,6 +1244,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public HideManager getHideManager() {
         return hideManager;
+    }
+
+    public VoiceChatConsentManager getVoiceChatConsentManager() {
+        return voiceChatConsentManager;
     }
 
     public CombatManager getCombatManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/VoiceChatConsentCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/VoiceChatConsentCommand.java
@@ -1,0 +1,53 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.VoiceChatConsent;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Locale;
+
+public class VoiceChatConsentCommand implements CommandExecutor, TabCompleter {
+
+    private final UltimateDonutSmp plugin;
+
+    public VoiceChatConsentCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ColorUtils.toComponent(plugin.getLanguageManager().message(
+                    "VOICE-CHAT.PLAYERS-ONLY", "&cOnly players can use this command.")));
+            return true;
+        }
+
+        if (args.length > 0 && args[0].equalsIgnoreCase("revoke")) {
+            if (plugin.getVoiceChatConsentManager().getConsent(player) == VoiceChatConsent.UNDECIDED) {
+                player.sendMessage(ColorUtils.toComponent(plugin.getLanguageManager().message(
+                        "VOICE-CHAT.NOTHING-TO-REVOKE",
+                        "&cYou have not agreed to the voice chat policy yet."), player));
+                return true;
+            }
+            plugin.getVoiceChatConsentManager().revoke(player);
+            return true;
+        }
+
+        plugin.getVoiceChatConsentManager().openMenu(player);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+        if (args.length == 1 && "revoke".startsWith(args[0].toLowerCase(Locale.ROOT))) {
+            return List.of("revoke");
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/hooks/SimpleVoiceChatHook.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/hooks/SimpleVoiceChatHook.java
@@ -1,0 +1,66 @@
+package com.bx.ultimateDonutSmp.hooks;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import de.maxhenkel.voicechat.api.BukkitVoicechatService;
+import de.maxhenkel.voicechat.api.VoicechatConnection;
+import de.maxhenkel.voicechat.api.VoicechatPlugin;
+import de.maxhenkel.voicechat.api.events.EventRegistration;
+import de.maxhenkel.voicechat.api.events.MicrophonePacketEvent;
+
+import java.util.UUID;
+
+/**
+ * Blocks microphone audio from players who have not accepted the voice chat policy.
+ *
+ * Simple Voice Chat is optional, so nothing here may be touched before
+ * {@code Bukkit.getPluginManager().getPlugin("voicechat")} is known to exist — loading this class
+ * without the API on the classpath throws.
+ */
+public class SimpleVoiceChatHook implements VoicechatPlugin {
+
+    private final UltimateDonutSmp plugin;
+
+    public SimpleVoiceChatHook(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    /** Returns true when Simple Voice Chat accepted the registration. */
+    public static boolean register(UltimateDonutSmp plugin) {
+        BukkitVoicechatService service = plugin.getServer().getServicesManager().load(BukkitVoicechatService.class);
+        if (service == null) {
+            return false;
+        }
+        service.registerPlugin(new SimpleVoiceChatHook(plugin));
+        return true;
+    }
+
+    @Override
+    public String getPluginId() {
+        return "ultimatedonutsmp";
+    }
+
+    @Override
+    public void registerEvents(EventRegistration registration) {
+        registration.registerEvent(MicrophonePacketEvent.class, this::onMicrophonePacket);
+    }
+
+    private void onMicrophonePacket(MicrophonePacketEvent event) {
+        if (!event.isCancellable() || event.isCancelled()) {
+            return;
+        }
+        UUID speaker = speakerUuid(event.getSenderConnection());
+        if (speaker == null) {
+            return;
+        }
+        if (!plugin.getVoiceChatConsentManager().mayTalk(speaker)) {
+            event.cancel();
+        }
+    }
+
+    private UUID speakerUuid(VoicechatConnection connection) {
+        if (connection == null || connection.getPlayer() == null) {
+            return null;
+        }
+        return connection.getPlayer().getUuid();
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -189,6 +189,7 @@ public class PlayerJoinQuitListener implements Listener {
         plugin.getCrateVisualManager().handleJoin(player);
         plugin.getPortalManager().refreshHologramsSoon();
         plugin.getFreezeManager().handleJoin(player);
+        plugin.getVoiceChatConsentManager().handleJoin(player);
         plugin.getStaffModeManager().handleJoin(player);
         plugin.getNetworkStaffChatManager().handleStaffJoin(player);
         if (plugin.getLunarRichPresenceManager() != null) {
@@ -369,6 +370,7 @@ public class PlayerJoinQuitListener implements Listener {
 
         // Clear combat tag
         plugin.getCombatManager().clearTag(player.getUniqueId());
+        plugin.getVoiceChatConsentManager().handleQuit(player.getUniqueId());
 
         // Cancel any pending teleport
         plugin.getTeleportManager().cancel(player.getUniqueId());

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -337,6 +337,7 @@ public class DatabaseManager {
             "  clear_entities_messages_enabled INTEGER DEFAULT 1," +
             "  bounty_alerts_enabled INTEGER DEFAULT 1," +
             "  tpa_confirm_menu_enabled INTEGER DEFAULT 1," +
+            "  voice_chat_consent INTEGER DEFAULT 0," +
             "  chainmail_on_respawn_enabled INTEGER DEFAULT 1," +
             "  lunar_teammates_enabled INTEGER DEFAULT 1," +
             "  tpa_requests_enabled INTEGER DEFAULT 1," +
@@ -736,6 +737,7 @@ public class DatabaseManager {
         ensureColumnExists("players", "clear_entities_messages_enabled", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "bounty_alerts_enabled", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "tpa_confirm_menu_enabled", "INTEGER DEFAULT 1");
+        ensureColumnExists("players", "voice_chat_consent", "INTEGER DEFAULT 0");
         ensureColumnExists("players", "chainmail_on_respawn_enabled", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "lunar_teammates_enabled", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "tpa_requests_enabled", "INTEGER DEFAULT 1");
@@ -1066,6 +1068,7 @@ public class DatabaseManager {
         data.setClearEntitiesMessagesEnabled(rs.getInt("clear_entities_messages_enabled") != 0);
         data.setBountyAlertsEnabled(rs.getInt("bounty_alerts_enabled") != 0);
         data.setTpaConfirmMenuEnabled(rs.getInt("tpa_confirm_menu_enabled") != 0);
+        data.setVoiceChatConsent(com.bx.ultimateDonutSmp.models.VoiceChatConsent.fromInt(rs.getInt("voice_chat_consent")));
         data.setChainmailOnRespawnEnabled(rs.getInt("chainmail_on_respawn_enabled") != 0);
         data.setLunarTeammatesEnabled(rs.getInt("lunar_teammates_enabled") != 0);
         data.setTpaRequestsChoice(com.bx.ultimateDonutSmp.models.ThreeChoice.fromInt(rs.getInt("tpa_requests_enabled")));
@@ -1637,8 +1640,9 @@ public class DatabaseManager {
                     duel_music_enabled, quiet_spawn_enabled, night_vision_enabled, keyall_remaining_seconds,
                     shard_booster_expiry, mob_spawn_disabled_until, phantom_disabled_until, destroy_pearl_on_death, randomized_coords, death_messages_choice,
                     advancement_messages_choice, join_leave_messages_choice, teleport_alerts_enabled,
-                    follow_alerts_enabled, explosion_sounds_enabled, display_donutplus_enabled)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    follow_alerts_enabled, explosion_sounds_enabled, display_donutplus_enabled,
+                    voice_chat_consent)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """;
 
         if (hikariDataSource != null && !hikariDataSource.isClosed()) {
@@ -1729,6 +1733,7 @@ public class DatabaseManager {
             ps.setInt(62, data.isFollowAlertsEnabled() ? 1 : 0);
             ps.setInt(63, data.isExplosionSoundsEnabled() ? 1 : 0);
             ps.setInt(64, data.isDisplayDonutPlusEnabled() ? 1 : 0);
+            ps.setInt(65, data.getVoiceChatConsent().ordinal());
             data.setDirty(false);
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -92,7 +92,9 @@ public class FeatureManager {
         MAINTENANCE("MAINTENANCE", "maintenance", "seamless maintenance system with lobby redirection.", "REDSTONE_LAMP", "MAINTENANCE"),
         HIDE("HIDE", "Hide", "Persistent player identity scrambling and configured disguises.", "NAME_TAG", "HIDE"),
         FRIENDS("FRIENDS", "friends", "player friends/follows system.", "PLAYER_HEAD", "FRIEND"),
-        SAFETY("SAFETY", "safety", "safety command and info.", "BOOK", "SAFETY");
+        SAFETY("SAFETY", "safety", "safety command and info.", "BOOK", "SAFETY"),
+        VOICE_CHAT("VOICE_CHAT", "voice chat",
+                "voice chat consent prompt, menu, and microphone gate.", "JUKEBOX", null);
 
         private final String configKey;
         private final String displayName;
@@ -347,6 +349,11 @@ public class FeatureManager {
             case SHARDS -> {
                 if (plugin.getShardManager() != null) {
                     plugin.getShardManager().reloadSettings();
+                }
+            }
+            case VOICE_CHAT -> {
+                if (plugin.getVoiceChatConsentManager() != null) {
+                    plugin.getVoiceChatConsentManager().refreshSettings();
                 }
             }
             case RTP_ZONE -> {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/VoiceChatConsentManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/VoiceChatConsentManager.java
@@ -1,0 +1,144 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.hooks.SimpleVoiceChatHook;
+import com.bx.ultimateDonutSmp.menus.VoiceChatConsentMenu;
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.VoiceChatConsent;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+public class VoiceChatConsentManager {
+
+    private static final String VOICECHAT_PLUGIN = "voicechat";
+
+    private final UltimateDonutSmp plugin;
+
+    /**
+     * Simple Voice Chat delivers microphone packets off the main thread, so the answer has to be
+     * readable without touching PlayerData or the Bukkit API.
+     */
+    private final Map<UUID, VoiceChatConsent> consentCache = new ConcurrentHashMap<>();
+
+    private volatile boolean enforcing;
+    private boolean hookRegistered;
+
+    public VoiceChatConsentManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        refreshSettings();
+    }
+
+    public boolean isEnabled() {
+        return plugin.getFeatureManager().isEnabled(FeatureManager.Feature.VOICE_CHAT);
+    }
+
+    public void refreshSettings() {
+        enforcing = isEnabled()
+                && plugin.getConfigManager().getConfig().getBoolean("VOICE-CHAT.MUTE-UNTIL-ACCEPTED", true);
+    }
+
+    /**
+     * Simple Voice Chat is a soft dependency, so the hook class stays untouched until the plugin is
+     * known to be installed.
+     */
+    public void registerVoicechatHook() {
+        if (hookRegistered || Bukkit.getPluginManager().getPlugin(VOICECHAT_PLUGIN) == null) {
+            return;
+        }
+        try {
+            hookRegistered = SimpleVoiceChatHook.register(plugin);
+        } catch (Throwable throwable) {
+            plugin.getLogger().log(Level.WARNING, "Could not hook into Simple Voice Chat.", throwable);
+        }
+    }
+
+    public boolean isVoicechatInstalled() {
+        return Bukkit.getPluginManager().getPlugin(VOICECHAT_PLUGIN) != null;
+    }
+
+    public VoiceChatConsent getConsent(Player player) {
+        if (player == null) {
+            return VoiceChatConsent.UNDECIDED;
+        }
+        PlayerData data = plugin.getPlayerDataManager().get(player);
+        return data == null ? VoiceChatConsent.UNDECIDED : data.getVoiceChatConsent();
+    }
+
+    /** Called from the microphone packet handler, so it must stay off the Bukkit API. */
+    public boolean mayTalk(UUID uuid) {
+        if (!enforcing) {
+            return true;
+        }
+        return consentCache.getOrDefault(uuid, VoiceChatConsent.UNDECIDED) == VoiceChatConsent.ACCEPTED;
+    }
+
+    public void handleJoin(Player player) {
+        if (player == null) {
+            return;
+        }
+        VoiceChatConsent consent = getConsent(player);
+        consentCache.put(player.getUniqueId(), consent);
+
+        if (!isEnabled() || consent != VoiceChatConsent.UNDECIDED) {
+            return;
+        }
+        if (!plugin.getConfigManager().getConfig().getBoolean("VOICE-CHAT.PROMPT-ON-JOIN", true)) {
+            return;
+        }
+
+        long delay = Math.max(1L,
+                plugin.getConfigManager().getConfig().getLong("VOICE-CHAT.PROMPT-DELAY-TICKS", 40L));
+        plugin.getSpigotScheduler().runEntityLater(player, () -> {
+            if (player.isOnline() && getConsent(player) == VoiceChatConsent.UNDECIDED) {
+                openMenu(player);
+            }
+        }, delay);
+    }
+
+    public void handleQuit(UUID uuid) {
+        if (uuid != null) {
+            consentCache.remove(uuid);
+        }
+    }
+
+    public void openMenu(Player player) {
+        if (player == null) {
+            return;
+        }
+        new VoiceChatConsentMenu(plugin).open(player);
+    }
+
+    public void accept(Player player) {
+        apply(player, VoiceChatConsent.ACCEPTED,
+                "VOICE-CHAT.ACCEPTED", "&aVoice chat is now enabled for you.");
+    }
+
+    public void decline(Player player) {
+        apply(player, VoiceChatConsent.DECLINED,
+                "VOICE-CHAT.DECLINED", "&cVoice chat will stay disabled.");
+    }
+
+    public void revoke(Player player) {
+        apply(player, VoiceChatConsent.UNDECIDED,
+                "VOICE-CHAT.REVOKED", "&cYou withdrew your voice chat consent. Voice chat is disabled again.");
+    }
+
+    private void apply(Player player, VoiceChatConsent consent, String messagePath, String fallback) {
+        if (player == null) {
+            return;
+        }
+        PlayerData data = plugin.getPlayerDataManager().get(player);
+        if (data != null) {
+            data.setVoiceChatConsent(consent);
+        }
+        consentCache.put(player.getUniqueId(), consent);
+        player.sendMessage(ColorUtils.toComponent(
+                plugin.getLanguageManager().message(messagePath, fallback), player));
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/VoiceChatConsentMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/VoiceChatConsentMenu.java
@@ -1,0 +1,80 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+public class VoiceChatConsentMenu extends BaseMenu {
+
+    private static final String ROOT = "VOICE-CHAT-CONSENT-MENU";
+
+    public VoiceChatConsentMenu(UltimateDonutSmp plugin) {
+        super(
+                plugin,
+                plugin.getLanguageManager().menu(
+                        ROOT + ".TITLE",
+                        plugin.getConfigManager().getMenus().getString(ROOT + ".TITLE", "&8Confirm Voice Chat")),
+                plugin.getConfigManager().getMenus().getInt(ROOT + ".SIZE", 27)
+        );
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        fill(Material.GRAY_STAINED_GLASS_PANE);
+
+        set(slot("INFO-BUTTON", 13), button("INFO-BUTTON", Material.JUKEBOX,
+                "&bVoice Chat Policy", List.of("&7Read this before you choose.")));
+        set(slot("CONFIRM-BUTTON", 11), button("CONFIRM-BUTTON", Material.LIME_STAINED_GLASS_PANE,
+                "&aConfirm", List.of("&fClick to turn voice chat on")));
+        set(slot("DECLINE-BUTTON", 15), button("DECLINE-BUTTON", Material.RED_STAINED_GLASS_PANE,
+                "&cDecline", List.of("&fVoice chat will stay disabled")));
+    }
+
+    @Override
+    public void handleClick(int slot, Player player) {
+        int confirmSlot = slot("CONFIRM-BUTTON", 11);
+        int declineSlot = slot("DECLINE-BUTTON", 15);
+
+        if (slot != confirmSlot && slot != declineSlot) {
+            return;
+        }
+
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+        player.closeInventory();
+
+        if (slot == confirmSlot) {
+            plugin.getVoiceChatConsentManager().accept(player);
+        } else {
+            plugin.getVoiceChatConsentManager().decline(player);
+        }
+    }
+
+    private int slot(String button, int fallback) {
+        return plugin.getConfigManager().getMenus().getInt(ROOT + "." + button + ".SLOT", fallback);
+    }
+
+    private org.bukkit.inventory.ItemStack button(String button, Material fallbackMaterial,
+                                                 String fallbackName, List<String> fallbackLore) {
+        String path = ROOT + "." + button;
+        Material material = ItemUtils.parseMaterial(
+                plugin.getConfigManager().getMenus().getString(path + ".MATERIAL", fallbackMaterial.name()));
+        if (material == null) {
+            material = fallbackMaterial;
+        }
+
+        String name = plugin.getLanguageManager().menu(
+                path + ".DISPLAY-NAME",
+                plugin.getConfigManager().getMenus().getString(path + ".DISPLAY-NAME", fallbackName));
+
+        List<String> configured = plugin.getConfigManager().getMenus().getStringList(path + ".LORE");
+        List<String> lore = plugin.getLanguageManager().menuList(
+                path + ".LORE", configured.isEmpty() ? fallbackLore : configured);
+
+        return ItemUtils.createItem(material, name, lore);
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -23,6 +23,7 @@ public class PlayerData {
     private boolean tpauto;
     private boolean phantomEnabled;
     private ThreeChoice paymentsChoice;
+    private VoiceChatConsent voiceChatConsent;
     private boolean scoreboardVisible;
     private boolean payAlertsEnabled;
     private boolean hotbarMessagesEnabled;
@@ -94,6 +95,7 @@ public class PlayerData {
         this.tpauto = false;
         this.phantomEnabled = true;
         this.paymentsChoice = ThreeChoice.ANYONE;
+        this.voiceChatConsent = VoiceChatConsent.UNDECIDED;
         this.scoreboardVisible = true;
         this.payAlertsEnabled = true;
         this.hotbarMessagesEnabled = true;
@@ -495,6 +497,15 @@ public class PlayerData {
 
     public void setTpaConfirmMenuEnabled(boolean tpaConfirmMenuEnabled) {
         this.tpaConfirmMenuEnabled = tpaConfirmMenuEnabled;
+        dirty = true;
+    }
+
+    public VoiceChatConsent getVoiceChatConsent() {
+        return voiceChatConsent;
+    }
+
+    public void setVoiceChatConsent(VoiceChatConsent voiceChatConsent) {
+        this.voiceChatConsent = voiceChatConsent == null ? VoiceChatConsent.UNDECIDED : voiceChatConsent;
         dirty = true;
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/models/VoiceChatConsent.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/VoiceChatConsent.java
@@ -1,0 +1,14 @@
+package com.bx.ultimateDonutSmp.models;
+
+public enum VoiceChatConsent {
+    UNDECIDED,
+    ACCEPTED,
+    DECLINED;
+
+    public static VoiceChatConsent fromInt(int val) {
+        if (val < 0 || val >= values().length) {
+            return UNDECIDED; // default fallback
+        }
+        return values()[val];
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1025,6 +1025,14 @@ AMETHYST-TOOLS:
     # A list configuration for Enchantments. Available options: Multiple items
     ENCHANTMENTS: []
 # Configuration section for Commands.
+# Configuration section for Voice Chat.
+VOICE-CHAT:
+  # Determines whether Prompt On Join is enabled or disabled. Available options: true, false
+  PROMPT-ON-JOIN: true
+  # The number for Prompt Delay Ticks. Available options: Any whole number
+  PROMPT-DELAY-TICKS: 40
+  # Determines whether Mute Until Accepted is enabled or disabled. Available options: true, false
+  MUTE-UNTIL-ACCEPTED: true
 COMMANDS:
   # Determines whether Chat is enabled or disabled. Available options: true, false
   CHAT: true

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1487,6 +1487,31 @@ MENUS:
       DISPLAY-NAME: "&cKeine Strafen gefunden"
       LORE:
       - "&7Keine Strafen entsprechen den aktuellen Filtern."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Voice-Chat bestätigen"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bVoice-Chat-Richtlinie"
+      LORE:
+      - "&7Deine Stimme wird aufgezeichnet, solange"
+      - "&7du in einem Sprachkanal sprichst."
+      - ""
+      - "&7Aufnahmen werden verworfen, außer jemand"
+      - "&7meldet dich. Eine gemeldete Aufnahme wird"
+      - "&7als Nachweis für Mute oder Bann behalten,"
+      - "&7und das Moderationsteam sieht sie sich an."
+      - ""
+      - "&7Du musst 13 Jahre oder älter sein."
+      - ""
+      - "&7Später anders entschieden? Führe"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aBestätigen"
+      LORE:
+      - "&fKlicke, um Voice-Chat zu aktivieren"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cAblehnen"
+      LORE:
+      - "&fVoice-Chat bleibt deaktiviert"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2921,6 +2946,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aVoice-Chat ist jetzt für dich aktiviert."
+    DECLINED: "&cVoice-Chat bleibt deaktiviert."
+    REVOKED: "&cDu hast deine Voice-Chat-Zustimmung zurückgezogen. Voice-Chat ist wieder deaktiviert."
+    NOTHING-TO-REVOKE: "&cDu hast der Voice-Chat-Richtlinie noch nicht zugestimmt."
+    PLAYERS-ONLY: "&cNur Spieler können diesen Befehl benutzen."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1608,6 +1608,31 @@ MENUS:
       DISPLAY-NAME: '&cNo Punishments Found'
       LORE:
       - '&7No punishments match the current filters.'
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: '&8Confirm Voice Chat'
+    INFO-BUTTON:
+      DISPLAY-NAME: '&bVoice Chat Policy'
+      LORE:
+      - '&7Your voice is recorded while you are'
+      - '&7talking in a voice channel.'
+      - ''
+      - '&7Recordings are thrown away unless somebody'
+      - '&7reports you. A reported recording is kept'
+      - '&7as proof for a mute or a ban, and the'
+      - '&7moderation team reviews it.'
+      - ''
+      - '&7You have to be 13 or older to talk.'
+      - ''
+      - '&7Changed your mind later? Run'
+      - '&f/voicechatconsent revoke'
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: '&aConfirm'
+      LORE:
+      - '&fClick to turn voice chat on'
+    DECLINE-BUTTON:
+      DISPLAY-NAME: '&cDecline'
+      LORE:
+      - '&fVoice chat will stay disabled'
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -3169,6 +3194,12 @@ MESSAGES:
     RELOADED: '&aAnvil moderation config reloaded.'
   SAFE-LOCATION-FOUND-HIDDEN: '&aSafe location found! teleporting you blindly...'
   SEARCH-FOUND-ACTIONBAR-HIDDEN: '&aFound safe location'
+  VOICE-CHAT:
+    ACCEPTED: '&aVoice chat is now enabled for you.'
+    DECLINED: '&cVoice chat will stay disabled.'
+    REVOKED: '&cYou withdrew your voice chat consent. Voice chat is disabled again.'
+    NOTHING-TO-REVOKE: '&cYou have not agreed to the voice chat policy yet.'
+    PLAYERS-ONLY: '&cOnly players can use this command.'
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: '&c☠ '

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1352,6 +1352,31 @@ MENUS:
       DISPLAY-NAME: "&cNo se encontraron castigos"
       LORE:
       - "&7Ningún castigo coincide con los filtros actuales."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Confirmar chat de voz"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bPolítica del chat de voz"
+      LORE:
+      - "&7Tu voz se graba mientras hablas"
+      - "&7en un canal de voz."
+      - ""
+      - "&7Las grabaciones se descartan salvo que"
+      - "&7alguien te reporte. Una grabación reportada"
+      - "&7se guarda como prueba de un silencio o baneo,"
+      - "&7y el equipo de moderación la revisa."
+      - ""
+      - "&7Tienes que tener 13 años o más para hablar."
+      - ""
+      - "&7¿Cambias de idea más adelante? Ejecuta"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aConfirmar"
+      LORE:
+      - "&fHaz clic para activar el chat de voz"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cRechazar"
+      LORE:
+      - "&fEl chat de voz seguirá desactivado"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2789,6 +2814,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aEl chat de voz ya está activado para ti."
+    DECLINED: "&cEl chat de voz seguirá desactivado."
+    REVOKED: "&cRetiraste tu consentimiento del chat de voz. El chat de voz vuelve a estar desactivado."
+    NOTHING-TO-REVOKE: "&cTodavía no has aceptado la política del chat de voz."
+    PLAYERS-ONLY: "&cSolo los jugadores pueden usar este comando."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1351,6 +1351,31 @@ MENUS:
       DISPLAY-NAME: "&cAucune sanction trouvée"
       LORE:
       - "&7Aucune sanction ne correspond aux filtres actuels."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Confirmer le chat vocal"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bPolitique du chat vocal"
+      LORE:
+      - "&7Ta voix est enregistrée pendant que tu"
+      - "&7parles dans un salon vocal."
+      - ""
+      - "&7Les enregistrements sont supprimés sauf si"
+      - "&7quelqu'un te signale. Un enregistrement signalé"
+      - "&7est gardé comme preuve pour un mute ou un ban,"
+      - "&7et l'équipe de modération l'examine."
+      - ""
+      - "&7Tu dois avoir 13 ans ou plus pour parler."
+      - ""
+      - "&7Tu changes d'avis plus tard ? Lance"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aConfirmer"
+      LORE:
+      - "&fClique pour activer le chat vocal"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cRefuser"
+      LORE:
+      - "&fLe chat vocal restera désactivé"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2789,6 +2814,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aLe chat vocal est maintenant activé pour toi."
+    DECLINED: "&cLe chat vocal restera désactivé."
+    REVOKED: "&cTu as retiré ton consentement au chat vocal. Le chat vocal est de nouveau désactivé."
+    NOTHING-TO-REVOKE: "&cTu n'as pas encore accepté la politique du chat vocal."
+    PLAYERS-ONLY: "&cSeuls les joueurs peuvent utiliser cette commande."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1488,6 +1488,31 @@ MENUS:
       DISPLAY-NAME: "&cHukuman tidak ditemukan"
       LORE:
       - "&7Tidak ada hukuman yang cocok dengan filter saat ini."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Konfirmasi Voice Chat"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bKebijakan Voice Chat"
+      LORE:
+      - "&7Suaramu direkam selama kamu berbicara"
+      - "&7di dalam channel suara."
+      - ""
+      - "&7Rekaman akan dibuang kecuali ada yang"
+      - "&7melaporkanmu. Rekaman yang dilaporkan"
+      - "&7disimpan sebagai bukti mute atau ban,"
+      - "&7dan tim moderasi akan meninjaunya."
+      - ""
+      - "&7Kamu harus berusia 13 tahun ke atas."
+      - ""
+      - "&7Berubah pikiran nanti? Jalankan"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aKonfirmasi"
+      LORE:
+      - "&fKlik untuk menyalakan voice chat"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cTolak"
+      LORE:
+      - "&fVoice chat akan tetap mati"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2922,6 +2947,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aVoice chat sekarang aktif untukmu."
+    DECLINED: "&cVoice chat akan tetap mati."
+    REVOKED: "&cKamu menarik persetujuan voice chat. Voice chat dimatikan lagi."
+    NOTHING-TO-REVOKE: "&cKamu belum menyetujui kebijakan voice chat."
+    PLAYERS-ONLY: "&cHanya pemain yang bisa memakai perintah ini."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1352,6 +1352,31 @@ MENUS:
       DISPLAY-NAME: "&cNenhuma punição encontrada"
       LORE:
       - "&7Nenhuma punição corresponde aos filtros atuais."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Confirmar chat de voz"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bPolítica do chat de voz"
+      LORE:
+      - "&7Sua voz é gravada enquanto você fala"
+      - "&7em um canal de voz."
+      - ""
+      - "&7As gravações são descartadas a menos que"
+      - "&7alguém denuncie você. Uma gravação denunciada"
+      - "&7fica guardada como prova de mute ou ban,"
+      - "&7e a equipe de moderação analisa."
+      - ""
+      - "&7Você precisa ter 13 anos ou mais para falar."
+      - ""
+      - "&7Mudou de ideia depois? Use"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aConfirmar"
+      LORE:
+      - "&fClique para ligar o chat de voz"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cRecusar"
+      LORE:
+      - "&fO chat de voz vai continuar desligado"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2790,6 +2815,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aO chat de voz agora está ligado para você."
+    DECLINED: "&cO chat de voz vai continuar desligado."
+    REVOKED: "&cVocê retirou seu consentimento do chat de voz. O chat de voz foi desligado de novo."
+    NOTHING-TO-REVOKE: "&cVocê ainda não aceitou a política do chat de voz."
+    PLAYERS-ONLY: "&cApenas jogadores podem usar este comando."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1351,6 +1351,31 @@ MENUS:
       DISPLAY-NAME: "&cНаказания не найдены"
       LORE:
       - "&7Нет наказаний, соответствующих текущим фильтрам."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8Подтверждение голосового чата"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&bПравила голосового чата"
+      LORE:
+      - "&7Твой голос записывается, пока ты"
+      - "&7говоришь в голосовом канале."
+      - ""
+      - "&7Записи удаляются, если на тебя никто"
+      - "&7не пожаловался. Записи по жалобе хранятся"
+      - "&7как доказательство для мута или бана,"
+      - "&7и команда модерации их проверяет."
+      - ""
+      - "&7Чтобы говорить, тебе должно быть 13 лет."
+      - ""
+      - "&7Передумал позже? Введи"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&aПодтвердить"
+      LORE:
+      - "&fНажми, чтобы включить голосовой чат"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&cОтказаться"
+      LORE:
+      - "&fГолосовой чат останется выключенным"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2787,6 +2812,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&aГолосовой чат теперь включён для тебя."
+    DECLINED: "&cГолосовой чат останется выключенным."
+    REVOKED: "&cТы отозвал согласие на голосовой чат. Голосовой чат снова выключен."
+    NOTHING-TO-REVOKE: "&cТы ещё не принял правила голосового чата."
+    PLAYERS-ONLY: "&cТолько игроки могут использовать эту команду."
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1350,6 +1350,31 @@ MENUS:
       DISPLAY-NAME: "&c未找到处罚"
       LORE:
       - "&7没有处罚符合当前筛选条件."
+  VOICE-CHAT-CONSENT-MENU:
+    TITLE: "&8确认语音聊天"
+    INFO-BUTTON:
+      DISPLAY-NAME: "&b语音聊天政策"
+      LORE:
+      - "&7你在语音频道里说话时，"
+      - "&7你的声音会被录制。"
+      - ""
+      - "&7除非有人举报你，"
+      - "&7否则录音会被丢弃。被举报的录音"
+      - "&7会作为禁言或封禁的证据保留，"
+      - "&7并由管理团队查看。"
+      - ""
+      - "&7你必须年满 13 岁才能说话。"
+      - ""
+      - "&7以后改变主意？请运行"
+      - "&f/voicechatconsent revoke"
+    CONFIRM-BUTTON:
+      DISPLAY-NAME: "&a确认"
+      LORE:
+      - "&f点击以开启语音聊天"
+    DECLINE-BUTTON:
+      DISPLAY-NAME: "&c拒绝"
+      LORE:
+      - "&f语音聊天将保持关闭"
 CONFIG:
   AUCTION_HOUSE:
     GUI:
@@ -2775,6 +2800,12 @@ MESSAGES:
     ADDED: "&aSuccessfully added '&e{word}&a' to banned words."
     ALREADY-EXISTS: "&cThat word is already in the banned list."
     RELOADED: "&aAnvil moderation config reloaded."
+  VOICE-CHAT:
+    ACCEPTED: "&a语音聊天已为你开启。"
+    DECLINED: "&c语音聊天将保持关闭。"
+    REVOKED: "&c你已撤回语音聊天同意。语音聊天已再次关闭。"
+    NOTHING-TO-REVOKE: "&c你还没有同意语音聊天政策。"
+    PLAYERS-ONLY: "&c只有玩家可以使用这个命令。"
 DEATH_MESSAGES:
   MESSAGES:
     PREFIX: "&c☠ "

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -2332,3 +2332,35 @@ SPAWNER-MENUS:
     TITLE: '&8Spawners Panel'
     SIZE: 27
 
+VOICE-CHAT-CONSENT-MENU:
+  TITLE: '&8Confirm Voice Chat'
+  SIZE: 27
+  INFO-BUTTON:
+    DISPLAY-NAME: '&bVoice Chat Policy'
+    MATERIAL: JUKEBOX
+    SLOT: 13
+    LORE:
+    - '&7Your voice is recorded while you are'
+    - '&7talking in a voice channel.'
+    - ''
+    - '&7Recordings are thrown away unless somebody'
+    - '&7reports you. A reported recording is kept'
+    - '&7as proof for a mute or a ban, and the'
+    - '&7moderation team reviews it.'
+    - ''
+    - '&7You have to be 13 or older to talk.'
+    - ''
+    - '&7Changed your mind later? Run'
+    - '&f/voicechatconsent revoke'
+  CONFIRM-BUTTON:
+    DISPLAY-NAME: '&aConfirm'
+    MATERIAL: LIME_STAINED_GLASS_PANE
+    SLOT: 11
+    LORE:
+    - '&fClick to turn voice chat on'
+  DECLINE-BUTTON:
+    DISPLAY-NAME: '&cDecline'
+    MATERIAL: RED_STAINED_GLASS_PANE
+    SLOT: 15
+    LORE:
+    - '&fVoice chat will stay disabled'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1162,3 +1162,9 @@ ALTS:
   KNOWN_IPS: '&7Known IPs: &f%ips%'
   # The text or value for Entry. Available options: Any valid string text
   ENTRY: '&8- &e%player% &7[%status%&7] &fshared: %ips%'
+VOICE-CHAT:
+  ACCEPTED: '&aVoice chat is now enabled for you.'
+  DECLINED: '&cVoice chat will stay disabled.'
+  REVOKED: '&cYou withdrew your voice chat consent. Voice chat is disabled again.'
+  NOTHING-TO-REVOKE: '&cYou have not agreed to the voice chat policy yet.'
+  PLAYERS-ONLY: '&cOnly players can use this command.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,7 @@ softdepend:
 - Apollo
 - Multiverse-Core
 - floodgate
+- voicechat
 loadbefore:
 - EconomyShopGUI
 - EconomyShopGUI-Premium
@@ -713,6 +714,14 @@ commands:
     description: Command safety
     permission: ultimatedonutsmp.command.safety
     permission-message: "&cYou do not have permission to use /safety."
+  voicechatconsent:
+    description: Open the voice chat consent menu
+    usage: /voicechatconsent [revoke]
+    aliases:
+    - vcconsent
+    - voiceconsent
+    permission: ultimatedonutsmp.command.voicechatconsent
+    permission-message: "&cYou do not have permission to use /voicechatconsent."
   friends:
     description: Command friends
     permission: ultimatedonutsmp.command.friends
@@ -1322,6 +1331,7 @@ permissions:
       ultimatedonutsmp.command.create: true
       ultimatedonutsmp.command.kill: true
       ultimatedonutsmp.command.safety: true
+      ultimatedonutsmp.command.voicechatconsent: true
       ultimatedonutsmp.command.friends: true
       ultimatedonutsmp.command.friend: true
       ultimatedonutsmp.command.spawnstash: true
@@ -1723,6 +1733,9 @@ permissions:
   ultimatedonutsmp.command.safety:
     description: Access to /safety command
     default: op
+  ultimatedonutsmp.command.voicechatconsent:
+    description: Access to /voicechatconsent command
+    default: true
   ultimatedonutsmp.command.friends:
     description: Access to /friends command
     default: true

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerKnownPlayersTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerKnownPlayersTest.java
@@ -64,7 +64,8 @@ class DatabaseManagerKnownPlayersTest {
                     + "randomized_coords INTEGER DEFAULT 0, death_messages_choice INTEGER DEFAULT 1, "
                     + "advancement_messages_choice INTEGER DEFAULT 1, join_leave_messages_choice INTEGER DEFAULT 1, "
                     + "teleport_alerts_enabled INTEGER DEFAULT 1, follow_alerts_enabled INTEGER DEFAULT 1, "
-                    + "explosion_sounds_enabled INTEGER DEFAULT 1, display_donutplus_enabled INTEGER DEFAULT 1)");
+                    + "explosion_sounds_enabled INTEGER DEFAULT 1, display_donutplus_enabled INTEGER DEFAULT 1, "
+                    + "voice_chat_consent INTEGER DEFAULT 0)");
 
             java.util.UUID testUuid = java.util.UUID.randomUUID();
             statement.execute("INSERT INTO players (uuid, username, kills, money) VALUES ('" + testUuid + "', 'Bob', 42, 500.0)");

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/VoiceChatConsentPersistenceTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/VoiceChatConsentPersistenceTest.java
@@ -1,0 +1,64 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.VoiceChatConsent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VoiceChatConsentPersistenceTest {
+
+    @Test
+    void newPlayersStartUndecided() {
+        assertEquals(VoiceChatConsent.UNDECIDED,
+                new PlayerData(UUID.randomUUID(), "Bob").getVoiceChatConsent());
+    }
+
+    @Test
+    void unknownStoredValuesFallBackToUndecided() {
+        assertEquals(VoiceChatConsent.UNDECIDED, VoiceChatConsent.fromInt(-1));
+        assertEquals(VoiceChatConsent.UNDECIDED, VoiceChatConsent.fromInt(7));
+        assertEquals(VoiceChatConsent.UNDECIDED, VoiceChatConsent.fromInt(0));
+        assertEquals(VoiceChatConsent.ACCEPTED, VoiceChatConsent.fromInt(1));
+        assertEquals(VoiceChatConsent.DECLINED, VoiceChatConsent.fromInt(2));
+    }
+
+    @Test
+    void nullConsentIsStoredAsUndecided() {
+        PlayerData data = new PlayerData(UUID.randomUUID(), "Bob");
+        data.setVoiceChatConsent(VoiceChatConsent.ACCEPTED);
+        data.setVoiceChatConsent(null);
+        assertEquals(VoiceChatConsent.UNDECIDED, data.getVoiceChatConsent());
+    }
+
+    @Test
+    void consentSurvivesASaveAndLoadRoundTrip() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = new DatabaseManager(null);
+
+            Field connectionField = DatabaseManager.class.getDeclaredField("connection");
+            connectionField.setAccessible(true);
+            connectionField.set(manager, connection);
+
+            Method createTables = DatabaseManager.class.getDeclaredMethod("createTables");
+            createTables.setAccessible(true);
+            createTables.invoke(manager);
+
+            UUID uuid = UUID.randomUUID();
+            PlayerData data = new PlayerData(uuid, "Bob");
+            data.setVoiceChatConsent(VoiceChatConsent.DECLINED);
+            manager.savePlayer(data);
+
+            PlayerData loaded = manager.loadPlayer(uuid);
+            assertNotNull(loaded);
+            assertEquals(VoiceChatConsent.DECLINED, loaded.getVoiceChatConsent());
+        }
+    }
+}


### PR DESCRIPTION
Closes #263

The issue reads as "open the existing consent menu automatically instead of manually", but there was no consent menu in this plugin to open. Nothing here touched voice chat at all. So this builds the flow from scratch: a menu, an answer stored per player, a command to reopen it, and a Simple Voice Chat integration that acts on what the player picked.

## The menu and when it opens

An undecided player gets the menu two seconds after joining, and keeps getting it on later joins until they pick something. Confirm records agreement and opens their microphone; decline records the refusal and the prompt stops coming back. Closing the menu with escape counts as neither, so it returns next join rather than trapping somebody in an inventory they cannot leave.

Layout, materials, slots and the policy text all come from `VOICE-CHAT-CONSENT-MENU` in `menus.yml`. Timing, and whether the prompt opens on its own at all, live in the new `VOICE-CHAT` block in `config.yml`.

## What declining blocks

`SimpleVoiceChatHook` registers a `VoicechatPlugin` and cancels `MicrophonePacketEvent` for anyone who has not confirmed. The hook drops their audio before it reaches another player, which is the part the policy exists for: nothing gets recorded for someone who never agreed to being recorded. They can still hear a channel.

I deliberately left `VoicechatConnection.setDisabled(true)` out of it. That flag is a client-side preference, and a player who accepts later would be left switched off with no obvious way back.

Voice chat events arrive off the main thread, so the hook reads answers from a `ConcurrentHashMap` filled on join instead of touching `PlayerData` or the Bukkit API.

## Command naming

Simple Voice Chat already owns `/voicechat`, so the `/voicechat revoke` in the issue would have collided with it. The command is `/voicechatconsent`, aliased to `/vcconsent` and `/voiceconsent`. Bare opens the menu; `revoke` throws the answer away and puts the player back at undecided.

## Dependency and storage

`voicechat-api` 2.6.20 joins `pom.xml` as `provided` alongside maxhenkel's repository, and `voicechat` goes into `softdepend`. Without Simple Voice Chat installed the menu still runs and still records answers, it just has nothing to gate, so servers that don't run it lose nothing.

The answer itself is a `voice_chat_consent` column on `players`. It's tri-state rather than boolean because "has not answered yet" is the state that drives the prompt. Existing databases pick the column up through the usual `ensureColumnExists` path.

## Policy wording

The screenshots carry DonutSMP's own privacy text and a link to their policy page. Copying that word for word would put one server's privacy policy in front of players on every other server running this plugin, so the bundled lore covers the same ground in neutral wording, and the wiki says plainly that admins should rewrite it before relying on it.

## Notes

- New config keys: `VOICE-CHAT.PROMPT-ON-JOIN`, `VOICE-CHAT.PROMPT-DELAY-TICKS`, `VOICE-CHAT.MUTE-UNTIL-ACCEPTED`.
- New language keys under `MENUS.VOICE-CHAT-CONSENT-MENU` and `MESSAGES.VOICE-CHAT`, written out across all eight language files.
- `VOICE_CHAT` is a real `/features` entry, and `applyRuntimeState` refreshes the microphone gate when somebody toggles it. Turning the feature off unmutes people straight away instead of waiting for a reload.
- `DatabaseManagerKnownPlayersTest` hand-builds the `players` schema, so it needed the new column too.
- `VoiceChatConsentPersistenceTest` covers the enum fallback and a real save/load round trip through SQLite, which is the thing that would catch a miscounted parameter in the 65-column player insert. Suite is at 411 tests, all green.
- Wiki pages touched: `Commands-and-Permissions.md`, `Config-config.yml.md`, `Config-menus.yml.md`, `Placeholders-and-Integrations.md`.
