### PR TITLE
feat(settings): add a combat timer toggle and drop lunar teammates (#264)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1135,6 +1135,12 @@ Notes:
   `SHOW_KILLS`, `SHOW_DEATHS` and `SHOW_PLAYTIME` each hide one line of it, matched by the
   placeholder the line carries in `SCOREBOARD.LINES`. A server that does not want players hiding
   their statistics can drop the whole row with `ENABLED: false` on those five.
+- `COMBAT_TIMER` hides the `COMBAT-MANAGER.ACTION-BAR` countdown. It only controls whether the
+  countdown is drawn: a player who turns it off is still tagged, still has their commands blocked,
+  and still dies on logout where `KILL-ON-LOGOUT` is on. Turning off `HOTBAR_MESSAGES` hides it as
+  well, since the countdown goes out on the action bar like every other hotbar notification.
+- Lunar teammates has no button. The setting still exists and still defaults to on, so the Apollo
+  team markers keep working; there is simply no longer a way for a player to switch them off.
 - A `menus.yml` written before the current grouping is backed up under `config-backups/` and
   regenerated on the next start, because merging bundled defaults never rewrites a `SLOT` that
   is already in the file.

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CombatManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CombatManager.java
@@ -1,6 +1,7 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
 import org.bukkit.scheduler.BukkitTask;
@@ -59,6 +60,9 @@ public class CombatManager {
                 if (t != null) t.cancel();
                 return;
             }
+            if (!showsCombatTimer(profileOf(p))) {
+                return;
+            }
             long remaining = getRemainingSeconds(uuid);
             String format = plugin.getConfigManager().getConfig()
                     .getString("COMBAT-MANAGER.ACTION-BAR", "&fcombat: &b${time}s")
@@ -69,6 +73,21 @@ public class CombatManager {
         if (task != null) {
             tasks.put(uuid, task);
         }
+    }
+
+    /**
+     * Whether the countdown should be drawn for this player.
+     *
+     * <p>The tag itself is unaffected: a player who hides the timer is still in combat, still has
+     * their commands blocked, and still dies on logout where the server turns that on. A player the
+     * plugin has no profile for keeps seeing it, so the timer never goes missing by accident.</p>
+     */
+    static boolean showsCombatTimer(PlayerData data) {
+        return data == null || data.isCombatTimerEnabled();
+    }
+
+    private PlayerData profileOf(Player player) {
+        return plugin.getPlayerDataManager() == null ? null : plugin.getPlayerDataManager().get(player);
     }
 
     public void clearTag(UUID uuid) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -2084,8 +2084,13 @@ public class ConfigManager {
         }
 
         // The first grouped layout, which put the confirmation prompts on their own row at 36.
-        return buttons.getInt("TPA_CONFIRM_MENUS.SLOT", -1) == 36
-                && buttons.getInt("NOTIFICATION_SOUNDS.SLOT", -1) == 16;
+        if (buttons.getInt("TPA_CONFIRM_MENUS.SLOT", -1) == 36
+                && buttons.getInt("NOTIFICATION_SOUNDS.SLOT", -1) == 16) {
+            return true;
+        }
+
+        // The layout before the combat timer took slot 22 off Lunar teammates.
+        return buttons.getInt("LUNAR_TEAMMATES.SLOT", -1) == 22;
     }
 
     private void backupInvalidFile(File file) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -381,7 +381,8 @@ public class DatabaseManager {
               "  show_shards_line INTEGER DEFAULT 1," +
               "  show_kills_line INTEGER DEFAULT 1," +
               "  show_deaths_line INTEGER DEFAULT 1," +
-              "  show_playtime_line INTEGER DEFAULT 1" +
+              "  show_playtime_line INTEGER DEFAULT 1," +
+              "  combat_timer_enabled INTEGER DEFAULT 1" +
               ")"
           );
         execute(
@@ -787,6 +788,7 @@ public class DatabaseManager {
         ensureColumnExists("players", "show_kills_line", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "show_deaths_line", "INTEGER DEFAULT 1");
         ensureColumnExists("players", "show_playtime_line", "INTEGER DEFAULT 1");
+        ensureColumnExists("players", "combat_timer_enabled", "INTEGER DEFAULT 1");
     }
 
     private void ensurePortalColumns() throws SQLException {
@@ -1126,6 +1128,7 @@ public class DatabaseManager {
         data.setShowKillsLine(rs.getInt("show_kills_line") != 0);
         data.setShowDeathsLine(rs.getInt("show_deaths_line") != 0);
         data.setShowPlaytimeLine(rs.getInt("show_playtime_line") != 0);
+        data.setCombatTimerEnabled(rs.getInt("combat_timer_enabled") != 0);
         data.setDirty(false);
         return data;
     }
@@ -1660,8 +1663,8 @@ public class DatabaseManager {
                     advancement_messages_choice, join_leave_messages_choice, teleport_alerts_enabled,
                     follow_alerts_enabled, explosion_sounds_enabled, display_donutplus_enabled,
                     voice_chat_consent, show_money_line, show_shards_line, show_kills_line,
-                    show_deaths_line, show_playtime_line)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    show_deaths_line, show_playtime_line, combat_timer_enabled)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """;
 
         if (hikariDataSource != null && !hikariDataSource.isClosed()) {
@@ -1758,6 +1761,7 @@ public class DatabaseManager {
             ps.setInt(68, data.isShowKillsLine() ? 1 : 0);
             ps.setInt(69, data.isShowDeathsLine() ? 1 : 0);
             ps.setInt(70, data.isShowPlaytimeLine() ? 1 : 0);
+            ps.setInt(71, data.isCombatTimerEnabled() ? 1 : 0);
             data.setDirty(false);
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -29,7 +29,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
 
     private static final Set<String> VALID_SETTINGS = Set.of(
             "PUBLIC_CHAT", "PRIVATE_MESSAGES", "SERVER_BROADCASTS", "TEAM_CHAT_VISIBILITY",
-            "LUNAR_TEAMMATES", "TPA_CONFIRM_MENUS", "QUICK_AUCTION_PURCHASE", "DESTROY_PEARL_ON_DEATH",
+            "TPA_CONFIRM_MENUS", "QUICK_AUCTION_PURCHASE", "DESTROY_PEARL_ON_DEATH",
             "PAY_CONFIRM_MENUS", "AUTO_CONFIRM_TPAS", "HOTBAR_MESSAGES", "NOTIFICATION_SOUNDS",
             "FOLLOW_ALERT_SETTINGS", "DISPLAY_DONUT_PLUS", "CHAINMAIL_ON_RESPAWN", "EXPLOSION_PARTICLES",
             "EXPLOSION_SOUNDS", "TELEPORT_ALERTS", "FAST_CRYSTALS", "RANDOMIZED_COORDS",
@@ -38,7 +38,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
             "AMETHYST_BREAK_MESSAGES", "DUEL_REQUESTS", "DEATH_MESSAGES", "KEY_ALL_NOTIFICATIONS",
             "QUICK_AUCTION_SELL", "ORDER_NOTIFICATIONS", "DISABLE_MOB_SPAWN", "DISABLE_PHANTOM_SPAWN",
             "NIGHT_VISION", "BOUNTY_ALERTS", "SCOREBOARD_VISIBILITY", "SHOW_MONEY", "SHOW_SHARDS",
-            "SHOW_KILLS", "SHOW_DEATHS", "SHOW_PLAYTIME"
+            "SHOW_KILLS", "SHOW_DEATHS", "SHOW_PLAYTIME", "COMBAT_TIMER"
     );
 
     private final Map<Integer, String> clickableButtons = new HashMap<>();
@@ -191,6 +191,8 @@ public final class PlayerSettingsMenu extends BaseMenu {
                     !data.isShowDeathsLine(), data::setShowDeathsLine);
             case "SHOW_PLAYTIME" -> toggleSidebarLine(player, "Show Playtime",
                     !data.isShowPlaytimeLine(), data::setShowPlaytimeLine);
+            case "COMBAT_TIMER" -> toggle(player, "Combat Timer",
+                    !data.isCombatTimerEnabled(), data::setCombatTimerEnabled);
             case "AUTO_CONFIRM_TPAS" -> {
                 boolean enabled = !(data.isTpauto() && data.isAutoTpaHereEnabled());
                 data.setTpauto(enabled);
@@ -410,6 +412,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "SHOW_KILLS" -> state(data.isShowKillsLine());
             case "SHOW_DEATHS" -> state(data.isShowDeathsLine());
             case "SHOW_PLAYTIME" -> state(data.isShowPlaytimeLine());
+            case "COMBAT_TIMER" -> state(data.isCombatTimerEnabled());
             case "AUTO_CONFIRM_TPAS" -> state(data.isTpauto() && data.isAutoTpaHereEnabled());
             case "NOTIFICATION_SOUNDS" -> state(data.isNotificationSoundsEnabled());
             case "RTP_COORDINATES" -> state(data.isRtpCoordinatesEnabled());

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -77,6 +77,7 @@ public class PlayerData {
     private boolean showKillsLine;
     private boolean showDeathsLine;
     private boolean showPlaytimeLine;
+    private boolean combatTimerEnabled;
     private long mobSpawnDisabledUntil;
     private long phantomDisabledUntil;
 
@@ -154,6 +155,7 @@ public class PlayerData {
         this.showKillsLine = true;
         this.showDeathsLine = true;
         this.showPlaytimeLine = true;
+        this.combatTimerEnabled = true;
         this.mobSpawnDisabledUntil = 0L;
         this.phantomDisabledUntil = 0L;
     }
@@ -1009,6 +1011,15 @@ public class PlayerData {
 
     public void setShowPlaytimeLine(boolean showPlaytimeLine) {
         this.showPlaytimeLine = showPlaytimeLine;
+        dirty = true;
+    }
+
+    public boolean isCombatTimerEnabled() {
+        return combatTimerEnabled;
+    }
+
+    public void setCombatTimerEnabled(boolean combatTimerEnabled) {
+        this.combatTimerEnabled = combatTimerEnabled;
         dirty = true;
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
@@ -158,8 +158,6 @@ public final class PlayerSettingDefaults {
         bindings.put("SERVER_BROADCASTS", bool(
                 PlayerData::isServerBroadcastsEnabled, PlayerData::setServerBroadcastsEnabled));
         bindings.put("TEAM_CHAT_VISIBILITY", bool(PlayerData::isTeamChatVisible, PlayerData::setTeamChatVisible));
-        bindings.put("LUNAR_TEAMMATES", bool(
-                PlayerData::isLunarTeammatesEnabled, PlayerData::setLunarTeammatesEnabled));
         bindings.put("TPA_CONFIRM_MENUS", bool(
                 PlayerData::isTpaConfirmMenuEnabled, PlayerData::setTpaConfirmMenuEnabled));
         bindings.put("DESTROY_PEARL_ON_DEATH", bool(
@@ -259,6 +257,7 @@ public final class PlayerSettingDefaults {
         bindings.put("SHOW_KILLS", bool(PlayerData::isShowKillsLine, PlayerData::setShowKillsLine));
         bindings.put("SHOW_DEATHS", bool(PlayerData::isShowDeathsLine, PlayerData::setShowDeathsLine));
         bindings.put("SHOW_PLAYTIME", bool(PlayerData::isShowPlaytimeLine, PlayerData::setShowPlaytimeLine));
+        bindings.put("COMBAT_TIMER", bool(PlayerData::isCombatTimerEnabled, PlayerData::setCombatTimerEnabled));
 
         return Map.copyOf(bindings);
     }

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -959,6 +959,11 @@ MENUS:
         LORE:
         - '&7Show the playtime line on the scoreboard'
         - '&fCurrently: {status}'
+      COMBAT_TIMER:
+        DISPLAY-NAME: '&#6BF18DCombat Timer'
+        LORE:
+        - '&7Show the combat countdown on your action bar'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: '&8Leaderboards'
     TYPE-MENU:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -773,12 +773,12 @@ SETTINGS-MENU:
       LORE:
       - '&7Play explosion sound effects'
       - '&fCurrently: {status}'
-    LUNAR_TEAMMATES:
-      DISPLAY-NAME: '&#6BF18DLunar Teammates'
-      MATERIAL: LIGHT_BLUE_DYE
+    COMBAT_TIMER:
+      DISPLAY-NAME: '&#6BF18DCombat Timer'
+      MATERIAL: DIAMOND_SWORD
       SLOT: 22
       LORE:
-      - '&7Show teammates on Lunar Client'
+      - '&7Show the combat countdown on your action bar'
       - '&fCurrently: {status}'
     DISPLAY_DONUT_PLUS:
       DISPLAY-NAME: '&#6BF18DDisplay Donut+'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/CombatManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/CombatManagerTest.java
@@ -1,8 +1,13 @@
 package com.bx.ultimateDonutSmp.managers;
 
+import com.bx.ultimateDonutSmp.models.PlayerData;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CombatManagerTest {
 
@@ -37,5 +42,19 @@ class CombatManagerTest {
     void anExpiredTagReadsZero() {
         assertEquals(0L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TWENTY_SECOND_EXPIRY));
         assertEquals(0L, CombatManager.remainingSeconds(TWENTY_SECOND_EXPIRY, TWENTY_SECOND_EXPIRY + 5_000L));
+    }
+
+    @Test
+    void theCountdownIsDrawnUntilThePlayerTurnsItOff() {
+        PlayerData data = new PlayerData(UUID.randomUUID(), "Tester");
+        assertTrue(CombatManager.showsCombatTimer(data));
+
+        data.setCombatTimerEnabled(false);
+        assertFalse(CombatManager.showsCombatTimer(data));
+    }
+
+    @Test
+    void aPlayerWithNoProfileKeepsSeeingTheCountdown() {
+        assertTrue(CombatManager.showsCombatTimer(null));
     }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -567,6 +567,18 @@ class ConfigManagerTest {
     }
 
     @Test
+    void theLayoutThatStillHadLunarTeammatesAtTwentyTwoIsRegeneratedToo() throws Exception {
+        YamlConfiguration previous = yaml(lines(
+                "SETTINGS-MENU:",
+                "  BUTTONS:",
+                "    LUNAR_TEAMMATES:",
+                "      SLOT: 22"
+        ));
+
+        assertTrue(hasLegacyButtons(previous));
+    }
+
+    @Test
     void aMenuWithoutSettingsButtonsIsLeftAlone() throws Exception {
         assertFalse(hasLegacyButtons(yaml(lines("OTHER-MENU:", "  SIZE: 27"))));
     }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerKnownPlayersTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerKnownPlayersTest.java
@@ -67,7 +67,8 @@ class DatabaseManagerKnownPlayersTest {
                     + "explosion_sounds_enabled INTEGER DEFAULT 1, display_donutplus_enabled INTEGER DEFAULT 1, "
                     + "voice_chat_consent INTEGER DEFAULT 0, show_money_line INTEGER DEFAULT 1, "
                     + "show_shards_line INTEGER DEFAULT 1, show_kills_line INTEGER DEFAULT 1, "
-                    + "show_deaths_line INTEGER DEFAULT 1, show_playtime_line INTEGER DEFAULT 1)");
+                    + "show_deaths_line INTEGER DEFAULT 1, show_playtime_line INTEGER DEFAULT 1, "
+                    + "combat_timer_enabled INTEGER DEFAULT 1)");
 
             java.util.UUID testUuid = java.util.UUID.randomUUID();
             statement.execute("INSERT INTO players (uuid, username, kills, money) VALUES ('" + testUuid + "', 'Bob', 42, 500.0)");

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
@@ -55,7 +55,8 @@ class PlayerSettingsConfigurationTest {
             "SHOW_SHARDS",
             "SHOW_KILLS",
             "SHOW_DEATHS",
-            "SHOW_PLAYTIME"
+            "SHOW_PLAYTIME",
+            "COMBAT_TIMER"
     );
 
     @Test
@@ -102,7 +103,7 @@ class PlayerSettingsConfigurationTest {
                 Map.entry("CHAINMAIL_ON_RESPAWN", 19),
                 Map.entry("EXPLOSION_PARTICLES", 20),
                 Map.entry("EXPLOSION_SOUNDS", 21),
-                Map.entry("LUNAR_TEAMMATES", 22),
+                Map.entry("COMBAT_TIMER", 22),
                 Map.entry("DISPLAY_DONUT_PLUS", 23),
                 Map.entry("MONEY_NAMETAGS", 24),
                 Map.entry("WORTH_DISPLAY", 25),


### PR DESCRIPTION
Closes #264

Slot 22 was the last button that did not line up with the reference menu. It has a combat timer there; we had Lunar teammates parked in it because the combat tag had no toggle of its own. This adds the toggle, gives it the slot and the diamond sword, and takes the Lunar button out.

## The combat timer already existed, the switch did not

`COMBAT-MANAGER` has run a countdown on the action bar for a while, on the format in `ACTION-BAR`. The only way for a player to get rid of it was Hotbar Messages, which also kills every other action bar notification the plugin sends. `COMBAT_TIMER` narrows that down to the countdown alone.

It gates drawing and nothing else. A player who hides the timer is still tagged, still has `BLOCK-COMMANDS` enforced against them, and still dies on logout on servers running `KILL-ON-LOGOUT`. Hiding the number does not hide the fight.

Hotbar Messages still wins over it, since the countdown leaves through `PlayerSettingUtils.sendActionBar` like everything else on the action bar. Decoupling the two would have handed the timer back to everyone who had already switched hotbar messages off, which is not what any of them asked for. Say the word if you would rather they were independent; it is a one line change.

The predicate is pure and static so it can be tested without a running server, the same trick the sidebar line matcher uses. A player the plugin has no profile for keeps seeing the timer, so it can never vanish because a lookup came back empty.

## Lunar teammates loses its button

Removed from `menus.yml` and from `VALID_SETTINGS`, exactly how `TOTEM_PARTICLES` was retired back in 0231fba0: the click handler and the button state stay in `PlayerSettingsMenu`, and the field, the column and `LunarTeammatesTask` are all untouched. It defaults to on, so the Apollo team markers carry on working. Players just cannot switch them off any more.

## Servers on the previous jar

Third fingerprint in `hasLegacyButtons`. Lunar teammates at slot 22 identifies the layout before this one, so anyone who already pulled it gets their `menus.yml` backed up and rebuilt rather than sitting on a menu where 22 is still a dye.

## Notes

Still 45 buttons: one in, one out. Every one of them now sits where the reference puts it.

One new `INTEGER DEFAULT 1` column, `combat_timer_enabled`, appended at the end so the existing bind indexes stay where they are. Default on, so nothing changes for anyone until they click it.

Tests cover the new slot, the third fingerprint, and the gate in both states plus the missing-profile case. 425 pass.
