### PR TITLE
feat(pvp): add a ranked arena with elo ranks kits and timed resets (#255)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -48,6 +48,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/leave` | `/leave` | None | Leave active duel or FFA instance | `ultimatedonutsmp.command.leave` |
 | `/ffa` | `/ffa [join]` | None | Join instanced FFA arena | `ultimatedonutsmp.command.ffa` |
 | `/ffastats` | `/ffastats [player]` | None | View FFA kill/death/streak stats | `ultimatedonutsmp.command.ffastats` |
+| `/pvp` | `/pvp [join\|leave\|kit\|stats\|top]` | None | Join the ranked PvP arena, pick a kit, or read the Elo ladder | `ultimatedonutsmp.command.pvp` |
 | `/bounty` | `/bounty [place\|list]` | None | Place or view player bounties | `ultimatedonutsmp.command.bounty` |
 | `/leaderboard` | `/leaderboard [type]` | `/lb`, `/top`, `/leaderboards`, `/baltop` | Open leaderboard menus; `/baltop` opens the money leaderboard directly | `ultimatedonutsmp.command.leaderboard` |
 | `/voicechatconsent` | `/voicechatconsent [revoke]` | `/vcconsent`, `/voiceconsent` | Open the voice chat consent menu, or withdraw an answer already given with `revoke` | `ultimatedonutsmp.command.voicechatconsent` |
@@ -93,6 +94,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/portal` | `/portal <create\|delete\|list\|setcuboid\|setdestination>` | Custom portal trigger setup | `ultimatedonutsmp.admin.portal` |
 | `/arena` | `/arena <create\|delete\|setpos1\|setpos2\|setreturn\|enable>` | Duel arena setup and configuration | `ultimatedonutsmp.admin.arena` |
 | `/ffaarena` | `/ffaarena <create\|delete\|setpos\|enable>` | Instanced FFA arena management | `ultimatedonutsmp.admin.ffaarena` |
+| `/pvp` | `/pvp <wand\|create\|setspawn\|setlobby\|setboundary\|kit\|schematic\|reset\|reload>` | Ranked PvP arena setup, kit editing, and schematic resets | `ultimatedonutsmp.admin.pvp` |
 | `/crate` | `/crate <create\|delete\|key\|keyall\|bind\|edit>` | Crate & virtual key administration | `ultimatedonutsmp.admin.crate` |
 | `/spawner` | `/spawner <give\|set\|type\|stack>` | Custom spawner stack administration | `ultimatedonutsmp.admin.spawner` |
 | `/addmoney` | `/addmoney <player> <amount>` | Add money to player balance | `ultimatedonutsmp.admin.addmoney` |

--- a/docs/wiki/Config-pvp.yml.md
+++ b/docs/wiki/Config-pvp.yml.md
@@ -1,0 +1,392 @@
+# Detailed Configuration & Setup Guide: `pvp.yml`
+
+This is the official, 100% complete technical setup guide for `pvp.yml` in **UltimateDonutSMP**.
+Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
+
+For the walkthrough that puts these settings together, see [Ranked PvP Arena](Ranked-PvP-Arena).
+
+---
+
+## Section: `SETTINGS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SETTINGS:
+  # Enable or disable the ranked PvP arena globally (true / false)
+  ENABLED: false
+  # Seconds a player stays in spectator after dying before the kit menu reopens
+  RESPAWN_DELAY_SECONDS: 3
+  # Drop the kit items when a player dies in the arena (true / false)
+  DROP_KIT_ON_DEATH: false
+  # Restore full health, hunger and remove potion effects on every arena spawn (true / false)
+  HEAL_ON_SPAWN: true
+  # Kill and remove a player who leaves the arena boundary (true / false)
+  KILL_OUTSIDE_BOUNDARY: true
+  # Seconds of protection after spawning, during which the player cannot deal or take damage
+  SPAWN_PROTECTION_SECONDS: 3
+  # Send players who disconnect inside the arena to the lobby when they rejoin (true / false)
+  LOBBY_ON_REJOIN: true
+  # Take the kit back when a player leaves the arena (true / false)
+  CLEAR_KIT_ON_LEAVE: true
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SETTINGS.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle. Ships off, because nothing works until `ARENA.SPAWN` is set and at least one kit exists. |
+| `SETTINGS.RESPAWN_DELAY_SECONDS` | `int` | `0` and above | `3` | Seconds in spectator between dying and the kit menu reopening. The remaining count is sent to the player each second. |
+| `SETTINGS.DROP_KIT_ON_DEATH` | `bool` | `true`, `false` | `false` | Leave this off and kit items never hit the floor, which is what keeps arena gear out of survival. |
+| `SETTINGS.HEAL_ON_SPAWN` | `bool` | `true`, `false` | `true` | Restores health and hunger and clears potion effects each time a kit is taken. |
+| `SETTINGS.KILL_OUTSIDE_BOUNDARY` | `bool` | `true`, `false` | `true` | Pulls a player out of the fight when they leave the boundary. Only has an effect once both wand corners are stored. |
+| `SETTINGS.SPAWN_PROTECTION_SECONDS` | `int` | `0` and above | `3` | Window after spawning where the player can neither deal nor take damage. `0` disables it. |
+| `SETTINGS.LOBBY_ON_REJOIN` | `bool` | `true`, `false` | `true` | A player who disconnects inside the arena is sent to the lobby on their next login instead of reappearing mid-fight. |
+| `SETTINGS.CLEAR_KIT_ON_LEAVE` | `bool` | `true`, `false` | `true` | Empties the kit out on the way back to survival. Turn it off when Multiverse-Inventories already owns the arena world - clearing an inventory that plugin manages would undo its work rather than help it. |
+
+---
+
+## Section: `ARENA`
+
+Written by `/pvp create`, `/pvp setspawn`, `/pvp setlobby` and `/pvp setboundary`. Editing it by hand
+is supported but rarely needed, and the config updater never overwrites it.
+
+### 1. Commented Setup Code Example
+
+```yaml
+ARENA:
+  # Display name shown in messages and on the scoreboard
+  NAME: 'Arena'
+  # World the arena lives in. Empty means the world of the spawn point below.
+  WORLD: ''
+  # Where players are put when they join or respawn (world,x,y,z,yaw,pitch)
+  SPAWN: ''
+  # Where players are sent on /pvp leave and after a disconnect (world,x,y,z,yaw,pitch)
+  LOBBY: ''
+  # The two wand corners of the arena boundary (world,x,y,z,yaw,pitch)
+  BOUNDARY_POS1: ''
+  BOUNDARY_POS2: ''
+  # Extra blocks of slack around the boundary before a player counts as outside
+  BOUNDARY_PADDING: 2
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ARENA.NAME` | `string` | Any text | `'Arena'` | Shown by `%pvp_arena%`. Set with `/pvp create <name>`. |
+| `ARENA.WORLD` | `string` | A loaded world name, or empty | `''` | Left empty the arena uses the world of `ARENA.SPAWN`, which is almost always right. |
+| `ARENA.SPAWN` | `string` | `world,x,y,z,yaw,pitch` | `''` | The one required setting. Without it `/pvp` refuses to let anyone in. |
+| `ARENA.LOBBY` | `string` | `world,x,y,z,yaw,pitch` | `''` | Falls back to the configured server spawn when empty. |
+| `ARENA.BOUNDARY_POS1` | `string` | `world,x,y,z,yaw,pitch` | `''` | First wand corner. With no corners the whole arena world counts as inside. |
+| `ARENA.BOUNDARY_POS2` | `string` | `world,x,y,z,yaw,pitch` | `''` | Second wand corner. |
+| `ARENA.BOUNDARY_PADDING` | `int` | `0` and above | `2` | Slack added around the box on every axis, so a player brushing the wall is not thrown out. |
+
+---
+
+## Section: `RESET`
+
+### 1. Commented Setup Code Example
+
+```yaml
+RESET:
+  # Enable the scheduled arena reset (true / false)
+  ENABLED: false
+  # How often the arena resets. Accepts 1d10h15m, 24h, 30m, 90s and combinations.
+  INTERVAL: '24h'
+  # Seconds of warning broadcast before the reset runs
+  WARNING_SECONDS: 30
+  # Teleport everyone in the arena to the lobby before pasting (true / false)
+  EVACUATE: true
+  # Schematic name as WorldEdit/FastAsyncWorldEdit knows it, without the file extension
+  SCHEMATIC: 'arena'
+  # Where the schematic is pasted. Empty pastes at the origin stored in the schematic itself.
+  PASTE_LOCATION: ''
+  COMMANDS:
+  - '//schematic load {schematic}'
+  - '//paste -o -a'
+  # Seconds to wait between the load command and the paste command
+  PASTE_DELAY_SECONDS: 5
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RESET.ENABLED` | `bool` | `true`, `false` | `false` | Turns the timer on. `/pvp reset` still works while this is off. |
+| `RESET.INTERVAL` | `string` | `1d10h15m`, `24h`, `30m`, `90s`, or a bare number of seconds | `'24h'` | Time between resets. The clock restarts when the plugin loads and after every reset. |
+| `RESET.WARNING_SECONDS` | `int` | `0` and above | `30` | Broadcasts one warning this long before the reset. `0` sends none. |
+| `RESET.EVACUATE` | `bool` | `true`, `false` | `true` | Sends everyone in the arena to the lobby before pasting, so nobody is buried by the schematic. |
+| `RESET.SCHEMATIC` | `string` | A schematic name without its extension | `'arena'` | Substituted into `{schematic}` in the commands below. Set from in game with `/pvp schematic load <name>`. |
+| `RESET.PASTE_LOCATION` | `string` | `world,x,y,z,yaw,pitch`, or empty | `''` | Fills `{world} {x} {y} {z}` in the commands. Empty relies on `-o`, which pastes at the origin stored in the schematic. |
+| `RESET.COMMANDS` | `list` | Console commands | load + paste | Run in order from console. WorldEdit and FastAsyncWorldEdit answer the same two commands, so either works and neither needs to be listed as a dependency. |
+| `RESET.PASTE_DELAY_SECONDS` | `int` | `1` and above | `5` | Wait between one command and the next. A large schematic is still loading when an immediate paste would fire. |
+
+---
+
+## Section: `BLOCKED_COMMANDS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BLOCKED_COMMANDS:
+  # Enable command blocking inside the arena (true / false)
+  ENABLED: true
+  COMMANDS:
+  - 'shop'
+  - 'sell'
+  - 'ah'
+  - 'auctionhouse'
+  - 'ec'
+  - 'enderchest'
+  - 'orders'
+  # Also block the ender chest when it is opened by clicking the block (true / false)
+  BLOCK_ENDER_CHEST_BLOCK: true
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BLOCKED_COMMANDS.ENABLED` | `bool` | `true`, `false` | `true` | Master switch. `/pvp` itself is never blocked. |
+| `BLOCKED_COMMANDS.COMMANDS` | `list` | Command labels, with or without the leading slash | shop, sell, ah, auctionhouse, ec, enderchest, orders | An entry covers its subcommands and its plugin-qualified form, so `shop` catches `/shop sell` and `/otherplugin:shop`. |
+| `BLOCKED_COMMANDS.BLOCK_ENDER_CHEST_BLOCK` | `bool` | `true`, `false` | `true` | Closes the second route into the ender chest: right clicking the block. Holders of `ultimatedonutsmp.admin.pvp` bypass both. |
+
+---
+
+## Section: `ELO`
+
+### 1. Commented Setup Code Example
+
+```yaml
+ELO:
+  # Elo every player starts on
+  STARTING: 0
+  # Elo the killer gains
+  GAIN_PER_KILL: 25
+  # Elo the victim loses
+  LOSS_PER_DEATH: 20
+  # Elo can never fall below this
+  MINIMUM: 0
+  # Elo can never rise above this. 0 removes the cap.
+  MAXIMUM: 0
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ELO.STARTING` | `int` | `0` and above | `0` | Elo a player who has never fought is treated as having. |
+| `ELO.GAIN_PER_KILL` | `int` | `0` and above | `25` | Added to the killer on a rewarded kill. |
+| `ELO.LOSS_PER_DEATH` | `int` | `0` and above | `20` | Taken from the victim. Kill-farm protection can waive this; see `ANTI_KILL_FARMING.APPLY_ELO_LOSS`. |
+| `ELO.MINIMUM` | `int` | `0` and above | `0` | Floor. Elo never drops below it. |
+| `ELO.MAXIMUM` | `int` | `0` and above | `0` | Ceiling. `0` means no ceiling. |
+
+---
+
+## Section: `RANKS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+RANKS:
+  LT5:
+    DISPLAY: '&7LT5'
+    ELO: 0
+  HT5:
+    DISPLAY: '&eHT5'
+    ELO: 600
+  HT1:
+    DISPLAY: '&c&lHT1'
+    ELO: 1500
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RANKS.<id>` | `section` | Any id | LT5 through HT1 | Rank ids are free-form. Rename them, add tiers or remove some; nothing in the code expects the LT/HT naming. |
+| `RANKS.<id>.DISPLAY` | `string` | Any text with colour codes | Varies | What `%pvp_rank%` renders. TAB reads this for the nametag. |
+| `RANKS.<id>.ELO` | `int` | `0` and above | Varies | Elo needed to hold the rank. A player takes the highest rank they meet, so they drop back down on their own when Elo falls. |
+
+---
+
+## Section: `LEVELS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+LEVELS:
+  # XP a rewarded kill is worth
+  XP_PER_KILL: 50
+  # XP needed to reach level 2
+  BASE_XP: 100
+  # Extra XP each further level costs on top of the previous one
+  XP_INCREASE_PER_LEVEL: 50
+  # Highest level a player can reach. 0 removes the cap.
+  MAX_LEVEL: 100
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `LEVELS.XP_PER_KILL` | `int` | `0` and above | `50` | XP a rewarded kill hands out. Independent of Elo. |
+| `LEVELS.BASE_XP` | `int` | `1` and above | `100` | Cost of level 2. |
+| `LEVELS.XP_INCREASE_PER_LEVEL` | `int` | `0` and above | `50` | Added to the cost of each level after that, giving 100, 150, 200 with the defaults. `0` makes every level cost the same. |
+| `LEVELS.MAX_LEVEL` | `int` | `0` and above | `100` | Ceiling. XP stops accumulating at the top. `0` removes the cap. |
+
+---
+
+## Section: `ANTI_KILL_FARMING`
+
+### 1. Commented Setup Code Example
+
+```yaml
+ANTI_KILL_FARMING:
+  # Enable kill-farm protection (true / false)
+  ENABLED: true
+  # Rewarded kills allowed against the same player before rewards drop
+  MAX_REWARDED_KILLS: 3
+  # How long the counter remembers a victim
+  COOLDOWN: '5m'
+  # Elo given for a kill past the limit
+  REDUCED_ELO: 0
+  # XP given for a kill past the limit
+  REDUCED_XP: 0
+  # Take Elo from the victim on an unrewarded kill (true / false)
+  APPLY_ELO_LOSS: false
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ANTI_KILL_FARMING.ENABLED` | `bool` | `true`, `false` | `true` | Master switch. Off, every kill pays in full. |
+| `ANTI_KILL_FARMING.MAX_REWARDED_KILLS` | `int` | `0` and above | `3` | Rewarded kills allowed per victim inside the cooldown window. |
+| `ANTI_KILL_FARMING.COOLDOWN` | `string` | Same format as `RESET.INTERVAL` | `'5m'` | How long the counter remembers a victim. A pair who go this long without a kill start fresh. |
+| `ANTI_KILL_FARMING.REDUCED_ELO` | `int` | `0` and above | `0` | Elo paid once the limit is passed. |
+| `ANTI_KILL_FARMING.REDUCED_XP` | `int` | `0` and above | `0` | XP paid once the limit is passed. |
+| `ANTI_KILL_FARMING.APPLY_ELO_LOSS` | `bool` | `true`, `false` | `false` | Whether an unrewarded kill still costs the victim Elo. Off by default so a farmed player is not punished for it. |
+
+> Tracking is per killer and victim UUID pair. Unrewarded kills still count toward kills, deaths, K/D and streaks, because they did happen - only the Elo and XP change.
+
+---
+
+## Section: `BROADCASTS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BROADCASTS:
+  LEVEL_UP:
+    GLOBAL: true
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7has reached PvP Level &c%pvp_level%&7!'
+  RANK_UP:
+    GLOBAL: true
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7ranked up to %pvp_rank% &7with &c%pvp_elo% &7elo!'
+  RANK_DOWN:
+    GLOBAL: false
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7dropped to %pvp_rank% &7with &c%pvp_elo% &7elo!'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BROADCASTS.LEVEL_UP.GLOBAL` | `bool` | `true`, `false` | `true` | `true` announces to the server, `false` only to the player. |
+| `BROADCASTS.LEVEL_UP.MESSAGE` | `string` | Any text; empty disables | See above | Supports `%player_name%`, `%pvp_level%`, `%pvp_old_level%`, `%pvp_rank%`, `%pvp_old_rank%`, `%pvp_elo%`, `%pvp_xp%`. |
+| `BROADCASTS.RANK_UP.GLOBAL` | `bool` | `true`, `false` | `true` | Rank promotions. |
+| `BROADCASTS.RANK_UP.MESSAGE` | `string` | Any text; empty disables | See above | Same placeholder set. |
+| `BROADCASTS.RANK_DOWN.GLOBAL` | `bool` | `true`, `false` | `false` | Demotions are personal by default. |
+| `BROADCASTS.RANK_DOWN.MESSAGE` | `string` | Any text; empty disables | See above | Same placeholder set. |
+
+> These placeholders are filled in by the arena itself, not by PlaceholderAPI, so a broadcast describes the player it is about rather than whoever is reading it - and it still reads correctly on a server with no PlaceholderAPI installed.
+
+---
+
+## Section: `SCOREBOARD`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SCOREBOARD:
+  # Show the arena sidebar instead of the survival one (true / false)
+  ENABLED: true
+  TITLE:
+  - '&c&lPVP ARENA'
+  LINES:
+  - ''
+  - '&fPLAYER: &c%player_name%'
+  - '&fRANK: %pvp_rank%'
+  - '&fLEVEL: &c%pvp_level%'
+  - '&fK/D: &c%pvp_kills%&7/&c%pvp_deaths%'
+  - ''
+  - '&fARENA RESET'
+  - '&c%pvp_arena_reset%'
+  # How the reset countdown is written
+  RESET_FORMAT: '{d}D:{h}H:{m}M:{s}S'
+  # Shown by %pvp_arena_reset% when no reset is scheduled
+  RESET_DISABLED_TEXT: '&7-'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SCOREBOARD.ENABLED` | `bool` | `true`, `false` | `true` | Off, arena players keep the normal `scoreboard.yml` sidebar. |
+| `SCOREBOARD.TITLE` | `list` | Colour-coded text | `'&c&lPVP ARENA'` | Animated frames, cycled at the survival sidebar's speed. |
+| `SCOREBOARD.LINES` | `list` | Colour-coded text with any placeholders | See above | Rendered top to bottom. Empty strings are spacer lines. |
+| `SCOREBOARD.RESET_FORMAT` | `string` | `{d} {h} {m} {s}` padded, `{D} {H} {M} {S}` unpadded | `'{d}D:{h}H:{m}M:{s}S'` | How `%pvp_arena_reset%` writes the countdown. |
+| `SCOREBOARD.RESET_DISABLED_TEXT` | `string` | Any text | `'&7-'` | Shown when no reset is scheduled. |
+
+---
+
+## Section: `KITS`
+
+Written by `/pvp kit create`, `/pvp kit edit` and the `/pvp kit` property commands, and excluded
+from the config updater so a plugin update never restores the empty default over your kits.
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `KITS.<id>.DISPLAY` | `string` | Any text | `&f<id>` | Menu name. Set with `/pvp kit display <name> <text>`. |
+| `KITS.<id>.ICON` | `string` | A material name | `IRON_SWORD` | Menu icon. Set with `/pvp kit icon <name> <material>`. |
+| `KITS.<id>.PERMISSION` | `string` | A permission node, or empty | `''` | Empty leaves the kit open to everyone. `/pvp kit permission <name> none` clears it. |
+| `KITS.<id>.SLOT` | `int` | `0`-`26`, or `-1` | `-1` | Fixed menu slot. `-1` places the kit automatically, centred with the others. |
+| `KITS.<id>.CONTENTS` | `section` | Serialized items by slot | – | The 36 inventory slots. Written by the editor. |
+| `KITS.<id>.ARMOR` | `section` | Serialized items by slot | – | Boots, leggings, chestplate, helmet, in that order. |
+| `KITS.<id>.OFFHAND` | `string` | A serialized item | – | Offhand item. |
+| `KITS.<id>.EFFECTS` | `list` | `TYPE:amplifier:duration` | empty | Potion effects applied on spawn, for example `SPEED:1:600`. |
+
+---
+
+## Section: `MESSAGES`
+
+Every player-facing string the arena sends. All of them go through the plugin's colour handling, so
+`&a` and `&#RRGGBB` both work.
+
+| Option / Key Path | Placeholders | Technical Function |
+| :--- | :--- | :--- |
+| `MESSAGES.DISABLED` | – | Sent when `SETTINGS.ENABLED` is off. |
+| `MESSAGES.NOT_SET_UP` | – | Sent when `ARENA.SPAWN` is missing. |
+| `MESSAGES.NO_KITS` | – | Sent when no kit is available to that player. |
+| `MESSAGES.JOINED` / `MESSAGES.LEFT` | – | Entering and leaving. |
+| `MESSAGES.ALREADY_IN` / `MESSAGES.NOT_IN` | – | Wrong-state responses. |
+| `MESSAGES.KIT_GIVEN` | `{kit}` | Confirms a kit choice. |
+| `MESSAGES.KIT_NO_PERMISSION` | – | Kit locked behind a permission. |
+| `MESSAGES.RESPAWN_COUNTDOWN` | `{seconds}` | Sent once a second while dead. |
+| `MESSAGES.BLOCKED_COMMAND` | – | Also used for a blocked ender chest. |
+| `MESSAGES.LEFT_BOUNDARY` | – | Sent when a player is removed for leaving the arena. |
+| `MESSAGES.KILL_REWARD` | `{victim}`, `{elo}`, `{xp}` | Sent to the killer. |
+| `MESSAGES.DEATH_PENALTY` | `{killer}`, `{elo}` | Sent to the victim. |
+| `MESSAGES.KILL_FARM_LIMIT` | `{victim}` | Sent instead of the reward line on an unrewarded kill. |
+| `MESSAGES.LEVEL_UP` | `{level}` | Personal level-up line. |
+| `MESSAGES.RANK_UP` / `MESSAGES.RANK_DOWN` | `{rank}` | Personal rank change lines. |
+| `MESSAGES.RESET_WARNING` | `{time}` | Broadcast before a reset. |
+| `MESSAGES.RESET_DONE` | – | Broadcast after a reset. |
+| `MESSAGES.RESET_NO_SCHEMATIC` | – | `/pvp reset` with nothing configured. |
+| `MESSAGES.STATS_HEADER` | `{player}` | `/pvp stats` header. |
+| `MESSAGES.STATS_LINE` | `{label}`, `{value}` | Each `/pvp stats` row. |
+| `MESSAGES.TOP_HEADER` | – | `/pvp top` header. |
+| `MESSAGES.TOP_LINE` | `{position}`, `{player}`, `{elo}`, `{rank}` | Each `/pvp top` row. |
+| `MESSAGES.TOP_EMPTY` | – | `/pvp top` with no records yet. |

--- a/docs/wiki/Duels-and-FFA.md
+++ b/docs/wiki/Duels-and-FFA.md
@@ -2,6 +2,8 @@
 
 UltimateDonutSMP provides built-in, production-grade 1v1 Duels and instanced Free-For-All (FFA) PvP systems with automatic map rollbacks, crystal speed optimizations, custom kits, and queue management.
 
+> Looking for a permanent arena where everyone fights at once and keeps an Elo rating between visits? That is the [Ranked PvP Arena](Ranked-PvP-Arena), a separate system. The FFA below is instanced: it pairs players in a throwaway copy of a map and rolls the blocks back afterwards.
+
 ---
 
 ## 1v1 Duels System Setup

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,7 +2,7 @@
 
 Welcome to the official wiki documentation for **UltimateDonutSMP**, an all-in-one, high-performance Paper, Spigot, and Folia plugin designed for DonutSMP-style Minecraft survival networks.
 
-UltimateDonutSMP replaces dozens of separate plugins by integrating economy, marketplaces, team systems, teleportation, PvP duels, FFA arenas, custom spawners, crates, staff utilities, security tools, and multi-server network syncing into a single, cohesive plugin.
+UltimateDonutSMP replaces dozens of separate plugins by integrating economy, marketplaces, team systems, teleportation, PvP duels, FFA and ranked arenas, custom spawners, crates, staff utilities, security tools, and multi-server network syncing into a single, cohesive plugin.
 
 ---
 
@@ -35,6 +35,9 @@ Explore the complete feature guide and documentation pages:
 
 - **[Duels & Instanced FFA](Duels-and-FFA)**  
   Setting up duel arenas (`/arena`), player duel queues (`/duel`, `/queue`), arena rollbacks, crystal speed tweaks, and instanced FFA arenas (`/ffaarena`, `/ffa`).
+
+- **[Ranked PvP Arena](Ranked-PvP-Arena)**  
+  Persistent ranked arena (`/pvp`) with editable kits, Elo, an LT/HT rank ladder, PvP levels, kill-farm protection, its own scoreboard, and scheduled schematic resets through WorldEdit or FAWE.
 
 - **[Economy & Marketplaces](Economy-and-Marketplaces)**  
   Vault economy, Shard currency, shop systems (`/shop`, `/sell`, `/worth`), Auction House (`/ah`), Orders board (`/orders`), and Billford rotating NPC trades (`/billford`).

--- a/docs/wiki/Placeholders-and-Integrations.md
+++ b/docs/wiki/Placeholders-and-Integrations.md
@@ -93,7 +93,38 @@ Used when Staff Mode or Streamer/Disguise mode is enabled:
 
 ---
 
-### 5. Punishment & Expiry Message Placeholders
+### 5. Ranked PvP Arena Expansion (`%pvp_*%`)
+
+Registered by the [ranked PvP arena](Ranked-PvP-Arena). Every number the arena tracks is published here rather than drawn by the plugin, so TAB keeps owning the nametag and any scoreboard or chat plugin can read the same values.
+
+| Placeholder | Output Description |
+| :--- | :--- |
+| `%pvp_rank%` | Rank display text, e.g. `HT5` |
+| `%pvp_rank_id%` | Rank id without colour codes |
+| `%pvp_elo%` | Current Elo |
+| `%pvp_level%` | Current PvP level |
+| `%pvp_xp%` | XP toward the next level |
+| `%pvp_next_xp%` | XP the next level costs |
+| `%pvp_kills%` | Arena kills |
+| `%pvp_deaths%` | Arena deaths |
+| `%pvp_kd%` | Kill/death ratio to two decimals |
+| `%pvp_streak%` | Current kill streak |
+| `%pvp_best_streak%` | Best kill streak |
+| `%pvp_joins%` | Times the player has entered the arena |
+| `%pvp_in_arena%` | `true` while the player is inside the arena |
+| `%pvp_arena%` | Configured arena name |
+| `%pvp_arena_reset%` | Countdown to the next reset, in `SCOREBOARD.RESET_FORMAT` |
+| `%pvp_arena_players%` | How many players are in the arena right now |
+
+A typical TAB nametag format:
+
+```
+%pvp_rank% | %luckperms-prefix% %player%
+```
+
+---
+
+### 6. Punishment & Expiry Message Placeholders
 
 Available for config and language message templates (`messages.yml` & `languages/*.yml`) when issuing punishments (`/offend`, `/ban`, `/mute`, etc.) or sending kick/mute screens:
 

--- a/docs/wiki/Ranked-PvP-Arena.md
+++ b/docs/wiki/Ranked-PvP-Arena.md
@@ -1,0 +1,239 @@
+# Ranked PvP Arena
+
+The ranked arena is a persistent free-for-all area with kits, an Elo rating, a rank ladder, a
+separate level track, and an optional scheduled reset that pastes a schematic back over the map. It
+is configured entirely through `pvp.yml` and the `/pvp` command, and it ships switched off.
+
+It is not a second FFA system. [Instanced FFA](Duels-and-FFA) matches two players in a throwaway
+copy of an arena and rolls the blocks back afterwards. The ranked arena is one permanent place that
+everyone fights in at once, and what carries over between visits is the rating rather than the map.
+
+---
+
+## What it does not do
+
+Three things are deliberately left to the plugins that already do them.
+
+- **Combat tagging.** The arena never tags anyone. Whatever combat plugin the server runs stays in
+  charge of tagging, logout punishment and command blocking during a fight.
+- **Inventory separation.** The arena does not snapshot or restore a survival inventory. Give it its
+  own world and let Multiverse-Inventories, or whatever else you already use, keep the two apart.
+  The arena only clears what it handed out when a player leaves.
+- **Nametags.** The arena publishes `%pvp_rank%` and the rest as PlaceholderAPI placeholders. TAB
+  keeps drawing the nametag from them.
+
+---
+
+## Setting one up
+
+Give yourself `ultimatedonutsmp.admin.pvp` and work through this in the world the arena lives in.
+
+```
+/pvp create Arena
+/pvp setspawn
+/pvp setlobby
+/pvp wand
+/pvp setboundary
+```
+
+`/pvp setspawn` is the only step the arena cannot open without. Run it where players should appear.
+`/pvp setlobby` records where `/pvp leave`, a boundary exit and a reconnect send people; without it
+the arena falls back to the server spawn.
+
+`/pvp wand` hands you a golden axe. Left click one corner of the arena, right click the opposite
+one, then `/pvp setboundary` stores them. Anyone who steps outside that box - plus the
+`ARENA.BOUNDARY_PADDING` slack - is pulled out of the fight. Skip the boundary entirely and the
+whole arena world counts as inside, which is usually what you want for a dedicated world.
+
+Finally switch it on:
+
+```yaml
+SETTINGS:
+  ENABLED: true
+```
+
+---
+
+## Kits
+
+A player picks a kit when they join and again after every respawn, so a kit has to exist before the
+arena will let anyone in.
+
+```
+/pvp kit create warrior
+```
+
+That opens the editor. The top four rows are the player's inventory - the first row is the hotbar -
+the four slots at the bottom left are boots, leggings, chestplate and helmet in that order, and the
+slot after the label is the offhand. Put the real items in. Enchantments, custom names, lore, potion
+types, stack sizes and items from other plugins all survive, because what gets stored is the item
+itself rather than a description of it. Closing the menu saves.
+
+The rest of a kit is set from the command line:
+
+```
+/pvp kit icon warrior NETHERITE_SWORD
+/pvp kit display warrior &cWarrior
+/pvp kit permission warrior ultimatedonutsmp.pvp.kit.warrior
+/pvp kit slot warrior 11
+```
+
+A kit with no permission is open to everyone. A kit with no slot is placed automatically, centred in
+the menu alongside the others. `/pvp kit list` shows what exists and `/pvp kit delete <name>`
+removes one.
+
+---
+
+## Elo, ranks and levels
+
+Every kill moves two numbers. Elo decides the rank, and XP decides the level; they are independent
+on purpose, so a long-serving player can be highly levelled and still rank badly.
+
+```yaml
+ELO:
+  GAIN_PER_KILL: 25
+  LOSS_PER_DEATH: 20
+
+LEVELS:
+  XP_PER_KILL: 50
+  BASE_XP: 100
+  XP_INCREASE_PER_LEVEL: 50
+```
+
+Ranks are whatever you define. The bundled ladder is the usual LT5 to HT1, but the ids, the names
+and the Elo each one costs are all yours:
+
+```yaml
+RANKS:
+  HT5:
+    DISPLAY: '&eHT5'
+    ELO: 600
+```
+
+A player holds the highest rank they still meet the Elo for, checked after every kill, so ranks go
+down as well as up with no separate demotion setting to keep in sync.
+
+Levels come off a straight line: level 2 costs `BASE_XP`, and every level after that costs one more
+`XP_INCREASE_PER_LEVEL` than the one before it. With the defaults that is 100, 150, 200 and so on.
+
+Rank and level changes can be announced to the whole server:
+
+```yaml
+BROADCASTS:
+  LEVEL_UP:
+    GLOBAL: true
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7has reached PvP Level &c%pvp_level%&7!'
+```
+
+---
+
+## Kill farming
+
+Killing the same player over and over stops paying:
+
+```yaml
+ANTI_KILL_FARMING:
+  ENABLED: true
+  MAX_REWARDED_KILLS: 3
+  COOLDOWN: '5m'
+  REDUCED_ELO: 0
+  REDUCED_XP: 0
+```
+
+The counter is per killer and victim pair and forgets a victim once the cooldown passes without
+another kill. Unrewarded kills still count toward K/D and the streak - they happened - they simply
+stop paying Elo and XP, and by default they stop costing the victim Elo too.
+
+---
+
+## The scoreboard
+
+While a player is in the arena the sidebar comes from `pvp.yml` instead of `scoreboard.yml`. It
+takes any PlaceholderAPI placeholder, including this feature's own.
+
+```yaml
+SCOREBOARD:
+  ENABLED: true
+  TITLE:
+  - '&c&lPVP ARENA'
+  LINES:
+  - '&fRANK: %pvp_rank%'
+  - '&fLEVEL: &c%pvp_level%'
+  - '&fK/D: &c%pvp_kills%&7/&c%pvp_deaths%'
+  - '&fARENA RESET'
+  - '&c%pvp_arena_reset%'
+  RESET_FORMAT: '{d}D:{h}H:{m}M:{s}S'
+```
+
+`RESET_FORMAT` takes `{d} {h} {m} {s}` padded to two digits and `{D} {H} {M} {S}` unpadded.
+
+---
+
+## Scheduled resets
+
+The arena can paste a schematic back over itself on a timer instead of regenerating the world.
+
+```yaml
+RESET:
+  ENABLED: true
+  INTERVAL: '24h'
+  WARNING_SECONDS: 30
+  EVACUATE: true
+  SCHEMATIC: 'arena'
+  COMMANDS:
+  - '//schematic load {schematic}'
+  - '//paste -o -a'
+  PASTE_DELAY_SECONDS: 5
+```
+
+Save the arena as a schematic with WorldEdit first, then point `SCHEMATIC` at it - the name only,
+no file extension. `/pvp schematic load <name>` sets it from in game, and `/pvp schematic location`
+records a paste position for configs that want one.
+
+The reset runs the commands from console, in order, waiting `PASTE_DELAY_SECONDS` between each. That
+gap matters: a large schematic is still loading when an immediate paste would fire. Because the work
+is done through commands rather than a compiled dependency, the same two lines drive WorldEdit and
+FastAsyncWorldEdit, and FAWE is worth installing for a big arena - it is far faster and much easier
+on the tick.
+
+`INTERVAL` accepts `1d10h15m`, `24h`, `30m`, `90s` and combinations of those. `/pvp reset` runs one
+immediately.
+
+---
+
+## Blocked commands
+
+Survival commands are switched off inside the arena.
+
+```yaml
+BLOCKED_COMMANDS:
+  ENABLED: true
+  COMMANDS:
+  - 'shop'
+  - 'sell'
+  - 'ah'
+  - 'ec'
+  - 'enderchest'
+  - 'orders'
+  BLOCK_ENDER_CHEST_BLOCK: true
+```
+
+A blocked entry covers its subcommands, so `shop` also blocks `/shop sell`, and a plugin-qualified
+form like `/otherplugin:shop` is caught too. `BLOCK_ENDER_CHEST_BLOCK` closes the other door into
+the ender chest, the block itself. Holders of `ultimatedonutsmp.admin.pvp` are exempt from all of
+it.
+
+---
+
+## Player commands
+
+| Command | What it does |
+| :--- | :--- |
+| `/pvp` | Join the arena and pick a kit |
+| `/pvp leave` | Leave and return to the lobby |
+| `/pvp kit` | Reopen the kit menu |
+| `/pvp stats [player]` | Elo, rank, level, XP, K/D and streaks |
+| `/pvp top [amount]` | The Elo ladder, offline players included |
+
+See [Config-pvp.yml](Config-pvp.yml) for every option, and
+[Placeholders & Integrations](Placeholders-and-Integrations) for the `%pvp_*%` catalog.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -5,6 +5,7 @@
 - **[Commands & Permissions](Commands-and-Permissions)**
 - **[Cuboids & Portals](Cuboids-and-Portals)**
 - **[Duels & Instanced FFA](Duels-and-FFA)**
+- **[Ranked PvP Arena](Ranked-PvP-Arena)**
 - **[Economy & Marketplaces](Economy-and-Marketplaces)**
 - **[Crates & Spawners](Crates-and-Spawners)**
 - **[Staff & Security Utilities](Staff-and-Security)**
@@ -13,7 +14,7 @@
 
 ---
 
-### ⚙️ YAML Configuration Guides (29 Files)
+### ⚙️ YAML Configuration Guides (30 Files)
 
 - **[config.yml Guide](Config-config.yml)**
 - **[messages.yml Guide](Config-messages.yml)**
@@ -40,6 +41,7 @@
 - **[hide.yml Guide](Config-hide.yml)**
 - **[invsee.yml Guide](Config-invsee.yml)**
 - **[orders.yml Guide](Config-orders.yml)**
+- **[pvp.yml Guide](Config-pvp.yml)**
 - **[rtp.yml Guide](Config-rtp.yml)**
 - **[server-wipe.yml Guide](Config-server-wipe.yml)**
 - **[spawn-stash.yml Guide](Config-spawn-stash.yml)**

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -5,6 +5,7 @@ import com.bx.ultimateDonutSmp.api.EconomyExpansion;
 import com.bx.ultimateDonutSmp.api.EconomyLeaderboardExpansion;
 import com.bx.ultimateDonutSmp.api.EconomyRankExpansion;
 import com.bx.ultimateDonutSmp.api.HideExpansion;
+import com.bx.ultimateDonutSmp.api.PvpExpansion;
 import com.bx.ultimateDonutSmp.api.UltimateDonutSmpExpansion;
 import com.bx.ultimateDonutSmp.api.UdsExpansion;
 import com.bx.ultimateDonutSmp.commands.*;
@@ -79,6 +80,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private FilterManager filterManager;
     private DuelManager duelManager;
     private FfaManager ffaManager;
+    private PvpManager pvpManager;
     private AuctionHouseManager auctionHouseManager;
     private AuctionOrderBotManager auctionOrderBotManager;
     private ServerNotificationManager serverNotificationManager;
@@ -226,6 +228,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         duelManager = new DuelManager(this);
         ffaManager = new FfaManager(this);
+        pvpManager = new PvpManager(this);
         auctionHouseManager = new AuctionHouseManager(this);
         auctionOrderBotManager = new AuctionOrderBotManager(this);
         serverNotificationManager = new ServerNotificationManager(this);
@@ -309,6 +312,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         SpawnerGenerationTask.start(this);
         DuelMatchTask.start(this);
         FfaMatchTask.start(this);
+        PvpArenaTask.start(this);
 
         // 8. PlaceholderAPI expansion
         if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -316,6 +320,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
             new UltimateDonutSmpExpansion(this).register();
             new UdsExpansion(this).register();
             new HideExpansion(this).register();
+            new PvpExpansion(this).register();
             new EconomyLeaderboardExpansion(this).register();
             new EconomyRankExpansion(this).register();
             getLogger().info("PlaceholderAPI expansion registered.");
@@ -417,6 +422,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         if (ffaManager != null) {
             ffaManager.shutdown();
+        }
+        if (pvpManager != null) {
+            pvpManager.shutdown();
         }
         if (spawnerManager != null && !suppressWipeSaves) {
             spawnerManager.shutdown();
@@ -543,6 +551,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         pm.registerEvents(new DuelListener(this), this);
         pm.registerEvents(new FfaListener(this), this);
+        pm.registerEvents(new PvpListener(this), this);
         pm.registerEvents(new AmethystToolsListener(this), this);
         pm.registerEvents(new SpawnerBlockListener(this), this);
         pm.registerEvents(new SpawnerInteractListener(this), this);
@@ -648,6 +657,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("ffa", new FfaCommand(this), FeatureManager.Feature.FFA);
         setExecutor("ffastats", new FfaStatsCommand(this), FeatureManager.Feature.FFA);
         setExecutor("ffaarena", new FfaArenaCommand(this), FeatureManager.Feature.FFA);
+        setExecutor("pvp", new PvpCommand(this), FeatureManager.Feature.PVP_ARENA);
         AuctionHouseCommand auctionHouseCommand = new AuctionHouseCommand(this);
         setExecutor("auctionhouse", auctionHouseCommand, FeatureManager.Feature.AUCTION_HOUSE);
         setTabCompleter("auctionhouse", auctionHouseCommand);
@@ -1065,6 +1075,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ordersManager.reload();
         duelManager.reload();
         ffaManager.reload();
+        pvpManager.reload();
         auctionHouseManager.reload();
         if (auctionOrderBotManager != null) {
             auctionOrderBotManager.reload();
@@ -1336,6 +1347,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public FfaManager getFfaManager() {
         return ffaManager;
+    }
+
+    public PvpManager getPvpManager() {
+        return pvpManager;
     }
 
     public AuctionHouseManager getAuctionHouseManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/api/PvpExpansion.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/api/PvpExpansion.java
@@ -1,0 +1,93 @@
+package com.bx.ultimateDonutSmp.api;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.models.PvpRank;
+import com.bx.ultimateDonutSmp.models.PvpStats;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.DecimalFormat;
+import java.util.Locale;
+
+/**
+ * The {@code %pvp_...%} placeholders.
+ *
+ * <p>Everything the arena tracks is exposed here rather than being drawn by the plugin itself, so
+ * TAB stays in charge of nametags and any scoreboard or chat plugin can read the same numbers.</p>
+ */
+public class PvpExpansion extends PlaceholderExpansion {
+
+    private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("0.00");
+
+    private final UltimateDonutSmp plugin;
+
+    public PvpExpansion(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "pvp";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "UltimateDonutSmp";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+        PvpManager pvp = plugin.getPvpManager();
+        if (pvp == null) {
+            return null;
+        }
+
+        String key = params.toLowerCase(Locale.ROOT);
+        if (key.equals("arena")) {
+            return pvp.getArenaName();
+        }
+        if (key.equals("arena_reset")) {
+            return pvp.getFormattedReset();
+        }
+        if (key.equals("arena_players")) {
+            return String.valueOf(pvp.getArenaPlayerCount());
+        }
+
+        if (player == null) {
+            return null;
+        }
+
+        PvpStats stats = pvp.getStats(player.getUniqueId());
+        PvpRank rank = pvp.getRankFor(stats.getElo());
+
+        return switch (key) {
+            case "rank" -> rank == null ? "" : rank.getDisplay();
+            case "rank_id" -> rank == null ? "" : rank.getId();
+            case "elo" -> String.valueOf(stats.getElo());
+            case "level" -> String.valueOf(stats.getLevel());
+            case "xp" -> String.valueOf(stats.getXp());
+            case "next_xp" -> String.valueOf(pvp.getXpForNextLevel(stats.getLevel()));
+            case "kills" -> String.valueOf(stats.getKills());
+            case "deaths" -> String.valueOf(stats.getDeaths());
+            case "kd" -> RATIO_FORMAT.format(stats.getKillDeathRatio());
+            case "streak" -> String.valueOf(stats.getStreak());
+            case "best_streak" -> String.valueOf(stats.getBestStreak());
+            case "joins" -> String.valueOf(stats.getArenaJoins());
+            case "in_arena" -> String.valueOf(pvp.isInArena(player.getUniqueId()));
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
@@ -1,0 +1,491 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.menus.PvpKitEditMenu;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.models.PvpRank;
+import com.bx.ultimateDonutSmp.models.PvpStats;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * {@code /pvp} - the player entrance to the arena and the whole admin setup tree behind it.
+ */
+public class PvpCommand implements CommandExecutor, TabCompleter {
+
+    private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("0.00");
+    private static final List<String> PLAYER_SUBCOMMANDS = List.of("join", "leave", "kit", "stats", "top");
+    private static final List<String> ADMIN_SUBCOMMANDS = List.of(
+            "wand", "create", "setspawn", "setlobby", "setboundary", "schematic", "reset", "reload"
+    );
+
+    private final UltimateDonutSmp plugin;
+
+    public PvpCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        PvpManager pvp = plugin.getPvpManager();
+        if (pvp == null) {
+            sender.sendMessage(ColorUtils.toComponent("&cThe PvP arena is not available."));
+            return true;
+        }
+
+        if (args.length == 0) {
+            if (!(sender instanceof Player player)) {
+                sendUsage(sender, label, true);
+                return true;
+            }
+            pvp.join(player);
+            return true;
+        }
+
+        String subcommand = args[0].toLowerCase(Locale.ROOT);
+        return switch (subcommand) {
+            case "join" -> requirePlayer(sender, player -> pvp.join(player));
+            case "leave" -> requirePlayer(sender, pvp::leave);
+            case "kit" -> handleKit(sender, label, args);
+            case "stats" -> handleStats(sender, args);
+            case "top" -> handleTop(sender, args);
+            case "wand" -> handleWand(sender);
+            case "create" -> handleCreate(sender, args);
+            case "setspawn" -> handleSetSpawn(sender);
+            case "setlobby" -> handleSetLobby(sender);
+            case "setboundary" -> handleSetBoundary(sender);
+            case "schematic" -> handleSchematic(sender, label, args);
+            case "reset" -> handleReset(sender);
+            case "reload" -> handleReload(sender);
+            default -> {
+                sendUsage(sender, label, isAdmin(sender));
+                yield true;
+            }
+        };
+    }
+
+    // ── Player subcommands ────────────────────────────────────────────────────
+
+    private boolean handleKit(CommandSender sender, String label, String[] args) {
+        PvpManager pvp = plugin.getPvpManager();
+        if (args.length == 1) {
+            return requirePlayer(sender, player -> {
+                if (!pvp.isInArena(player.getUniqueId())) {
+                    send(player, pvp.message("NOT_IN", "&cYou are not in the PvP arena."));
+                    return;
+                }
+                pvp.openKitMenu(player);
+            });
+        }
+
+        String action = args[1].toLowerCase(Locale.ROOT);
+        if (action.equals("list")) {
+            if (pvp.getKits().isEmpty()) {
+                send(sender, "&cThere are no PvP kits yet.");
+                return true;
+            }
+            send(sender, "&ePvP kits:");
+            for (PvpKit kit : pvp.getKits()) {
+                send(sender, "&7- &f" + kit.getId()
+                        + " &8(" + kit.getDisplayName() + "&8)"
+                        + " &7icon=&f" + kit.getIcon().name()
+                        + " &7permission=&f" + (kit.getPermission().isBlank() ? "-" : kit.getPermission())
+                        + " &7empty=&f" + kit.isEmpty());
+            }
+            return true;
+        }
+
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        if (args.length < 3) {
+            send(sender, "&e/" + label + " kit <create|edit|delete|icon|permission|slot|display> <name> [value]");
+            return true;
+        }
+
+        String name = args[2].toLowerCase(Locale.ROOT);
+        switch (action) {
+            case "create" -> {
+                if (pvp.getKit(name) != null) {
+                    send(sender, "&cA kit called &f" + name + " &calready exists.");
+                    return true;
+                }
+                PvpKit created = pvp.createKit(name);
+                send(sender, "&aCreated the &f" + name + " &akit. Fill it in with &f/" + label + " kit edit " + name);
+                if (sender instanceof Player player) {
+                    new PvpKitEditMenu(plugin, created).open(player);
+                }
+            }
+            case "edit" -> {
+                PvpKit kit = pvp.getKit(name);
+                if (kit == null) {
+                    send(sender, "&cNo kit called &f" + name + "&c.");
+                    return true;
+                }
+                if (!(sender instanceof Player player)) {
+                    send(sender, "&cOnly a player can edit a kit.");
+                    return true;
+                }
+                new PvpKitEditMenu(plugin, kit).open(player);
+            }
+            case "delete" -> {
+                if (!pvp.deleteKit(name)) {
+                    send(sender, "&cNo kit called &f" + name + "&c.");
+                    return true;
+                }
+                send(sender, "&aDeleted the &f" + name + " &akit.");
+            }
+            case "icon", "permission", "slot", "display" -> {
+                PvpKit kit = pvp.getKit(name);
+                if (kit == null) {
+                    send(sender, "&cNo kit called &f" + name + "&c.");
+                    return true;
+                }
+                if (args.length < 4) {
+                    send(sender, "&e/" + label + " kit " + action + " " + name + " <value>");
+                    return true;
+                }
+                String value = String.join(" ", java.util.Arrays.copyOfRange(args, 3, args.length));
+                applyKitProperty(sender, pvp, kit, action, value);
+            }
+            default -> send(sender, "&e/" + label + " kit <create|edit|delete|list|icon|permission|slot|display>");
+        }
+        return true;
+    }
+
+    private void applyKitProperty(CommandSender sender, PvpManager pvp, PvpKit kit, String action, String value) {
+        switch (action) {
+            case "icon" -> {
+                org.bukkit.Material material = com.bx.ultimateDonutSmp.utils.ItemUtils.parseMaterial(value);
+                if (material == null) {
+                    send(sender, "&cUnknown material: &f" + value);
+                    return;
+                }
+                kit.setIcon(material);
+                send(sender, "&aIcon for &f" + kit.getId() + " &aset to &f" + material.name());
+            }
+            case "permission" -> {
+                kit.setPermission(value.equalsIgnoreCase("none") ? "" : value);
+                send(sender, "&aPermission for &f" + kit.getId() + " &aset to &f"
+                        + (kit.getPermission().isBlank() ? "none" : kit.getPermission()));
+            }
+            case "slot" -> {
+                try {
+                    kit.setMenuSlot(Integer.parseInt(value.trim()));
+                } catch (NumberFormatException exception) {
+                    send(sender, "&cThat is not a slot number: &f" + value);
+                    return;
+                }
+                send(sender, "&aSlot for &f" + kit.getId() + " &aset to &f" + kit.getMenuSlot());
+            }
+            default -> {
+                kit.setDisplayName(value);
+                send(sender, "&aName for &f" + kit.getId() + " &aset to &r" + value);
+            }
+        }
+        pvp.saveKit(kit);
+    }
+
+    private boolean handleStats(CommandSender sender, String[] args) {
+        PvpManager pvp = plugin.getPvpManager();
+        UUID target;
+        String name;
+
+        if (args.length > 1) {
+            OfflinePlayer offline = Bukkit.getOfflinePlayer(args[1]);
+            if (offline.getUniqueId() == null) {
+                send(sender, "&cNo player called &f" + args[1] + "&c.");
+                return true;
+            }
+            target = offline.getUniqueId();
+            name = offline.getName() == null ? args[1] : offline.getName();
+        } else if (sender instanceof Player player) {
+            target = player.getUniqueId();
+            name = player.getName();
+        } else {
+            send(sender, "&e/pvp stats <player>");
+            return true;
+        }
+
+        PvpStats stats = pvp.getStats(target);
+        PvpRank rank = pvp.getRankFor(stats.getElo());
+        send(sender, pvp.message("STATS_HEADER", "&8&m--------&r &cPvP stats: &f{player} &8&m--------")
+                .replace("{player}", name));
+        statLine(sender, pvp, "Rank", rank == null ? "-" : rank.getDisplay());
+        statLine(sender, pvp, "Elo", String.valueOf(stats.getElo()));
+        statLine(sender, pvp, "Level", String.valueOf(stats.getLevel()));
+        statLine(sender, pvp, "XP", stats.getXp() + " / " + pvp.getXpForNextLevel(stats.getLevel()));
+        statLine(sender, pvp, "Kills", String.valueOf(stats.getKills()));
+        statLine(sender, pvp, "Deaths", String.valueOf(stats.getDeaths()));
+        statLine(sender, pvp, "K/D", RATIO_FORMAT.format(stats.getKillDeathRatio()));
+        statLine(sender, pvp, "Streak", stats.getStreak() + " (best " + stats.getBestStreak() + ")");
+        statLine(sender, pvp, "Arena joins", String.valueOf(stats.getArenaJoins()));
+        return true;
+    }
+
+    private void statLine(CommandSender sender, PvpManager pvp, String label, String value) {
+        send(sender, pvp.message("STATS_LINE", "&7{label}: &f{value}")
+                .replace("{label}", label)
+                .replace("{value}", value));
+    }
+
+    private boolean handleTop(CommandSender sender, String[] args) {
+        PvpManager pvp = plugin.getPvpManager();
+        int limit = 10;
+        if (args.length > 1) {
+            try {
+                limit = Math.max(1, Math.min(50, Integer.parseInt(args[1].trim())));
+            } catch (NumberFormatException ignored) {
+                limit = 10;
+            }
+        }
+
+        List<PvpManager.TopEntry> top = pvp.getTop(limit);
+        if (top.isEmpty()) {
+            send(sender, pvp.message("TOP_EMPTY", "&7Nobody has fought in the arena yet."));
+            return true;
+        }
+
+        send(sender, pvp.message("TOP_HEADER", "&8&m--------&r &cTop PvP players &8&m--------"));
+        int position = 1;
+        for (PvpManager.TopEntry entry : top) {
+            PvpRank rank = pvp.getRankFor(entry.elo());
+            send(sender, pvp.message("TOP_LINE", "&7#{position} &f{player} &8- &c{elo} elo &8(&7{rank}&8)")
+                    .replace("{position}", String.valueOf(position++))
+                    .replace("{player}", entry.name())
+                    .replace("{elo}", String.valueOf(entry.elo()))
+                    .replace("{rank}", rank == null ? "-" : rank.getDisplay()));
+        }
+        return true;
+    }
+
+    // ── Admin subcommands ─────────────────────────────────────────────────────
+
+    private boolean handleWand(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        return requirePlayer(sender, player -> {
+            player.getInventory().addItem(plugin.getPvpManager().createWand());
+            send(player, "&aLeft click for corner 1, right click for corner 2, then run &f/pvp setboundary&a.");
+        });
+    }
+
+    private boolean handleCreate(CommandSender sender, String[] args) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        if (args.length < 2) {
+            send(sender, "&e/pvp create <name>");
+            return true;
+        }
+
+        plugin.getPvpManager().setArenaName(String.join(" ", java.util.Arrays.copyOfRange(args, 1, args.length)));
+        send(sender, "&aArena named &f" + plugin.getPvpManager().getArenaName()
+                + "&a. Set the spawn with &f/pvp setspawn&a.");
+        return true;
+    }
+
+    private boolean handleSetSpawn(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        return requirePlayer(sender, player -> {
+            plugin.getPvpManager().setSpawn(player.getLocation());
+            send(player, "&aArena spawn set to where you are standing.");
+        });
+    }
+
+    private boolean handleSetLobby(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        return requirePlayer(sender, player -> {
+            plugin.getPvpManager().setLobby(player.getLocation());
+            send(player, "&aArena lobby set to where you are standing.");
+        });
+    }
+
+    private boolean handleSetBoundary(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        return requirePlayer(sender, player -> {
+            PvpManager pvp = plugin.getPvpManager();
+            Location first = pvp.getWandSelection(player.getUniqueId(), 1);
+            Location second = pvp.getWandSelection(player.getUniqueId(), 2);
+            if (first == null || second == null) {
+                send(player, "&cSelect both corners with &f/pvp wand &cfirst.");
+                return;
+            }
+            pvp.setBoundaryCorner(1, first);
+            pvp.setBoundaryCorner(2, second);
+            send(player, "&aArena boundary saved.");
+        });
+    }
+
+    private boolean handleSchematic(CommandSender sender, String label, String[] args) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        if (args.length < 2) {
+            send(sender, "&e/" + label + " schematic <load <name>|location>");
+            return true;
+        }
+
+        PvpManager pvp = plugin.getPvpManager();
+        String action = args[1].toLowerCase(Locale.ROOT);
+        if (action.equals("load")) {
+            if (args.length < 3) {
+                send(sender, "&e/" + label + " schematic load <name>");
+                return true;
+            }
+            pvp.setResetSchematic(args[2]);
+            send(sender, "&aReset schematic set to &f" + args[2] + "&a.");
+            return true;
+        }
+
+        if (action.equals("location")) {
+            return requirePlayer(sender, player -> {
+                pvp.setPasteLocation(player.getLocation());
+                send(player, "&aSchematic paste location set to where you are standing.");
+            });
+        }
+
+        send(sender, "&e/" + label + " schematic <load <name>|location>");
+        return true;
+    }
+
+    private boolean handleReset(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        plugin.getPvpManager().resetArena(sender);
+        send(sender, "&aRunning the arena reset.");
+        return true;
+    }
+
+    private boolean handleReload(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        plugin.getConfigManager().reloadPvp();
+        plugin.getPvpManager().reload();
+        send(sender, "&aReloaded pvp.yml.");
+        return true;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private boolean isAdmin(CommandSender sender) {
+        return PermissionUtils.has(sender, "ultimatedonutsmp.admin.pvp");
+    }
+
+    private boolean requireAdmin(CommandSender sender) {
+        if (isAdmin(sender)) {
+            return true;
+        }
+        send(sender, "&cYou do not have permission to manage the PvP arena.");
+        return false;
+    }
+
+    private boolean requirePlayer(CommandSender sender, java.util.function.Consumer<Player> action) {
+        if (sender instanceof Player player) {
+            action.accept(player);
+        } else {
+            send(sender, "&cOnly a player can run that.");
+        }
+        return true;
+    }
+
+    private void send(CommandSender sender, String text) {
+        if (sender != null && text != null && !text.isBlank()) {
+            sender.sendMessage(ColorUtils.toComponent(text));
+        }
+    }
+
+    private void sendUsage(CommandSender sender, String label, boolean admin) {
+        send(sender, "&e/" + label + " &7- join the arena");
+        send(sender, "&e/" + label + " leave &7- leave the arena");
+        send(sender, "&e/" + label + " kit &7- pick a kit again");
+        send(sender, "&e/" + label + " stats [player] &7- see a record");
+        send(sender, "&e/" + label + " top [amount] &7- see the elo ladder");
+        if (!admin) {
+            return;
+        }
+        send(sender, "&e/" + label + " wand &7- get the boundary wand");
+        send(sender, "&e/" + label + " create <name> &7- name the arena");
+        send(sender, "&e/" + label + " setspawn &8| &esetlobby &8| &esetboundary");
+        send(sender, "&e/" + label + " kit <create|edit|delete|list|icon|permission|slot|display>");
+        send(sender, "&e/" + label + " schematic <load <name>|location>");
+        send(sender, "&e/" + label + " reset &8| &ereload");
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        PvpManager pvp = plugin.getPvpManager();
+        List<String> options = new ArrayList<>();
+
+        if (args.length == 1) {
+            options.addAll(PLAYER_SUBCOMMANDS);
+            if (isAdmin(sender)) {
+                options.addAll(ADMIN_SUBCOMMANDS);
+            }
+            return filter(options, args[0]);
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("kit")) {
+            options.add("list");
+            if (isAdmin(sender)) {
+                options.addAll(List.of("create", "edit", "delete", "icon", "permission", "slot", "display"));
+            }
+            return filter(options, args[1]);
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("schematic") && isAdmin(sender)) {
+            return filter(List.of("load", "location"), args[1]);
+        }
+
+        if (args.length == 3 && args[0].equalsIgnoreCase("kit") && pvp != null) {
+            for (PvpKit kit : pvp.getKits()) {
+                options.add(kit.getId());
+            }
+            return filter(options, args[2]);
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("stats")) {
+            for (Player online : Bukkit.getOnlinePlayers()) {
+                options.add(online.getName());
+            }
+            return filter(options, args[1]);
+        }
+
+        return List.of();
+    }
+
+    private List<String> filter(List<String> options, String prefix) {
+        String lower = prefix == null ? "" : prefix.toLowerCase(Locale.ROOT);
+        List<String> matches = new ArrayList<>();
+        for (String option : options) {
+            if (option.toLowerCase(Locale.ROOT).startsWith(lower)) {
+                matches.add(option);
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/InventoryClickListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/InventoryClickListener.java
@@ -7,6 +7,7 @@ import com.bx.ultimateDonutSmp.menus.ShopEditorMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersInventoryItemMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersDepositMenu;
 import com.bx.ultimateDonutSmp.menus.OrdersNewMenu;
+import com.bx.ultimateDonutSmp.menus.PvpKitEditMenu;
 import com.bx.ultimateDonutSmp.menus.RTPMenu;
 import com.bx.ultimateDonutSmp.menus.SellMenu;
 import org.bukkit.entity.Player;
@@ -70,6 +71,11 @@ public class InventoryClickListener implements Listener {
             return;
         }
 
+        if (menu instanceof PvpKitEditMenu pvpKitEditMenu) {
+            pvpKitEditMenu.handleInventoryClick(event);
+            return;
+        }
+
         if (menu instanceof OrdersNewMenu && event.getRawSlot() == 23) {
             handleProtectedMenuClick(event, player, menu);
             return;
@@ -120,6 +126,11 @@ public class InventoryClickListener implements Listener {
 
         if (menu instanceof OrdersDepositMenu ordersDepositMenu) {
             ordersDepositMenu.handleInventoryDrag(event);
+            return;
+        }
+
+        if (menu instanceof PvpKitEditMenu pvpKitEditMenu) {
+            pvpKitEditMenu.handleInventoryDrag(event);
             return;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PvpListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PvpListener.java
@@ -1,0 +1,259 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.models.PvpSession;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+import java.util.Set;
+
+/**
+ * Everything the ranked arena has to react to in the world: deaths, respawns, the boundary wand,
+ * the command block list, and the two protections that keep a freshly spawned player alive long
+ * enough to actually fight.
+ */
+public class PvpListener implements Listener {
+
+    private static final Set<String> ALWAYS_ALLOWED = Set.of("pvp", "arena");
+
+    private final UltimateDonutSmp plugin;
+
+    public PvpListener(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    private PvpManager pvp() {
+        return plugin.getPvpManager();
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onDeath(PlayerDeathEvent event) {
+        Player victim = event.getEntity();
+        if (pvp() == null || !pvp().isInArena(victim.getUniqueId())) {
+            return;
+        }
+
+        if (!plugin.getConfigManager().getPvp().getBoolean("SETTINGS.DROP_KIT_ON_DEATH", false)) {
+            event.getDrops().clear();
+            event.setDroppedExp(0);
+            event.setKeepLevel(true);
+        }
+
+        pvp().handleDeath(victim, victim.getKiller());
+
+        // Sitting on the death screen would stall the respawn countdown, so the arena takes the
+        // choice away and puts the player straight into spectator for it.
+        plugin.getSpigotScheduler().runEntityLater(victim, () -> {
+            if (victim.isOnline() && victim.isDead()) {
+                victim.spigot().respawn();
+            }
+        }, 1L);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        if (pvp() == null || !pvp().isInArena(player.getUniqueId())) {
+            return;
+        }
+
+        Location spawn = pvp().getSpawn();
+        if (spawn != null) {
+            event.setRespawnLocation(spawn);
+        }
+
+        plugin.getSpigotScheduler().runEntityLater(player, () -> {
+            if (!player.isOnline() || !pvp().isInArena(player.getUniqueId())) {
+                return;
+            }
+            player.setGameMode(GameMode.SPECTATOR);
+            if (spawn != null) {
+                plugin.getSpigotScheduler().teleport(player, spawn);
+            }
+        }, 1L);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        if (pvp() != null) {
+            pvp().handleQuit(event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        if (pvp() != null) {
+            pvp().handleJoin(event.getPlayer());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        Player player = event.getPlayer();
+        if (pvp() == null || !pvp().isInArena(player.getUniqueId()) || !pvp().shouldBlockCommands()) {
+            return;
+        }
+        if (PermissionUtils.has(player, "ultimatedonutsmp.admin.pvp")) {
+            return;
+        }
+
+        String typed = event.getMessage().trim().toLowerCase();
+        String label = typed.startsWith("/") ? typed.substring(1) : typed;
+        int space = label.indexOf(' ');
+        if (space >= 0) {
+            label = label.substring(0, space);
+        }
+        if (ALWAYS_ALLOWED.contains(label)) {
+            return;
+        }
+
+        if (pvp().isBlockedCommand(event.getMessage())) {
+            event.setCancelled(true);
+            player.sendMessage(ColorUtils.toComponent(
+                    pvp().message("BLOCKED_COMMAND", "&cYou cannot use that command inside the PvP arena.")));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEnderChestOpen(InventoryOpenEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        if (pvp() == null || !pvp().isInArena(player.getUniqueId()) || !pvp().shouldBlockEnderChestBlock()) {
+            return;
+        }
+        if (PermissionUtils.has(player, "ultimatedonutsmp.admin.pvp")) {
+            return;
+        }
+
+        if (event.getInventory().getType() == InventoryType.ENDER_CHEST) {
+            event.setCancelled(true);
+            player.sendMessage(ColorUtils.toComponent(
+                    pvp().message("BLOCKED_COMMAND", "&cYou cannot use that command inside the PvP arena.")));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onDrop(PlayerDropItemEvent event) {
+        if (pvp() != null && pvp().isInArena(event.getPlayer().getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player) || pvp() == null) {
+            return;
+        }
+
+        PvpSession session = pvp().getSession(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        // A player who owes the arena a kit choice is standing there empty handed, and one inside
+        // the spawn window has not had a chance to move yet. Neither is a fair fight.
+        if (session.isAwaitingKit() || isSpawnProtected(session)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onDamageByEntity(EntityDamageByEntityEvent event) {
+        if (pvp() == null || !(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player attacker = resolveAttacker(event);
+        if (attacker == null) {
+            return;
+        }
+
+        PvpSession attackerSession = pvp().getSession(attacker.getUniqueId());
+        if (attackerSession != null && (attackerSession.isAwaitingKit() || isSpawnProtected(attackerSession))) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onWandUse(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (pvp() == null || event.getClickedBlock() == null || !pvp().isWand(event.getItem())) {
+            return;
+        }
+        if (!PermissionUtils.has(player, "ultimatedonutsmp.admin.pvp")) {
+            return;
+        }
+
+        Action action = event.getAction();
+        if (action != Action.LEFT_CLICK_BLOCK && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        event.setCancelled(true);
+        int corner = action == Action.LEFT_CLICK_BLOCK ? 1 : 2;
+        Location location = event.getClickedBlock().getLocation();
+        pvp().setWandSelection(player.getUniqueId(), corner, location);
+        player.sendMessage(ColorUtils.toComponent("&aCorner &f" + corner + " &aset to &f"
+                + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ()));
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEnderChestBlock(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (pvp() == null
+                || event.getAction() != Action.RIGHT_CLICK_BLOCK
+                || event.getClickedBlock() == null
+                || event.getClickedBlock().getType() != Material.ENDER_CHEST) {
+            return;
+        }
+        if (!pvp().isInArena(player.getUniqueId()) || !pvp().shouldBlockEnderChestBlock()) {
+            return;
+        }
+        if (PermissionUtils.has(player, "ultimatedonutsmp.admin.pvp")) {
+            return;
+        }
+
+        event.setCancelled(true);
+        player.sendMessage(ColorUtils.toComponent(
+                pvp().message("BLOCKED_COMMAND", "&cYou cannot use that command inside the PvP arena.")));
+    }
+
+    private boolean isSpawnProtected(PvpSession session) {
+        return session.isSpawnProtected(
+                System.currentTimeMillis(),
+                plugin.getConfigManager().getPvp().getInt("SETTINGS.SPAWN_PROTECTION_SECONDS", 3)
+        );
+    }
+
+    private Player resolveAttacker(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) {
+            return player;
+        }
+        if (event.getDamager() instanceof Projectile projectile && projectile.getShooter() instanceof Player player) {
+            return player;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -49,6 +49,7 @@ public class ConfigManager {
             "filter.yml",
             "duels.yml",
             "ffa.yml",
+            "pvp.yml",
             "crates.yml",
             "spawners.yml",
             "spawn-stash.yml",
@@ -87,6 +88,7 @@ public class ConfigManager {
     private FileConfiguration orders;
     private FileConfiguration duels;
     private FileConfiguration ffa;
+    private FileConfiguration pvp;
     private FileConfiguration crates;
     private FileConfiguration spawners;
     private FileConfiguration spawnStash;
@@ -133,6 +135,7 @@ public class ConfigManager {
         orders       = load("orders.yml", orders);
         duels        = load("duels.yml", duels);
         ffa          = load("ffa.yml", ffa);
+        pvp          = load("pvp.yml", pvp);
         crates       = load("crates.yml", crates);
         spawners     = load("spawners.yml", spawners);
         spawnStash   = load("spawn-stash.yml", spawnStash);
@@ -1891,6 +1894,16 @@ public class ConfigManager {
             return true;
         }
 
+        // The ranked arena writes its geometry and its kits from /pvp, so both trees are live
+        // server content and must survive a config update that would otherwise restore the
+        // bundled empty arena and kit list.
+        if ("pvp.yml".equals(resourceName)
+                && (path.equals("ARENA") || path.startsWith("ARENA.")
+                || path.equals("KITS") || path.startsWith("KITS.")
+                || path.equals("RANKS") || path.startsWith("RANKS."))) {
+            return true;
+        }
+
         // Bot settings and item definitions are customized by server admins.
         if (("orders.yml".equals(resourceName) || "auction-house.yml".equals(resourceName))
                 && (path.equals("BOTS") || path.startsWith("BOTS.") || path.equals("ITEMS") || path.startsWith("ITEMS."))) {
@@ -2138,10 +2151,12 @@ public class ConfigManager {
     public FileConfiguration getOrdersConfig()  { return getOrders(); }
     public FileConfiguration getDuels()         { return localized("CONFIG.DUELS", duels); }
     public FileConfiguration getFfa()           { return localized("CONFIG.FFA", ffa); }
+    public FileConfiguration getPvp()           { return localized("CONFIG.PVP", pvp); }
     public FileConfiguration getCrates()        { return localized("CONFIG.CRATES", crates); }
     public FileConfiguration getOriginalCrates() { return crates; }
     public FileConfiguration getOriginalDuels() { return duels; }
     public FileConfiguration getOriginalFfa() { return ffa; }
+    public FileConfiguration getOriginalPvp() { return pvp; }
     public FileConfiguration getOriginalMenus() { return menus; }
     public FileConfiguration getOriginalShop() { return shop; }
     public FileConfiguration getSpawners()      { return localized("CONFIG.SPAWNERS", spawners); }
@@ -2174,6 +2189,7 @@ public class ConfigManager {
     public void reloadOrders() { orders = load("orders.yml", orders); }
     public void reloadDuels() { duels = load("duels.yml", duels); }
     public void reloadFfa() { ffa = load("ffa.yml", ffa); }
+    public void reloadPvp() { pvp = load("pvp.yml", pvp); }
     public void reloadCrates() { crates = load("crates.yml", crates); }
     public void reloadSpawners() { spawners = load("spawners.yml", spawners); }
     public void reloadSpawnStash() { spawnStash = load("spawn-stash.yml", spawnStash); }
@@ -2188,6 +2204,7 @@ public class ConfigManager {
     public boolean saveConfig() { return save("config.yml", config); }
     public boolean saveDuels() { return save("duels.yml", duels); }
     public boolean saveFfa() { return save("ffa.yml", ffa); }
+    public boolean savePvp() { return save("pvp.yml", pvp); }
     public boolean saveCrates() { return save("crates.yml", crates); }
     public boolean saveShop() { return save("shop.yml", shop); }
     public boolean saveRtp() { return save("rtp.yml", rtp); }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -71,6 +71,8 @@ public class FeatureManager {
         ORDERS("ORDERS", "orders", "orders board commands, menus, and expiry task.", "WRITABLE_BOOK", null),
         DUELS("DUELS", "duels", "duel commands, queues, arenas, matches, and tasks.", "DIAMOND_SWORD", null),
         FFA("FFA", "ffa", "ffa commands, arenas, matches, and tasks.", "IRON_SWORD", null),
+        PVP_ARENA("PVP_ARENA", "ranked pvp arena",
+                "ranked pvp arena, kits, elo, levels, and scheduled resets.", "NETHERITE_SWORD", null),
         STAFF_MODE("STAFF_MODE", "staff mode", "staff mode command, hotbar, vanish, and staff tools.", "NETHERITE_CHESTPLATE", null),
         STAFF_CHAT("STAFF_CHAT", "staff chat", "staff chat command and network staff chat.", "ECHO_SHARD", null),
         STAFF_ALERTS("STAFF_ALERTS", "staff alerts", "helpop, reports, and network staff alerts.", "BELL", null),

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
@@ -1,0 +1,1362 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.menus.PvpKitMenu;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.models.PvpRank;
+import com.bx.ultimateDonutSmp.models.PvpSession;
+import com.bx.ultimateDonutSmp.models.PvpStats;
+import com.bx.ultimateDonutSmp.utils.AttributeUtils;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemSerializationUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.LocationUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The ranked PvP arena: sessions, kits, Elo, ranks, levels, and the scheduled schematic reset.
+ *
+ * <p>It deliberately owns no combat logic of its own. Damage, tagging and logout punishment stay
+ * with whatever combat plugin the server already runs, and this class only reacts to the deaths
+ * that come out of it.</p>
+ */
+public class PvpManager {
+
+    private static final Pattern DURATION_PATTERN = Pattern.compile("(\\d+)\\s*([dhms])", Pattern.CASE_INSENSITIVE);
+    private static final String WAND_NAME = "&cPvP Arena Wand";
+    private static final String WAND_KEY = "pvp_arena_wand";
+
+    private final UltimateDonutSmp plugin;
+
+    private final Map<UUID, PvpSession> sessions = new ConcurrentHashMap<>();
+    private final Map<UUID, PvpStats> statsCache = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<UUID, KillRecord>> killHistory = new ConcurrentHashMap<>();
+    private final Map<UUID, Location[]> wandSelections = new ConcurrentHashMap<>();
+    private final Map<String, PvpKit> kits = new LinkedHashMap<>();
+    private final List<PvpRank> ranks = new ArrayList<>();
+    private final java.util.Set<UUID> lobbyOnRejoin = ConcurrentHashMap.newKeySet();
+
+    private long nextResetAt;
+    private boolean resetWarningSent;
+
+    public PvpManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        ensureTables();
+        loadRanks();
+        loadKits();
+        scheduleNextReset();
+    }
+
+    // ── Configuration ─────────────────────────────────────────────────────────
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getPvp();
+    }
+
+    public boolean isEnabled() {
+        return config().getBoolean("SETTINGS.ENABLED", false);
+    }
+
+    /** True once the arena has at least a spawn point, which is the minimum to let players in. */
+    public boolean isConfigured() {
+        return getSpawn() != null;
+    }
+
+    public void reload() {
+        loadRanks();
+        loadKits();
+        scheduleNextReset();
+    }
+
+    public void shutdown() {
+        for (UUID uuid : new ArrayList<>(sessions.keySet())) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                removeFromArena(player, true);
+            }
+        }
+        sessions.clear();
+        for (Map.Entry<UUID, PvpStats> entry : statsCache.entrySet()) {
+            saveStats(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void loadRanks() {
+        ranks.clear();
+        ConfigurationSection section = config().getConfigurationSection("RANKS");
+        if (section == null) {
+            return;
+        }
+
+        for (String id : section.getKeys(false)) {
+            ranks.add(new PvpRank(
+                    id,
+                    section.getString(id + ".DISPLAY", id),
+                    section.getInt(id + ".ELO", 0)
+            ));
+        }
+        ranks.sort(Comparator.comparingInt(PvpRank::getEloRequirement));
+    }
+
+    // ── Ranks, levels and Elo ─────────────────────────────────────────────────
+
+    public List<PvpRank> getRanks() {
+        return List.copyOf(ranks);
+    }
+
+    public PvpRank getRankFor(int elo) {
+        return PvpRank.resolve(ranks, elo);
+    }
+
+    public PvpRank getRank(UUID uuid) {
+        return getRankFor(getStats(uuid).getElo());
+    }
+
+    public String getRankDisplay(UUID uuid) {
+        PvpRank rank = getRank(uuid);
+        return rank == null ? "" : rank.getDisplay();
+    }
+
+    /**
+     * XP needed to move from {@code level} to the next one.
+     *
+     * <p>Level 1 costs the configured base, and every level after it costs one more increment,
+     * so the curve stays a straight line an owner can reason about from two numbers.</p>
+     */
+    public static int xpForLevel(int level, int baseXp, int increasePerLevel) {
+        int normalized = Math.max(1, level);
+        return Math.max(1, baseXp + (normalized - 1) * increasePerLevel);
+    }
+
+    public int getXpForNextLevel(int level) {
+        return xpForLevel(
+                level,
+                config().getInt("LEVELS.BASE_XP", 100),
+                config().getInt("LEVELS.XP_INCREASE_PER_LEVEL", 50)
+        );
+    }
+
+    // ── Stats ─────────────────────────────────────────────────────────────────
+
+    public PvpStats getStats(UUID uuid) {
+        if (uuid == null) {
+            return PvpStats.starting(config().getInt("ELO.STARTING", 0));
+        }
+        return statsCache.computeIfAbsent(uuid, this::loadStats);
+    }
+
+    private void updateStats(UUID uuid, PvpStats stats) {
+        if (uuid == null || stats == null) {
+            return;
+        }
+        statsCache.put(uuid, stats);
+        saveStats(uuid, stats);
+    }
+
+    /** The Elo ladder, best first. Reads straight from the database so offline players count. */
+    public List<TopEntry> getTop(int limit) {
+        List<TopEntry> top = new ArrayList<>();
+        Connection connection = connection();
+        if (connection == null) {
+            return top;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "select player_uuid, elo from pvp_stats order by elo desc limit ?")) {
+            ps.setInt(1, Math.max(1, limit));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    UUID uuid = parseUuid(rs.getString("player_uuid"));
+                    if (uuid == null) {
+                        continue;
+                    }
+                    String name = plugin.getDatabaseManager().getLastKnownUsername(uuid);
+                    if (name == null || name.isBlank()) {
+                        name = Bukkit.getOfflinePlayer(uuid).getName();
+                    }
+                    top.add(new TopEntry(uuid, name == null ? uuid.toString() : name, rs.getInt("elo")));
+                }
+            }
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to read the PvP leaderboard", exception);
+        }
+        return top;
+    }
+
+    // ── Arena geometry ────────────────────────────────────────────────────────
+
+    public String getArenaName() {
+        return config().getString("ARENA.NAME", "Arena");
+    }
+
+    public Location getSpawn() {
+        return LocationUtils.parse(config().getString("ARENA.SPAWN", ""));
+    }
+
+    public Location getLobby() {
+        Location lobby = LocationUtils.parse(config().getString("ARENA.LOBBY", ""));
+        if (lobby != null) {
+            return lobby;
+        }
+        return plugin.getSpawnManager() == null ? null : plugin.getSpawnManager().getSpawnLocation();
+    }
+
+    public World getArenaWorld() {
+        String configured = config().getString("ARENA.WORLD", "");
+        if (configured != null && !configured.isBlank()) {
+            World world = Bukkit.getWorld(configured);
+            if (world != null) {
+                return world;
+            }
+        }
+        Location spawn = getSpawn();
+        return spawn == null ? null : spawn.getWorld();
+    }
+
+    public void setSpawn(Location location) {
+        writeConfig("ARENA.SPAWN", LocationUtils.serialize(location));
+        if (location != null && location.getWorld() != null) {
+            writeConfig("ARENA.WORLD", location.getWorld().getName());
+        }
+    }
+
+    public void setLobby(Location location) {
+        writeConfig("ARENA.LOBBY", LocationUtils.serialize(location));
+    }
+
+    public void setArenaName(String name) {
+        writeConfig("ARENA.NAME", name);
+    }
+
+    /** Stores one of the two boundary corners. {@code index} is 1 or 2. */
+    public void setBoundaryCorner(int index, Location location) {
+        writeConfig(index <= 1 ? "ARENA.BOUNDARY_POS1" : "ARENA.BOUNDARY_POS2", LocationUtils.serialize(location));
+    }
+
+    public boolean hasBoundary() {
+        return LocationUtils.parse(config().getString("ARENA.BOUNDARY_POS1", "")) != null
+                && LocationUtils.parse(config().getString("ARENA.BOUNDARY_POS2", "")) != null;
+    }
+
+    /**
+     * Whether a location still counts as inside the arena.
+     *
+     * <p>With both wand corners set this is the cuboid between them plus the configured padding.
+     * With no corners set the whole arena world counts, which is the sane reading for a server
+     * that dedicates a world to the arena.</p>
+     */
+    public boolean isInsideArena(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+
+        World arenaWorld = getArenaWorld();
+        if (arenaWorld == null || !arenaWorld.getName().equals(location.getWorld().getName())) {
+            return false;
+        }
+
+        Location first = LocationUtils.parse(config().getString("ARENA.BOUNDARY_POS1", ""));
+        Location second = LocationUtils.parse(config().getString("ARENA.BOUNDARY_POS2", ""));
+        if (first == null || second == null) {
+            return true;
+        }
+
+        double padding = Math.max(0, config().getInt("ARENA.BOUNDARY_PADDING", 2));
+        return location.getX() >= Math.min(first.getX(), second.getX()) - padding
+                && location.getX() <= Math.max(first.getX(), second.getX()) + padding
+                && location.getY() >= Math.min(first.getY(), second.getY()) - padding
+                && location.getY() <= Math.max(first.getY(), second.getY()) + padding
+                && location.getZ() >= Math.min(first.getZ(), second.getZ()) - padding
+                && location.getZ() <= Math.max(first.getZ(), second.getZ()) + padding;
+    }
+
+    // ── Wand ──────────────────────────────────────────────────────────────────
+
+    public ItemStack createWand() {
+        ItemStack wand = ItemUtils.createItem(Material.GOLDEN_AXE, WAND_NAME, List.of(
+                "&7Left click a block to set corner &f1",
+                "&7Right click a block to set corner &f2",
+                "&7Then run &f/pvp setboundary"
+        ));
+        ItemMeta meta = wand.getItemMeta();
+        if (meta != null) {
+            meta.getPersistentDataContainer().set(plugin.getKey(WAND_KEY), PersistentDataType.BYTE, (byte) 1);
+            wand.setItemMeta(meta);
+        }
+        return wand;
+    }
+
+    /** Identified by a data tag rather than its name, so renaming it on an anvil cannot break it. */
+    public boolean isWand(ItemStack item) {
+        if (item == null || item.getType() != Material.GOLDEN_AXE || !item.hasItemMeta()) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        return meta != null
+                && meta.getPersistentDataContainer().has(plugin.getKey(WAND_KEY), PersistentDataType.BYTE);
+    }
+
+    public void setWandSelection(UUID uuid, int index, Location location) {
+        Location[] selection = wandSelections.computeIfAbsent(uuid, key -> new Location[2]);
+        selection[index <= 1 ? 0 : 1] = location;
+    }
+
+    public Location getWandSelection(UUID uuid, int index) {
+        Location[] selection = wandSelections.get(uuid);
+        return selection == null ? null : selection[index <= 1 ? 0 : 1];
+    }
+
+    // ── Kits ──────────────────────────────────────────────────────────────────
+
+    public List<PvpKit> getKits() {
+        return List.copyOf(kits.values());
+    }
+
+    public PvpKit getKit(String id) {
+        return id == null ? null : kits.get(id.toLowerCase(Locale.ROOT));
+    }
+
+    public boolean canUseKit(Player player, PvpKit kit) {
+        if (player == null || kit == null) {
+            return false;
+        }
+        String permission = kit.getPermission();
+        return permission == null || permission.isBlank() || PermissionUtils.has(player, permission);
+    }
+
+    /** The kits a player is actually allowed to pick, in menu order. */
+    public List<PvpKit> getAvailableKits(Player player) {
+        List<PvpKit> available = new ArrayList<>();
+        for (PvpKit kit : kits.values()) {
+            if (canUseKit(player, kit)) {
+                available.add(kit);
+            }
+        }
+        return available;
+    }
+
+    public PvpKit createKit(String id) {
+        String normalized = id.toLowerCase(Locale.ROOT);
+        PvpKit kit = new PvpKit(normalized);
+        kits.put(normalized, kit);
+        saveKit(kit);
+        return kit;
+    }
+
+    public boolean deleteKit(String id) {
+        if (id == null) {
+            return false;
+        }
+        String normalized = id.toLowerCase(Locale.ROOT);
+        if (kits.remove(normalized) == null) {
+            return false;
+        }
+        writeConfig("KITS." + normalized, null);
+        return true;
+    }
+
+    public void giveKit(Player player, PvpKit kit) {
+        if (player == null || kit == null) {
+            return;
+        }
+
+        PlayerInventory inventory = player.getInventory();
+        inventory.clear();
+        for (int slot = 0; slot < PvpKit.CONTENT_SIZE; slot++) {
+            ItemStack item = kit.getContents()[slot];
+            inventory.setItem(slot, item == null ? null : item.clone());
+        }
+        ItemStack[] armor = new ItemStack[4];
+        for (int slot = 0; slot < 4; slot++) {
+            ItemStack piece = kit.getArmor()[slot];
+            armor[slot] = piece == null ? null : piece.clone();
+        }
+        inventory.setArmorContents(armor);
+        inventory.setItemInOffHand(kit.getOffhand() == null ? null : kit.getOffhand().clone());
+
+        for (PotionEffect effect : kit.getEffects()) {
+            player.addPotionEffect(effect);
+        }
+        player.updateInventory();
+    }
+
+    private void loadKits() {
+        kits.clear();
+        ConfigurationSection section = config().getConfigurationSection("KITS");
+        if (section == null) {
+            return;
+        }
+
+        for (String id : section.getKeys(false)) {
+            PvpKit kit = new PvpKit(id.toLowerCase(Locale.ROOT));
+            kit.setDisplayName(section.getString(id + ".DISPLAY", "&f" + id));
+            kit.setIcon(ItemUtils.parseMaterial(section.getString(id + ".ICON", "IRON_SWORD")));
+            kit.setPermission(section.getString(id + ".PERMISSION", ""));
+            kit.setMenuSlot(section.getInt(id + ".SLOT", -1));
+
+            readItems(section.getConfigurationSection(id + ".CONTENTS"), kit.getContents());
+            readItems(section.getConfigurationSection(id + ".ARMOR"), kit.getArmor());
+            kit.setOffhand(readItem(section.getString(id + ".OFFHAND", "")));
+
+            List<PotionEffect> effects = new ArrayList<>();
+            for (String raw : section.getStringList(id + ".EFFECTS")) {
+                PotionEffect effect = parseEffect(raw);
+                if (effect != null) {
+                    effects.add(effect);
+                }
+            }
+            kit.setEffects(effects);
+            kits.put(kit.getId(), kit);
+        }
+    }
+
+    public void saveKit(PvpKit kit) {
+        FileConfiguration pvp = plugin.getConfigManager().getOriginalPvp();
+        if (pvp == null || kit == null) {
+            return;
+        }
+
+        String root = "KITS." + kit.getId();
+        pvp.set(root, null);
+        pvp.set(root + ".DISPLAY", kit.getDisplayName());
+        pvp.set(root + ".ICON", kit.getIcon().name());
+        pvp.set(root + ".PERMISSION", kit.getPermission());
+        pvp.set(root + ".SLOT", kit.getMenuSlot());
+        writeItems(pvp, root + ".CONTENTS", kit.getContents());
+        writeItems(pvp, root + ".ARMOR", kit.getArmor());
+        pvp.set(root + ".OFFHAND", writeItem(kit.getOffhand()));
+
+        List<String> effects = new ArrayList<>();
+        for (PotionEffect effect : kit.getEffects()) {
+            effects.add(effect.getType().getName() + ":" + effect.getAmplifier() + ":" + effect.getDuration());
+        }
+        pvp.set(root + ".EFFECTS", effects);
+        plugin.getConfigManager().savePvp();
+    }
+
+    private void readItems(ConfigurationSection section, ItemStack[] target) {
+        if (section == null) {
+            return;
+        }
+        for (String key : section.getKeys(false)) {
+            int slot = parseInt(key, -1);
+            if (slot < 0 || slot >= target.length) {
+                continue;
+            }
+            target[slot] = readItem(section.getString(key, ""));
+        }
+    }
+
+    private ItemStack readItem(String encoded) {
+        if (encoded == null || encoded.isBlank()) {
+            return null;
+        }
+        try {
+            return ItemSerializationUtils.deserialize(encoded);
+        } catch (IOException | ClassNotFoundException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to read a stored PvP kit item", exception);
+            return null;
+        }
+    }
+
+    private void writeItems(FileConfiguration pvp, String root, ItemStack[] items) {
+        for (int slot = 0; slot < items.length; slot++) {
+            ItemStack item = items[slot];
+            if (item == null || item.getType() == Material.AIR) {
+                continue;
+            }
+            pvp.set(root + "." + slot, writeItem(item));
+        }
+    }
+
+    private String writeItem(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR) {
+            return null;
+        }
+        try {
+            return ItemSerializationUtils.serialize(item);
+        } catch (IOException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to store a PvP kit item", exception);
+            return null;
+        }
+    }
+
+    private PotionEffect parseEffect(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        String[] parts = raw.split(":");
+        org.bukkit.potion.PotionEffectType type = org.bukkit.potion.PotionEffectType.getByName(parts[0].trim());
+        if (type == null) {
+            return null;
+        }
+        int amplifier = parts.length > 1 ? parseInt(parts[1], 0) : 0;
+        int duration = parts.length > 2 ? parseInt(parts[2], 20 * 60) : 20 * 60;
+        return new PotionEffect(type, duration, amplifier, false, false);
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────────────
+
+    public boolean isInArena(UUID uuid) {
+        return uuid != null && sessions.containsKey(uuid);
+    }
+
+    public PvpSession getSession(UUID uuid) {
+        return uuid == null ? null : sessions.get(uuid);
+    }
+
+    public int getArenaPlayerCount() {
+        return sessions.size();
+    }
+
+    /**
+     * Puts a player into the arena and asks them for a kit.
+     *
+     * @return false when the arena is off, unconfigured, has no kits, or the player is already in
+     */
+    public boolean join(Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        if (!isEnabled()) {
+            send(player, message("DISABLED", "&cThe PvP arena is not enabled."));
+            return false;
+        }
+        if (!isConfigured()) {
+            send(player, message("NOT_SET_UP", "&cThe PvP arena has not been set up yet."));
+            return false;
+        }
+        if (isInArena(player.getUniqueId())) {
+            send(player, message("ALREADY_IN", "&cYou are already in the PvP arena."));
+            return false;
+        }
+        if (getAvailableKits(player).isEmpty()) {
+            send(player, message("NO_KITS", "&cThere are no PvP kits to choose from yet."));
+            return false;
+        }
+
+        PvpSession session = new PvpSession(player.getUniqueId(), System.currentTimeMillis());
+        sessions.put(player.getUniqueId(), session);
+        updateStats(player.getUniqueId(), getStats(player.getUniqueId()).recordArenaJoin());
+
+        Location spawn = getSpawn();
+        plugin.getSpigotScheduler().teleport(player, spawn).thenRun(() ->
+                plugin.getSpigotScheduler().runEntity(player, () -> openKitMenu(player)));
+        send(player, message("JOINED", "&aYou joined the PvP arena."));
+        return true;
+    }
+
+    public void leave(Player player) {
+        if (player == null || !isInArena(player.getUniqueId())) {
+            if (player != null) {
+                send(player, message("NOT_IN", "&cYou are not in the PvP arena."));
+            }
+            return;
+        }
+        removeFromArena(player, false);
+        send(player, message("LEFT", "&aYou left the PvP arena."));
+    }
+
+    /**
+     * Takes a player out of the arena and sends them to the lobby.
+     *
+     * @param silent true during shutdown, where messages would never reach the client anyway
+     */
+    public void removeFromArena(Player player, boolean silent) {
+        if (player == null) {
+            return;
+        }
+
+        sessions.remove(player.getUniqueId());
+        killHistory.remove(player.getUniqueId());
+        takeKitBack(player);
+        if (player.getGameMode() == GameMode.SPECTATOR) {
+            player.setGameMode(GameMode.SURVIVAL);
+        }
+
+        Location lobby = getLobby();
+        if (lobby != null && !silent) {
+            plugin.getSpigotScheduler().teleport(player, lobby);
+        }
+        if (plugin.getScoreboardManager() != null) {
+            plugin.getScoreboardManager().invalidatePlayer(player);
+        }
+    }
+
+    /**
+     * Empties the kit out of a player on their way back to survival.
+     *
+     * <p>Switched off, nothing is touched on the way out. That is the right setting on a server
+     * where Multiverse-Inventories - or anything else that separates inventories per world -
+     * already owns this, since the arena clearing an inventory it does not own would undo that
+     * plugin's work rather than help it.</p>
+     */
+    private void takeKitBack(Player player) {
+        if (!config().getBoolean("SETTINGS.CLEAR_KIT_ON_LEAVE", true)) {
+            return;
+        }
+
+        player.getInventory().clear();
+        player.getInventory().setArmorContents(new ItemStack[4]);
+        player.getInventory().setItemInOffHand(null);
+        for (PotionEffect effect : new ArrayList<>(player.getActivePotionEffects())) {
+            player.removePotionEffect(effect.getType());
+        }
+    }
+
+    public void openKitMenu(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        new PvpKitMenu(plugin).open(player);
+    }
+
+    /**
+     * Reopens the picker when it is closed with no kit taken.
+     *
+     * <p>A player in the arena with no kit cannot fight and cannot be fought, so closing the menu
+     * to escape it would leave them a permanent spectator. The check runs a tick later because
+     * taking a kit closes the menu too, and by then the session says a kit was chosen.</p>
+     */
+    public void handleKitMenuClosed(Player player) {
+        if (player == null) {
+            return;
+        }
+        plugin.getSpigotScheduler().runEntityLater(player, () -> {
+            PvpSession session = getSession(player.getUniqueId());
+            if (player.isOnline() && session != null && session.isAwaitingKit() && session.getRespawnAt() <= 0) {
+                openKitMenu(player);
+            }
+        }, 1L);
+    }
+
+    /** Hands a player their chosen kit and drops them back onto the arena spawn. */
+    public void selectKit(Player player, PvpKit kit) {
+        PvpSession session = getSession(player.getUniqueId());
+        if (session == null || kit == null) {
+            return;
+        }
+        if (!canUseKit(player, kit)) {
+            send(player, message("KIT_NO_PERMISSION", "&cYou do not have access to that kit."));
+            return;
+        }
+
+        session.setKitId(kit.getId());
+        session.setAwaitingKit(false);
+        session.setRespawnAt(0L);
+        session.setSpawnedAt(System.currentTimeMillis());
+
+        player.setGameMode(GameMode.SURVIVAL);
+        if (config().getBoolean("SETTINGS.HEAL_ON_SPAWN", true)) {
+            heal(player);
+        }
+        giveKit(player, kit);
+
+        Location spawn = getSpawn();
+        if (spawn != null) {
+            plugin.getSpigotScheduler().teleport(player, spawn);
+        }
+        send(player, message("KIT_GIVEN", "&aYou picked the &f{kit} &akit.")
+                .replace("{kit}", ColorUtils.strip(ColorUtils.colorize(kit.getDisplayName()))));
+    }
+
+    private void heal(Player player) {
+        player.setHealth(Math.max(1.0D, AttributeUtils.getMaxHealth(player)));
+        player.setFoodLevel(20);
+        player.setSaturation(20F);
+        player.setFireTicks(0);
+        for (PotionEffect effect : new ArrayList<>(player.getActivePotionEffects())) {
+            player.removePotionEffect(effect.getType());
+        }
+    }
+
+    // ── Death, respawn, connection ────────────────────────────────────────────
+
+    /** Called from the death event once the arena has been confirmed as the place it happened. */
+    public void handleDeath(Player victim, Player killer) {
+        PvpSession session = getSession(victim.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        session.setAwaitingKit(true);
+        session.setKitId(null);
+        session.setSpawnedAt(0L);
+        session.setRespawnAt(System.currentTimeMillis()
+                + Math.max(0, config().getInt("SETTINGS.RESPAWN_DELAY_SECONDS", 3)) * 1000L);
+
+        updateStats(victim.getUniqueId(), getStats(victim.getUniqueId()).recordDeath());
+
+        if (killer == null || killer.getUniqueId().equals(victim.getUniqueId())) {
+            return;
+        }
+        if (!isInArena(killer.getUniqueId())) {
+            return;
+        }
+        awardKill(killer, victim);
+    }
+
+    /**
+     * Applies the Elo, XP, rank and level changes for one arena kill.
+     *
+     * <p>Kill-farm protection only reduces the reward, it never refuses to count the kill, so the
+     * K/D and streak on the scoreboard still describe what actually happened in the arena.</p>
+     */
+    private void awardKill(Player killer, Player victim) {
+        boolean rewarded = registerKill(killer.getUniqueId(), victim.getUniqueId());
+
+        int eloGain = rewarded
+                ? config().getInt("ELO.GAIN_PER_KILL", 25)
+                : config().getInt("ANTI_KILL_FARMING.REDUCED_ELO", 0);
+        int xpGain = rewarded
+                ? config().getInt("LEVELS.XP_PER_KILL", 50)
+                : config().getInt("ANTI_KILL_FARMING.REDUCED_XP", 0);
+        int eloLoss = rewarded || config().getBoolean("ANTI_KILL_FARMING.APPLY_ELO_LOSS", false)
+                ? config().getInt("ELO.LOSS_PER_DEATH", 20)
+                : 0;
+
+        PvpStats killerStats = getStats(killer.getUniqueId()).recordKill();
+        PvpRank oldRank = getRankFor(killerStats.getElo());
+        int oldLevel = killerStats.getLevel();
+
+        killerStats = killerStats.withElo(clampElo(killerStats.getElo() + eloGain));
+        killerStats = applyXp(killerStats, xpGain);
+        updateStats(killer.getUniqueId(), killerStats);
+
+        PvpStats victimBefore = getStats(victim.getUniqueId());
+        PvpRank victimOldRank = getRankFor(victimBefore.getElo());
+        PvpStats victimStats = victimBefore.withElo(clampElo(victimBefore.getElo() - eloLoss));
+        updateStats(victim.getUniqueId(), victimStats);
+
+        if (rewarded) {
+            send(killer, message("KILL_REWARD", "&8[&cPVP&8] &7You killed &f{victim} &8(&c+{elo} elo&8, &c+{xp} xp&8)")
+                    .replace("{victim}", victim.getName())
+                    .replace("{elo}", String.valueOf(eloGain))
+                    .replace("{xp}", String.valueOf(xpGain)));
+        } else {
+            send(killer, message("KILL_FARM_LIMIT", "&7No reward - you have already killed &f{victim} &7too recently.")
+                    .replace("{victim}", victim.getName()));
+        }
+        send(victim, message("DEATH_PENALTY", "&8[&cPVP&8] &f{killer} &7killed you &8(&c-{elo} elo&8)")
+                .replace("{killer}", killer.getName())
+                .replace("{elo}", String.valueOf(eloLoss)));
+
+        announceLevel(killer, oldLevel, killerStats);
+        announceRank(killer, oldRank, getRankFor(killerStats.getElo()), killerStats);
+        announceRank(victim, victimOldRank, getRankFor(victimStats.getElo()), victimStats);
+    }
+
+    private int clampElo(int elo) {
+        int minimum = config().getInt("ELO.MINIMUM", 0);
+        int maximum = config().getInt("ELO.MAXIMUM", 0);
+        int clamped = Math.max(minimum, elo);
+        return maximum > 0 ? Math.min(maximum, clamped) : clamped;
+    }
+
+    /** Adds XP and rolls the player up as many levels as it pays for. */
+    private PvpStats applyXp(PvpStats stats, int xpGain) {
+        if (xpGain <= 0) {
+            return stats;
+        }
+
+        int maxLevel = config().getInt("LEVELS.MAX_LEVEL", 100);
+        int level = stats.getLevel();
+        int xp = stats.getXp() + xpGain;
+
+        while (maxLevel <= 0 || level < maxLevel) {
+            int needed = getXpForNextLevel(level);
+            if (xp < needed) {
+                break;
+            }
+            xp -= needed;
+            level++;
+        }
+
+        if (maxLevel > 0 && level >= maxLevel) {
+            level = maxLevel;
+            xp = 0;
+        }
+        return stats.withProgress(level, xp);
+    }
+
+    public void handleQuit(Player player) {
+        if (player == null || !isInArena(player.getUniqueId())) {
+            return;
+        }
+
+        sessions.remove(player.getUniqueId());
+        killHistory.remove(player.getUniqueId());
+        if (config().getBoolean("SETTINGS.LOBBY_ON_REJOIN", true)) {
+            lobbyOnRejoin.add(player.getUniqueId());
+        }
+        takeKitBack(player);
+    }
+
+    /** Sends a player who logged out inside the arena back to the lobby on their next join. */
+    public void handleJoin(Player player) {
+        if (player == null || !lobbyOnRejoin.remove(player.getUniqueId())) {
+            return;
+        }
+
+        Location lobby = getLobby();
+        if (lobby != null) {
+            plugin.getSpigotScheduler().runEntityLater(player, () -> {
+                if (player.isOnline()) {
+                    plugin.getSpigotScheduler().teleport(player, lobby);
+                    if (player.getGameMode() == GameMode.SPECTATOR) {
+                        player.setGameMode(GameMode.SURVIVAL);
+                    }
+                }
+            }, 10L);
+        }
+    }
+
+    // ── Anti kill-farming ─────────────────────────────────────────────────────
+
+    /**
+     * Records a kill and says whether it earns full rewards.
+     *
+     * <p>The counter for a victim expires after the configured cooldown, so a pair who keep
+     * meeting over a long session never permanently lock each other out of rewards.</p>
+     */
+    public boolean registerKill(UUID killer, UUID victim) {
+        if (!config().getBoolean("ANTI_KILL_FARMING.ENABLED", true)) {
+            return true;
+        }
+
+        long now = System.currentTimeMillis();
+        long cooldown = parseDuration(config().getString("ANTI_KILL_FARMING.COOLDOWN", "5m"));
+        int limit = Math.max(0, config().getInt("ANTI_KILL_FARMING.MAX_REWARDED_KILLS", 3));
+
+        Map<UUID, KillRecord> victims = killHistory.computeIfAbsent(killer, key -> new ConcurrentHashMap<>());
+        KillRecord record = victims.get(victim);
+        if (record == null || (cooldown > 0 && now - record.lastKillAt() > cooldown)) {
+            victims.put(victim, new KillRecord(1, now));
+            return limit > 0;
+        }
+
+        int count = record.count() + 1;
+        victims.put(victim, new KillRecord(count, now));
+        return count <= limit;
+    }
+
+    // ── Broadcasts ────────────────────────────────────────────────────────────
+
+    private void announceLevel(Player player, int oldLevel, PvpStats stats) {
+        if (stats.getLevel() <= oldLevel) {
+            return;
+        }
+
+        send(player, message("LEVEL_UP", "&aYou reached PvP Level &f{level}&a!")
+                .replace("{level}", String.valueOf(stats.getLevel())));
+
+        String template = config().getString("BROADCASTS.LEVEL_UP.MESSAGE", "");
+        if (template == null || template.isBlank()) {
+            return;
+        }
+        broadcast(player, stats, oldLevel, null,
+                config().getBoolean("BROADCASTS.LEVEL_UP.GLOBAL", true), template);
+    }
+
+    private void announceRank(Player player, PvpRank oldRank, PvpRank newRank, PvpStats stats) {
+        if (oldRank == null || newRank == null || oldRank.getId().equals(newRank.getId())) {
+            return;
+        }
+
+        boolean up = newRank.getEloRequirement() > oldRank.getEloRequirement();
+        send(player, message(up ? "RANK_UP" : "RANK_DOWN",
+                up ? "&aYou ranked up to {rank}&a!" : "&cYou dropped to {rank}&c.")
+                .replace("{rank}", newRank.getDisplay()));
+
+        String root = up ? "BROADCASTS.RANK_UP" : "BROADCASTS.RANK_DOWN";
+        String template = config().getString(root + ".MESSAGE", "");
+        if (template == null || template.isBlank()) {
+            return;
+        }
+        broadcast(player, stats, stats.getLevel(), oldRank,
+                config().getBoolean(root + ".GLOBAL", up), template);
+    }
+
+    /**
+     * Sends a progression announcement.
+     *
+     * <p>The placeholders are filled in here rather than left to PlaceholderAPI, so the message
+     * still reads correctly on a server that does not run PlaceholderAPI at all, and so a global
+     * broadcast describes the player it is about instead of whoever is reading it.</p>
+     */
+    private void broadcast(Player player, PvpStats stats, int oldLevel, PvpRank oldRank, boolean global, String template) {
+        PvpRank rank = getRankFor(stats.getElo());
+        String text = template
+                .replace("%player_name%", player.getName())
+                .replace("%pvp_level%", String.valueOf(stats.getLevel()))
+                .replace("%pvp_old_level%", String.valueOf(oldLevel))
+                .replace("%pvp_rank%", rank == null ? "" : rank.getDisplay())
+                .replace("%pvp_old_rank%", oldRank == null ? "" : oldRank.getDisplay())
+                .replace("%pvp_elo%", String.valueOf(stats.getElo()))
+                .replace("%pvp_xp%", String.valueOf(stats.getXp()));
+
+        if (global) {
+            broadcastToServer(text);
+        } else {
+            send(player, text);
+        }
+    }
+
+    // ── Blocked commands ──────────────────────────────────────────────────────
+
+    public boolean shouldBlockCommands() {
+        return config().getBoolean("BLOCKED_COMMANDS.ENABLED", true);
+    }
+
+    public boolean shouldBlockEnderChestBlock() {
+        return config().getBoolean("BLOCKED_COMMANDS.BLOCK_ENDER_CHEST_BLOCK", true);
+    }
+
+    /** Matches a typed command against the blocked list, ignoring the slash and any arguments. */
+    public boolean isBlockedCommand(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return false;
+        }
+
+        String typed = raw.trim().toLowerCase(Locale.ROOT);
+        if (typed.startsWith("/")) {
+            typed = typed.substring(1);
+        }
+        int space = typed.indexOf(' ');
+        String label = space < 0 ? typed : typed.substring(0, space);
+
+        for (String blocked : config().getStringList("BLOCKED_COMMANDS.COMMANDS")) {
+            if (blocked == null || blocked.isBlank()) {
+                continue;
+            }
+            String normalized = blocked.trim().toLowerCase(Locale.ROOT);
+            if (normalized.startsWith("/")) {
+                normalized = normalized.substring(1);
+            }
+            if (label.equals(normalized) || label.endsWith(":" + normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ── Scoreboard ────────────────────────────────────────────────────────────
+
+    public boolean hasArenaScoreboard(Player player) {
+        return player != null
+                && isEnabled()
+                && isInArena(player.getUniqueId())
+                && config().getBoolean("SCOREBOARD.ENABLED", true);
+    }
+
+    public List<String> getScoreboardTitles() {
+        return config().getStringList("SCOREBOARD.TITLE");
+    }
+
+    public List<String> getScoreboardLines() {
+        return config().getStringList("SCOREBOARD.LINES");
+    }
+
+    // ── Arena reset ───────────────────────────────────────────────────────────
+
+    public boolean isResetEnabled() {
+        return config().getBoolean("RESET.ENABLED", false)
+                && parseDuration(config().getString("RESET.INTERVAL", "24h")) > 0;
+    }
+
+    /** Milliseconds until the next scheduled reset, or -1 when resets are switched off. */
+    public long getMillisUntilReset() {
+        if (!isResetEnabled() || nextResetAt <= 0) {
+            return -1L;
+        }
+        return Math.max(0L, nextResetAt - System.currentTimeMillis());
+    }
+
+    public String getFormattedReset() {
+        long remaining = getMillisUntilReset();
+        if (remaining < 0) {
+            return config().getString("SCOREBOARD.RESET_DISABLED_TEXT", "&7-");
+        }
+        return formatDuration(remaining, config().getString("SCOREBOARD.RESET_FORMAT", "{d}D:{h}H:{m}M:{s}S"));
+    }
+
+    public void setResetSchematic(String schematic) {
+        writeConfig("RESET.SCHEMATIC", schematic == null ? "" : schematic.trim());
+    }
+
+    public void setPasteLocation(Location location) {
+        writeConfig("RESET.PASTE_LOCATION", LocationUtils.serialize(location));
+    }
+
+    private void scheduleNextReset() {
+        long interval = parseDuration(config().getString("RESET.INTERVAL", "24h"));
+        nextResetAt = isResetEnabled() ? System.currentTimeMillis() + interval : 0L;
+        resetWarningSent = false;
+    }
+
+    /**
+     * Runs the configured reset commands from console.
+     *
+     * <p>Going through the commands instead of a compiled WorldEdit dependency is deliberate: the
+     * same two lines drive WorldEdit and FastAsyncWorldEdit, so a server can swap between them
+     * without the plugin caring, and one that runs neither simply has the feature switched off.</p>
+     */
+    public void resetArena(CommandSender initiator) {
+        String schematic = config().getString("RESET.SCHEMATIC", "");
+        List<String> commands = config().getStringList("RESET.COMMANDS");
+        if (schematic == null || schematic.isBlank() || commands.isEmpty()) {
+            if (initiator != null) {
+                send(initiator, message("RESET_NO_SCHEMATIC", "&cNo schematic is configured for the arena reset."));
+            }
+            return;
+        }
+
+        if (config().getBoolean("RESET.EVACUATE", true)) {
+            for (UUID uuid : new ArrayList<>(sessions.keySet())) {
+                Player player = Bukkit.getPlayer(uuid);
+                if (player != null) {
+                    removeFromArena(player, false);
+                }
+            }
+        }
+
+        Location paste = LocationUtils.parse(config().getString("RESET.PASTE_LOCATION", ""));
+        long delay = Math.max(0, config().getInt("RESET.PASTE_DELAY_SECONDS", 5)) * 20L;
+
+        // The first command loads the schematic into the console's WorldEdit session and the rest
+        // paste it. They cannot run back to back: a large schematic is still loading when the paste
+        // would fire, which is exactly the manual wait the reporter described.
+        dispatch(commands.get(0), schematic, paste);
+        for (int index = 1; index < commands.size(); index++) {
+            String command = commands.get(index);
+            plugin.getSpigotScheduler().runGlobalLater(() -> dispatch(command, schematic, paste), delay * index);
+        }
+
+        plugin.getSpigotScheduler().runGlobalLater(() -> {
+            String done = message("RESET_DONE", "&8[&cPVP&8] &7The arena has been reset.");
+            if (!done.isBlank()) {
+                broadcastToServer(done);
+            }
+        }, delay * Math.max(1, commands.size() - 1) + 20L);
+
+        scheduleNextReset();
+    }
+
+    private void dispatch(String command, String schematic, Location paste) {
+        String resolved = command.replace("{schematic}", schematic);
+        if (paste != null && paste.getWorld() != null) {
+            resolved = resolved
+                    .replace("{world}", paste.getWorld().getName())
+                    .replace("{x}", String.valueOf(paste.getBlockX()))
+                    .replace("{y}", String.valueOf(paste.getBlockY()))
+                    .replace("{z}", String.valueOf(paste.getBlockZ()));
+        }
+        plugin.getSpigotScheduler().dispatchConsoleCommand(resolved);
+    }
+
+    // ── Tick ──────────────────────────────────────────────────────────────────
+
+    /** Runs once a second: respawn countdowns, boundary checks, and the reset schedule. */
+    public void tick() {
+        long now = System.currentTimeMillis();
+
+        for (UUID uuid : new ArrayList<>(sessions.keySet())) {
+            Player player = Bukkit.getPlayer(uuid);
+            PvpSession session = sessions.get(uuid);
+            if (player == null || session == null) {
+                sessions.remove(uuid);
+                continue;
+            }
+
+            if (session.getRespawnAt() > 0 && now >= session.getRespawnAt()) {
+                session.setRespawnAt(0L);
+                plugin.getSpigotScheduler().runEntity(player, () -> openKitMenu(player));
+                continue;
+            }
+
+            if (session.getRespawnAt() > 0) {
+                long seconds = Math.max(1L, (session.getRespawnAt() - now + 999L) / 1000L);
+                send(player, message("RESPAWN_COUNTDOWN", "&fRespawning in &c{seconds}&f...")
+                        .replace("{seconds}", String.valueOf(seconds)));
+                continue;
+            }
+
+            if (!session.isAwaitingKit()
+                    && config().getBoolean("SETTINGS.KILL_OUTSIDE_BOUNDARY", true)
+                    && !isInsideArena(player.getLocation())) {
+                send(player, message("LEFT_BOUNDARY", "&cYou left the arena and were removed from the fight."));
+                removeFromArena(player, false);
+            }
+        }
+
+        tickReset(now);
+    }
+
+    private void tickReset(long now) {
+        if (!isResetEnabled()) {
+            return;
+        }
+        if (nextResetAt <= 0) {
+            scheduleNextReset();
+            return;
+        }
+
+        long warning = Math.max(0, config().getInt("RESET.WARNING_SECONDS", 30)) * 1000L;
+        if (!resetWarningSent && warning > 0 && nextResetAt - now <= warning) {
+            resetWarningSent = true;
+            String text = message("RESET_WARNING", "&8[&cPVP&8] &7The arena resets in &c{time}&7.")
+                    .replace("{time}", formatDuration(Math.max(0L, nextResetAt - now), "{D}m {S}s"));
+            if (!text.isBlank()) {
+                broadcastToServer(text);
+            }
+        }
+
+        if (now >= nextResetAt) {
+            resetArena(null);
+        }
+    }
+
+    // ── Duration helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Reads a duration written the way the config documents it: {@code 1d10h15m}, {@code 24h},
+     * {@code 30m}, {@code 90s}, or a bare number of seconds.
+     *
+     * @return the duration in milliseconds, or 0 when nothing could be read
+     */
+    public static long parseDuration(String input) {
+        if (input == null || input.isBlank()) {
+            return 0L;
+        }
+
+        String trimmed = input.trim();
+        Matcher matcher = DURATION_PATTERN.matcher(trimmed);
+        long total = 0L;
+        boolean matched = false;
+        while (matcher.find()) {
+            matched = true;
+            long amount = Long.parseLong(matcher.group(1));
+            total += switch (matcher.group(2).toLowerCase(Locale.ROOT)) {
+                case "d" -> amount * 86_400_000L;
+                case "h" -> amount * 3_600_000L;
+                case "m" -> amount * 60_000L;
+                default -> amount * 1_000L;
+            };
+        }
+
+        if (matched) {
+            return total;
+        }
+        try {
+            return Long.parseLong(trimmed) * 1_000L;
+        } catch (NumberFormatException exception) {
+            return 0L;
+        }
+    }
+
+    /**
+     * Renders a duration into a configured template.
+     *
+     * <p>{@code {d} {h} {m} {s}} are zero padded to two digits and {@code {D} {H} {M} {S}} are
+     * not, so an owner can write either {@code 01D:10H} or {@code 1d 10h} without the code
+     * choosing for them.</p>
+     */
+    public static String formatDuration(long millis, String format) {
+        String template = format == null || format.isBlank() ? "{d}D:{h}H:{m}M:{s}S" : format;
+        long totalSeconds = Math.max(0L, millis) / 1000L;
+        long days = totalSeconds / 86_400L;
+        long hours = (totalSeconds % 86_400L) / 3_600L;
+        long minutes = (totalSeconds % 3_600L) / 60L;
+        long seconds = totalSeconds % 60L;
+
+        return template
+                .replace("{d}", pad(days))
+                .replace("{h}", pad(hours))
+                .replace("{m}", pad(minutes))
+                .replace("{s}", pad(seconds))
+                .replace("{D}", String.valueOf(days))
+                .replace("{H}", String.valueOf(hours))
+                .replace("{M}", String.valueOf(minutes))
+                .replace("{S}", String.valueOf(seconds));
+    }
+
+    private static String pad(long value) {
+        return value < 10 ? "0" + value : String.valueOf(value);
+    }
+
+    // ── Messages and small helpers ────────────────────────────────────────────
+
+    public String message(String key, String fallback) {
+        String configured = config().getString("MESSAGES." + key, fallback);
+        return configured == null ? "" : configured;
+    }
+
+    /** Sends one already-resolved line to everyone online. */
+    private void broadcastToServer(String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        String rendered = ColorUtils.toComponent(text);
+        plugin.getSpigotScheduler().forEachOnlinePlayer(online -> online.sendMessage(rendered));
+    }
+
+    private void send(CommandSender target, String text) {
+        if (target != null && text != null && !text.isBlank()) {
+            target.sendMessage(ColorUtils.toComponent(text));
+        }
+    }
+
+    private void writeConfig(String path, Object value) {
+        FileConfiguration pvp = plugin.getConfigManager().getOriginalPvp();
+        if (pvp == null) {
+            return;
+        }
+        pvp.set(path, value);
+        plugin.getConfigManager().savePvp();
+    }
+
+    private static int parseInt(String input, int fallback) {
+        try {
+            return Integer.parseInt(input.trim());
+        } catch (NumberFormatException | NullPointerException exception) {
+            return fallback;
+        }
+    }
+
+    private static UUID parseUuid(String input) {
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            return null;
+        }
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    private Connection connection() {
+        return plugin.getDatabaseManager() == null ? null : plugin.getDatabaseManager().getConnection();
+    }
+
+    private void ensureTables() {
+        Connection connection = connection();
+        if (connection == null) {
+            return;
+        }
+
+        try (Statement st = connection.createStatement()) {
+            plugin.getDatabaseManager().executeSchema(st, """
+                    CREATE TABLE IF NOT EXISTS pvp_stats (
+                      player_uuid TEXT PRIMARY KEY,
+                      elo INTEGER DEFAULT 0,
+                      pvp_level INTEGER DEFAULT 1,
+                      pvp_xp INTEGER DEFAULT 0,
+                      kills INTEGER DEFAULT 0,
+                      deaths INTEGER DEFAULT 0,
+                      streak INTEGER DEFAULT 0,
+                      best_streak INTEGER DEFAULT 0,
+                      arena_joins INTEGER DEFAULT 0,
+                      updated_at INTEGER DEFAULT 0
+                    )
+                    """);
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to create the PvP arena tables", exception);
+        }
+    }
+
+    private PvpStats loadStats(UUID uuid) {
+        PvpStats empty = PvpStats.starting(config().getInt("ELO.STARTING", 0));
+        Connection connection = connection();
+        if (uuid == null || connection == null) {
+            return empty;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "select elo, pvp_level, pvp_xp, kills, deaths, streak, best_streak, arena_joins"
+                        + " from pvp_stats where player_uuid = ?")) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new PvpStats(
+                            rs.getInt("elo"),
+                            rs.getInt("pvp_level"),
+                            rs.getInt("pvp_xp"),
+                            rs.getInt("kills"),
+                            rs.getInt("deaths"),
+                            rs.getInt("streak"),
+                            rs.getInt("best_streak"),
+                            rs.getInt("arena_joins")
+                    );
+                }
+            }
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to load PvP stats for " + uuid, exception);
+        }
+        return empty;
+    }
+
+    private void saveStats(UUID uuid, PvpStats stats) {
+        Connection connection = connection();
+        if (uuid == null || stats == null || connection == null) {
+            return;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "replace into pvp_stats (player_uuid, elo, pvp_level, pvp_xp, kills, deaths, streak,"
+                        + " best_streak, arena_joins, updated_at) values (?,?,?,?,?,?,?,?,?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setInt(2, stats.getElo());
+            ps.setInt(3, stats.getLevel());
+            ps.setInt(4, stats.getXp());
+            ps.setInt(5, stats.getKills());
+            ps.setInt(6, stats.getDeaths());
+            ps.setInt(7, stats.getStreak());
+            ps.setInt(8, stats.getBestStreak());
+            ps.setInt(9, stats.getArenaJoins());
+            ps.setLong(10, System.currentTimeMillis());
+            ps.executeUpdate();
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to save PvP stats for " + uuid, exception);
+        }
+    }
+
+    /** How often a killer has been rewarded for one particular victim, and when that last happened. */
+    private record KillRecord(int count, long lastKillAt) {
+    }
+
+    /** One row of the Elo ladder. */
+    public record TopEntry(UUID uuid, String name, int elo) {
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ScoreboardManager.java
@@ -603,6 +603,16 @@ public class ScoreboardManager {
     }
 
     private List<String> getLines(Player player, SidebarSettings settings) {
+        // Inside the ranked arena the sidebar is the arena's own, straight out of pvp.yml. None of
+        // the survival extras below apply there, so it returns before any of them are read.
+        if (usesArenaSidebar(player)) {
+            List<String> arenaLines = new ArrayList<>();
+            for (String line : plugin.getPvpManager().getScoreboardLines()) {
+                arenaLines.add(applySidebarLayoutPlaceholders(line, settings));
+            }
+            return arenaLines;
+        }
+
         List<String> lines = new ArrayList<>();
         String teamLine = settings.teamLine();
         String boosterLine = settings.boosterLine();
@@ -891,7 +901,9 @@ public class ScoreboardManager {
     }
 
     private String getTitle(Player player, SidebarSettings settings) {
-        List<String> titles = settings.titles();
+        List<String> titles = usesArenaSidebar(player)
+                ? plugin.getPvpManager().getScoreboardTitles()
+                : settings.titles();
         if (titles.isEmpty()) {
             return ColorUtils.colorize("EconomySMP", player);
         }
@@ -909,6 +921,11 @@ public class ScoreboardManager {
             rendered.add(alignSidebarIconColumn(text, settings));
         }
         return rendered;
+    }
+
+    /** True while the player is in the ranked PvP arena and it wants the sidebar. */
+    private boolean usesArenaSidebar(Player player) {
+        return plugin.getPvpManager() != null && plugin.getPvpManager().hasArenaScoreboard(player);
     }
 
     private boolean isVisibleFor(Player player) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitEditMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitEditMenu.java
@@ -1,0 +1,126 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * The kit editor. An admin drops the real items in, and closing the menu stores them.
+ *
+ * <p>Editing by hand beats a form of dropdowns here: whatever the item is - enchantments, custom
+ * name, lore, potion, stack size, a plugin's own custom item - it round-trips exactly, because
+ * what gets saved is the {@link ItemStack} itself rather than a description of it.</p>
+ */
+public class PvpKitEditMenu extends BaseMenu {
+
+    /** Chest slots 0-35 map straight onto the kit's 36 inventory slots. */
+    private static final int CONTENT_END = 36;
+    private static final int DIVIDER_START = 36;
+    private static final int DIVIDER_END = 45;
+    private static final int ARMOR_START = 45;
+    private static final int LABEL_SLOT = 49;
+    private static final int OFFHAND_SLOT = 50;
+    private static final int[] FILLER_SLOTS = {51, 52, 53};
+
+    private final PvpKit kit;
+    private boolean saved;
+
+    public PvpKitEditMenu(UltimateDonutSmp plugin, PvpKit kit) {
+        super(plugin, "&8Editing kit: &f" + kit.getId(), 54);
+        this.kit = kit;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+
+        for (int slot = 0; slot < CONTENT_END; slot++) {
+            inventory.setItem(slot, kit.getContents()[slot]);
+        }
+        for (int slot = DIVIDER_START; slot < DIVIDER_END; slot++) {
+            inventory.setItem(slot, ItemUtils.createItem(
+                    Material.GRAY_STAINED_GLASS_PANE,
+                    "&8-",
+                    List.of("&7Rows above: the kit inventory.",
+                            "&7Row below: armour and offhand.",
+                            "&7Close the menu to save.")
+            ));
+        }
+        for (int slot = 0; slot < 4; slot++) {
+            inventory.setItem(ARMOR_START + slot, kit.getArmor()[slot]);
+        }
+        inventory.setItem(OFFHAND_SLOT, kit.getOffhand());
+
+        inventory.setItem(LABEL_SLOT, ItemUtils.createItem(
+                Material.PAPER,
+                "&fArmour and offhand",
+                List.of(
+                        "&7The four slots to the left are",
+                        "&7boots, leggings, chestplate, helmet.",
+                        "&7The slot to the right is the offhand."
+                )
+        ));
+        for (int slot : FILLER_SLOTS) {
+            inventory.setItem(slot, ItemUtils.createItem(Material.BLACK_STAINED_GLASS_PANE, "&8-", null));
+        }
+    }
+
+    /** Free placement everywhere except the labelled slots, which stay put. */
+    public void handleInventoryClick(InventoryClickEvent event) {
+        int raw = event.getRawSlot();
+        if (raw >= 0 && raw < inventory.getSize() && isLocked(raw)) {
+            event.setCancelled(true);
+        }
+    }
+
+    public void handleInventoryDrag(InventoryDragEvent event) {
+        for (int raw : event.getRawSlots()) {
+            if (raw >= 0 && raw < inventory.getSize() && isLocked(raw)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    private boolean isLocked(int slot) {
+        if (slot >= DIVIDER_START && slot < DIVIDER_END) {
+            return true;
+        }
+        if (slot == LABEL_SLOT) {
+            return true;
+        }
+        for (int filler : FILLER_SLOTS) {
+            if (slot == filler) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void onClose(Player player) {
+        if (saved) {
+            return;
+        }
+        saved = true;
+
+        for (int slot = 0; slot < CONTENT_END; slot++) {
+            kit.getContents()[slot] = inventory.getItem(slot);
+        }
+        for (int slot = 0; slot < 4; slot++) {
+            kit.getArmor()[slot] = inventory.getItem(ARMOR_START + slot);
+        }
+        kit.setOffhand(inventory.getItem(OFFHAND_SLOT));
+
+        plugin.getPvpManager().saveKit(kit);
+        player.sendMessage(ColorUtils.toComponent("&aSaved the &f" + kit.getId() + " &akit."));
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitMenu.java
@@ -1,0 +1,103 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The kit picker shown when a player joins the arena and again after every respawn.
+ *
+ * <p>A kit with a configured slot keeps it; the rest fill the middle row outwards, so a server
+ * with three kits gets them centred without anyone having to pick slot numbers.</p>
+ */
+public class PvpKitMenu extends BaseMenu {
+
+    private static final List<Integer> CENTERED_SLOTS = List.of(
+            13, 12, 14, 11, 15, 10, 16, 9, 17,
+            4, 22, 3, 5, 21, 23, 2, 6, 20, 24, 1, 7, 19, 25, 0, 8, 18, 26
+    );
+
+    private final Map<Integer, String> slotKits = new HashMap<>();
+
+    public PvpKitMenu(UltimateDonutSmp plugin) {
+        super(plugin, "&8PvP kit", 27);
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        slotKits.clear();
+        fill(Material.BLACK_STAINED_GLASS_PANE);
+
+        List<PvpKit> kits = plugin.getPvpManager().getAvailableKits(player);
+        if (kits.isEmpty()) {
+            set(13, ItemUtils.createItem(
+                    Material.BARRIER,
+                    "&cNo kits",
+                    List.of("&7There are no PvP kits to choose from yet.")
+            ));
+            return;
+        }
+
+        List<PvpKit> unplaced = new ArrayList<>();
+        for (PvpKit kit : kits) {
+            int slot = kit.getMenuSlot();
+            if (slot >= 0 && slot < inventory.getSize() && !slotKits.containsKey(slot)) {
+                place(slot, kit);
+            } else {
+                unplaced.add(kit);
+            }
+        }
+
+        int cursor = 0;
+        for (PvpKit kit : unplaced) {
+            while (cursor < CENTERED_SLOTS.size() && slotKits.containsKey(CENTERED_SLOTS.get(cursor))) {
+                cursor++;
+            }
+            if (cursor >= CENTERED_SLOTS.size()) {
+                break;
+            }
+            place(CENTERED_SLOTS.get(cursor), kit);
+        }
+    }
+
+    private void place(int slot, PvpKit kit) {
+        ItemStack icon = ItemUtils.createItem(
+                kit.getIcon(),
+                kit.getDisplayName(),
+                List.of("&7Click to take this kit.")
+        );
+        set(slot, icon);
+        slotKits.put(slot, kit.getId());
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        String kitId = slotKits.get(slot);
+        if (kitId == null) {
+            return;
+        }
+
+        PvpKit kit = plugin.getPvpManager().getKit(kitId);
+        if (kit == null) {
+            return;
+        }
+
+        player.closeInventory();
+        plugin.getPvpManager().selectKit(player, kit);
+    }
+
+    @Override
+    public void onClose(Player player) {
+        plugin.getPvpManager().handleKitMenuClosed(player);
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpKit.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpKit.java
@@ -1,0 +1,124 @@
+package com.bx.ultimateDonutSmp.models;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One arena kit: the hotbar and inventory contents, the four armour pieces, the offhand item,
+ * any effects applied on spawn, and how the kit shows up in the selection menu.
+ *
+ * <p>The items are stored as real {@link ItemStack}s rather than a material/enchantment
+ * description, so whatever an admin puts in the kit editor - custom names, lore, enchantments,
+ * potions, stack sizes - comes back out exactly as they left it.</p>
+ */
+public class PvpKit {
+
+    /** Main inventory slots a kit fills: the hotbar plus the three storage rows. */
+    public static final int CONTENT_SIZE = 36;
+
+    private final String id;
+    private String displayName;
+    private Material icon;
+    private String permission;
+    private int menuSlot;
+    private final ItemStack[] contents;
+    private final ItemStack[] armor;
+    private ItemStack offhand;
+    private final List<PotionEffect> effects;
+
+    public PvpKit(String id) {
+        this.id = id == null ? "" : id;
+        this.displayName = "&f" + this.id;
+        this.icon = Material.IRON_SWORD;
+        this.permission = "";
+        this.menuSlot = -1;
+        this.contents = new ItemStack[CONTENT_SIZE];
+        this.armor = new ItemStack[4];
+        this.effects = new ArrayList<>();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName == null || displayName.isBlank() ? "&f" + id : displayName;
+    }
+
+    public Material getIcon() {
+        return icon;
+    }
+
+    public void setIcon(Material icon) {
+        this.icon = icon == null ? Material.IRON_SWORD : icon;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public void setPermission(String permission) {
+        this.permission = permission == null ? "" : permission.trim();
+    }
+
+    public int getMenuSlot() {
+        return menuSlot;
+    }
+
+    public void setMenuSlot(int menuSlot) {
+        this.menuSlot = menuSlot;
+    }
+
+    /** The live contents array. Callers write into it directly when saving an edited kit. */
+    public ItemStack[] getContents() {
+        return contents;
+    }
+
+    /** The live armour array, ordered the way Bukkit orders it: boots, leggings, chestplate, helmet. */
+    public ItemStack[] getArmor() {
+        return armor;
+    }
+
+    public ItemStack getOffhand() {
+        return offhand;
+    }
+
+    public void setOffhand(ItemStack offhand) {
+        this.offhand = offhand;
+    }
+
+    public List<PotionEffect> getEffects() {
+        return Collections.unmodifiableList(effects);
+    }
+
+    public void setEffects(List<PotionEffect> newEffects) {
+        effects.clear();
+        if (newEffects != null) {
+            effects.addAll(newEffects);
+        }
+    }
+
+    /** True when the kit would hand a player nothing at all. */
+    public boolean isEmpty() {
+        for (ItemStack item : contents) {
+            if (item != null && item.getType() != Material.AIR) {
+                return false;
+            }
+        }
+        for (ItemStack item : armor) {
+            if (item != null && item.getType() != Material.AIR) {
+                return false;
+            }
+        }
+        return offhand == null || offhand.getType() == Material.AIR;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpRank.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpRank.java
@@ -1,0 +1,55 @@
+package com.bx.ultimateDonutSmp.models;
+
+import java.util.List;
+
+/**
+ * One configured PvP rank: an id, the text shown for it, and the Elo a player needs to hold it.
+ *
+ * <p>Ranks are ordered by their requirement rather than by their name, so a server owner can rename
+ * or reorder the whole ladder in pvp.yml without the code caring what the tiers are called.</p>
+ */
+public class PvpRank {
+
+    private final String id;
+    private final String display;
+    private final int eloRequirement;
+
+    public PvpRank(String id, String display, int eloRequirement) {
+        this.id = id == null ? "" : id;
+        this.display = display == null || display.isBlank() ? this.id : display;
+        this.eloRequirement = eloRequirement;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    public int getEloRequirement() {
+        return eloRequirement;
+    }
+
+    /**
+     * Picks the rank a player holds at the given Elo: the highest one they still meet.
+     *
+     * <p>The list is expected to be sorted by requirement ascending, which is how
+     * {@code PvpManager} loads it. Below the cheapest rank the player keeps that cheapest rank
+     * rather than having none, so the ladder always has a floor.</p>
+     */
+    public static PvpRank resolve(List<PvpRank> ranks, int elo) {
+        if (ranks == null || ranks.isEmpty()) {
+            return null;
+        }
+
+        PvpRank current = ranks.get(0);
+        for (PvpRank rank : ranks) {
+            if (elo >= rank.getEloRequirement()) {
+                current = rank;
+            }
+        }
+        return current;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpSession.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpSession.java
@@ -1,0 +1,76 @@
+package com.bx.ultimateDonutSmp.models;
+
+import java.util.UUID;
+
+/**
+ * What the plugin remembers about a player while they are inside the ranked arena.
+ *
+ * <p>Deliberately no inventory snapshot: the arena is expected to be its own world so that
+ * Multiverse-Inventories - or whatever else already separates inventories - keeps owning the
+ * survival one. Storing a copy here would fight that plugin for the same job.</p>
+ */
+public class PvpSession {
+
+    private final UUID playerUuid;
+    private final long joinedAt;
+
+    private String kitId;
+    private long spawnedAt;
+    private long respawnAt;
+    private boolean awaitingKit;
+
+    public PvpSession(UUID playerUuid, long joinedAt) {
+        this.playerUuid = playerUuid;
+        this.joinedAt = joinedAt;
+        this.awaitingKit = true;
+    }
+
+    public UUID getPlayerUuid() {
+        return playerUuid;
+    }
+
+    public long getJoinedAt() {
+        return joinedAt;
+    }
+
+    public String getKitId() {
+        return kitId;
+    }
+
+    public void setKitId(String kitId) {
+        this.kitId = kitId;
+    }
+
+    public long getSpawnedAt() {
+        return spawnedAt;
+    }
+
+    public void setSpawnedAt(long spawnedAt) {
+        this.spawnedAt = spawnedAt;
+    }
+
+    /** Epoch millis the respawn countdown ends, or 0 when the player is not waiting to respawn. */
+    public long getRespawnAt() {
+        return respawnAt;
+    }
+
+    public void setRespawnAt(long respawnAt) {
+        this.respawnAt = respawnAt;
+    }
+
+    /** True while the player still owes the arena a kit choice, so they must not be fought yet. */
+    public boolean isAwaitingKit() {
+        return awaitingKit;
+    }
+
+    public void setAwaitingKit(boolean awaitingKit) {
+        this.awaitingKit = awaitingKit;
+    }
+
+    /** True while the player is inside the configured spawn protection window. */
+    public boolean isSpawnProtected(long now, int protectionSeconds) {
+        return protectionSeconds > 0
+                && spawnedAt > 0
+                && now - spawnedAt < protectionSeconds * 1000L;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpStats.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpStats.java
@@ -1,0 +1,91 @@
+package com.bx.ultimateDonutSmp.models;
+
+/**
+ * A player's ranked arena record. Immutable, so a kill produces a new instance the way
+ * {@link FfaStats} does and nothing can hold a stale half-updated copy.
+ */
+public class PvpStats {
+
+    private final int elo;
+    private final int level;
+    private final int xp;
+    private final int kills;
+    private final int deaths;
+    private final int streak;
+    private final int bestStreak;
+    private final int arenaJoins;
+
+    public PvpStats(int elo, int level, int xp, int kills, int deaths, int streak, int bestStreak, int arenaJoins) {
+        this.elo = Math.max(0, elo);
+        this.level = Math.max(1, level);
+        this.xp = Math.max(0, xp);
+        this.kills = Math.max(0, kills);
+        this.deaths = Math.max(0, deaths);
+        this.streak = Math.max(0, streak);
+        this.bestStreak = Math.max(0, bestStreak);
+        this.arenaJoins = Math.max(0, arenaJoins);
+    }
+
+    public static PvpStats starting(int startingElo) {
+        return new PvpStats(startingElo, 1, 0, 0, 0, 0, 0, 0);
+    }
+
+    public int getElo() {
+        return elo;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public int getXp() {
+        return xp;
+    }
+
+    public int getKills() {
+        return kills;
+    }
+
+    public int getDeaths() {
+        return deaths;
+    }
+
+    public int getStreak() {
+        return streak;
+    }
+
+    public int getBestStreak() {
+        return bestStreak;
+    }
+
+    public int getArenaJoins() {
+        return arenaJoins;
+    }
+
+    /** Kills over deaths, counting a death-free record as its own kill count. */
+    public double getKillDeathRatio() {
+        return deaths <= 0 ? kills : (double) kills / (double) deaths;
+    }
+
+    public PvpStats withElo(int newElo) {
+        return new PvpStats(newElo, level, xp, kills, deaths, streak, bestStreak, arenaJoins);
+    }
+
+    public PvpStats withProgress(int newLevel, int newXp) {
+        return new PvpStats(elo, newLevel, newXp, kills, deaths, streak, bestStreak, arenaJoins);
+    }
+
+    public PvpStats recordKill() {
+        int newStreak = streak + 1;
+        return new PvpStats(elo, level, xp, kills + 1, deaths, newStreak,
+                Math.max(bestStreak, newStreak), arenaJoins);
+    }
+
+    public PvpStats recordDeath() {
+        return new PvpStats(elo, level, xp, kills, deaths + 1, 0, bestStreak, arenaJoins);
+    }
+
+    public PvpStats recordArenaJoin() {
+        return new PvpStats(elo, level, xp, kills, deaths, streak, bestStreak, arenaJoins + 1);
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/PvpArenaTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/PvpArenaTask.java
@@ -1,0 +1,28 @@
+package com.bx.ultimateDonutSmp.tasks;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+
+/**
+ * Drives the arena once a second: respawn countdowns, the boundary check, and the reset schedule.
+ * A second is fine for all three - the countdown is spoken in whole seconds and the boundary has
+ * its own padding so a fast player cannot slip past between two checks.
+ */
+public class PvpArenaTask implements Runnable {
+
+    private final UltimateDonutSmp plugin;
+
+    private PvpArenaTask(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public static void start(UltimateDonutSmp plugin) {
+        plugin.getSpigotScheduler().runGlobalTimer(new PvpArenaTask(plugin), 20L, 20L);
+    }
+
+    @Override
+    public void run() {
+        if (plugin.getPvpManager() != null && plugin.getPvpManager().isEnabled()) {
+            plugin.getPvpManager().tick();
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -178,6 +178,11 @@ commands:
     usage: /ffaarena <create|delete|setpos|setdisplay|settings|enable|disable|list|reload>
     permission: ultimatedonutsmp.command.ffaarena
     permission-message: "&cYou do not have permission to use /ffaarena."
+  pvp:
+    description: Join the ranked PvP arena
+    usage: /pvp [join|leave|kit|stats|top|wand|create|setspawn|setlobby|setboundary|schematic|reset|reload]
+    permission: ultimatedonutsmp.command.pvp
+    permission-message: "&cYou do not have permission to use /pvp."
   auctionhouse:
     description: Open the Auction House
     usage: /auctionhouse [sell|my|claims|cancel|reload]
@@ -787,6 +792,7 @@ permissions:
       ultimatedonutsmp.admin.orders: true
       ultimatedonutsmp.admin.duels: true
       ultimatedonutsmp.admin.ffa: true
+      ultimatedonutsmp.admin.pvp: true
       ultimatedonutsmp.admin.auctionhouse: true
       ultimatedonutsmp.admin.clearlag: true
       ultimatedonutsmp.admin.cuboid: true
@@ -869,6 +875,9 @@ permissions:
     default: op
   ultimatedonutsmp.admin.ffa:
     description: Manage FFA system and arenas
+    default: op
+  ultimatedonutsmp.admin.pvp:
+    description: Manage the ranked PvP arena and its kits
     default: op
   ultimatedonutsmp.admin.cuboid:
     description: Manage cuboid regions
@@ -1237,6 +1246,7 @@ permissions:
       ultimatedonutsmp.command.ffa: true
       ultimatedonutsmp.command.ffastats: true
       ultimatedonutsmp.command.ffaarena: true
+      ultimatedonutsmp.command.pvp: true
       ultimatedonutsmp.command.auctionhouse: true
       ultimatedonutsmp.command.enderchest: true
       ultimatedonutsmp.command.sell: true
@@ -1416,6 +1426,9 @@ permissions:
     default: true
   ultimatedonutsmp.command.ffastats:
     description: Access to /ffastats command
+    default: true
+  ultimatedonutsmp.command.pvp:
+    description: Access to /pvp command
     default: true
   ultimatedonutsmp.command.ffaarena:
     description: Access to /ffaarena command

--- a/src/main/resources/pvp.yml
+++ b/src/main/resources/pvp.yml
@@ -1,0 +1,238 @@
+# ==============================================================================
+# UltimateDonutSMP - Ranked PvP Arena Configuration
+# ==============================================================================
+# The ranked arena is a persistent free-for-all area with kits, Elo, ranks and
+# levels. It does not tag combat on its own - whatever combat plugin you already
+# run stays in charge of that.
+
+# General ranked arena settings
+SETTINGS:
+  # Enable or disable the ranked PvP arena globally (true / false)
+  ENABLED: false
+  # Seconds a player stays in spectator after dying before the kit menu reopens
+  RESPAWN_DELAY_SECONDS: 3
+  # Drop the kit items when a player dies in the arena (true / false)
+  DROP_KIT_ON_DEATH: false
+  # Restore full health, hunger and remove potion effects on every arena spawn (true / false)
+  HEAL_ON_SPAWN: true
+  # Kill and remove a player who leaves the arena boundary (true / false)
+  KILL_OUTSIDE_BOUNDARY: true
+  # Seconds of protection after spawning, during which the player cannot deal or take damage
+  SPAWN_PROTECTION_SECONDS: 3
+  # Send players who disconnect inside the arena to the lobby when they rejoin (true / false)
+  LOBBY_ON_REJOIN: true
+  # Take the kit back when a player leaves the arena (true / false). Turn this off if
+  # Multiverse-Inventories, or anything else that separates inventories per world, already
+  # owns the arena world - it will swap the inventory back on its own.
+  CLEAR_KIT_ON_LEAVE: true
+
+# Arena geometry. These are written by /pvp create, /pvp wand and /pvp setlobby,
+# so there is normally no reason to edit them by hand.
+ARENA:
+  # Display name shown in messages and on the scoreboard
+  NAME: 'Arena'
+  # World the arena lives in. Empty means the world of the spawn point below.
+  WORLD: ''
+  # Where players are put when they join or respawn (world,x,y,z,yaw,pitch)
+  SPAWN: ''
+  # Where players are sent on /pvp leave and after a disconnect (world,x,y,z,yaw,pitch)
+  LOBBY: ''
+  # The two wand corners of the arena boundary (world,x,y,z,yaw,pitch)
+  BOUNDARY_POS1: ''
+  BOUNDARY_POS2: ''
+  # Extra blocks of slack around the boundary before a player counts as outside
+  BOUNDARY_PADDING: 2
+
+# Automatic arena resets, driven by a schematic paste rather than a world regen
+RESET:
+  # Enable the scheduled arena reset (true / false)
+  ENABLED: false
+  # How often the arena resets. Accepts 1d10h15m, 24h, 30m, 90s and combinations.
+  INTERVAL: '24h'
+  # Seconds of warning broadcast before the reset runs
+  WARNING_SECONDS: 30
+  # Teleport everyone in the arena to the lobby before pasting (true / false)
+  EVACUATE: true
+  # Schematic name as WorldEdit/FastAsyncWorldEdit knows it, without the file extension
+  SCHEMATIC: 'arena'
+  # Where the schematic is pasted. Empty pastes at the origin stored in the schematic
+  # itself, which is what -o in the paste command below uses.
+  PASTE_LOCATION: ''
+  # Commands run from console to perform the reset. {schematic} is replaced with the
+  # schematic name and {x} {y} {z} {world} with the paste location when one is set.
+  # FastAsyncWorldEdit understands the same commands as WorldEdit and is much faster
+  # on a large arena, so leaving these alone works with either one installed.
+  COMMANDS:
+  - '//schematic load {schematic}'
+  - '//paste -o -a'
+  # Seconds to wait between the load command and the paste command
+  PASTE_DELAY_SECONDS: 5
+
+# Commands players cannot run while they are inside the arena
+BLOCKED_COMMANDS:
+  # Enable command blocking inside the arena (true / false)
+  ENABLED: true
+  # Commands to block, with or without the leading slash. Subcommands are covered too,
+  # so "shop" also blocks "/shop sell".
+  COMMANDS:
+  - 'shop'
+  - 'sell'
+  - 'ah'
+  - 'auctionhouse'
+  - 'ec'
+  - 'enderchest'
+  - 'orders'
+  # Also block the ender chest when it is opened by clicking the block (true / false)
+  BLOCK_ENDER_CHEST_BLOCK: true
+
+# Elo awarded and taken on every rewarded kill
+ELO:
+  # Elo every player starts on
+  STARTING: 0
+  # Elo the killer gains
+  GAIN_PER_KILL: 25
+  # Elo the victim loses
+  LOSS_PER_DEATH: 20
+  # Elo can never fall below this
+  MINIMUM: 0
+  # Elo can never rise above this. 0 removes the cap.
+  MAXIMUM: 0
+
+# PvP ranks, lowest requirement first. Rank ids are free-form, so LT/HT is only the
+# default naming - rename them, add more or remove some as you like. A player holds
+# the highest rank whose ELO requirement they meet, and drops back down on their own
+# when their Elo falls under it.
+RANKS:
+  LT5:
+    DISPLAY: '&7LT5'
+    ELO: 0
+  LT4:
+    DISPLAY: '&7LT4'
+    ELO: 100
+  LT3:
+    DISPLAY: '&fLT3'
+    ELO: 200
+  LT2:
+    DISPLAY: '&fLT2'
+    ELO: 300
+  LT1:
+    DISPLAY: '&eLT1'
+    ELO: 400
+  HT5:
+    DISPLAY: '&eHT5'
+    ELO: 600
+  HT4:
+    DISPLAY: '&6HT4'
+    ELO: 800
+  HT3:
+    DISPLAY: '&6HT3'
+    ELO: 1000
+  HT2:
+    DISPLAY: '&cHT2'
+    ELO: 1200
+  HT1:
+    DISPLAY: '&c&lHT1'
+    ELO: 1500
+
+# PvP level progression, separate from Elo
+LEVELS:
+  # XP a rewarded kill is worth
+  XP_PER_KILL: 50
+  # XP needed to reach level 2
+  BASE_XP: 100
+  # Extra XP each further level costs on top of the previous one
+  XP_INCREASE_PER_LEVEL: 50
+  # Highest level a player can reach. 0 removes the cap.
+  MAX_LEVEL: 100
+
+# Stops a player farming Elo and XP off the same opponent
+ANTI_KILL_FARMING:
+  # Enable kill-farm protection (true / false)
+  ENABLED: true
+  # Rewarded kills allowed against the same player before rewards drop
+  MAX_REWARDED_KILLS: 3
+  # How long the counter remembers a victim. Accepts the same format as RESET.INTERVAL.
+  COOLDOWN: '5m'
+  # Elo given for a kill past the limit
+  REDUCED_ELO: 0
+  # XP given for a kill past the limit
+  REDUCED_XP: 0
+  # Take Elo from the victim on an unrewarded kill (true / false)
+  APPLY_ELO_LOSS: false
+
+# Broadcasts sent when a player levels up or changes rank
+BROADCASTS:
+  LEVEL_UP:
+    # Announce level ups to the whole server instead of only the player (true / false)
+    GLOBAL: true
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7has reached PvP Level &c%pvp_level%&7!'
+  RANK_UP:
+    # Announce rank ups to the whole server instead of only the player (true / false)
+    GLOBAL: true
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7ranked up to %pvp_rank% &7with &c%pvp_elo% &7elo!'
+  RANK_DOWN:
+    # Announce rank downs to the whole server instead of only the player (true / false)
+    GLOBAL: false
+    MESSAGE: '&8[&cPVP&8] &f%player_name% &7dropped to %pvp_rank% &7with &c%pvp_elo% &7elo!'
+
+# The sidebar shown while a player is inside the arena. It replaces the normal
+# scoreboard for as long as they are in there and takes any PlaceholderAPI
+# placeholder, including the %pvp_...% ones this feature registers.
+SCOREBOARD:
+  # Show the arena sidebar instead of the survival one (true / false)
+  ENABLED: true
+  # Animated title frames, cycled at the same speed as the survival scoreboard
+  TITLE:
+  - '&c&lPVP ARENA'
+  # Sidebar lines from top to bottom
+  LINES:
+  - ''
+  - '&fPLAYER: &c%player_name%'
+  - '&fRANK: %pvp_rank%'
+  - '&fLEVEL: &c%pvp_level%'
+  - '&fK/D: &c%pvp_kills%&7/&c%pvp_deaths%'
+  - ''
+  - '&fARENA RESET'
+  - '&c%pvp_arena_reset%'
+  - ''
+  - '&7play.example.net'
+  # How the reset countdown is written. {d} {h} {m} {s} are the padded parts and
+  # {D} {H} {M} {S} the unpadded ones.
+  RESET_FORMAT: '{d}D:{h}H:{m}M:{s}S'
+  # Shown by %pvp_arena_reset% when no reset is scheduled
+  RESET_DISABLED_TEXT: '&7-'
+
+# Kit definitions. These are written by /pvp kit create and /pvp kit edit, which
+# store the real items with their enchantments, names and lore, so hand editing is
+# not expected here.
+KITS: {}
+
+# Messages this feature sends. Every one of them goes through the plugin's colour
+# codes, so &a and &#RRGGBB both work.
+MESSAGES:
+  DISABLED: '&cThe PvP arena is not enabled.'
+  NOT_SET_UP: '&cThe PvP arena has not been set up yet.'
+  NO_KITS: '&cThere are no PvP kits to choose from yet.'
+  JOINED: '&aYou joined the PvP arena.'
+  LEFT: '&aYou left the PvP arena.'
+  ALREADY_IN: '&cYou are already in the PvP arena.'
+  NOT_IN: '&cYou are not in the PvP arena.'
+  KIT_GIVEN: '&aYou picked the &f{kit} &akit.'
+  KIT_NO_PERMISSION: '&cYou do not have access to that kit.'
+  RESPAWN_COUNTDOWN: '&fRespawning in &c{seconds}&f...'
+  BLOCKED_COMMAND: '&cYou cannot use that command inside the PvP arena.'
+  LEFT_BOUNDARY: '&cYou left the arena and were removed from the fight.'
+  KILL_REWARD: '&8[&cPVP&8] &7You killed &f{victim} &8(&c+{elo} elo&8, &c+{xp} xp&8)'
+  DEATH_PENALTY: '&8[&cPVP&8] &f{killer} &7killed you &8(&c-{elo} elo&8)'
+  KILL_FARM_LIMIT: '&7No reward - you have already killed &f{victim} &7too recently.'
+  LEVEL_UP: '&aYou reached PvP Level &f{level}&a!'
+  RANK_UP: '&aYou ranked up to {rank}&a!'
+  RANK_DOWN: '&cYou dropped to {rank}&c.'
+  RESET_WARNING: '&8[&cPVP&8] &7The arena resets in &c{time}&7.'
+  RESET_DONE: '&8[&cPVP&8] &7The arena has been reset.'
+  RESET_NO_SCHEMATIC: '&cNo schematic is configured for the arena reset.'
+  STATS_HEADER: '&8&m--------&r &cPvP stats: &f{player} &8&m--------'
+  STATS_LINE: '&7{label}: &f{value}'
+  TOP_HEADER: '&8&m--------&r &cTop PvP players &8&m--------'
+  TOP_LINE: '&7#{position} &f{player} &8- &c{elo} elo &8(&7{rank}&8)'
+  TOP_EMPTY: '&7Nobody has fought in the arena yet.'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
@@ -1,0 +1,84 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Guards the shape of the bundled ranked arena config and its command registration. */
+class PvpConfigurationTest {
+
+    private static YamlConfiguration pvp() throws Exception {
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.load(new File("src/main/resources/pvp.yml"));
+        return configuration;
+    }
+
+    @Test
+    void theArenaShipsSwitchedOffWithAnEmptyArenaAndNoKits() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        // Nothing about this feature can work before an admin has run the setup commands, so it
+        // must not start doing anything on a server that merely updated the plugin.
+        assertFalse(pvp.getBoolean("SETTINGS.ENABLED"));
+        assertFalse(pvp.getBoolean("RESET.ENABLED"));
+        assertEquals("", pvp.getString("ARENA.SPAWN"));
+        assertTrue(pvp.getConfigurationSection("KITS").getKeys(false).isEmpty());
+    }
+
+    @Test
+    void theDefaultRankLadderRisesWithoutGaps() throws Exception {
+        YamlConfiguration pvp = pvp();
+        assertNotNull(pvp.getConfigurationSection("RANKS"));
+
+        int previous = Integer.MIN_VALUE;
+        for (String id : pvp.getConfigurationSection("RANKS").getKeys(false)) {
+            int elo = pvp.getInt("RANKS." + id + ".ELO");
+            assertTrue(elo > previous, id + " must need more elo than the rank before it");
+            assertFalse(pvp.getString("RANKS." + id + ".DISPLAY", "").isBlank());
+            previous = elo;
+        }
+        assertEquals(0, pvp.getInt("RANKS.LT5.ELO"), "the bottom rank has to be reachable from zero elo");
+    }
+
+    @Test
+    void theResetIsDrivenByCommandsThatWorkOnWorldEditAndFawe() throws Exception {
+        List<String> commands = pvp().getStringList("RESET.COMMANDS");
+
+        assertEquals(2, commands.size());
+        assertTrue(commands.get(0).contains("{schematic}"), "the load command has to name the schematic");
+        assertTrue(commands.get(1).startsWith("//paste"));
+        assertTrue(pvp().getInt("RESET.PASTE_DELAY_SECONDS") > 0, "a paste must not race the load");
+    }
+
+    @Test
+    void theSurvivalCommandsTheReporterListedAreBlockedByDefault() throws Exception {
+        List<String> blocked = pvp().getStringList("BLOCKED_COMMANDS.COMMANDS");
+
+        assertTrue(pvp().getBoolean("BLOCKED_COMMANDS.ENABLED"));
+        assertTrue(pvp().getBoolean("BLOCKED_COMMANDS.BLOCK_ENDER_CHEST_BLOCK"));
+        for (String command : List.of("shop", "sell", "ah", "ec", "enderchest", "orders")) {
+            assertTrue(blocked.contains(command), "expected /" + command + " to be blocked by default");
+        }
+    }
+
+    @Test
+    void theCommandAndItsPermissionsAreRegistered() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        plugin.load(new File("src/main/resources/plugin.yml"));
+
+        assertTrue(plugin.isConfigurationSection("commands.pvp"));
+        assertEquals("ultimatedonutsmp.command.pvp", plugin.getString("commands.pvp.permission"));
+        assertEquals("true", plugin.getString("permissions.ultimatedonutsmp.command.pvp.default"));
+        assertEquals("op", plugin.getString("permissions.ultimatedonutsmp.admin.pvp.default"));
+        assertTrue(plugin.getBoolean(
+                "permissions.ultimatedonutsmp.admin.children.ultimatedonutsmp.admin.pvp"
+        ));
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpProgressionTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpProgressionTest.java
@@ -1,0 +1,104 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PvpRank;
+import com.bx.ultimateDonutSmp.models.PvpStats;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The arena maths that runs without a server: durations, the level curve, and the rank ladder. */
+class PvpProgressionTest {
+
+    private static final List<PvpRank> LADDER = List.of(
+            new PvpRank("LT5", "&7LT5", 0),
+            new PvpRank("LT1", "&eLT1", 400),
+            new PvpRank("HT5", "&eHT5", 600),
+            new PvpRank("HT1", "&cHT1", 1500)
+    );
+
+    @Test
+    void durationsReadEveryUnitAndCombination() {
+        assertEquals(86_400_000L, PvpManager.parseDuration("24h"));
+        assertEquals(1_800_000L, PvpManager.parseDuration("30m"));
+        assertEquals(90_000L, PvpManager.parseDuration("90s"));
+        assertEquals(
+                86_400_000L + 10 * 3_600_000L + 15 * 60_000L,
+                PvpManager.parseDuration("1d10h15m")
+        );
+    }
+
+    @Test
+    void aBareNumberIsReadAsSecondsAndJunkIsZero() {
+        assertEquals(45_000L, PvpManager.parseDuration("45"));
+        assertEquals(0L, PvpManager.parseDuration(""));
+        assertEquals(0L, PvpManager.parseDuration(null));
+        assertEquals(0L, PvpManager.parseDuration("soon"));
+    }
+
+    @Test
+    void theResetCountdownFillsBothPaddedAndUnpaddedPlaceholders() {
+        long remaining = PvpManager.parseDuration("1d10h15m1s");
+
+        assertEquals("01D:10H:15M:01S", PvpManager.formatDuration(remaining, "{d}D:{h}H:{m}M:{s}S"));
+        assertEquals("1d 10h 15m 1s", PvpManager.formatDuration(remaining, "{D}d {H}h {M}m {S}s"));
+    }
+
+    @Test
+    void theLevelCurveGrowsByOneIncrementPerLevel() {
+        assertEquals(100, PvpManager.xpForLevel(1, 100, 50));
+        assertEquals(150, PvpManager.xpForLevel(2, 100, 50));
+        assertEquals(300, PvpManager.xpForLevel(5, 100, 50));
+
+        // A flat curve is a legitimate setting, and no level may ever cost nothing.
+        assertEquals(100, PvpManager.xpForLevel(9, 100, 0));
+        assertTrue(PvpManager.xpForLevel(3, 0, 0) > 0);
+    }
+
+    @Test
+    void aPlayerHoldsTheHighestRankTheirEloReaches() {
+        assertEquals("LT5", PvpRank.resolve(LADDER, 0).getId());
+        assertEquals("LT5", PvpRank.resolve(LADDER, 399).getId());
+        assertEquals("LT1", PvpRank.resolve(LADDER, 400).getId());
+        assertEquals("HT5", PvpRank.resolve(LADDER, 1499).getId());
+        assertEquals("HT1", PvpRank.resolve(LADDER, 9999).getId());
+    }
+
+    @Test
+    void anEloDropTakesTheRankBackDownWithIt() {
+        assertEquals("HT5", PvpRank.resolve(LADDER, 620).getId());
+        assertEquals("LT1", PvpRank.resolve(LADDER, 580).getId());
+    }
+
+    @Test
+    void theBottomRankIsTheFloorAndAnEmptyLadderHasNone() {
+        assertEquals("LT5", PvpRank.resolve(LADDER, -50).getId());
+        assertNull(PvpRank.resolve(List.of(), 100));
+        assertNull(PvpRank.resolve(null, 100));
+    }
+
+    @Test
+    void killsAndDeathsMoveTheStreakAndTheRatio() {
+        PvpStats stats = PvpStats.starting(250).recordKill().recordKill().recordKill();
+
+        assertEquals(250, stats.getElo());
+        assertEquals(3, stats.getKills());
+        assertEquals(3, stats.getStreak());
+        assertEquals(3, stats.getBestStreak());
+        assertEquals(3.0D, stats.getKillDeathRatio());
+
+        PvpStats afterDeath = stats.recordDeath();
+        assertEquals(0, afterDeath.getStreak());
+        assertEquals(3, afterDeath.getBestStreak(), "the best streak is a record, not a counter");
+        assertEquals(3.0D, afterDeath.getKillDeathRatio());
+    }
+
+    @Test
+    void eloNeverGoesNegativeAndTheLevelNeverDropsBelowOne() {
+        assertEquals(0, PvpStats.starting(0).withElo(-40).getElo());
+        assertEquals(1, PvpStats.starting(0).withProgress(0, 10).getLevel());
+    }
+}


### PR DESCRIPTION
Closes #255

This adds the ranked PvP arena as its own system in `pvp.yml`. One permanent arena that everyone fights in at once, with kits, an Elo rating, a configurable rank ladder, a separate level track, and an optional reset that pastes a schematic back over the map. It ships switched off, so nothing changes on an existing server until an admin sets it up.

It does not replace the instanced FFA already in the plugin. That one pairs two players in a throwaway copy of a map and rolls the blocks back afterwards. Here the map stays and the rating is what carries over between visits. The two share nothing, which is why this is a new subsystem instead of more settings in `ffa.yml`.

## Arena and setup

`/pvp create`, `/pvp setspawn`, `/pvp setlobby`, `/pvp wand` and `/pvp setboundary` write the geometry into `pvp.yml`. The spawn is the only one you cannot skip. The wand is a golden axe marked with plugin data rather than by its name, the same way the cuboid wand already works, so renaming it on an anvil cannot break it.

With both wand corners set, the boundary is the box between them plus `ARENA.BOUNDARY_PADDING`. With no corners at all the whole arena world counts as inside, which is what you want on a server that gives the arena its own world. Step outside either way and you are pulled out of the fight.

## Kits

`/pvp kit create` and `/pvp kit edit` open an editor where the admin drops the real items in. What gets stored is the `ItemStack` itself rather than a description of it, so enchantments, custom names, lore, potion types, stack sizes and items from other plugins all come back out exactly as they went in. Icon, display name, permission and menu slot are set from the command line.

The picker opens on join and again after every respawn. Closing it without choosing reopens it a tick later, since a player in the arena with no kit cannot fight and cannot be fought, and would otherwise be left a permanent spectator.

## Elo, ranks and levels

Elo decides the rank, XP decides the level, and the two are independent on purpose. A player holds the highest rank whose Elo requirement they meet, rechecked after every kill, so demotion falls out of the same rule as promotion instead of needing a second setting that can drift out of sync with the first. The bundled ladder is LT5 through HT1, but the ids, names and thresholds are all config and nothing in the code expects that naming.

Levels come off a straight line. Level 2 costs `BASE_XP`, and each level after that costs one more `XP_INCREASE_PER_LEVEL` than the one before it.

## Kill farming

Tracked per killer and victim UUID pair, with a cooldown that forgets a victim once it passes without another kill. Kills past the limit still count toward K/D and the streak, because they did happen. They just stop paying Elo and XP, and by default they stop costing the victim Elo too.

## Scoreboard and placeholders

Inside the arena the sidebar comes from `pvp.yml` instead of `scoreboard.yml`. That reuses the existing renderer rather than adding a second one: `ScoreboardManager` reads the arena's title and lines when the player is in a session, and behaves exactly as before otherwise, so the Folia and Spigot paths, the line splitting and the icon alignment all stay shared.

A `%pvp_*%` expansion publishes rank, rank_id, elo, level, xp, next_xp, kills, deaths, kd, streak, best_streak, joins, in_arena, arena, arena_reset and arena_players. The plugin never draws a nametag itself, so TAB keeps owning that with a format like `%pvp_rank% | %luckperms-prefix% %player%`.

## Schematic resets

The reset runs console commands with a configurable gap between them, defaulting to `//schematic load {schematic}` and then `//paste -o -a` five seconds later. Going through commands instead of the WorldEdit API is the point: WorldEdit and FastAsyncWorldEdit answer the same two lines, so a server can swap between them freely and one running neither just leaves the feature off. Compiling against the API would have meant a new Maven dependency and a repository for something optional. FAWE is the one to install on a large arena and needs no config change to use. The gap between load and paste is the manual wait the issue describes, automated.

## What was deliberately left out

Three parts of the request are handed to plugins that already do them, as the issue asked:

- Combat. The arena never tags anyone. Whatever combat plugin is already running stays in charge.
- Inventories. Nothing is snapshotted or restored. `SETTINGS.CLEAR_KIT_ON_LEAVE` takes the kit back on the way out and can be switched off where Multiverse-Inventories owns the arena world, since clearing an inventory that plugin manages would undo its work rather than help it.
- Nametags. Only the placeholders are published.

## Notes

- `pvp.yml` is new and self-contained, so no language-file keys were added. `ARENA`, `KITS` and `RANKS` are excluded in `ConfigManager.isUserManagedBundledPath`, so a plugin update never restores the bundled empty arena over live kits.
- Stats live in a new `pvp_stats` table, created the same way the FFA tables are, so `/pvp top` includes offline players.
- Blocked commands cover subcommands and the plugin-qualified form, so `shop` also catches `/shop sell` and `/otherplugin:shop`. The ender chest is closed off through the block as well as the command.
- New feature toggle `PVP_ARENA`, new `/pvp` command with tab completion, new permissions `ultimatedonutsmp.command.pvp` (default true) and `ultimatedonutsmp.admin.pvp` (default op).
- Docs: new `Ranked-PvP-Arena` and `Config-pvp.yml` pages, with the sidebar, home, commands, placeholder and FFA pages updated to point at them.
- 14 new tests cover duration parsing and formatting, the level curve, the rank ladder going up and coming back down, the stat transitions, and the shape of the bundled config. Full suite is 439 passing.
