### PR TITLE
feat(settings): group the settings menu by what each option does (#264)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -753,7 +753,7 @@ before the colours are applied, and PlaceholderAPI placeholders resolve too when
 
 Two per-player switches under `/settings` still apply on top of everything configured here. Join,
 leave and first-join lines follow **Join/Leave Messages**, which is the same option that already
-governs the server's own join and quit text and can be narrowed to friends only. The Auction House
+governs the server's own join and quit text and is limited to people the player follows. The Auction House
 and Order lines follow **Server Broadcasts**, plus **Auction Alerts** and **Order Alerts**
 respectively, so a player who muted one marketplace does not get its announcements back through
 this system.

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -911,9 +911,19 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Buttons are grouped a row at a time: chat and messages on the first row,
+    # alerts on the second, gameplay and display on the third, then who may reach
+    # you, the confirmation prompts, and finally the world around you.
     # Every setting below accepts two optional keys:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
-    #   ENABLED: false    Removes the option from /settings and pins every player to DEFAULT.
+    #                     On/off buttons take true or false. The privacy buttons
+    #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     true/false also work as shortcuts.
+    #   ENABLED: false    Removes the option from /settings and pins every player to the
+    #                     DEFAULT above. Use this instead of deleting the block - deleted
+    #                     blocks are restored from the bundled defaults on the next start.
     # Example, hide advancement messages and keep them off for everyone:
     # ADVANCEMENT_MESSAGES:
     #   DEFAULT: OFF
@@ -928,6 +938,7 @@ SETTINGS-MENU:
     #   LORE:
     #   - '&7Toggle flight via external plugin'
     #   - '&fCurrently: {status}'
+    # Row 1 - chat and messages
     PUBLIC_CHAT:
       DISPLAY-NAME: '&#6BF18DPublic Chat'
       MATERIAL: OAK_SIGN
@@ -937,7 +948,7 @@ SETTINGS-MENU:
       - '&fCurrently: {status}'
     PRIVATE_MESSAGES:
       DISPLAY-NAME: '&#6BF18DPrivate Messages'
-      MATERIAL: SPRUCE_SIGN
+      MATERIAL: DARK_OAK_SIGN
       SLOT: 1
       LORE:
       - '&7Private messages privacy settings'
@@ -949,51 +960,40 @@ SETTINGS-MENU:
       LORE:
       - '&7Receive server broadcasts'
       - '&fCurrently: {status}'
-    TEAM_CHAT_VISIBILITY:
-      DISPLAY-NAME: '&#6BF18DTeam Chat Visibility'
-      MATERIAL: DARK_OAK_SIGN
+    HOTBAR_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DHotbar Messages'
+      MATERIAL: CRIMSON_SIGN
       SLOT: 3
       LORE:
-      - '&7Show team chat in main chat'
+      - '&7Show action bar status notifications'
       - '&fCurrently: {status}'
-    LUNAR_TEAMMATES:
-      DISPLAY-NAME: '&#6BF18DLunar Teammates'
-      MATERIAL: BIRCH_SIGN
+    DEATH_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DDeath Messages'
+      MATERIAL: SPRUCE_SIGN
       SLOT: 4
       LORE:
-      - '&7Show teammates on Lunar Client'
+      - '&7Show death message notifications'
       - '&fCurrently: {status}'
-    TPA_CONFIRM_MENUS:
-      DISPLAY-NAME: '&#6BF18DTpa Confirm Menus'
+    JOIN_LEAVE_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DJoin/Leave Messages'
       MATERIAL: JUNGLE_SIGN
       SLOT: 5
       LORE:
-      - '&7Show confirmation GUI for TPA'
+      - '&7Show join and leave notifications'
       - '&fCurrently: {status}'
-    QUICK_AUCTION_PURCHASE:
-      DISPLAY-NAME: '&#6BF18DQuick Auction Purchase'
-      MATERIAL: GOLD_NUGGET
-      SLOT: 9
+    ADVANCEMENT_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DAdvancement Messages'
+      MATERIAL: BIRCH_SIGN
+      SLOT: 6
       LORE:
-      - '&7Fast buy auction items directly'
+      - '&7Show advancement achievement notifications'
       - '&fCurrently: {status}'
-    DESTROY_PEARL_ON_DEATH:
-      DISPLAY-NAME: '&#6BF18DDestroy Pearl on Death'
-      MATERIAL: ENDER_PEARL
-      SLOT: 10
-      LORE:
-      - '&7Destroy thrown ender pearls when you die'
-      - '&fCurrently: {status}'
-    PAY_CONFIRM_MENUS:
-      DISPLAY-NAME: '&#6BF18DPay Confirm Menus'
-      MATERIAL: OAK_SIGN
-      SLOT: 11
-      LORE:
-      - '&7Show confirmation GUI for payments'
-      - '&fCurrently: {status}'
-    AUTO_CONFIRM_TPAS:
-      DISPLAY-NAME: '&bTp Auto'
+    TEAM_CHAT_VISIBILITY:
+      DISPLAY-NAME: '&#6BF18DTeam Chat Visibility'
       MATERIAL: ACACIA_SIGN
+      SLOT: 7
+      LORE:
+      - '&7Show team chat in main chat'
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -1007,29 +1007,29 @@ SETTINGS-MENU:
 | `SETTINGS-MENU.BUTTONS.PUBLIC_CHAT.SLOT` | `int` | Any valid integer number | `'0'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.PUBLIC_CHAT.SLOT` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.PUBLIC_CHAT.LORE` | `list` | List of configured items/strings | `['&7Receive public chat messages', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.PUBLIC_CHAT.LORE` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DPrivate Messages'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.DISPLAY-NAME` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.MATERIAL` | `str` | Any string text | `'SPRUCE_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.MATERIAL` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.MATERIAL` | `str` | Any string text | `'DARK_OAK_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.MATERIAL` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.SLOT` | `int` | Any valid integer number | `'1'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.SLOT` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.LORE` | `list` | List of configured items/strings | `['&7Private messages privacy settings', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.PRIVATE_MESSAGES.LORE` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DServer Broadcasts'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.DISPLAY-NAME` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.MATERIAL` | `str` | Any string text | `'WARPED_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.MATERIAL` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.SLOT` | `int` | Any valid integer number | `'2'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.SLOT` in `menus.yml`. |
 | `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.LORE` | `list` | List of configured items/strings | `['&7Receive server broadcasts', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.SERVER_BROADCASTS.LORE` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DTeam Chat Visibility'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.DISPLAY-NAME` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.MATERIAL` | `str` | Any string text | `'DARK_OAK_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.MATERIAL` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.SLOT` | `int` | Any valid integer number | `'3'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.SLOT` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.LORE` | `list` | List of configured items/strings | `['&7Show team chat in main chat', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.TEAM_CHAT_VISIBILITY.LORE` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DLunar Teammates'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.DISPLAY-NAME` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.MATERIAL` | `str` | Any string text | `'BIRCH_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.MATERIAL` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.SLOT` | `int` | Any valid integer number | `'4'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.SLOT` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.LORE` | `list` | List of configured items/strings | `['&7Show teammates on Lunar Client', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.LUNAR_TEAMMATES.LORE` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DTpa Confirm Menus'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.DISPLAY-NAME` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.MATERIAL` | `str` | Any string text | `'JUNGLE_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.MATERIAL` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.SLOT` | `int` | Any valid integer number | `'5'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.SLOT` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.LORE` | `list` | List of configured items/strings | `['&7Show confirmation GUI for TPA', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.TPA_CONFIRM_MENUS.LORE` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DQuick Auction Purchase'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.DISPLAY-NAME` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.MATERIAL` | `str` | Any string text | `'GOLD_NUGGET'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.MATERIAL` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.SLOT` | `int` | Any valid integer number | `'9'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.SLOT` in `menus.yml`. |
-| `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.LORE` | `list` | List of configured items/strings | `['&7Fast buy auction items directly', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.QUICK_AUCTION_PURCHASE.LORE` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DHotbar Messages'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.DISPLAY-NAME` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.MATERIAL` | `str` | Any string text | `'CRIMSON_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.MATERIAL` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.SLOT` | `int` | Any valid integer number | `'3'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.SLOT` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.LORE` | `list` | List of configured items/strings | `['&7Show action bar status notifications', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.HOTBAR_MESSAGES.LORE` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DDeath Messages'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.DISPLAY-NAME` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.MATERIAL` | `str` | Any string text | `'SPRUCE_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.MATERIAL` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.SLOT` | `int` | Any valid integer number | `'4'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.SLOT` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.LORE` | `list` | List of configured items/strings | `['&7Show death message notifications', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.DEATH_MESSAGES.LORE` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DJoin/Leave Messages'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.DISPLAY-NAME` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.MATERIAL` | `str` | Any string text | `'JUNGLE_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.MATERIAL` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.SLOT` | `int` | Any valid integer number | `'5'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.SLOT` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.LORE` | `list` | List of configured items/strings | `['&7Show join and leave notifications', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.JOIN_LEAVE_MESSAGES.LORE` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.DISPLAY-NAME` | `str` | Any string text | `'&#6BF18DAdvancement Messages'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.DISPLAY-NAME` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.MATERIAL` | `str` | Any string text | `'BIRCH_SIGN'` | Configures the technical `MATERIAL` parameter for `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.MATERIAL` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.SLOT` | `int` | Any valid integer number | `'6'` | Configures the technical `SLOT` parameter for `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.SLOT` in `menus.yml`. |
+| `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.LORE` | `list` | List of configured items/strings | `['&7Show advancement achievement notifications', '&fCurrently: {status}']` | Configures the technical `LORE` parameter for `SETTINGS-MENU.BUTTONS.ADVANCEMENT_MESSAGES.LORE` in `menus.yml`. |
 | *(128 additional sub-keys configured in section)* | | | | |
 
 ### 3. Practical Setup Example
@@ -1039,9 +1039,19 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Buttons are grouped a row at a time: chat and messages on the first row,
+    # alerts on the second, gameplay and display on the third, then who may reach
+    # you, the confirmation prompts, and finally the world around you.
     # Every setting below accepts two optional keys:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
-    #   ENABLED: false    Removes the option from /settings and pins every player to DEFAULT.
+    #                     On/off buttons take true or false. The privacy buttons
+    #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     true/false also work as shortcuts.
+    #   ENABLED: false    Removes the option from /settings and pins every player to the
+    #                     DEFAULT above. Use this instead of deleting the block - deleted
+    #                     blocks are restored from the bundled defaults on the next start.
     # Example, hide advancement messages and keep them off for everyone:
     # ADVANCEMENT_MESSAGES:
     #   DEFAULT: OFF
@@ -1056,6 +1066,7 @@ SETTINGS-MENU:
     #   LORE:
     #   - '&7Toggle flight via external plugin'
     #   - '&fCurrently: {status}'
+    # Row 1 - chat and messages
     PUBLIC_CHAT:
       DISPLAY-NAME: '&#6BF18DPublic Chat'
       MATERIAL: OAK_SIGN
@@ -1065,20 +1076,9 @@ SETTINGS-MENU:
       - '&fCurrently: {status}'
     PRIVATE_MESSAGES:
       DISPLAY-NAME: '&#6BF18DPrivate Messages'
-      MATERIAL: SPRUCE_SIGN
+      MATERIAL: DARK_OAK_SIGN
       SLOT: 1
       LORE:
-      - '&7Private messages privacy settings'
-      - '&fCurrently: {status}'
-    SERVER_BROADCASTS:
-      DISPLAY-NAME: '&#6BF18DServer Broadcasts'
-      MATERIAL: WARPED_SIGN
-      SLOT: 2
-      LORE:
-      - '&7Receive server broadcasts'
-      - '&fCurrently: {status}'
-    TEAM_CHAT_VISIBILITY:
-    
 ```
 
 ### 4. Per-Setting Defaults & Removing Options
@@ -1126,6 +1126,14 @@ Notes:
   it, so treat re-enabling an option as a reset for the players affected.
 - `QUICK_AUCTION_PURCHASE` and `QUICK_AUCTION_SELL` are stored by the auction house instead of
   the player profile, so they support `ENABLED` but not `DEFAULT`.
+- The bundled slots put one theme on each row and leave the rest of the row empty: chat and
+  messages on the first, alerts on the second, gameplay and display on the third, who may reach
+  you on the fourth, the confirmation prompts and auction shortcuts on the fifth, and the world
+  around you on the last. Moving a button is only a matter of changing its `SLOT`, and the
+  trailing gaps are there so a server can slot its own buttons into the row they belong to.
+- A `menus.yml` written before that grouping existed is backed up under `config-backups/` and
+  regenerated on the next start, because merging bundled defaults never rewrites a `SLOT` that
+  is already in the file.
 
 ---
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -821,7 +821,7 @@ SERVER-NOTIFICATIONS:
 | `SERVER-NOTIFICATIONS.ORDERS.COMPLETE.MESSAGE` | `str` | Any string text | `&8[&6ORDER&8] &f{player} &7completed &e{owner}&7's order...` | Supports `{player}`, `{owner}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}`, `{total}`, `{total_formatted}`. |
 
 Join, leave and first-join lines follow each player's **Join/Leave Messages** choice under
-`/settings`. The Auction House and Order lines follow **Server Broadcasts** plus **Auction
+`/settings`, which is either people they follow or nobody. The Auction House and Order lines follow **Server Broadcasts** plus **Auction
 Alerts** and **Order Alerts**. Bot listings and bot orders are never announced.
 
 ---

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerAdvancementDoneListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerAdvancementDoneListener.java
@@ -2,7 +2,6 @@ package com.bx.ultimateDonutSmp.listeners;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
-import com.bx.ultimateDonutSmp.models.ThreeChoice;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
@@ -84,24 +83,17 @@ public class PlayerAdvancementDoneListener implements Listener {
         final String finalAnnouncement = ColorUtils.colorize(announcement);
 
         plugin.getSpigotScheduler().forEachOnlinePlayer(p -> {
-            if (shouldReceiveAdvancement(p, player)) {
+            if (shouldReceiveAdvancement(p)) {
                 p.sendMessage(ColorUtils.toComponent(finalAnnouncement));
             }
         });
     }
 
-    private boolean shouldReceiveAdvancement(Player receiver, Player victim) {
+    private boolean shouldReceiveAdvancement(Player receiver) {
         PlayerData receiverData = plugin.getPlayerDataManager().get(receiver);
         if (receiverData == null) {
             return true;
         }
-        ThreeChoice choice = receiverData.getAdvancementMessagesChoice();
-        if (choice == ThreeChoice.OFF) {
-            return false;
-        }
-        if (choice == ThreeChoice.FRIENDS_FOLLOWED) {
-            return plugin.getFriendsManager() != null && plugin.getFriendsManager().isFollowing(receiver.getUniqueId(), victim.getUniqueId());
-        }
-        return true;
+        return receiverData.isAdvancementMessagesEnabled();
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -455,14 +455,11 @@ public class PlayerJoinQuitListener implements Listener {
         if (receiverData == null) {
             return true;
         }
-        com.bx.ultimateDonutSmp.models.ThreeChoice choice = receiverData.getJoinLeaveMessagesChoice();
-        if (choice == com.bx.ultimateDonutSmp.models.ThreeChoice.OFF) {
+        com.bx.ultimateDonutSmp.models.TwoChoice choice = receiverData.getJoinLeaveMessagesChoice();
+        if (choice == com.bx.ultimateDonutSmp.models.TwoChoice.OFF) {
             return false;
         }
-        if (choice == com.bx.ultimateDonutSmp.models.ThreeChoice.FRIENDS_FOLLOWED) {
-            return plugin.getFriendsManager() != null && plugin.getFriendsManager().isFollowing(receiver.getUniqueId(), joiner.getUniqueId());
-        }
-        return true;
+        return plugin.getFriendsManager() != null && plugin.getFriendsManager().isFollowing(receiver.getUniqueId(), joiner.getUniqueId());
     }
 
     private String kickMessage(PunishmentRecord record) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -2068,7 +2068,16 @@ public class ConfigManager {
     }
 
     private boolean hasLegacyButtons(YamlConfiguration config) {
-        return false;
+        ConfigurationSection buttons = config.getConfigurationSection("SETTINGS-MENU.BUTTONS");
+        if (buttons == null) {
+            return false;
+        }
+        // Slots 31 to 33 held join/leave, pay alerts and money nametags in the old grouping and are
+        // unused by the current one, so all three together identify a menus.yml that predates it.
+        // Merging never rewrites a slot that is already there, so the file has to be regenerated.
+        return buttons.getInt("JOIN_LEAVE_MESSAGES.SLOT", -1) == 31
+                && buttons.getInt("PAY_ALERTS.SLOT", -1) == 32
+                && buttons.getInt("MONEY_NAMETAGS.SLOT", -1) == 33;
     }
 
     private void backupInvalidFile(File file) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -1102,8 +1102,11 @@ public class DatabaseManager {
         data.setDestroyPearlOnDeath(rs.getInt("destroy_pearl_on_death") != 0);
         data.setRandomizedCoords(rs.getInt("randomized_coords") != 0);
         data.setDeathMessagesChoice(com.bx.ultimateDonutSmp.models.TwoChoice.fromInt(rs.getInt("death_messages_choice")));
-        data.setAdvancementMessagesChoice(com.bx.ultimateDonutSmp.models.ThreeChoice.fromInt(rs.getInt("advancement_messages_choice")));
-        data.setJoinLeaveMessagesChoice(com.bx.ultimateDonutSmp.models.ThreeChoice.fromInt(rs.getInt("join_leave_messages_choice")));
+        // Both columns used to hold a ThreeChoice ordinal. Rows written before the two options
+        // became on/off and friends/off still read correctly: 0 was OFF, and 1 (anyone) and
+        // 2 (friends) both mean the option was on.
+        data.setAdvancementMessagesEnabled(rs.getInt("advancement_messages_choice") != 0);
+        data.setJoinLeaveMessagesChoice(com.bx.ultimateDonutSmp.models.TwoChoice.fromInt(rs.getInt("join_leave_messages_choice")));
         data.setTeleportAlertsEnabled(rs.getInt("teleport_alerts_enabled") != 0);
         data.setFollowAlertsEnabled(rs.getInt("follow_alerts_enabled") != 0);
         data.setExplosionSoundsEnabled(rs.getInt("explosion_sounds_enabled") != 0);
@@ -1727,7 +1730,7 @@ public class DatabaseManager {
             ps.setInt(56, data.isDestroyPearlOnDeath() ? 1 : 0);
             ps.setInt(57, data.isRandomizedCoords() ? 1 : 0);
             ps.setInt(58, data.getDeathMessagesChoice().ordinal());
-            ps.setInt(59, data.getAdvancementMessagesChoice().ordinal());
+            ps.setInt(59, data.isAdvancementMessagesEnabled() ? 1 : 0);
             ps.setInt(60, data.getJoinLeaveMessagesChoice().ordinal());
             ps.setInt(61, data.isTeleportAlertsEnabled() ? 1 : 0);
             ps.setInt(62, data.isFollowAlertsEnabled() ? 1 : 0);

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -270,13 +270,11 @@ public final class PlayerSettingsMenu extends BaseMenu {
                 data.setDeathMessagesChoice(nextTwoChoice(data.getDeathMessagesChoice()));
                 sendChoiceMessage(player, "Death Messages", formatTwoChoice(data.getDeathMessagesChoice()));
             }
-            case "ADVANCEMENT_MESSAGES" -> {
-                data.setAdvancementMessagesChoice(nextThreeChoice(data.getAdvancementMessagesChoice()));
-                sendChoiceMessage(player, "Advancement Messages", formatThreeChoice(data.getAdvancementMessagesChoice()));
-            }
+            case "ADVANCEMENT_MESSAGES" -> toggle(player, "Advancement Messages",
+                    !data.isAdvancementMessagesEnabled(), data::setAdvancementMessagesEnabled);
             case "JOIN_LEAVE_MESSAGES" -> {
-                data.setJoinLeaveMessagesChoice(nextThreeChoice(data.getJoinLeaveMessagesChoice()));
-                sendChoiceMessage(player, "Join/Leave Messages", formatThreeChoice(data.getJoinLeaveMessagesChoice()));
+                data.setJoinLeaveMessagesChoice(nextTwoChoice(data.getJoinLeaveMessagesChoice()));
+                sendChoiceMessage(player, "Join/Leave Messages", formatTwoChoice(data.getJoinLeaveMessagesChoice()));
             }
             case "TELEPORT_ALERTS" -> toggle(player, "Teleport Alerts",
                     !data.isTeleportAlertsEnabled(), data::setTeleportAlertsEnabled);
@@ -430,8 +428,8 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "DESTROY_PEARL_ON_DEATH" -> state(data.isDestroyPearlOnDeath());
             case "RANDOMIZED_COORDS" -> state(data.isRandomizedCoords());
             case "DEATH_MESSAGES" -> new ButtonState(formatTwoChoice(data.getDeathMessagesChoice()), true);
-            case "ADVANCEMENT_MESSAGES" -> new ButtonState(formatThreeChoice(data.getAdvancementMessagesChoice()), true);
-            case "JOIN_LEAVE_MESSAGES" -> new ButtonState(formatThreeChoice(data.getJoinLeaveMessagesChoice()), true);
+            case "ADVANCEMENT_MESSAGES" -> state(data.isAdvancementMessagesEnabled());
+            case "JOIN_LEAVE_MESSAGES" -> new ButtonState(formatTwoChoice(data.getJoinLeaveMessagesChoice()), true);
             case "TELEPORT_ALERTS" -> state(data.isTeleportAlertsEnabled());
             case "FOLLOW_ALERT_SETTINGS" -> state(data.isFollowAlertsEnabled());
             case "EXPLOSION_SOUNDS" -> state(data.isExplosionSoundsEnabled());

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -66,8 +66,8 @@ public class PlayerData {
     private boolean destroyPearlOnDeath;
     private boolean randomizedCoords;
     private TwoChoice deathMessagesChoice;
-    private ThreeChoice advancementMessagesChoice;
-    private ThreeChoice joinLeaveMessagesChoice;
+    private boolean advancementMessagesEnabled;
+    private TwoChoice joinLeaveMessagesChoice;
     private boolean teleportAlertsEnabled;
     private boolean followAlertsEnabled;
     private boolean explosionSoundsEnabled;
@@ -138,8 +138,8 @@ public class PlayerData {
         this.destroyPearlOnDeath = true;
         this.randomizedCoords = false;
         this.deathMessagesChoice = TwoChoice.FRIENDS_FOLLOWED;
-        this.advancementMessagesChoice = ThreeChoice.ANYONE;
-        this.joinLeaveMessagesChoice = ThreeChoice.ANYONE;
+        this.advancementMessagesEnabled = true;
+        this.joinLeaveMessagesChoice = TwoChoice.FRIENDS_FOLLOWED;
         this.teleportAlertsEnabled = true;
         this.followAlertsEnabled = true;
         this.explosionSoundsEnabled = true;
@@ -903,20 +903,20 @@ public class PlayerData {
         dirty = true;
     }
 
-    public ThreeChoice getAdvancementMessagesChoice() {
-        return advancementMessagesChoice;
+    public boolean isAdvancementMessagesEnabled() {
+        return advancementMessagesEnabled;
     }
 
-    public void setAdvancementMessagesChoice(ThreeChoice advancementMessagesChoice) {
-        this.advancementMessagesChoice = advancementMessagesChoice;
+    public void setAdvancementMessagesEnabled(boolean advancementMessagesEnabled) {
+        this.advancementMessagesEnabled = advancementMessagesEnabled;
         dirty = true;
     }
 
-    public ThreeChoice getJoinLeaveMessagesChoice() {
+    public TwoChoice getJoinLeaveMessagesChoice() {
         return joinLeaveMessagesChoice;
     }
 
-    public void setJoinLeaveMessagesChoice(ThreeChoice joinLeaveMessagesChoice) {
+    public void setJoinLeaveMessagesChoice(TwoChoice joinLeaveMessagesChoice) {
         this.joinLeaveMessagesChoice = joinLeaveMessagesChoice;
         dirty = true;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
@@ -206,11 +206,11 @@ public final class PlayerSettingDefaults {
         bindings.put("WORTH_DISPLAY", bool(PlayerData::isWorthDisplayEnabled, PlayerData::setWorthDisplayEnabled));
         bindings.put("MONEY_NAMETAGS", bool(
                 PlayerData::isMoneyNametagsEnabled, PlayerData::setMoneyNametagsEnabled));
-        bindings.put("JOIN_LEAVE_MESSAGES", threeChoice(
+        bindings.put("JOIN_LEAVE_MESSAGES", twoChoice(
                 PlayerData::getJoinLeaveMessagesChoice, PlayerData::setJoinLeaveMessagesChoice));
         bindings.put("PAY_ALERTS", bool(PlayerData::isPayAlertsEnabled, PlayerData::setPayAlertsEnabled));
-        bindings.put("ADVANCEMENT_MESSAGES", threeChoice(
-                PlayerData::getAdvancementMessagesChoice, PlayerData::setAdvancementMessagesChoice));
+        bindings.put("ADVANCEMENT_MESSAGES", bool(
+                PlayerData::isAdvancementMessagesEnabled, PlayerData::setAdvancementMessagesEnabled));
         bindings.put("AUCTION_NOTIFICATIONS", bool(
                 PlayerData::isAuctionNotificationsEnabled, PlayerData::setAuctionNotificationsEnabled));
         bindings.put("AMETHYST_BREAK_MESSAGES", bool(

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -596,13 +596,16 @@ SETTINGS-MENU:
   TITLE: '&8Settings'
   SIZE: 54
   BUTTONS:
+    # Buttons are grouped a row at a time: chat and messages on the first row,
+    # alerts on the second, gameplay and display on the third, then who may reach
+    # you, the confirmation prompts, and finally the world around you.
     # Every setting below accepts two optional keys:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
-    #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS,
-    #                     ADVANCEMENT_MESSAGES, JOIN_LEAVE_MESSAGES) take ANYONE,
-    #                     FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES takes
-    #                     FRIENDS_FOLLOWED or OFF. true/false also work as shortcuts.
+    #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted
     #                     blocks are restored from the bundled defaults on the next start.
@@ -620,6 +623,7 @@ SETTINGS-MENU:
     #   LORE:
     #   - '&7Toggle flight via external plugin'
     #   - '&fCurrently: {status}'
+    # Row 1 - chat and messages
     PUBLIC_CHAT:
       DISPLAY-NAME: '&#6BF18DPublic Chat'
       MATERIAL: OAK_SIGN
@@ -629,7 +633,7 @@ SETTINGS-MENU:
       - '&fCurrently: {status}'
     PRIVATE_MESSAGES:
       DISPLAY-NAME: '&#6BF18DPrivate Messages'
-      MATERIAL: SPRUCE_SIGN
+      MATERIAL: DARK_OAK_SIGN
       SLOT: 1
       LORE:
       - '&7Private messages privacy settings'
@@ -641,68 +645,90 @@ SETTINGS-MENU:
       LORE:
       - '&7Receive server broadcasts'
       - '&fCurrently: {status}'
-    TEAM_CHAT_VISIBILITY:
-      DISPLAY-NAME: '&#6BF18DTeam Chat Visibility'
-      MATERIAL: DARK_OAK_SIGN
-      SLOT: 3
-      LORE:
-      - '&7Show team chat in main chat'
-      - '&fCurrently: {status}'
-    LUNAR_TEAMMATES:
-      DISPLAY-NAME: '&#6BF18DLunar Teammates'
-      MATERIAL: BIRCH_SIGN
-      SLOT: 4
-      LORE:
-      - '&7Show teammates on Lunar Client'
-      - '&fCurrently: {status}'
-    TPA_CONFIRM_MENUS:
-      DISPLAY-NAME: '&#6BF18DTpa Confirm Menus'
-      MATERIAL: JUNGLE_SIGN
-      SLOT: 5
-      LORE:
-      - '&7Show confirmation GUI for TPA'
-      - '&fCurrently: {status}'
-    QUICK_AUCTION_PURCHASE:
-      DISPLAY-NAME: '&#6BF18DQuick Auction Purchase'
-      MATERIAL: GOLD_NUGGET
-      SLOT: 9
-      LORE:
-      - '&7Fast buy auction items directly'
-      - '&fCurrently: {status}'
-    DESTROY_PEARL_ON_DEATH:
-      DISPLAY-NAME: '&#6BF18DDestroy Pearl on Death'
-      MATERIAL: ENDER_PEARL
-      SLOT: 10
-      LORE:
-      - '&7Destroy thrown ender pearls when you die'
-      - '&fCurrently: {status}'
-    PAY_CONFIRM_MENUS:
-      DISPLAY-NAME: '&#6BF18DPay Confirm Menus'
-      MATERIAL: OAK_SIGN
-      SLOT: 11
-      LORE:
-      - '&7Show confirmation GUI for payments'
-      - '&fCurrently: {status}'
-    AUTO_CONFIRM_TPAS:
-      DISPLAY-NAME: '&bTp Auto'
-      MATERIAL: ACACIA_SIGN
-      SLOT: 12
-      LORE:
-      - '&7Auto-confirm teleport requests'
-      - '&fCurrently: {status}'
     HOTBAR_MESSAGES:
       DISPLAY-NAME: '&#6BF18DHotbar Messages'
-      MATERIAL: PAPER
-      SLOT: 13
+      MATERIAL: CRIMSON_SIGN
+      SLOT: 3
       LORE:
       - '&7Show action bar status notifications'
       - '&fCurrently: {status}'
-    NOTIFICATION_SOUNDS:
-      DISPLAY-NAME: '&#6BF18DNotification Sounds'
-      MATERIAL: NOTE_BLOCK
+    DEATH_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DDeath Messages'
+      MATERIAL: SPRUCE_SIGN
+      SLOT: 4
+      LORE:
+      - '&7Show death message notifications'
+      - '&fCurrently: {status}'
+    JOIN_LEAVE_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DJoin/Leave Messages'
+      MATERIAL: JUNGLE_SIGN
+      SLOT: 5
+      LORE:
+      - '&7Show join and leave notifications'
+      - '&fCurrently: {status}'
+    ADVANCEMENT_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DAdvancement Messages'
+      MATERIAL: BIRCH_SIGN
+      SLOT: 6
+      LORE:
+      - '&7Show advancement achievement notifications'
+      - '&fCurrently: {status}'
+    TEAM_CHAT_VISIBILITY:
+      DISPLAY-NAME: '&#6BF18DTeam Chat Visibility'
+      MATERIAL: ACACIA_SIGN
+      SLOT: 7
+      LORE:
+      - '&7Show team chat in main chat'
+      - '&fCurrently: {status}'
+    AMETHYST_BREAK_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DAmethyst Break Messages'
+      MATERIAL: BAMBOO_SIGN
+      SLOT: 8
+      LORE:
+      - '&7Show message when amethyst cluster breaks'
+      - '&fCurrently: {status}'
+    # Row 2 - alerts
+    PAY_ALERTS:
+      DISPLAY-NAME: '&#6BF18DPay Alerts'
+      MATERIAL: GOLD_NUGGET
+      SLOT: 9
+      LORE:
+      - '&7Receive pay alerts'
+      - '&fCurrently: {status}'
+    TELEPORT_ALERTS:
+      DISPLAY-NAME: '&#6BF18DTeleport Alerts'
+      MATERIAL: BELL
+      SLOT: 10
+      LORE:
+      - '&7Sound and message alerts for TPA'
+      - '&fCurrently: {status}'
+    BOUNTY_ALERTS:
+      DISPLAY-NAME: '&#6BF18DBounty Alerts'
+      MATERIAL: WITHER_SKELETON_SKULL
+      SLOT: 11
+      LORE:
+      - '&7Notify when bounties are set/claimed'
+      - '&fCurrently: {status}'
+    AUCTION_NOTIFICATIONS:
+      DISPLAY-NAME: '&#6BF18DAuction Alerts'
+      MATERIAL: GOLD_INGOT
+      SLOT: 12
+      LORE:
+      - '&7Notify when items are bought/sold'
+      - '&fCurrently: {status}'
+    ORDER_NOTIFICATIONS:
+      DISPLAY-NAME: '&#6BF18DOrder Alerts'
+      MATERIAL: MAP
+      SLOT: 13
+      LORE:
+      - '&7Notify when order transactions occur'
+      - '&fCurrently: {status}'
+    KEY_ALL_NOTIFICATIONS:
+      DISPLAY-NAME: '&#6BF18DKey All Notifications'
+      MATERIAL: TRIPWIRE_HOOK
       SLOT: 14
       LORE:
-      - '&7Play notification sounds'
+      - '&7Show key-all event notifications'
       - '&fCurrently: {status}'
     FOLLOW_ALERT_SETTINGS:
       DISPLAY-NAME: '&#6BF18DFollow Alerts'
@@ -711,12 +737,20 @@ SETTINGS-MENU:
       LORE:
       - '&7Notify when players follow you'
       - '&fCurrently: {status}'
-    DISPLAY_DONUT_PLUS:
-      DISPLAY-NAME: '&#6BF18DDisplay Donut+'
+    NOTIFICATION_SOUNDS:
+      DISPLAY-NAME: '&#6BF18DNotification Sounds'
+      MATERIAL: NOTE_BLOCK
+      SLOT: 16
+      LORE:
+      - '&7Play notification sounds'
+      - '&fCurrently: {status}'
+    # Row 3 - gameplay and display
+    FAST_CRYSTALS:
+      DISPLAY-NAME: '&#6BF18DFast Crystals'
       MATERIAL: END_CRYSTAL
       SLOT: 18
       LORE:
-      - '&7Display your premium Donut+ status'
+      - '&7Faster end crystal placement speed'
       - '&fCurrently: {status}'
     CHAINMAIL_ON_RESPAWN:
       DISPLAY-NAME: '&#6BF18DChainmail on Respawn'
@@ -739,27 +773,42 @@ SETTINGS-MENU:
       LORE:
       - '&7Play explosion sound effects'
       - '&fCurrently: {status}'
-    TELEPORT_ALERTS:
-      DISPLAY-NAME: '&#6BF18DTeleport Alerts'
-      MATERIAL: FEATHER
+    DESTROY_PEARL_ON_DEATH:
+      DISPLAY-NAME: '&#6BF18DDestroy Pearl on Death'
+      MATERIAL: CHORUS_FRUIT
       SLOT: 22
       LORE:
-      - '&7Sound and message alerts for TPA'
+      - '&7Destroy thrown ender pearls when you die'
       - '&fCurrently: {status}'
-    FAST_CRYSTALS:
-      DISPLAY-NAME: '&#6BF18DFast Crystals'
-      MATERIAL: DIAMOND
+    DISPLAY_DONUT_PLUS:
+      DISPLAY-NAME: '&#6BF18DDisplay Donut+'
+      MATERIAL: FEATHER
       SLOT: 23
       LORE:
-      - '&7Faster end crystal placement speed'
+      - '&7Display your premium Donut+ status'
       - '&fCurrently: {status}'
-    RANDOMIZED_COORDS:
-      DISPLAY-NAME: '&#6BF18DRandomized Coords'
-      MATERIAL: COMPASS
+    MONEY_NAMETAGS:
+      DISPLAY-NAME: '&#6BF18DMoney Nametags'
+      MATERIAL: NAME_TAG
       SLOT: 24
       LORE:
-      - '&7Show randomized coords on HUD (Kick on toggle)'
+      - '&7Show player balances under their names'
       - '&fCurrently: {status}'
+    WORTH_DISPLAY:
+      DISPLAY-NAME: '&#6BF18DWorth Display'
+      MATERIAL: DIAMOND
+      SLOT: 25
+      LORE:
+      - '&7Show item worth values in item lore'
+      - '&fCurrently: {status}'
+    LUNAR_TEAMMATES:
+      DISPLAY-NAME: '&#6BF18DLunar Teammates'
+      MATERIAL: LIGHT_BLUE_DYE
+      SLOT: 26
+      LORE:
+      - '&7Show teammates on Lunar Client'
+      - '&fCurrently: {status}'
+    # Row 4 - who may reach you
     TPA_REQUESTS:
       DISPLAY-NAME: '&#6BF18DTpa Requests'
       MATERIAL: ENDER_PEARL
@@ -781,117 +830,77 @@ SETTINGS-MENU:
       LORE:
       - '&7Incoming payments privacy settings'
       - '&fCurrently: {status}'
-    WORTH_DISPLAY:
-      DISPLAY-NAME: '&#6BF18DWorth Display'
-      MATERIAL: NETHERITE_SCRAP
-      SLOT: 30
-      LORE:
-      - '&7Show item worth values in item lore'
-      - '&fCurrently: {status}'
-    MONEY_NAMETAGS:
-      DISPLAY-NAME: '&#6BF18DMoney Nametags'
-      MATERIAL: NAME_TAG
-      SLOT: 33
-      LORE:
-      - '&7Show player balances under their names'
-      - '&fCurrently: {status}'
-    JOIN_LEAVE_MESSAGES:
-      DISPLAY-NAME: '&#6BF18DJoin/Leave Messages'
-      MATERIAL: PAPER
-      SLOT: 31
-      LORE:
-      - '&7Show join and leave notifications'
-      - '&fCurrently: {status}'
-    PAY_ALERTS:
-      DISPLAY-NAME: '&#6BF18DPay Alerts'
-      MATERIAL: PAPER
-      SLOT: 32
-      LORE:
-      - '&7Receive pay alerts'
-      - '&fCurrently: {status}'
-    ADVANCEMENT_MESSAGES:
-      DISPLAY-NAME: '&#6BF18DAdvancement Messages'
-      MATERIAL: LECTERN
-      SLOT: 36
-      LORE:
-      - '&7Show advancement achievement notifications'
-      - '&fCurrently: {status}'
-    AUCTION_NOTIFICATIONS:
-      DISPLAY-NAME: '&#6BF18DAuction Alerts'
-      MATERIAL: GOLD_INGOT
-      SLOT: 37
-      LORE:
-      - '&7Notify when items are bought/sold'
-      - '&fCurrently: {status}'
-    AMETHYST_BREAK_MESSAGES:
-      DISPLAY-NAME: '&#6BF18DAmethyst Break Messages'
-      MATERIAL: AMETHYST_SHARD
-      SLOT: 38
-      LORE:
-      - '&7Show message when amethyst cluster breaks'
-      - '&fCurrently: {status}'
     DUEL_REQUESTS:
       DISPLAY-NAME: '&#6BF18DDuel Requests'
       MATERIAL: IRON_SWORD
-      SLOT: 39
+      SLOT: 30
       LORE:
       - '&7Receive incoming duel requests'
       - '&fCurrently: {status}'
-    DEATH_MESSAGES:
-      DISPLAY-NAME: '&#6BF18DDeath Messages'
-      MATERIAL: SKELETON_SKULL
-      SLOT: 40
+    RANDOMIZED_COORDS:
+      DISPLAY-NAME: '&#6BF18DRandomized Coords'
+      MATERIAL: NETHERITE_INGOT
+      SLOT: 31
       LORE:
-      - '&7Show death message notifications'
+      - '&7Show randomized coords on HUD (Kick on toggle)'
       - '&fCurrently: {status}'
-    KEY_ALL_NOTIFICATIONS:
-      DISPLAY-NAME: '&#6BF18DKey All Notifications'
-      MATERIAL: CLOCK
-      SLOT: 41
+    # Row 5 - confirmation prompts and quick actions
+    TPA_CONFIRM_MENUS:
+      DISPLAY-NAME: '&#6BF18DTpa Confirm Menus'
+      MATERIAL: COMPASS
+      SLOT: 36
       LORE:
-      - '&7Show key-all event notifications'
+      - '&7Show confirmation GUI for TPA'
+      - '&fCurrently: {status}'
+    PAY_CONFIRM_MENUS:
+      DISPLAY-NAME: '&#6BF18DPay Confirm Menus'
+      MATERIAL: PAPER
+      SLOT: 37
+      LORE:
+      - '&7Show confirmation GUI for payments'
+      - '&fCurrently: {status}'
+    AUTO_CONFIRM_TPAS:
+      DISPLAY-NAME: '&#6BF18DAuto-Confirm Tpas'
+      MATERIAL: CLOCK
+      SLOT: 38
+      LORE:
+      - '&7Auto-confirm teleport requests'
+      - '&fCurrently: {status}'
+    QUICK_AUCTION_PURCHASE:
+      DISPLAY-NAME: '&#6BF18DQuick Auction Purchase'
+      MATERIAL: EMERALD_BLOCK
+      SLOT: 39
+      LORE:
+      - '&7Fast buy auction items directly'
       - '&fCurrently: {status}'
     QUICK_AUCTION_SELL:
       DISPLAY-NAME: '&#6BF18DQuick Auction Sell'
-      MATERIAL: GOLD_INGOT
-      SLOT: 45
+      MATERIAL: GOLD_BLOCK
+      SLOT: 40
       LORE:
       - '&7Fast sell items to auction house'
       - '&fCurrently: {status}'
-    ORDER_NOTIFICATIONS:
-      DISPLAY-NAME: '&#6BF18DOrder Alerts'
-      MATERIAL: GOLD_BLOCK
-      SLOT: 46
-      LORE:
-      - '&7Notify when order transactions occur'
-      - '&fCurrently: {status}'
+    # Row 6 - the world around you
     DISABLE_MOB_SPAWN:
       DISPLAY-NAME: '&#6BF18DDisable Mob Spawns'
       MATERIAL: ZOMBIE_HEAD
-      SLOT: 47
+      SLOT: 45
       LORE:
       - '&7Prevent mobs spawning around you'
       - '&fCurrently: {status}'
     DISABLE_PHANTOM_SPAWN:
       DISPLAY-NAME: '&#6BF18DDisable Phantom Spawn'
       MATERIAL: PHANTOM_MEMBRANE
-      SLOT: 48
+      SLOT: 46
       LORE:
       - '&7Prevent phantoms spawning above you'
       - '&fCurrently: {status}'
     NIGHT_VISION:
       DISPLAY-NAME: '&#6BF18DNight Vision'
       MATERIAL: GOLDEN_CARROT
-      SLOT: 49
+      SLOT: 47
       LORE:
       - '&7Permanent night vision effect'
-      - '&fCurrently: {status}'
-    BOUNTY_ALERTS:
-      DISPLAY-NAME: '&#6BF18DBounty Alerts'
-      MATERIAL: PAPER
-      SLOT: 50
-      LORE:
-      - '&7Notify when bounties are set/claimed'
       - '&fCurrently: {status}'
 LEADERBOARDS-MENU:
   TITLE: '&8Leaderboards'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -526,6 +526,42 @@ class ConfigManagerTest {
         }
     }
 
+    @Test
+    void bundledSettingsMenuIsNotMistakenForTheOldLayout() throws Exception {
+        YamlConfiguration bundled = new YamlConfiguration();
+        bundled.options().parseComments(true);
+        bundled.load(Path.of("src/main/resources/menus.yml").toFile());
+
+        assertFalse(hasLegacyButtons(bundled));
+    }
+
+    @Test
+    void theSettingsMenuThatPredatesTheGroupedLayoutIsRegenerated() throws Exception {
+        YamlConfiguration old = yaml(lines(
+                "SETTINGS-MENU:",
+                "  BUTTONS:",
+                "    JOIN_LEAVE_MESSAGES:",
+                "      SLOT: 31",
+                "    PAY_ALERTS:",
+                "      SLOT: 32",
+                "    MONEY_NAMETAGS:",
+                "      SLOT: 33"
+        ));
+
+        assertTrue(hasLegacyButtons(old));
+    }
+
+    @Test
+    void aMenuWithoutSettingsButtonsIsLeftAlone() throws Exception {
+        assertFalse(hasLegacyButtons(yaml(lines("OTHER-MENU:", "  SIZE: 27"))));
+    }
+
+    private static boolean hasLegacyButtons(YamlConfiguration configuration) throws Exception {
+        Method method = ConfigManager.class.getDeclaredMethod("hasLegacyButtons", YamlConfiguration.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(new ConfigManager(null), configuration);
+    }
+
     private static int repairMiscasedPlaceholders(
             String resourceName,
             List<String> lines

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerSettingsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerSettingsTest.java
@@ -75,8 +75,8 @@ class DatabaseManagerPlayerSettingsTest {
             original.setDestroyPearlOnDeath(false);
             original.setRandomizedCoords(true);
             original.setDeathMessagesChoice(TwoChoice.OFF);
-            original.setAdvancementMessagesChoice(ThreeChoice.FRIENDS_FOLLOWED);
-            original.setJoinLeaveMessagesChoice(ThreeChoice.OFF);
+            original.setAdvancementMessagesEnabled(false);
+            original.setJoinLeaveMessagesChoice(TwoChoice.OFF);
             original.setTeleportAlertsEnabled(false);
             original.setFollowAlertsEnabled(false);
             original.setExplosionSoundsEnabled(false);
@@ -110,8 +110,8 @@ class DatabaseManagerPlayerSettingsTest {
             assertFalse(loaded.isDestroyPearlOnDeath());
             assertTrue(loaded.isRandomizedCoords());
             assertEquals(TwoChoice.OFF, loaded.getDeathMessagesChoice());
-            assertEquals(ThreeChoice.FRIENDS_FOLLOWED, loaded.getAdvancementMessagesChoice());
-            assertEquals(ThreeChoice.OFF, loaded.getJoinLeaveMessagesChoice());
+            assertFalse(loaded.isAdvancementMessagesEnabled());
+            assertEquals(TwoChoice.OFF, loaded.getJoinLeaveMessagesChoice());
             assertFalse(loaded.isTeleportAlertsEnabled());
             assertFalse(loaded.isFollowAlertsEnabled());
             assertFalse(loaded.isExplosionSoundsEnabled());

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
@@ -5,6 +5,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PlayerSettingsConfigurationTest {
@@ -70,49 +72,68 @@ class PlayerSettingsConfigurationTest {
             assertTrue(buttons.isConfigurationSection(setting), setting);
         }
 
-        Map<String, Integer> centeredSlots = Map.ofEntries(
+        // One theme per row, left aligned: chat, alerts, gameplay and display, who may reach you,
+        // confirmation prompts, then the world around you.
+        Map<String, Integer> groupedSlots = Map.ofEntries(
                 Map.entry("PUBLIC_CHAT", 0),
                 Map.entry("PRIVATE_MESSAGES", 1),
                 Map.entry("SERVER_BROADCASTS", 2),
-                Map.entry("TEAM_CHAT_VISIBILITY", 3),
-                Map.entry("LUNAR_TEAMMATES", 4),
-                Map.entry("TPA_CONFIRM_MENUS", 5),
-                Map.entry("QUICK_AUCTION_PURCHASE", 9),
-                Map.entry("DESTROY_PEARL_ON_DEATH", 10),
-                Map.entry("PAY_CONFIRM_MENUS", 11),
-                Map.entry("PAY_ALERTS", 32),
-                Map.entry("AUTO_CONFIRM_TPAS", 12),
-                Map.entry("HOTBAR_MESSAGES", 13),
-                Map.entry("NOTIFICATION_SOUNDS", 14),
+                Map.entry("HOTBAR_MESSAGES", 3),
+                Map.entry("DEATH_MESSAGES", 4),
+                Map.entry("JOIN_LEAVE_MESSAGES", 5),
+                Map.entry("ADVANCEMENT_MESSAGES", 6),
+                Map.entry("TEAM_CHAT_VISIBILITY", 7),
+                Map.entry("AMETHYST_BREAK_MESSAGES", 8),
+                Map.entry("PAY_ALERTS", 9),
+                Map.entry("TELEPORT_ALERTS", 10),
+                Map.entry("BOUNTY_ALERTS", 11),
+                Map.entry("AUCTION_NOTIFICATIONS", 12),
+                Map.entry("ORDER_NOTIFICATIONS", 13),
+                Map.entry("KEY_ALL_NOTIFICATIONS", 14),
                 Map.entry("FOLLOW_ALERT_SETTINGS", 15),
-                Map.entry("DISPLAY_DONUT_PLUS", 18),
+                Map.entry("NOTIFICATION_SOUNDS", 16),
+                Map.entry("FAST_CRYSTALS", 18),
                 Map.entry("CHAINMAIL_ON_RESPAWN", 19),
                 Map.entry("EXPLOSION_PARTICLES", 20),
                 Map.entry("EXPLOSION_SOUNDS", 21),
-                Map.entry("TELEPORT_ALERTS", 22),
-                Map.entry("FAST_CRYSTALS", 23),
-                Map.entry("RANDOMIZED_COORDS", 24),
+                Map.entry("DESTROY_PEARL_ON_DEATH", 22),
+                Map.entry("DISPLAY_DONUT_PLUS", 23),
+                Map.entry("MONEY_NAMETAGS", 24),
+                Map.entry("WORTH_DISPLAY", 25),
+                Map.entry("LUNAR_TEAMMATES", 26),
                 Map.entry("TPA_REQUESTS", 27),
                 Map.entry("TPA_HERE_REQUESTS", 28),
                 Map.entry("PAYMENTS", 29),
-                Map.entry("WORTH_DISPLAY", 30),
-                Map.entry("MONEY_NAMETAGS", 33),
-                Map.entry("JOIN_LEAVE_MESSAGES", 31),
-                Map.entry("ADVANCEMENT_MESSAGES", 36),
-                Map.entry("AUCTION_NOTIFICATIONS", 37),
-                Map.entry("AMETHYST_BREAK_MESSAGES", 38),
-                Map.entry("DUEL_REQUESTS", 39),
-                Map.entry("DEATH_MESSAGES", 40),
-                Map.entry("KEY_ALL_NOTIFICATIONS", 41),
-                Map.entry("QUICK_AUCTION_SELL", 45),
-                Map.entry("ORDER_NOTIFICATIONS", 46),
-                Map.entry("DISABLE_MOB_SPAWN", 47),
-                Map.entry("DISABLE_PHANTOM_SPAWN", 48),
-                Map.entry("NIGHT_VISION", 49),
-                Map.entry("BOUNTY_ALERTS", 50)
+                Map.entry("DUEL_REQUESTS", 30),
+                Map.entry("RANDOMIZED_COORDS", 31),
+                Map.entry("TPA_CONFIRM_MENUS", 36),
+                Map.entry("PAY_CONFIRM_MENUS", 37),
+                Map.entry("AUTO_CONFIRM_TPAS", 38),
+                Map.entry("QUICK_AUCTION_PURCHASE", 39),
+                Map.entry("QUICK_AUCTION_SELL", 40),
+                Map.entry("DISABLE_MOB_SPAWN", 45),
+                Map.entry("DISABLE_PHANTOM_SPAWN", 46),
+                Map.entry("NIGHT_VISION", 47)
         );
-        centeredSlots.forEach((key, slot) ->
+        groupedSlots.forEach((key, slot) ->
                 assertEquals(slot, buttons.getInt(key + ".SLOT"), key));
+        assertEquals(groupedSlots.size(), buttons.getKeys(false).size(),
+                "every button belongs to one of the six groups");
+    }
+
+    @Test
+    void settingsMenuGivesEveryButtonItsOwnIcon() throws Exception {
+        YamlConfiguration menus = load("menus.yml");
+        ConfigurationSection buttons = menus.getConfigurationSection("SETTINGS-MENU.BUTTONS");
+        assertNotNull(buttons);
+
+        Map<String, String> owners = new HashMap<>();
+        for (String key : buttons.getKeys(false)) {
+            String material = buttons.getString(key + ".MATERIAL");
+            assertNotNull(material, key);
+            String previous = owners.put(material, key);
+            assertNull(previous, key + " reuses the " + material + " icon already on " + previous);
+        }
     }
 
     @Test

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaultsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaultsTest.java
@@ -36,7 +36,7 @@ class PlayerSettingDefaultsTest {
         PlayerSettingDefaults.applyDefaults(buttons, data, warnings::add);
 
         assertEquals(List.of(), warnings);
-        assertEquals(untouched.getAdvancementMessagesChoice(), data.getAdvancementMessagesChoice());
+        assertEquals(untouched.isAdvancementMessagesEnabled(), data.isAdvancementMessagesEnabled());
         assertEquals(untouched.isPublicChatEnabled(), data.isPublicChatEnabled());
     }
 
@@ -53,8 +53,8 @@ class PlayerSettingDefaultsTest {
         PlayerData data = newPlayer();
         PlayerSettingDefaults.applyDefaults(buttons, data);
 
-        assertEquals(ThreeChoice.OFF, data.getAdvancementMessagesChoice());
-        assertEquals(ThreeChoice.OFF, data.getJoinLeaveMessagesChoice());
+        assertFalse(data.isAdvancementMessagesEnabled());
+        assertEquals(TwoChoice.OFF, data.getJoinLeaveMessagesChoice());
         assertEquals(ThreeChoice.FRIENDS_FOLLOWED, data.getPrivateMessagesChoice());
         assertEquals(TwoChoice.OFF, data.getDeathMessagesChoice());
         assertFalse(data.isPublicChatEnabled());
@@ -98,7 +98,7 @@ class PlayerSettingDefaultsTest {
         List<String> warnings = new ArrayList<>();
         PlayerSettingDefaults.applyDefaults(buttons, data, warnings::add);
 
-        assertEquals(ThreeChoice.ANYONE, data.getAdvancementMessagesChoice());
+        assertTrue(data.isAdvancementMessagesEnabled());
         assertEquals(2, warnings.size());
     }
 
@@ -110,13 +110,13 @@ class PlayerSettingDefaultsTest {
         buttons.set("PUBLIC_CHAT.ENABLED", false);
 
         PlayerData data = newPlayer();
-        data.setAdvancementMessagesChoice(ThreeChoice.ANYONE);
+        data.setAdvancementMessagesEnabled(true);
         data.setPublicChatEnabled(false);
         data.setDirty(false);
 
         PlayerSettingDefaults.applyDisabledOptions(buttons, data);
 
-        assertEquals(ThreeChoice.OFF, data.getAdvancementMessagesChoice());
+        assertFalse(data.isAdvancementMessagesEnabled());
         // No DEFAULT configured, so PUBLIC_CHAT falls back to the built-in value.
         assertTrue(data.isPublicChatEnabled());
         assertFalse(data.isDirty(), "pinning a removed option must not schedule a database write");
@@ -128,11 +128,11 @@ class PlayerSettingDefaultsTest {
         buttons.set("ADVANCEMENT_MESSAGES.DEFAULT", "OFF");
 
         PlayerData data = newPlayer();
-        data.setAdvancementMessagesChoice(ThreeChoice.FRIENDS_FOLLOWED);
+        data.setAdvancementMessagesEnabled(true);
 
         PlayerSettingDefaults.applyDisabledOptions(buttons, data);
 
-        assertEquals(ThreeChoice.FRIENDS_FOLLOWED, data.getAdvancementMessagesChoice());
+        assertTrue(data.isAdvancementMessagesEnabled());
     }
 
     @Test


### PR DESCRIPTION
Closes #264

The buttons in `/settings` had drifted into no order at all. Chat options sat on four different rows, four buttons all used a plain sheet of paper as their icon, and slots 34 and 35 were holes in the middle of a row while join/leave, pay alerts and money nametags had been parked at 31, 32 and 33 with nothing nearby that belonged with them. This puts one theme on each row, following the DonutSMP menu the reporter linked.

## The new rows

Row one is chat and messages, and every button on it is a sign, so the whole row reads as one thing at a glance: public chat, private messages, server broadcasts, hotbar messages, death messages, join/leave, advancements, team chat and amethyst breaks. Row two collects the alerts: pay, teleport, bounty, auction, order, key-all, follow, plus the sound toggle. Row three is what the game looks and feels like while you play it, so fast crystals, the respawn kit, explosion particles and sounds, pearl destruction, Donut+, money nametags, worth lore and Lunar teammates all live there. Row four is the short list of who is allowed to reach you at all, row five holds the confirmation prompts and the two auction shortcuts, and the last row is the world around you.

Each row stops where its group stops instead of running to the edge, so most rows end with a gap. That is deliberate. A server adding its own button to one of these groups now has somewhere obvious to put it.

Every button also has an icon of its own. The four paper buttons and the two sharing gold ingots were impossible to tell apart while scanning, so bounty alerts moved to a wither skeleton skull, order alerts to a map and teleport alerts to a bell, and the settings that left the chat row handed their signs over to the ones that joined it. A test fails if two buttons ever claim the same material again.

## Two settings that changed what they offer

Join/Leave Messages was three-way (anyone, friends/followed, off) and is now friends/followed or off, matching every other Friends/Followed option. Advancement Messages was three-way too and is a plain on/off toggle now. Both columns keep the same name and type in the database, and old rows still read correctly, since 0 already meant off and the two non-zero values both meant the option was on. Nobody logs in to find something switched off that they had turned on.

## Getting the layout onto servers that already run the plugin

Merging bundled defaults never rewrites a `SLOT` that is already in an admin's file, so a server upgrading would have kept the old scatter forever. `ConfigManager.hasLegacyButtons` picks the old layout out by the trio at slots 31, 32 and 33, which no button uses any more, and backs the file up under `config-backups/` before regenerating it. Same mechanism the last layout change used.

## Notes

Nothing was removed. The five toggles the reporter wanted gone (show money, shards, kills, deaths, playtime) are DonutSMP's scoreboard line switches and have never existed here, so there was nothing to delete. All 39 existing settings survive, just somewhere more sensible.

`AUTO_CONFIRM_TPAS` was displaying as "Tp Auto" in a colour no other button used. It reads "Auto-Confirm Tpas" in the theme colour now.

No new config or language keys, so the language files are untouched. Tests cover the row grouping, the one-icon-per-button rule, the legacy detector against both the bundled file and a fabricated old one, and the two settings that changed shape. 415 pass.
