### PR TITLE
feat(pvp): add the ranked queue match history and leaderboard menus (#255)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -48,7 +48,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/leave` | `/leave` | None | Leave active duel or FFA instance | `ultimatedonutsmp.command.leave` |
 | `/ffa` | `/ffa [join]` | None | Join instanced FFA arena | `ultimatedonutsmp.command.ffa` |
 | `/ffastats` | `/ffastats [player]` | None | View FFA kill/death/streak stats | `ultimatedonutsmp.command.ffastats` |
-| `/pvp` | `/pvp [join\|leave\|kit\|stats\|top]` | None | Join the ranked PvP arena, pick a kit, or read the Elo ladder | `ultimatedonutsmp.command.pvp` |
+| `/pvp` | `/pvp [join\|leave\|kit\|stats\|top\|queue\|leaderboard\|history]` | None | Join the ranked PvP arena, queue for a 1v1, or browse leaderboards and match history | `ultimatedonutsmp.command.pvp` |
 | `/bounty` | `/bounty [place\|list]` | None | Place or view player bounties | `ultimatedonutsmp.command.bounty` |
 | `/leaderboard` | `/leaderboard [type]` | `/lb`, `/top`, `/leaderboards`, `/baltop` | Open leaderboard menus; `/baltop` opens the money leaderboard directly | `ultimatedonutsmp.command.leaderboard` |
 | `/voicechatconsent` | `/voicechatconsent [revoke]` | `/vcconsent`, `/voiceconsent` | Open the voice chat consent menu, or withdraw an answer already given with `revoke` | `ultimatedonutsmp.command.voicechatconsent` |
@@ -94,7 +94,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/portal` | `/portal <create\|delete\|list\|setcuboid\|setdestination>` | Custom portal trigger setup | `ultimatedonutsmp.admin.portal` |
 | `/arena` | `/arena <create\|delete\|setpos1\|setpos2\|setreturn\|enable>` | Duel arena setup and configuration | `ultimatedonutsmp.admin.arena` |
 | `/ffaarena` | `/ffaarena <create\|delete\|setpos\|enable>` | Instanced FFA arena management | `ultimatedonutsmp.admin.ffaarena` |
-| `/pvp` | `/pvp <wand\|create\|setspawn\|setlobby\|setboundary\|kit\|schematic\|reset\|reload>` | Ranked PvP arena setup, kit editing, and schematic resets | `ultimatedonutsmp.admin.pvp` |
+| `/pvp` | `/pvp <wand\|create\|setspawn\|setspawn2\|setlobby\|setboundary\|kit\|schematic\|assign\|reset\|reload>` | Ranked PvP arena setup, kit editing, assigned matches, and schematic resets | `ultimatedonutsmp.admin.pvp` |
 | `/crate` | `/crate <create\|delete\|key\|keyall\|bind\|edit>` | Crate & virtual key administration | `ultimatedonutsmp.admin.crate` |
 | `/spawner` | `/spawner <give\|set\|type\|stack>` | Custom spawner stack administration | `ultimatedonutsmp.admin.spawner` |
 | `/addmoney` | `/addmoney <player> <amount>` | Add money to player balance | `ultimatedonutsmp.admin.addmoney` |

--- a/docs/wiki/Config-pvp.yml.md
+++ b/docs/wiki/Config-pvp.yml.md
@@ -61,6 +61,8 @@ ARENA:
   WORLD: ''
   # Where players are put when they join or respawn (world,x,y,z,yaw,pitch)
   SPAWN: ''
+  # Where the second player in a ranked 1v1 match starts
+  SPAWN_2: ''
   # Where players are sent on /pvp leave and after a disconnect (world,x,y,z,yaw,pitch)
   LOBBY: ''
   # The two wand corners of the arena boundary (world,x,y,z,yaw,pitch)
@@ -77,6 +79,7 @@ ARENA:
 | `ARENA.NAME` | `string` | Any text | `'Arena'` | Shown by `%pvp_arena%`. Set with `/pvp create <name>`. |
 | `ARENA.WORLD` | `string` | A loaded world name, or empty | `''` | Left empty the arena uses the world of `ARENA.SPAWN`, which is almost always right. |
 | `ARENA.SPAWN` | `string` | `world,x,y,z,yaw,pitch` | `''` | The one required setting. Without it `/pvp` refuses to let anyone in. |
+| `ARENA.SPAWN_2` | `string` | `world,x,y,z,yaw,pitch` | `''` | Where the second fighter in a ranked match starts. Empty puts both of them on `ARENA.SPAWN`. Set with `/pvp setspawn2`. |
 | `ARENA.LOBBY` | `string` | `world,x,y,z,yaw,pitch` | `''` | Falls back to the configured server spawn when empty. |
 | `ARENA.BOUNDARY_POS1` | `string` | `world,x,y,z,yaw,pitch` | `''` | First wand corner. With no corners the whole arena world counts as inside. |
 | `ARENA.BOUNDARY_POS2` | `string` | `world,x,y,z,yaw,pitch` | `''` | Second wand corner. |
@@ -121,6 +124,72 @@ RESET:
 | `RESET.PASTE_LOCATION` | `string` | `world,x,y,z,yaw,pitch`, or empty | `''` | Fills `{world} {x} {y} {z}` in the commands. Empty relies on `-o`, which pastes at the origin stored in the schematic. |
 | `RESET.COMMANDS` | `list` | Console commands | load + paste | Run in order from console. WorldEdit and FastAsyncWorldEdit answer the same two commands, so either works and neither needs to be listed as a dependency. |
 | `RESET.PASTE_DELAY_SECONDS` | `int` | `1` and above | `5` | Wait between one command and the next. A large schematic is still loading when an immediate paste would fire. |
+
+---
+
+## Section: `MATCH`
+
+### 1. Commented Setup Code Example
+
+```yaml
+MATCH:
+  # Enable the ranked queue, /pvp assign and the match history (true / false)
+  ENABLED: true
+  # Seconds both players stand protected at the start of a match
+  COUNTDOWN_SECONDS: 5
+  # Longest a match may run before it is called a draw
+  MAX_DURATION: '5m'
+  # Elo the winner gains
+  ELO_WIN: 20
+  # Elo the loser drops
+  ELO_LOSS: 15
+  # Elo both players take on a draw or an aborted match
+  ELO_DRAW: 0
+  # Heal both players and re-hand the kit when a match starts (true / false)
+  HEAL_ON_START: true
+  # How the date is written in the match history
+  DATE_FORMAT: 'dd/MM/yyyy HH:mm'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `MATCH.ENABLED` | `bool` | `true`, `false` | `true` | Covers the queue, `/pvp assign` and the history menu. The open arena keeps working with this off. |
+| `MATCH.COUNTDOWN_SECONDS` | `int` | `0` and above | `5` | Neither fighter can deal or take damage until it runs out. |
+| `MATCH.MAX_DURATION` | `string` | Same format as `RESET.INTERVAL` | `'5m'` | A match still running at this point is called a draw. `0` lets it run forever. |
+| `MATCH.ELO_WIN` | `int` | `0` and above | `20` | Added to the winner. |
+| `MATCH.ELO_LOSS` | `int` | `0` and above | `15` | Taken from the loser. `ELO.MINIMUM` still applies, and the history stores the change that actually landed. |
+| `MATCH.ELO_DRAW` | `int` | Any integer | `0` | Applied to both on a draw or an aborted match. |
+| `MATCH.HEAL_ON_START` | `bool` | `true`, `false` | `true` | Full health and a fresh kit at the opening countdown. |
+| `MATCH.DATE_FORMAT` | `string` | A Java date pattern | `'dd/MM/yyyy HH:mm'` | Used by the history menu. An unreadable pattern falls back to the default rather than breaking the menu. |
+
+---
+
+## Section: `MENUS`
+
+Titles and sizes are yours; the slot layouts are fixed so a size change cannot leave a button with
+nowhere to sit.
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `MENUS.QUEUE.TITLE` | `string` | Any text | `'&8PvP queue'` | Title of `/pvp queue`. |
+| `MENUS.QUEUE.SIZE` | `int` | 27, 36, 45, 54 | `27` | Anything else falls back to 27. |
+| `MENUS.QUEUE.CONFIRM.MATERIAL` | `string` | A material name | `LIME_STAINED_GLASS_PANE` | The join button. |
+| `MENUS.QUEUE.CONFIRM.DISPLAY-NAME` | `string` | Any text | `'&aCONFIRM'` | |
+| `MENUS.QUEUE.CANCEL.MATERIAL` | `string` | A material name | `RED_STAINED_GLASS_PANE` | Leaves the queue, or closes the menu when not queued. |
+| `MENUS.QUEUE.CANCEL.DISPLAY-NAME` | `string` | Any text | `'&cLEAVE'` | |
+| `MENUS.LEADERBOARD.TITLE` | `string` | Any text | `'&8Leaderboards'` | |
+| `MENUS.LEADERBOARD.SIZE` | `int` | 27, 36, 45, 54 | `27` | |
+| `MENUS.LEADERBOARD.ENTRIES` | `int` | 1-15 | `10` | How many players each board lists in its lore. |
+| `MENUS.LEADERBOARD.LINE` | `string` | `{position}`, `{player}`, `{value}` | `'&7#{position} &f{player} &8- &c{value}'` | One ranking row. |
+| `MENUS.LEADERBOARD.ICONS.<board>` | `string` | A material name | Varies | One per board: `ELO`, `LEVEL`, `KILLS`, `DEATHS`, `STREAK`, `JOINS`. |
+| `MENUS.HISTORY.TITLE` | `string` | `{player}` | `'&8Match history &7- &f{player}'` | The history menu pages 45 matches at a time. |
+| `MENUS.ASSIGN.TITLE` | `string` | Any text | `'&8Assign match'` | |
+| `MENUS.ASSIGN.SIZE` | `int` | 27, 36, 45, 54 | `27` | |
+| `MENUS.ASSIGN.CONFIRM.MATERIAL` | `string` | A material name | `LIME_STAINED_GLASS_PANE` | Shown once two different players and a kit are picked. |
+| `MENUS.ASSIGN.CONFIRM.DISPLAY-NAME` | `string` | Any text | `'&aSTART MATCH'` | |
+| `MENUS.ASSIGN.BLOCKED.MATERIAL` | `string` | A material name | `RED_STAINED_GLASS_PANE` | Shown while the selection is incomplete. |
 
 ---
 
@@ -390,3 +459,13 @@ Every player-facing string the arena sends. All of them go through the plugin's 
 | `MESSAGES.TOP_HEADER` | – | `/pvp top` header. |
 | `MESSAGES.TOP_LINE` | `{position}`, `{player}`, `{elo}`, `{rank}` | Each `/pvp top` row. |
 | `MESSAGES.TOP_EMPTY` | – | `/pvp top` with no records yet. |
+| `MESSAGES.QUEUE_JOINED` | `{kit}` | Confirms a place in the ranked queue. |
+| `MESSAGES.QUEUE_LEFT` | – | Left the queue. |
+| `MESSAGES.QUEUE_ALREADY_IN` / `MESSAGES.QUEUE_NOT_IN` | – | Wrong-state queue responses. |
+| `MESSAGES.MATCH_ALREADY_IN` | – | Already fighting a ranked match. |
+| `MESSAGES.MATCH_LEAVE_ARENA_FIRST` | – | Queueing while inside the open arena. |
+| `MESSAGES.MATCH_NEEDS_TWO` | – | `/pvp assign` with one player, or the same player twice. |
+| `MESSAGES.MATCH_STARTED` | `{first}`, `{second}` | Sent to both fighters when a match opens. |
+| `MESSAGES.MATCH_COUNTDOWN` | `{seconds}` | Sent once a second during the opening countdown. |
+| `MESSAGES.MATCH_WIN` / `MESSAGES.MATCH_LOSS` | `{opponent}`, `{elo}`, `{hits}`, `{crystals}` | The result lines. |
+| `MESSAGES.MATCH_DRAW` | `{opponent}` | Sent when the duration cap runs out. |

--- a/docs/wiki/Ranked-PvP-Arena.md
+++ b/docs/wiki/Ranked-PvP-Arena.md
@@ -1,8 +1,10 @@
 # Ranked PvP Arena
 
 The ranked arena is a persistent free-for-all area with kits, an Elo rating, a rank ladder, a
-separate level track, and an optional scheduled reset that pastes a schematic back over the map. It
-is configured entirely through `pvp.yml` and the `/pvp` command, and it ships switched off.
+separate level track, and an optional scheduled reset that pastes a schematic back over the map. On
+top of that sits a ranked 1v1 queue with its own match history, leaderboards and an assign menu for
+testers. All of it is configured through `pvp.yml` and the `/pvp` command, and it ships switched
+off.
 
 It is not a second FFA system. [Instanced FFA](Duels-and-FFA) matches two players in a throwaway
 copy of an arena and rolls the blocks back afterwards. The ranked arena is one permanent place that
@@ -38,7 +40,8 @@ Give yourself `ultimatedonutsmp.admin.pvp` and work through this in the world th
 
 `/pvp setspawn` is the only step the arena cannot open without. Run it where players should appear.
 `/pvp setlobby` records where `/pvp leave`, a boundary exit and a reconnect send people; without it
-the arena falls back to the server spawn.
+the arena falls back to the server spawn. `/pvp setspawn2` marks where the second player in a ranked
+1v1 starts; leave it unset and both fighters spawn on the same point.
 
 `/pvp wand` hands you a golden axe. Left click one corner of the arena, right click the opposite
 one, then `/pvp setboundary` stores them. Anyone who steps outside that box - plus the
@@ -124,6 +127,61 @@ BROADCASTS:
     GLOBAL: true
     MESSAGE: '&8[&cPVP&8] &f%player_name% &7has reached PvP Level &c%pvp_level%&7!'
 ```
+
+---
+
+## Ranked 1v1 matches
+
+Alongside the open arena there is a ranked queue. `/pvp queue` opens a menu, the player picks the kit
+they want to fight with, and confirming puts them in line. As soon as a second person is waiting the
+two are paired, dropped on `ARENA.SPAWN` and `ARENA.SPAWN_2`, handed the kit, and held for a short
+countdown during which neither can be hurt.
+
+Pairing is by wait time, not by rating. On a survival server the queue is rarely more than a handful
+of people, and holding a high rated player back to look for a closer opponent mostly means nobody
+gets a fight at all.
+
+The match ends when somebody dies, disconnects, leaves the arena boundary, or `MATCH.MAX_DURATION`
+runs out, which is a draw. The winner gains `MATCH.ELO_WIN`, the loser drops `MATCH.ELO_LOSS`, and
+both are sent back to the lobby. Ranked deaths never trigger the open arena's per-kill rewards or its
+respawn countdown, so a match scores itself once and only once.
+
+```yaml
+MATCH:
+  ENABLED: true
+  COUNTDOWN_SECONDS: 5
+  MAX_DURATION: '5m'
+  ELO_WIN: 20
+  ELO_LOSS: 15
+```
+
+---
+
+## The menus
+
+Four menus cover the ranked side.
+
+`/pvp queue` is the queue itself: the available kits in the middle, a confirm button on the right, a
+leave button on the left. The kit is chosen before queueing rather than after being paired, so two
+matched players arrive already agreed on the loadout.
+
+`/pvp leaderboard` shows one icon per board, with its ranking in the icon's lore. Elo, level, kills,
+deaths, best streak and arena joins each get their own, and the icon materials and the row format are
+config. Clicking an icon refreshes it.
+
+`/pvp history [player]` lists past matches newest first, one item each. The lore carries the date,
+how long the match ran, who won, and both fighters' hits, crystals and Elo change. Those numbers come
+from the stored match row rather than from the players' current totals, so an old entry still reads
+correctly long after the ladder has moved on.
+
+`/pvp assign` is the tester's menu. Click the two player slots to cycle through everyone online,
+click the middle slot to pick the kit, then confirm to start the match without either player having
+queued. `/pvp assign <player> <player> [kit]` does the same thing from the command line, which is
+what you want when running the same fixture repeatedly. Both need `ultimatedonutsmp.admin.pvp`.
+
+Hits and crystals are counted separately during a match. A crystal explosion names the crystal as
+the damager rather than whoever set it off, so in a ranked match it is credited to the opponent,
+which is exact because a match only ever has two people in it.
 
 ---
 
@@ -234,6 +292,10 @@ it.
 | `/pvp kit` | Reopen the kit menu |
 | `/pvp stats [player]` | Elo, rank, level, XP, K/D and streaks |
 | `/pvp top [amount]` | The Elo ladder, offline players included |
+| `/pvp queue` | Open the ranked 1v1 queue |
+| `/pvp queue leave` | Leave the queue |
+| `/pvp leaderboard` | Open the leaderboards |
+| `/pvp history [player]` | Browse ranked match history |
 
 See [Config-pvp.yml](Config-pvp.yml) for every option, and
 [Placeholders & Integrations](Placeholders-and-Integrations) for the `%pvp_*%` catalog.

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -81,6 +81,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private DuelManager duelManager;
     private FfaManager ffaManager;
     private PvpManager pvpManager;
+    private PvpMatchManager pvpMatchManager;
     private AuctionHouseManager auctionHouseManager;
     private AuctionOrderBotManager auctionOrderBotManager;
     private ServerNotificationManager serverNotificationManager;
@@ -229,6 +230,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         duelManager = new DuelManager(this);
         ffaManager = new FfaManager(this);
         pvpManager = new PvpManager(this);
+        pvpMatchManager = new PvpMatchManager(this);
         auctionHouseManager = new AuctionHouseManager(this);
         auctionOrderBotManager = new AuctionOrderBotManager(this);
         serverNotificationManager = new ServerNotificationManager(this);
@@ -422,6 +424,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         }
         if (ffaManager != null) {
             ffaManager.shutdown();
+        }
+        if (pvpMatchManager != null) {
+            pvpMatchManager.shutdown();
         }
         if (pvpManager != null) {
             pvpManager.shutdown();
@@ -1076,6 +1081,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         duelManager.reload();
         ffaManager.reload();
         pvpManager.reload();
+        pvpMatchManager.reload();
         auctionHouseManager.reload();
         if (auctionOrderBotManager != null) {
             auctionOrderBotManager.reload();
@@ -1351,6 +1357,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public PvpManager getPvpManager() {
         return pvpManager;
+    }
+
+    public PvpMatchManager getPvpMatchManager() {
+        return pvpMatchManager;
     }
 
     public AuctionHouseManager getAuctionHouseManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
@@ -2,7 +2,11 @@ package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.menus.PvpAssignMatchMenu;
 import com.bx.ultimateDonutSmp.menus.PvpKitEditMenu;
+import com.bx.ultimateDonutSmp.menus.PvpLeaderboardMenu;
+import com.bx.ultimateDonutSmp.menus.PvpMatchHistoryMenu;
+import com.bx.ultimateDonutSmp.menus.PvpQueueMenu;
 import com.bx.ultimateDonutSmp.models.PvpKit;
 import com.bx.ultimateDonutSmp.models.PvpRank;
 import com.bx.ultimateDonutSmp.models.PvpStats;
@@ -29,9 +33,12 @@ import java.util.UUID;
 public class PvpCommand implements CommandExecutor, TabCompleter {
 
     private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("0.00");
-    private static final List<String> PLAYER_SUBCOMMANDS = List.of("join", "leave", "kit", "stats", "top");
+    private static final List<String> PLAYER_SUBCOMMANDS = List.of(
+            "join", "leave", "kit", "stats", "top", "queue", "leaderboard", "history"
+    );
     private static final List<String> ADMIN_SUBCOMMANDS = List.of(
-            "wand", "create", "setspawn", "setlobby", "setboundary", "schematic", "reset", "reload"
+            "wand", "create", "setspawn", "setspawn2", "setlobby", "setboundary",
+            "schematic", "assign", "reset", "reload"
     );
 
     private final UltimateDonutSmp plugin;
@@ -64,9 +71,14 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
             case "kit" -> handleKit(sender, label, args);
             case "stats" -> handleStats(sender, args);
             case "top" -> handleTop(sender, args);
+            case "queue" -> handleQueue(sender, args);
+            case "leaderboard", "lb" -> requirePlayer(sender, p -> new PvpLeaderboardMenu(plugin).open(p));
+            case "history" -> handleHistory(sender, args);
+            case "assign" -> handleAssign(sender, args);
             case "wand" -> handleWand(sender);
             case "create" -> handleCreate(sender, args);
             case "setspawn" -> handleSetSpawn(sender);
+            case "setspawn2" -> handleSetSpawn2(sender);
             case "setlobby" -> handleSetLobby(sender);
             case "setboundary" -> handleSetBoundary(sender);
             case "schematic" -> handleSchematic(sender, label, args);
@@ -264,14 +276,72 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         send(sender, pvp.message("TOP_HEADER", "&8&m--------&r &cTop PvP players &8&m--------"));
         int position = 1;
         for (PvpManager.TopEntry entry : top) {
-            PvpRank rank = pvp.getRankFor(entry.elo());
+            PvpRank rank = pvp.getRankFor(entry.value());
             send(sender, pvp.message("TOP_LINE", "&7#{position} &f{player} &8- &c{elo} elo &8(&7{rank}&8)")
                     .replace("{position}", String.valueOf(position++))
                     .replace("{player}", entry.name())
-                    .replace("{elo}", String.valueOf(entry.elo()))
+                    .replace("{elo}", String.valueOf(entry.value()))
                     .replace("{rank}", rank == null ? "-" : rank.getDisplay()));
         }
         return true;
+    }
+
+    private boolean handleQueue(CommandSender sender, String[] args) {
+        return requirePlayer(sender, player -> {
+            if (args.length > 1 && args[1].equalsIgnoreCase("leave")) {
+                boolean left = plugin.getPvpMatchManager().leaveQueue(player.getUniqueId());
+                send(player, left
+                        ? plugin.getPvpManager().message("QUEUE_LEFT", "&aYou left the ranked queue.")
+                        : plugin.getPvpManager().message("QUEUE_NOT_IN", "&cYou are not in the queue."));
+                return;
+            }
+            new PvpQueueMenu(plugin).open(player);
+        });
+    }
+
+    private boolean handleHistory(CommandSender sender, String[] args) {
+        UUID target;
+        if (args.length > 1) {
+            OfflinePlayer offline = Bukkit.getOfflinePlayer(args[1]);
+            target = offline.getUniqueId();
+        } else if (sender instanceof Player player) {
+            target = player.getUniqueId();
+        } else {
+            send(sender, "&e/pvp history <player>");
+            return true;
+        }
+
+        UUID resolved = target;
+        return requirePlayer(sender, player -> new PvpMatchHistoryMenu(plugin, resolved).open(player));
+    }
+
+    /**
+     * Opens the assign menu, or starts the match straight away when both names are given.
+     *
+     * <p>Naming both players skips the menu entirely, which is what a tester running the same
+     * fixture repeatedly actually wants.</p>
+     */
+    private boolean handleAssign(CommandSender sender, String[] args) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+
+        if (args.length >= 3) {
+            Player first = Bukkit.getPlayerExact(args[1]);
+            Player second = Bukkit.getPlayerExact(args[2]);
+            if (first == null || second == null) {
+                send(sender, "&cBoth players have to be online.");
+                return true;
+            }
+            String kitId = args.length >= 4 ? args[3] : null;
+            plugin.getPvpMatchManager().startMatch(first, second, kitId, sender);
+            return true;
+        }
+
+        UUID first = args.length >= 2 && Bukkit.getPlayerExact(args[1]) != null
+                ? Bukkit.getPlayerExact(args[1]).getUniqueId()
+                : null;
+        return requirePlayer(sender, player -> new PvpAssignMatchMenu(plugin, first, null).open(player));
     }
 
     // ── Admin subcommands ─────────────────────────────────────────────────────
@@ -308,6 +378,16 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         return requirePlayer(sender, player -> {
             plugin.getPvpManager().setSpawn(player.getLocation());
             send(player, "&aArena spawn set to where you are standing.");
+        });
+    }
+
+    private boolean handleSetSpawn2(CommandSender sender) {
+        if (!requireAdmin(sender)) {
+            return true;
+        }
+        return requirePlayer(sender, player -> {
+            plugin.getPvpManager().setSpawn2(player.getLocation());
+            send(player, "&aSecond ranked match spawn set to where you are standing.");
         });
     }
 
@@ -425,12 +505,16 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         send(sender, "&e/" + label + " kit &7- pick a kit again");
         send(sender, "&e/" + label + " stats [player] &7- see a record");
         send(sender, "&e/" + label + " top [amount] &7- see the elo ladder");
+        send(sender, "&e/" + label + " queue &7- join the ranked 1v1 queue");
+        send(sender, "&e/" + label + " leaderboard &7- open the leaderboards");
+        send(sender, "&e/" + label + " history [player] &7- browse ranked matches");
         if (!admin) {
             return;
         }
         send(sender, "&e/" + label + " wand &7- get the boundary wand");
         send(sender, "&e/" + label + " create <name> &7- name the arena");
-        send(sender, "&e/" + label + " setspawn &8| &esetlobby &8| &esetboundary");
+        send(sender, "&e/" + label + " setspawn &8| &esetspawn2 &8| &esetlobby &8| &esetboundary");
+        send(sender, "&e/" + label + " assign [player] [player] [kit] &7- put two players in a match");
         send(sender, "&e/" + label + " kit <create|edit|delete|list|icon|permission|slot|display>");
         send(sender, "&e/" + label + " schematic <load <name>|location>");
         send(sender, "&e/" + label + " reset &8| &ereload");
@@ -466,6 +550,25 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
                 options.add(kit.getId());
             }
             return filter(options, args[2]);
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("queue")) {
+            return filter(List.of("leave"), args[1]);
+        }
+
+        if (args.length == 4 && args[0].equalsIgnoreCase("assign") && pvp != null && isAdmin(sender)) {
+            for (PvpKit kit : pvp.getKits()) {
+                options.add(kit.getId());
+            }
+            return filter(options, args[3]);
+        }
+
+        if ((args.length == 2 || args.length == 3)
+                && (args[0].equalsIgnoreCase("history") || args[0].equalsIgnoreCase("assign"))) {
+            for (Player online : Bukkit.getOnlinePlayers()) {
+                options.add(online.getName());
+            }
+            return filter(options, args[args.length - 1]);
         }
 
         if (args.length == 2 && args[0].equalsIgnoreCase("stats")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PvpListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PvpListener.java
@@ -2,12 +2,14 @@ package com.bx.ultimateDonutSmp.listeners;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.models.PvpMatch;
 import com.bx.ultimateDonutSmp.models.PvpSession;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -74,7 +76,21 @@ public class PvpListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
-        if (pvp() == null || !pvp().isInArena(player.getUniqueId())) {
+        if (pvp() == null) {
+            return;
+        }
+
+        // Losing a ranked match takes the player out of the arena while they are still dead, so the
+        // lobby trip they were owed lands here instead.
+        if (pvp().consumeLobbyOnRespawn(player.getUniqueId())) {
+            Location lobby = pvp().getLobby();
+            if (lobby != null) {
+                event.setRespawnLocation(lobby);
+            }
+            return;
+        }
+
+        if (!pvp().isInArena(player.getUniqueId())) {
             return;
         }
 
@@ -96,8 +112,15 @@ public class PvpListener implements Listener {
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
-        if (pvp() != null) {
-            pvp().handleQuit(event.getPlayer());
+        if (pvp() == null) {
+            return;
+        }
+
+        // The arena is told first so it can remember to send the player to the lobby next login.
+        // Ending the match afterwards then awards the win to whoever is left standing.
+        pvp().handleQuit(event.getPlayer());
+        if (plugin.getPvpMatchManager() != null) {
+            plugin.getPvpMatchManager().handleQuit(event.getPlayer());
         }
     }
 
@@ -174,7 +197,7 @@ public class PvpListener implements Listener {
 
         // A player who owes the arena a kit choice is standing there empty handed, and one inside
         // the spawn window has not had a chance to move yet. Neither is a fair fight.
-        if (session.isAwaitingKit() || isSpawnProtected(session)) {
+        if (session.isAwaitingKit() || isSpawnProtected(session) || isCountingDown(player)) {
             event.setCancelled(true);
         }
     }
@@ -191,9 +214,50 @@ public class PvpListener implements Listener {
         }
 
         PvpSession attackerSession = pvp().getSession(attacker.getUniqueId());
-        if (attackerSession != null && (attackerSession.isAwaitingKit() || isSpawnProtected(attackerSession))) {
+        if (attackerSession != null
+                && (attackerSession.isAwaitingKit() || isSpawnProtected(attackerSession) || isCountingDown(attacker))) {
             event.setCancelled(true);
         }
+    }
+
+    /**
+     * Counts what the match history reports: direct hits, and crystals separately.
+     *
+     * <p>A crystal explosion names the crystal as the damager rather than whoever set it off, so in
+     * a ranked match it is credited to the opponent. That is exact here because a match only ever
+     * has two people in it.</p>
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMatchDamage(EntityDamageByEntityEvent event) {
+        if (plugin.getPvpMatchManager() == null || !(event.getEntity() instanceof Player victim)) {
+            return;
+        }
+
+        PvpMatch match = plugin.getPvpMatchManager().getMatch(victim.getUniqueId());
+        if (match == null) {
+            return;
+        }
+
+        if (event.getDamager() instanceof EnderCrystal) {
+            Player opponent = org.bukkit.Bukkit.getPlayer(match.opponentOf(victim.getUniqueId()));
+            if (opponent != null) {
+                plugin.getPvpMatchManager().handleCrystal(opponent, victim);
+            }
+            return;
+        }
+
+        Player attacker = resolveAttacker(event);
+        if (attacker != null && match.involves(attacker.getUniqueId())) {
+            plugin.getPvpMatchManager().handleHit(attacker, victim);
+        }
+    }
+
+    private boolean isCountingDown(Player player) {
+        if (plugin.getPvpMatchManager() == null) {
+            return false;
+        }
+        PvpMatch match = plugin.getPvpMatchManager().getMatch(player.getUniqueId());
+        return match != null && match.isCountingDown(System.currentTimeMillis());
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
@@ -67,6 +67,7 @@ public class PvpManager {
     private final Map<String, PvpKit> kits = new LinkedHashMap<>();
     private final List<PvpRank> ranks = new ArrayList<>();
     private final java.util.Set<UUID> lobbyOnRejoin = ConcurrentHashMap.newKeySet();
+    private final java.util.Set<UUID> lobbyOnRespawn = ConcurrentHashMap.newKeySet();
 
     private long nextResetAt;
     private boolean resetWarningSent;
@@ -187,14 +188,25 @@ public class PvpManager {
 
     /** The Elo ladder, best first. Reads straight from the database so offline players count. */
     public List<TopEntry> getTop(int limit) {
+        return getTop(TopCategory.ELO, limit);
+    }
+
+    /**
+     * One leaderboard, best first.
+     *
+     * <p>The column comes from {@link TopCategory} rather than from a caller-supplied string, so
+     * the ordering can be chosen freely without ever building SQL out of user input.</p>
+     */
+    public List<TopEntry> getTop(TopCategory category, int limit) {
         List<TopEntry> top = new ArrayList<>();
         Connection connection = connection();
-        if (connection == null) {
+        if (connection == null || category == null) {
             return top;
         }
 
         try (PreparedStatement ps = connection.prepareStatement(
-                "select player_uuid, elo from pvp_stats order by elo desc limit ?")) {
+                "select player_uuid, " + category.column() + " as value from pvp_stats"
+                        + " order by value desc limit ?")) {
             ps.setInt(1, Math.max(1, limit));
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
@@ -206,7 +218,7 @@ public class PvpManager {
                     if (name == null || name.isBlank()) {
                         name = Bukkit.getOfflinePlayer(uuid).getName();
                     }
-                    top.add(new TopEntry(uuid, name == null ? uuid.toString() : name, rs.getInt("elo")));
+                    top.add(new TopEntry(uuid, name == null ? uuid.toString() : name, rs.getInt("value")));
                 }
             }
         } catch (SQLException exception) {
@@ -223,6 +235,12 @@ public class PvpManager {
 
     public Location getSpawn() {
         return LocationUtils.parse(config().getString("ARENA.SPAWN", ""));
+    }
+
+    /** Where the second player in a ranked match starts. Falls back to the single arena spawn. */
+    public Location getSpawn2() {
+        Location second = LocationUtils.parse(config().getString("ARENA.SPAWN_2", ""));
+        return second != null ? second : getSpawn();
     }
 
     public Location getLobby() {
@@ -250,6 +268,10 @@ public class PvpManager {
         if (location != null && location.getWorld() != null) {
             writeConfig("ARENA.WORLD", location.getWorld().getName());
         }
+    }
+
+    public void setSpawn2(Location location) {
+        writeConfig("ARENA.SPAWN_2", LocationUtils.serialize(location));
     }
 
     public void setLobby(Location location) {
@@ -609,7 +631,13 @@ public class PvpManager {
 
         Location lobby = getLobby();
         if (lobby != null && !silent) {
-            plugin.getSpigotScheduler().teleport(player, lobby);
+            // Losing a ranked match removes the player while they are still on the death screen,
+            // and a teleport there does not survive the respawn. Hand it to the respawn instead.
+            if (player.isDead()) {
+                lobbyOnRespawn.add(player.getUniqueId());
+            } else {
+                plugin.getSpigotScheduler().teleport(player, lobby);
+            }
         }
         if (plugin.getScoreboardManager() != null) {
             plugin.getScoreboardManager().invalidatePlayer(player);
@@ -635,6 +663,25 @@ public class PvpManager {
         for (PotionEffect effect : new ArrayList<>(player.getActivePotionEffects())) {
             player.removePotionEffect(effect.getType());
         }
+    }
+
+    /**
+     * Opens a session for a player the ranked queue is about to drop into a match.
+     *
+     * <p>Unlike {@link #join(Player)} there is no kit menu: the match already decided the kit, and
+     * the pair have to arrive holding it at the same moment.</p>
+     */
+    public void startSession(Player player) {
+        if (player == null) {
+            return;
+        }
+
+        PvpSession session = new PvpSession(player.getUniqueId(), System.currentTimeMillis());
+        session.setAwaitingKit(false);
+        session.setSpawnedAt(System.currentTimeMillis());
+        sessions.put(player.getUniqueId(), session);
+        updateStats(player.getUniqueId(), getStats(player.getUniqueId()).recordArenaJoin());
+        player.setGameMode(GameMode.SURVIVAL);
     }
 
     public void openKitMenu(Player player) {
@@ -693,6 +740,10 @@ public class PvpManager {
                 .replace("{kit}", ColorUtils.strip(ColorUtils.colorize(kit.getDisplayName()))));
     }
 
+    public void healPlayer(Player player) {
+        heal(player);
+    }
+
     private void heal(Player player) {
         player.setHealth(Math.max(1.0D, AttributeUtils.getMaxHealth(player)));
         player.setFoodLevel(20);
@@ -709,6 +760,13 @@ public class PvpManager {
     public void handleDeath(Player victim, Player killer) {
         PvpSession session = getSession(victim.getUniqueId());
         if (session == null) {
+            return;
+        }
+
+        // A ranked match scores itself: the win and the Elo come from the match result, so the
+        // open arena's per-kill rewards and respawn countdown must not also fire here.
+        if (plugin.getPvpMatchManager() != null && plugin.getPvpMatchManager().isInMatch(victim.getUniqueId())) {
+            plugin.getPvpMatchManager().handleDeath(victim);
             return;
         }
 
@@ -825,6 +883,15 @@ public class PvpManager {
         takeKitBack(player);
     }
 
+    /**
+     * Whether this player still owes the arena a trip to the lobby when they respawn.
+     *
+     * <p>Reading it clears it, so the respawn that acts on it is the only one that can.</p>
+     */
+    public boolean consumeLobbyOnRespawn(UUID uuid) {
+        return uuid != null && lobbyOnRespawn.remove(uuid);
+    }
+
     /** Sends a player who logged out inside the arena back to the lobby on their next join. */
     public void handleJoin(Player player) {
         if (player == null || !lobbyOnRejoin.remove(player.getUniqueId())) {
@@ -841,6 +908,38 @@ public class PvpManager {
                     }
                 }
             }, 10L);
+        }
+    }
+
+    /**
+     * Moves a player's Elo by a ranked match result and announces any rank change.
+     *
+     * @return the change that actually landed, which the floor or ceiling may have cut short
+     */
+    public int applyMatchElo(UUID uuid, int delta) {
+        if (uuid == null) {
+            return 0;
+        }
+
+        PvpStats before = getStats(uuid);
+        PvpRank oldRank = getRankFor(before.getElo());
+        PvpStats after = before.withElo(clampElo(before.getElo() + delta));
+        updateStats(uuid, after);
+
+        Player player = Bukkit.getPlayer(uuid);
+        if (player != null) {
+            announceRank(player, oldRank, getRankFor(after.getElo()), after);
+        }
+        return after.getElo() - before.getElo();
+    }
+
+    /** Books a ranked match win and loss against the same kill and death counters the arena uses. */
+    public void recordMatchOutcome(UUID winner, UUID loser) {
+        if (winner != null) {
+            updateStats(winner, getStats(winner).recordKill());
+        }
+        if (loser != null) {
+            updateStats(loser, getStats(loser).recordDeath());
         }
     }
 
@@ -1118,7 +1217,11 @@ public class PvpManager {
                     && config().getBoolean("SETTINGS.KILL_OUTSIDE_BOUNDARY", true)
                     && !isInsideArena(player.getLocation())) {
                 send(player, message("LEFT_BOUNDARY", "&cYou left the arena and were removed from the fight."));
-                removeFromArena(player, false);
+                if (plugin.getPvpMatchManager() != null && plugin.getPvpMatchManager().isInMatch(uuid)) {
+                    plugin.getPvpMatchManager().handleBoundaryExit(player);
+                } else {
+                    removeFromArena(player, false);
+                }
             }
         }
 
@@ -1356,7 +1459,39 @@ public class PvpManager {
     private record KillRecord(int count, long lastKillAt) {
     }
 
-    /** One row of the Elo ladder. */
-    public record TopEntry(UUID uuid, String name, int elo) {
+    /** One row of a leaderboard: who, and their score in whichever category was asked for. */
+    public record TopEntry(UUID uuid, String name, int value) {
+    }
+
+    /** The leaderboards the menu offers, each naming the column it sorts on. */
+    public enum TopCategory {
+        ELO("elo", "Elo", "DIAMOND"),
+        LEVEL("pvp_level", "Level", "EXPERIENCE_BOTTLE"),
+        KILLS("kills", "Kills", "DIAMOND_SWORD"),
+        DEATHS("deaths", "Deaths", "SKELETON_SKULL"),
+        STREAK("best_streak", "Best streak", "BLAZE_POWDER"),
+        JOINS("arena_joins", "Arena joins", "IRON_DOOR");
+
+        private final String column;
+        private final String displayName;
+        private final String icon;
+
+        TopCategory(String column, String displayName, String icon) {
+            this.column = column;
+            this.displayName = displayName;
+            this.icon = icon;
+        }
+
+        public String column() {
+            return column;
+        }
+
+        public String displayName() {
+            return displayName;
+        }
+
+        public String icon() {
+            return icon;
+        }
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
@@ -1,0 +1,655 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.models.PvpMatch;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+/**
+ * The ranked 1v1 side of the arena: the queue, the matches it produces, and their history.
+ *
+ * <p>This sits beside the open arena rather than inside it. Both use the same Elo, ranks and kits
+ * from {@link PvpManager}, but a queued match is a fight between two named players with a result,
+ * which is what makes a history entry worth keeping. Kills in the open arena are not matches and
+ * never appear here.</p>
+ */
+public class PvpMatchManager {
+
+    private final UltimateDonutSmp plugin;
+
+    private final Map<UUID, QueueEntry> queue = new LinkedHashMap<>();
+    private final Map<UUID, PvpMatch> active = new ConcurrentHashMap<>();
+    private final AtomicLong localIds = new AtomicLong();
+
+    public PvpMatchManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        ensureTables();
+    }
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getPvp();
+    }
+
+    private PvpManager pvp() {
+        return plugin.getPvpManager();
+    }
+
+    public boolean isEnabled() {
+        return pvp() != null && pvp().isEnabled() && config().getBoolean("MATCH.ENABLED", true);
+    }
+
+    public void reload() {
+        // Nothing cached from the config, but a reload has to clear a queue that may now point at
+        // kits or an arena that no longer exist.
+        clearQueue();
+    }
+
+    public void shutdown() {
+        for (PvpMatch match : new ArrayList<>(active.values())) {
+            endMatch(match, null, PvpMatch.Result.ABORTED, true);
+        }
+        queue.clear();
+    }
+
+    // ── Queue ─────────────────────────────────────────────────────────────────
+
+    public boolean isQueued(UUID uuid) {
+        synchronized (queue) {
+            return queue.containsKey(uuid);
+        }
+    }
+
+    public int getQueueSize() {
+        synchronized (queue) {
+            return queue.size();
+        }
+    }
+
+    public String getQueuedKit(UUID uuid) {
+        synchronized (queue) {
+            QueueEntry entry = queue.get(uuid);
+            return entry == null ? null : entry.kitId();
+        }
+    }
+
+    /** Seconds a player has been waiting, or -1 when they are not queued. */
+    public long getQueuedSeconds(UUID uuid) {
+        synchronized (queue) {
+            QueueEntry entry = queue.get(uuid);
+            return entry == null ? -1L : (System.currentTimeMillis() - entry.queuedAt()) / 1000L;
+        }
+    }
+
+    /**
+     * Puts a player in the ranked queue with the kit they picked, and starts a match as soon as
+     * somebody else is waiting.
+     *
+     * @return false when the queue refused them, with the reason already sent
+     */
+    public boolean joinQueue(Player player, PvpKit kit) {
+        if (player == null || kit == null) {
+            return false;
+        }
+        if (!isEnabled()) {
+            send(player, message("DISABLED", "&cThe PvP arena is not enabled."));
+            return false;
+        }
+        if (!pvp().isConfigured()) {
+            send(player, message("NOT_SET_UP", "&cThe PvP arena has not been set up yet."));
+            return false;
+        }
+        if (isInMatch(player.getUniqueId())) {
+            send(player, message("MATCH_ALREADY_IN", "&cYou are already in a ranked match."));
+            return false;
+        }
+        if (pvp().isInArena(player.getUniqueId())) {
+            send(player, message("MATCH_LEAVE_ARENA_FIRST", "&cLeave the arena before queueing."));
+            return false;
+        }
+        if (!pvp().canUseKit(player, kit)) {
+            send(player, message("KIT_NO_PERMISSION", "&cYou do not have access to that kit."));
+            return false;
+        }
+
+        UUID opponent;
+        synchronized (queue) {
+            if (queue.containsKey(player.getUniqueId())) {
+                send(player, message("QUEUE_ALREADY_IN", "&cYou are already in the queue."));
+                return false;
+            }
+            queue.put(player.getUniqueId(), new QueueEntry(kit.getId(), System.currentTimeMillis()));
+            opponent = findOpponent(player.getUniqueId());
+        }
+
+        send(player, message("QUEUE_JOINED", "&aYou joined the ranked queue. Waiting for an opponent...")
+                .replace("{kit}", kit.getId()));
+
+        if (opponent == null) {
+            return true;
+        }
+
+        Player other = Bukkit.getPlayer(opponent);
+        if (other == null) {
+            leaveQueue(opponent);
+            return true;
+        }
+
+        String kitId = kit.getId();
+        synchronized (queue) {
+            queue.remove(player.getUniqueId());
+            queue.remove(opponent);
+        }
+        startMatch(other, player, kitId, null);
+        return true;
+    }
+
+    /**
+     * The first other player waiting.
+     *
+     * <p>Pairing is by wait time rather than by rating. The queue on a survival server is rarely
+     * more than a handful of people, and holding a high rated player back to look for a closer
+     * match would mostly mean nobody gets a fight at all.</p>
+     */
+    private UUID findOpponent(UUID self) {
+        for (Map.Entry<UUID, QueueEntry> entry : queue.entrySet()) {
+            if (!entry.getKey().equals(self) && Bukkit.getPlayer(entry.getKey()) != null) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    public boolean leaveQueue(UUID uuid) {
+        synchronized (queue) {
+            return queue.remove(uuid) != null;
+        }
+    }
+
+    private void clearQueue() {
+        synchronized (queue) {
+            queue.clear();
+        }
+    }
+
+    // ── Matches ───────────────────────────────────────────────────────────────
+
+    public boolean isInMatch(UUID uuid) {
+        return uuid != null && active.containsKey(uuid);
+    }
+
+    public PvpMatch getMatch(UUID uuid) {
+        return uuid == null ? null : active.get(uuid);
+    }
+
+    public int getActiveMatchCount() {
+        return active.size() / 2;
+    }
+
+    /**
+     * Starts a ranked match between two players.
+     *
+     * @param initiator the tester who assigned it, or null when the queue paired them
+     * @return false when either player could not be put in, with the reason already sent
+     */
+    public boolean startMatch(Player first, Player second, String kitId, org.bukkit.command.CommandSender initiator) {
+        if (first == null || second == null || first.getUniqueId().equals(second.getUniqueId())) {
+            send(initiator, message("MATCH_NEEDS_TWO", "&cA ranked match needs two different players."));
+            return false;
+        }
+        if (!isEnabled() || !pvp().isConfigured()) {
+            send(initiator, message("NOT_SET_UP", "&cThe PvP arena has not been set up yet."));
+            return false;
+        }
+        if (isInMatch(first.getUniqueId()) || isInMatch(second.getUniqueId())) {
+            send(initiator, message("MATCH_ALREADY_IN", "&cYou are already in a ranked match."));
+            return false;
+        }
+
+        PvpKit kit = pvp().getKit(kitId);
+        if (kit == null) {
+            List<PvpKit> kits = pvp().getKits();
+            if (kits.isEmpty()) {
+                send(initiator, message("NO_KITS", "&cThere are no PvP kits to choose from yet."));
+                return false;
+            }
+            kit = kits.get(0);
+        }
+
+        leaveQueue(first.getUniqueId());
+        leaveQueue(second.getUniqueId());
+
+        long now = System.currentTimeMillis();
+        PvpMatch match = new PvpMatch(
+                localIds.incrementAndGet(),
+                first.getUniqueId(), first.getName(),
+                second.getUniqueId(), second.getName(),
+                kit.getId(),
+                now
+        );
+        match.setEloBefore(
+                pvp().getStats(first.getUniqueId()).getElo(),
+                pvp().getStats(second.getUniqueId()).getElo()
+        );
+        match.setCountdownEndsAt(now + Math.max(0, config().getInt("MATCH.COUNTDOWN_SECONDS", 5)) * 1000L);
+
+        active.put(first.getUniqueId(), match);
+        active.put(second.getUniqueId(), match);
+
+        prepare(first, kit, pvp().getSpawn());
+        prepare(second, kit, pvp().getSpawn2());
+
+        String announcement = message("MATCH_STARTED", "&8[&cPVP&8] &f{first} &7vs &f{second}")
+                .replace("{first}", first.getName())
+                .replace("{second}", second.getName());
+        send(first, announcement);
+        send(second, announcement);
+        if (initiator != null && !(initiator instanceof Player player && match.involves(player.getUniqueId()))) {
+            send(initiator, announcement);
+        }
+        return true;
+    }
+
+    /** Drops a player onto their side of the arena with the match kit in hand. */
+    private void prepare(Player player, PvpKit kit, Location spawn) {
+        pvp().startSession(player);
+        if (spawn != null) {
+            plugin.getSpigotScheduler().teleport(player, spawn);
+        }
+        if (config().getBoolean("MATCH.HEAL_ON_START", true)) {
+            pvp().healPlayer(player);
+        }
+        pvp().giveKit(player, kit);
+    }
+
+    /** Called when a player in a ranked match dies. The other one wins. */
+    public void handleDeath(Player victim) {
+        PvpMatch match = getMatch(victim.getUniqueId());
+        if (match == null) {
+            return;
+        }
+        endMatch(match, match.opponentOf(victim.getUniqueId()), PvpMatch.Result.DECIDED, false);
+    }
+
+    /** A player who disconnects mid-match hands the win to their opponent. */
+    public void handleQuit(Player player) {
+        leaveQueue(player.getUniqueId());
+        PvpMatch match = getMatch(player.getUniqueId());
+        if (match != null) {
+            endMatch(match, match.opponentOf(player.getUniqueId()), PvpMatch.Result.DECIDED, false);
+        }
+    }
+
+    /** Called when a player leaves the arena boundary during a match. */
+    public void handleBoundaryExit(Player player) {
+        PvpMatch match = getMatch(player.getUniqueId());
+        if (match != null) {
+            endMatch(match, match.opponentOf(player.getUniqueId()), PvpMatch.Result.DECIDED, false);
+        }
+    }
+
+    public void handleHit(Player attacker, Player victim) {
+        PvpMatch match = getMatch(attacker.getUniqueId());
+        if (match != null && match.involves(victim.getUniqueId())) {
+            match.addHit(attacker.getUniqueId());
+        }
+    }
+
+    public void handleCrystal(Player attacker, Player victim) {
+        PvpMatch match = getMatch(attacker.getUniqueId());
+        if (match != null && match.involves(victim.getUniqueId())) {
+            match.addCrystal(attacker.getUniqueId());
+        }
+    }
+
+    /**
+     * Finishes a match, moves the Elo, writes the record, and sends both players home.
+     *
+     * @param winner the winner, or null for a draw
+     * @param silent true during shutdown, where no message would reach anyone
+     */
+    private void endMatch(PvpMatch match, UUID winner, PvpMatch.Result result, boolean silent) {
+        if (match == null || active.get(match.getFirstUuid()) != match) {
+            return;
+        }
+
+        active.remove(match.getFirstUuid());
+        active.remove(match.getSecondUuid());
+        match.setEndedAt(System.currentTimeMillis());
+        match.setWinnerUuid(winner);
+        match.setResult(result);
+
+        int win = config().getInt("MATCH.ELO_WIN", 20);
+        int loss = config().getInt("MATCH.ELO_LOSS", 15);
+        int draw = config().getInt("MATCH.ELO_DRAW", 0);
+
+        int firstDelta;
+        int secondDelta;
+        if (result != PvpMatch.Result.DECIDED || winner == null) {
+            firstDelta = draw;
+            secondDelta = draw;
+        } else if (match.isFirst(winner)) {
+            firstDelta = win;
+            secondDelta = -loss;
+        } else {
+            firstDelta = -loss;
+            secondDelta = win;
+        }
+
+        // The stored delta is what the Elo floor and ceiling actually allowed, so the history never
+        // shows a player losing points they did not have.
+        int appliedFirst = pvp().applyMatchElo(match.getFirstUuid(), firstDelta);
+        int appliedSecond = pvp().applyMatchElo(match.getSecondUuid(), secondDelta);
+        match.setEloDelta(appliedFirst, appliedSecond);
+
+        if (result == PvpMatch.Result.DECIDED && winner != null) {
+            pvp().recordMatchOutcome(winner, match.opponentOf(winner));
+        }
+
+        insertMatch(match);
+
+        Player first = Bukkit.getPlayer(match.getFirstUuid());
+        Player second = Bukkit.getPlayer(match.getSecondUuid());
+        if (!silent) {
+            announceResult(match, first);
+            announceResult(match, second);
+        }
+        if (first != null) {
+            pvp().removeFromArena(first, silent);
+        }
+        if (second != null) {
+            pvp().removeFromArena(second, silent);
+        }
+    }
+
+    private void announceResult(PvpMatch match, Player player) {
+        if (player == null) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        UUID opponent = match.opponentOf(uuid);
+        boolean won = match.getWinnerUuid() != null && match.getWinnerUuid().equals(uuid);
+        String key = match.getResult() == PvpMatch.Result.DECIDED ? (won ? "MATCH_WIN" : "MATCH_LOSS") : "MATCH_DRAW";
+        String fallback = switch (key) {
+            case "MATCH_WIN" -> "&aYou beat &f{opponent} &8(&a{elo} elo&8)";
+            case "MATCH_LOSS" -> "&cYou lost to &f{opponent} &8(&c{elo} elo&8)";
+            default -> "&7The match against &f{opponent} &7ended in a draw.";
+        };
+
+        send(player, message(key, fallback)
+                .replace("{opponent}", opponent == null ? "?" : resolveName(opponent))
+                .replace("{elo}", formatDelta(match.getEloDelta(uuid)))
+                .replace("{hits}", String.valueOf(match.getHits(uuid)))
+                .replace("{crystals}", String.valueOf(match.getCrystals(uuid))));
+    }
+
+    /** Runs once a second alongside the arena tick: countdown lines and the duration cap. */
+    public void tick() {
+        long now = System.currentTimeMillis();
+        long cap = PvpManager.parseDuration(config().getString("MATCH.MAX_DURATION", "5m"));
+
+        for (PvpMatch match : new ArrayList<>(active.values())) {
+            if (match.isCountingDown(now)) {
+                long seconds = Math.max(1L, (match.getCountdownEndsAt() - now + 999L) / 1000L);
+                String text = message("MATCH_COUNTDOWN", "&fStarting in &c{seconds}&f...")
+                        .replace("{seconds}", String.valueOf(seconds));
+                send(Bukkit.getPlayer(match.getFirstUuid()), text);
+                send(Bukkit.getPlayer(match.getSecondUuid()), text);
+                continue;
+            }
+
+            if (cap > 0 && now - match.getStartedAt() > cap) {
+                endMatch(match, null, PvpMatch.Result.DRAW, false);
+            }
+        }
+    }
+
+    // ── History ───────────────────────────────────────────────────────────────
+
+    public int countHistory(UUID uuid) {
+        Connection connection = connection();
+        if (uuid == null || connection == null) {
+            return 0;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "select count(*) from pvp_matches where player_one_uuid = ? or player_two_uuid = ?")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getInt(1) : 0;
+            }
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to count PvP matches for " + uuid, exception);
+            return 0;
+        }
+    }
+
+    /** A player's matches, most recent first. */
+    public List<PvpMatch> getHistory(UUID uuid, int limit, int offset) {
+        List<PvpMatch> history = new ArrayList<>();
+        Connection connection = connection();
+        if (uuid == null || connection == null) {
+            return history;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "select id, player_one_uuid, player_one_name, player_two_uuid, player_two_name, kit_id,"
+                        + " winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals,"
+                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta"
+                        + " from pvp_matches where player_one_uuid = ? or player_two_uuid = ?"
+                        + " order by ended_at desc limit ? offset ?")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, uuid.toString());
+            ps.setInt(3, Math.max(1, limit));
+            ps.setInt(4, Math.max(0, offset));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    PvpMatch match = readMatch(rs);
+                    if (match != null) {
+                        history.add(match);
+                    }
+                }
+            }
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to read PvP matches for " + uuid, exception);
+        }
+        return history;
+    }
+
+    private PvpMatch readMatch(ResultSet rs) throws SQLException {
+        UUID first = parseUuid(rs.getString("player_one_uuid"));
+        UUID second = parseUuid(rs.getString("player_two_uuid"));
+        if (first == null || second == null) {
+            return null;
+        }
+
+        PvpMatch match = new PvpMatch(
+                rs.getLong("id"),
+                first, rs.getString("player_one_name"),
+                second, rs.getString("player_two_name"),
+                rs.getString("kit_id"),
+                rs.getLong("started_at")
+        );
+        match.setEndedAt(rs.getLong("ended_at"));
+        match.setWinnerUuid(parseUuid(rs.getString("winner_uuid")));
+        match.setHits(rs.getInt("one_hits"), rs.getInt("two_hits"));
+        match.setCrystals(rs.getInt("one_crystals"), rs.getInt("two_crystals"));
+        match.setEloBefore(rs.getInt("one_elo_before"), rs.getInt("two_elo_before"));
+        match.setEloDelta(rs.getInt("one_elo_delta"), rs.getInt("two_elo_delta"));
+        try {
+            match.setResult(PvpMatch.Result.valueOf(rs.getString("result")));
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            match.setResult(PvpMatch.Result.ABORTED);
+        }
+        return match;
+    }
+
+    // ── Formatting helpers used by the menus ──────────────────────────────────
+
+    /** Formats a stored match timestamp with the configured date pattern. */
+    public String formatDate(long epochMillis) {
+        String pattern = config().getString("MATCH.DATE_FORMAT", "dd/MM/yyyy HH:mm");
+        try {
+            return DateTimeFormatter.ofPattern(pattern)
+                    .withZone(ZoneId.systemDefault())
+                    .format(Instant.ofEpochMilli(epochMillis));
+        } catch (IllegalArgumentException exception) {
+            return DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+                    .withZone(ZoneId.systemDefault())
+                    .format(Instant.ofEpochMilli(epochMillis));
+        }
+    }
+
+    /** Renders a match length as mm:ss, or hh:mm:ss once it runs past an hour. */
+    public static String formatMatchDuration(long seconds) {
+        long safe = Math.max(0L, seconds);
+        long hours = safe / 3600L;
+        long minutes = (safe % 3600L) / 60L;
+        long remainder = safe % 60L;
+        if (hours > 0) {
+            return String.format("%02d:%02d:%02d", hours, minutes, remainder);
+        }
+        return String.format("%02d:%02d", minutes, remainder);
+    }
+
+    /** Writes an Elo change the way the history reads it: {@code +20}, {@code -15}, {@code 0}. */
+    public static String formatDelta(int delta) {
+        return delta > 0 ? "+" + delta : String.valueOf(delta);
+    }
+
+    public String resolveName(UUID uuid) {
+        if (uuid == null) {
+            return "?";
+        }
+        Player online = Bukkit.getPlayer(uuid);
+        if (online != null) {
+            return online.getName();
+        }
+        String known = plugin.getDatabaseManager() == null
+                ? null
+                : plugin.getDatabaseManager().getLastKnownUsername(uuid);
+        if (known != null && !known.isBlank()) {
+            return known;
+        }
+        String offline = Bukkit.getOfflinePlayer(uuid).getName();
+        return offline == null ? uuid.toString().substring(0, 8) : offline;
+    }
+
+    public String message(String key, String fallback) {
+        return pvp() == null ? fallback : pvp().message(key, fallback);
+    }
+
+    private void send(org.bukkit.command.CommandSender target, String text) {
+        if (target != null && text != null && !text.isBlank()) {
+            target.sendMessage(ColorUtils.toComponent(text));
+        }
+    }
+
+    private static UUID parseUuid(String input) {
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            return null;
+        }
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    private Connection connection() {
+        return plugin.getDatabaseManager() == null ? null : plugin.getDatabaseManager().getConnection();
+    }
+
+    private void ensureTables() {
+        Connection connection = connection();
+        if (connection == null) {
+            return;
+        }
+
+        try (Statement st = connection.createStatement()) {
+            plugin.getDatabaseManager().executeSchema(st, """
+                    CREATE TABLE IF NOT EXISTS pvp_matches (
+                      id INTEGER PRIMARY KEY AUTOINCREMENT,
+                      player_one_uuid TEXT NOT NULL,
+                      player_one_name TEXT,
+                      player_two_uuid TEXT NOT NULL,
+                      player_two_name TEXT,
+                      kit_id TEXT,
+                      winner_uuid TEXT,
+                      result TEXT,
+                      started_at INTEGER DEFAULT 0,
+                      ended_at INTEGER DEFAULT 0,
+                      one_hits INTEGER DEFAULT 0,
+                      two_hits INTEGER DEFAULT 0,
+                      one_crystals INTEGER DEFAULT 0,
+                      two_crystals INTEGER DEFAULT 0,
+                      one_elo_before INTEGER DEFAULT 0,
+                      two_elo_before INTEGER DEFAULT 0,
+                      one_elo_delta INTEGER DEFAULT 0,
+                      two_elo_delta INTEGER DEFAULT 0
+                    )
+                    """);
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to create the PvP match tables", exception);
+        }
+    }
+
+    private void insertMatch(PvpMatch match) {
+        Connection connection = connection();
+        if (connection == null) {
+            return;
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "insert into pvp_matches (player_one_uuid, player_one_name, player_two_uuid, player_two_name,"
+                        + " kit_id, winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals,"
+                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta)"
+                        + " values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")) {
+            ps.setString(1, match.getFirstUuid().toString());
+            ps.setString(2, match.getFirstName());
+            ps.setString(3, match.getSecondUuid().toString());
+            ps.setString(4, match.getSecondName());
+            ps.setString(5, match.getKitId());
+            ps.setString(6, match.getWinnerUuid() == null ? null : match.getWinnerUuid().toString());
+            ps.setString(7, match.getResult() == null ? PvpMatch.Result.ABORTED.name() : match.getResult().name());
+            ps.setLong(8, match.getStartedAt());
+            ps.setLong(9, match.getEndedAt());
+            ps.setInt(10, match.getFirstHits());
+            ps.setInt(11, match.getSecondHits());
+            ps.setInt(12, match.getFirstCrystals());
+            ps.setInt(13, match.getSecondCrystals());
+            ps.setInt(14, match.getFirstEloBefore());
+            ps.setInt(15, match.getSecondEloBefore());
+            ps.setInt(16, match.getFirstEloDelta());
+            ps.setInt(17, match.getSecondEloDelta());
+            ps.executeUpdate();
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to store a PvP match", exception);
+        }
+    }
+
+    /** One player waiting in the ranked queue, and the kit they will fight with. */
+    private record QueueEntry(String kitId, long queuedAt) {
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpAssignMatchMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpAssignMatchMenu.java
@@ -1,0 +1,179 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lets a tester put two named players into a ranked match without either of them queueing.
+ *
+ * <p>The two player slots cycle through everyone online instead of opening a picker, which keeps
+ * the whole assignment on one screen the way the queue menu is.</p>
+ */
+public class PvpAssignMatchMenu extends BaseMenu {
+
+    private static final String PATH = "MENUS.ASSIGN";
+    private static final int FIRST_SLOT = 11;
+    private static final int KIT_SLOT = 13;
+    private static final int SECOND_SLOT = 15;
+    private static final int CONFIRM_SLOT = 22;
+
+    private UUID firstUuid;
+    private UUID secondUuid;
+    private String kitId;
+
+    public PvpAssignMatchMenu(UltimateDonutSmp plugin, UUID firstUuid, UUID secondUuid) {
+        super(plugin, configuredTitle(plugin), configuredSize(plugin));
+        this.firstUuid = firstUuid;
+        this.secondUuid = secondUuid;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        fill(Material.BLACK_STAINED_GLASS_PANE);
+
+        List<PvpKit> kits = plugin.getPvpManager().getKits();
+        if (kitId == null && !kits.isEmpty()) {
+            kitId = kits.get(0).getId();
+        }
+
+        set(FIRST_SLOT, playerIcon(firstUuid, "&aPlayer one"));
+        set(SECOND_SLOT, playerIcon(secondUuid, "&aPlayer two"));
+
+        PvpKit kit = plugin.getPvpManager().getKit(kitId);
+        set(KIT_SLOT, ItemUtils.createItem(
+                kit == null ? Material.BARRIER : kit.getIcon(),
+                kit == null ? "&cNo kit" : kit.getDisplayName(),
+                kit == null
+                        ? List.of("&7Create a kit before assigning a match.")
+                        : List.of("&7Kit for this match.", "&eClick &7to pick the next one.")
+        ));
+
+        boolean ready = firstUuid != null && secondUuid != null && !firstUuid.equals(secondUuid) && kit != null;
+        set(CONFIRM_SLOT, ItemUtils.createItem(
+                ItemUtils.parseMaterial(config().getString(PATH + "."
+                        + (ready ? "CONFIRM" : "BLOCKED") + ".MATERIAL",
+                        ready ? "LIME_STAINED_GLASS_PANE" : "RED_STAINED_GLASS_PANE")),
+                config().getString(PATH + ".CONFIRM.DISPLAY-NAME", ready ? "&aSTART MATCH" : "&cNOT READY"),
+                ready
+                        ? List.of("&7Click to start the match.")
+                        : List.of("&7Pick two different players and a kit first.")
+        ));
+    }
+
+    private ItemStack playerIcon(UUID uuid, String title) {
+        List<String> lore = new ArrayList<>();
+        if (uuid == null) {
+            lore.add("&7Nobody selected.");
+        } else {
+            lore.add("&7Selected: &f" + plugin.getPvpMatchManager().resolveName(uuid));
+        }
+        lore.add("&eClick &7for the next player online.");
+        lore.add("&eShift click &7to clear.");
+
+        if (uuid == null) {
+            return ItemUtils.createItem(Material.PLAYER_HEAD, title, lore);
+        }
+        return ItemUtils.createPlayerHead(Bukkit.getOfflinePlayer(uuid), title, lore);
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        if (slot == FIRST_SLOT || slot == SECOND_SLOT) {
+            boolean first = slot == FIRST_SLOT;
+            if (clickType.isShiftClick()) {
+                if (first) {
+                    firstUuid = null;
+                } else {
+                    secondUuid = null;
+                }
+            } else if (first) {
+                firstUuid = nextPlayer(firstUuid, secondUuid);
+            } else {
+                secondUuid = nextPlayer(secondUuid, firstUuid);
+            }
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            build(player);
+            return;
+        }
+
+        if (slot == KIT_SLOT) {
+            kitId = nextKit();
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            build(player);
+            return;
+        }
+
+        if (slot != CONFIRM_SLOT || firstUuid == null || secondUuid == null) {
+            return;
+        }
+
+        Player first = Bukkit.getPlayer(firstUuid);
+        Player second = Bukkit.getPlayer(secondUuid);
+        if (first == null || second == null) {
+            build(player);
+            return;
+        }
+
+        SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+        player.closeInventory();
+        plugin.getPvpMatchManager().startMatch(first, second, kitId, player);
+    }
+
+    /** The next online player after the current one, skipping whoever is already in the other slot. */
+    private UUID nextPlayer(UUID current, UUID excluded) {
+        List<UUID> online = new ArrayList<>();
+        for (Player candidate : Bukkit.getOnlinePlayers()) {
+            if (excluded == null || !candidate.getUniqueId().equals(excluded)) {
+                online.add(candidate.getUniqueId());
+            }
+        }
+        if (online.isEmpty()) {
+            return null;
+        }
+
+        int index = current == null ? -1 : online.indexOf(current);
+        return online.get((index + 1) % online.size());
+    }
+
+    private String nextKit() {
+        List<PvpKit> kits = plugin.getPvpManager().getKits();
+        if (kits.isEmpty()) {
+            return null;
+        }
+
+        int index = -1;
+        for (int position = 0; position < kits.size(); position++) {
+            if (kits.get(position).getId().equals(kitId)) {
+                index = position;
+                break;
+            }
+        }
+        return kits.get((index + 1) % kits.size()).getId();
+    }
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getPvp();
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin) {
+        return plugin.getConfigManager().getPvp().getString(PATH + ".TITLE", "&8Assign match");
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int size = plugin.getConfigManager().getPvp().getInt(PATH + ".SIZE", 27);
+        return size >= 27 && size <= 54 && size % 9 == 0 ? size : 27;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpLeaderboardMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpLeaderboardMenu.java
@@ -1,0 +1,95 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PvpManager;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One icon per leaderboard, each carrying its own top ten in the lore.
+ *
+ * <p>Holding the ranking in the lore rather than behind a second menu means the whole board is
+ * readable by pointing at an icon, and a click only has to refresh it.</p>
+ */
+public class PvpLeaderboardMenu extends BaseMenu {
+
+    private static final String PATH = "MENUS.LEADERBOARD";
+    private static final List<Integer> CATEGORY_SLOTS = List.of(10, 11, 12, 14, 15, 16);
+
+    private final Map<Integer, PvpManager.TopCategory> slotCategories = new HashMap<>();
+
+    public PvpLeaderboardMenu(UltimateDonutSmp plugin) {
+        super(plugin, configuredTitle(plugin), configuredSize(plugin));
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        slotCategories.clear();
+        fill(Material.BLACK_STAINED_GLASS_PANE);
+
+        int shown = Math.max(1, Math.min(15, config().getInt(PATH + ".ENTRIES", 10)));
+        PvpManager.TopCategory[] categories = PvpManager.TopCategory.values();
+
+        for (int index = 0; index < categories.length && index < CATEGORY_SLOTS.size(); index++) {
+            PvpManager.TopCategory category = categories[index];
+            int slot = CATEGORY_SLOTS.get(index);
+            set(slot, ItemUtils.createItem(
+                    ItemUtils.parseMaterial(config().getString(
+                            PATH + ".ICONS." + category.name(), category.icon())),
+                    "&c&l" + category.displayName(),
+                    buildLore(category, shown)
+            ));
+            slotCategories.put(slot, category);
+        }
+    }
+
+    private List<String> buildLore(PvpManager.TopCategory category, int shown) {
+        List<PvpManager.TopEntry> top = plugin.getPvpManager().getTop(category, shown);
+        List<String> lore = new ArrayList<>();
+        if (top.isEmpty()) {
+            lore.add("&7Nobody has fought in the arena yet.");
+            return lore;
+        }
+
+        String template = config().getString(PATH + ".LINE", "&7#{position} &f{player} &8- &c{value}");
+        int position = 1;
+        for (PvpManager.TopEntry entry : top) {
+            lore.add(template
+                    .replace("{position}", String.valueOf(position++))
+                    .replace("{player}", entry.name())
+                    .replace("{value}", String.valueOf(entry.value())));
+        }
+        return lore;
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        if (slotCategories.containsKey(slot)) {
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            build(player);
+        }
+    }
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getPvp();
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin) {
+        return plugin.getConfigManager().getPvp().getString(PATH + ".TITLE", "&8Leaderboards");
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int size = plugin.getConfigManager().getPvp().getInt(PATH + ".SIZE", 27);
+        return size >= 27 && size <= 54 && size % 9 == 0 ? size : 27;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpMatchHistoryMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpMatchHistoryMenu.java
@@ -1,0 +1,158 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.PvpMatchManager;
+import com.bx.ultimateDonutSmp.models.PvpMatch;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A player's ranked matches, newest first, one item per match.
+ *
+ * <p>Everything about a match is in the item's lore rather than behind another click: the date, how
+ * long it ran, who won, and both fighters' hits, crystals and Elo change. The numbers come from the
+ * stored match row, so an old entry still reads correctly after the players' totals have moved on.</p>
+ */
+public class PvpMatchHistoryMenu extends BaseMenu {
+
+    private static final String PATH = "MENUS.HISTORY";
+    private static final int ITEMS_PER_PAGE = 45;
+    private static final int PREVIOUS_PAGE_SLOT = 48;
+    private static final int PAGE_INFO_SLOT = 49;
+    private static final int NEXT_PAGE_SLOT = 50;
+
+    private final UUID targetUuid;
+
+    private int page;
+    private int totalPages = 1;
+    private boolean hasPreviousPage;
+    private boolean hasNextPage;
+
+    public PvpMatchHistoryMenu(UltimateDonutSmp plugin, UUID targetUuid) {
+        super(plugin, configuredTitle(plugin, targetUuid), 54);
+        this.targetUuid = targetUuid;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        fill(Material.BLACK_STAINED_GLASS_PANE);
+
+        PvpMatchManager matches = plugin.getPvpMatchManager();
+        int total = matches.countHistory(targetUuid);
+        totalPages = Math.max(1, (int) Math.ceil(total / (double) ITEMS_PER_PAGE));
+        if (page >= totalPages) {
+            page = totalPages - 1;
+        }
+
+        int offset = page * ITEMS_PER_PAGE;
+        hasPreviousPage = page > 0;
+        hasNextPage = offset + ITEMS_PER_PAGE < total;
+
+        List<PvpMatch> history = matches.getHistory(targetUuid, ITEMS_PER_PAGE, offset);
+        if (history.isEmpty()) {
+            set(22, ItemUtils.createItem(Material.BARRIER, "&cNo matches",
+                    List.of("&7This player has not fought a ranked match yet.")));
+        } else {
+            for (int index = 0; index < history.size(); index++) {
+                set(index, createMatchItem(history.get(index), offset + index + 1));
+            }
+        }
+
+        buildPageButtons(total);
+    }
+
+    private ItemStack createMatchItem(PvpMatch match, int number) {
+        PvpMatchManager matches = plugin.getPvpMatchManager();
+        UUID opponent = match.opponentOf(targetUuid);
+        boolean won = match.getWinnerUuid() != null && match.getWinnerUuid().equals(targetUuid);
+        boolean decided = match.getResult() == PvpMatch.Result.DECIDED;
+
+        String result = decided
+                ? (won ? "&aWIN" : "&cLOSS")
+                : (match.getResult() == PvpMatch.Result.DRAW ? "&eDRAW" : "&7ABORTED");
+
+        List<String> lore = new ArrayList<>();
+        lore.add("&7Date: &f" + matches.formatDate(match.getEndedAt()));
+        lore.add("&7Duration: &f"
+                + PvpMatchManager.formatMatchDuration(match.getDurationSeconds(match.getEndedAt())));
+        lore.add("&7Result: " + result);
+        lore.add("");
+        lore.add("&f" + matches.resolveName(match.getFirstUuid())
+                + " &7vs &f" + matches.resolveName(match.getSecondUuid()));
+        lore.add("");
+        appendPlayerLines(lore, match, match.getFirstUuid());
+        lore.add("");
+        appendPlayerLines(lore, match, match.getSecondUuid());
+
+        return ItemUtils.createPlayerHead(
+                opponent == null ? null : Bukkit.getOfflinePlayer(opponent),
+                (won ? "&a" : "&c") + "Match #" + number,
+                lore
+        );
+    }
+
+    private void appendPlayerLines(List<String> lore, PvpMatch match, UUID uuid) {
+        PvpMatchManager matches = plugin.getPvpMatchManager();
+        int after = match.getEloBefore(uuid) + match.getEloDelta(uuid);
+        lore.add("&a" + matches.resolveName(uuid));
+        lore.add("&7Hits: &f" + match.getHits(uuid));
+        lore.add("&7Crystals: &f" + match.getCrystals(uuid));
+        lore.add("&7ELO: &f" + after + " &8(" + deltaColor(match.getEloDelta(uuid))
+                + PvpMatchManager.formatDelta(match.getEloDelta(uuid)) + "&8)");
+    }
+
+    private String deltaColor(int delta) {
+        if (delta > 0) {
+            return "&a";
+        }
+        return delta < 0 ? "&c" : "&7";
+    }
+
+    private void buildPageButtons(int total) {
+        Material arrow = ItemUtils.parseMaterial(
+                plugin.getConfigManager().getMenus().getString("GLOBAL.PAGE-MENU.MATERIAL", "ARROW"));
+
+        if (hasPreviousPage) {
+            set(PREVIOUS_PAGE_SLOT, ItemUtils.createItem(arrow, "&ePrevious page", List.of("&7Page " + page)));
+        }
+        if (hasNextPage) {
+            set(NEXT_PAGE_SLOT, ItemUtils.createItem(arrow, "&eNext page", List.of("&7Page " + (page + 2))));
+        }
+        set(PAGE_INFO_SLOT, ItemUtils.createItem(Material.PAPER,
+                "&ePage &f" + (page + 1) + "&7/&f" + totalPages,
+                List.of("&7Matches: &f" + total)));
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        if (slot == PREVIOUS_PAGE_SLOT && hasPreviousPage) {
+            page--;
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.PAGE-TURN"));
+            build(player);
+            return;
+        }
+
+        if (slot == NEXT_PAGE_SLOT && hasNextPage) {
+            page++;
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.PAGE-TURN"));
+            build(player);
+        }
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin, UUID targetUuid) {
+        FileConfiguration pvp = plugin.getConfigManager().getPvp();
+        String template = pvp.getString(PATH + ".TITLE", "&8Match history &7- &f{player}");
+        return template.replace("{player}", plugin.getPvpMatchManager().resolveName(targetUuid));
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpQueueMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpQueueMenu.java
@@ -1,0 +1,134 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The ranked queue menu: pick the kit you want to fight with, then confirm to join.
+ *
+ * <p>The kit is chosen before queueing rather than after being matched, so two players who are
+ * paired arrive already agreed on the loadout and the fight can start on a countdown instead of on
+ * a second round of menus.</p>
+ */
+public class PvpQueueMenu extends BaseMenu {
+
+    private static final String PATH = "MENUS.QUEUE";
+    private static final List<Integer> KIT_SLOTS = List.of(12, 13, 14, 11, 15);
+    private static final int CANCEL_SLOT = 10;
+    private static final int CONFIRM_SLOT = 16;
+
+    private final Map<Integer, String> slotKits = new HashMap<>();
+    private String selectedKit;
+
+    public PvpQueueMenu(UltimateDonutSmp plugin) {
+        super(plugin, configuredTitle(plugin), configuredSize(plugin));
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        slotKits.clear();
+        fill(Material.BLACK_STAINED_GLASS_PANE);
+
+        List<PvpKit> kits = plugin.getPvpManager().getAvailableKits(player);
+        if (kits.isEmpty()) {
+            set(13, ItemUtils.createItem(Material.BARRIER, "&cNo kits",
+                    List.of("&7There are no PvP kits to choose from yet.")));
+            return;
+        }
+
+        if (selectedKit == null || plugin.getPvpManager().getKit(selectedKit) == null) {
+            String queued = plugin.getPvpMatchManager().getQueuedKit(player.getUniqueId());
+            selectedKit = queued != null ? queued : kits.get(0).getId();
+        }
+
+        for (int index = 0; index < kits.size() && index < KIT_SLOTS.size(); index++) {
+            PvpKit kit = kits.get(index);
+            int slot = KIT_SLOTS.get(index);
+            boolean chosen = kit.getId().equals(selectedKit);
+
+            List<String> lore = new ArrayList<>();
+            lore.add(chosen ? "&aSelected" : "&7Click to select this kit.");
+            set(slot, ItemUtils.setGlint(
+                    ItemUtils.createItem(kit.getIcon(), kit.getDisplayName(), lore),
+                    chosen
+            ));
+            slotKits.put(slot, kit.getId());
+        }
+
+        boolean queued = plugin.getPvpMatchManager().isQueued(player.getUniqueId());
+        set(CONFIRM_SLOT, ItemUtils.createItem(
+                ItemUtils.parseMaterial(config().getString(PATH + ".CONFIRM.MATERIAL", "LIME_STAINED_GLASS_PANE")),
+                config().getString(PATH + ".CONFIRM.DISPLAY-NAME", "&aCONFIRM"),
+                queued
+                        ? List.of("&7Already in the queue.", "&7Waiting: &f" + waiting(player) + "s")
+                        : List.of("&7Click to join the queue.", "&7In queue: &f"
+                        + plugin.getPvpMatchManager().getQueueSize())
+        ));
+        set(CANCEL_SLOT, ItemUtils.createItem(
+                ItemUtils.parseMaterial(config().getString(PATH + ".CANCEL.MATERIAL", "RED_STAINED_GLASS_PANE")),
+                config().getString(PATH + ".CANCEL.DISPLAY-NAME", "&cLEAVE"),
+                List.of(queued ? "&7Click to leave the queue." : "&7Click to close this menu.")
+        ));
+    }
+
+    private long waiting(Player player) {
+        return Math.max(0L, plugin.getPvpMatchManager().getQueuedSeconds(player.getUniqueId()));
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        String kitId = slotKits.get(slot);
+        if (kitId != null) {
+            selectedKit = kitId;
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            build(player);
+            return;
+        }
+
+        if (slot == CANCEL_SLOT) {
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            if (plugin.getPvpMatchManager().leaveQueue(player.getUniqueId())) {
+                player.sendMessage(ColorUtils.toComponent(plugin.getPvpManager()
+                        .message("QUEUE_LEFT", "&aYou left the ranked queue.")));
+            }
+            player.closeInventory();
+            return;
+        }
+
+        if (slot == CONFIRM_SLOT) {
+            PvpKit kit = plugin.getPvpManager().getKit(selectedKit);
+            if (kit == null) {
+                return;
+            }
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            player.closeInventory();
+            plugin.getPvpMatchManager().joinQueue(player, kit);
+        }
+    }
+
+    private FileConfiguration config() {
+        return plugin.getConfigManager().getPvp();
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin) {
+        return plugin.getConfigManager().getPvp().getString(PATH + ".TITLE", "&8PvP queue");
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int size = plugin.getConfigManager().getPvp().getInt(PATH + ".SIZE", 27);
+        return size >= 27 && size <= 54 && size % 9 == 0 ? size : 27;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpMatch.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpMatch.java
@@ -1,0 +1,234 @@
+package com.bx.ultimateDonutSmp.models;
+
+import java.util.UUID;
+
+/**
+ * One ranked 1v1 match: who fought, how it went, and what it cost them.
+ *
+ * <p>The per-player counters live here rather than in {@link PvpStats} because they describe a
+ * single fight. The history menu reads them straight back out, so a match that has ended is a
+ * complete record on its own and never has to be recomputed from the players' totals.</p>
+ */
+public class PvpMatch {
+
+    /** How a match finished. A match that is still running has no result yet. */
+    public enum Result {
+        DECIDED,
+        DRAW,
+        ABORTED
+    }
+
+    private final long id;
+    private final UUID firstUuid;
+    private final UUID secondUuid;
+    private final String firstName;
+    private final String secondName;
+    private final String kitId;
+    private final long startedAt;
+
+    private long endedAt;
+    private long countdownEndsAt;
+    private UUID winnerUuid;
+    private Result result;
+
+    private int firstHits;
+    private int secondHits;
+    private int firstCrystals;
+    private int secondCrystals;
+    private int firstEloBefore;
+    private int secondEloBefore;
+    private int firstEloDelta;
+    private int secondEloDelta;
+
+    public PvpMatch(
+            long id,
+            UUID firstUuid,
+            String firstName,
+            UUID secondUuid,
+            String secondName,
+            String kitId,
+            long startedAt
+    ) {
+        this.id = id;
+        this.firstUuid = firstUuid;
+        this.firstName = firstName;
+        this.secondUuid = secondUuid;
+        this.secondName = secondName;
+        this.kitId = kitId;
+        this.startedAt = startedAt;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public UUID getFirstUuid() {
+        return firstUuid;
+    }
+
+    public UUID getSecondUuid() {
+        return secondUuid;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getSecondName() {
+        return secondName;
+    }
+
+    public String getKitId() {
+        return kitId;
+    }
+
+    public long getStartedAt() {
+        return startedAt;
+    }
+
+    public long getEndedAt() {
+        return endedAt;
+    }
+
+    public void setEndedAt(long endedAt) {
+        this.endedAt = endedAt;
+    }
+
+    /** Epoch millis the opening countdown ends. Until then neither player can be damaged. */
+    public long getCountdownEndsAt() {
+        return countdownEndsAt;
+    }
+
+    public void setCountdownEndsAt(long countdownEndsAt) {
+        this.countdownEndsAt = countdownEndsAt;
+    }
+
+    public boolean isCountingDown(long now) {
+        return countdownEndsAt > 0 && now < countdownEndsAt;
+    }
+
+    public UUID getWinnerUuid() {
+        return winnerUuid;
+    }
+
+    public void setWinnerUuid(UUID winnerUuid) {
+        this.winnerUuid = winnerUuid;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    /** Seconds the match ran for, counted to whichever end time it has so far. */
+    public long getDurationSeconds(long now) {
+        long end = endedAt > 0 ? endedAt : now;
+        return Math.max(0L, (end - startedAt) / 1000L);
+    }
+
+    public boolean involves(UUID uuid) {
+        return uuid != null && (uuid.equals(firstUuid) || uuid.equals(secondUuid));
+    }
+
+    /** The other player in the match, or null when the uuid is not one of the two. */
+    public UUID opponentOf(UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        if (uuid.equals(firstUuid)) {
+            return secondUuid;
+        }
+        return uuid.equals(secondUuid) ? firstUuid : null;
+    }
+
+    public boolean isFirst(UUID uuid) {
+        return firstUuid.equals(uuid);
+    }
+
+    public void addHit(UUID uuid) {
+        if (isFirst(uuid)) {
+            firstHits++;
+        } else if (secondUuid.equals(uuid)) {
+            secondHits++;
+        }
+    }
+
+    public void addCrystal(UUID uuid) {
+        if (isFirst(uuid)) {
+            firstCrystals++;
+        } else if (secondUuid.equals(uuid)) {
+            secondCrystals++;
+        }
+    }
+
+    public int getHits(UUID uuid) {
+        return isFirst(uuid) ? firstHits : secondHits;
+    }
+
+    public int getCrystals(UUID uuid) {
+        return isFirst(uuid) ? firstCrystals : secondCrystals;
+    }
+
+    public int getFirstHits() {
+        return firstHits;
+    }
+
+    public int getSecondHits() {
+        return secondHits;
+    }
+
+    public int getFirstCrystals() {
+        return firstCrystals;
+    }
+
+    public int getSecondCrystals() {
+        return secondCrystals;
+    }
+
+    public void setHits(int first, int second) {
+        this.firstHits = first;
+        this.secondHits = second;
+    }
+
+    public void setCrystals(int first, int second) {
+        this.firstCrystals = first;
+        this.secondCrystals = second;
+    }
+
+    public int getEloBefore(UUID uuid) {
+        return isFirst(uuid) ? firstEloBefore : secondEloBefore;
+    }
+
+    public int getEloDelta(UUID uuid) {
+        return isFirst(uuid) ? firstEloDelta : secondEloDelta;
+    }
+
+    public int getFirstEloBefore() {
+        return firstEloBefore;
+    }
+
+    public int getSecondEloBefore() {
+        return secondEloBefore;
+    }
+
+    public int getFirstEloDelta() {
+        return firstEloDelta;
+    }
+
+    public int getSecondEloDelta() {
+        return secondEloDelta;
+    }
+
+    public void setEloBefore(int first, int second) {
+        this.firstEloBefore = first;
+        this.secondEloBefore = second;
+    }
+
+    public void setEloDelta(int first, int second) {
+        this.firstEloDelta = first;
+        this.secondEloDelta = second;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/PvpArenaTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/PvpArenaTask.java
@@ -21,8 +21,13 @@ public class PvpArenaTask implements Runnable {
 
     @Override
     public void run() {
-        if (plugin.getPvpManager() != null && plugin.getPvpManager().isEnabled()) {
-            plugin.getPvpManager().tick();
+        if (plugin.getPvpManager() == null || !plugin.getPvpManager().isEnabled()) {
+            return;
+        }
+
+        plugin.getPvpManager().tick();
+        if (plugin.getPvpMatchManager() != null) {
+            plugin.getPvpMatchManager().tick();
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -180,7 +180,7 @@ commands:
     permission-message: "&cYou do not have permission to use /ffaarena."
   pvp:
     description: Join the ranked PvP arena
-    usage: /pvp [join|leave|kit|stats|top|wand|create|setspawn|setlobby|setboundary|schematic|reset|reload]
+    usage: /pvp [join|leave|kit|stats|top|queue|leaderboard|history|assign|wand|create|setspawn|setspawn2|setlobby|setboundary|schematic|reset|reload]
     permission: ultimatedonutsmp.command.pvp
     permission-message: "&cYou do not have permission to use /pvp."
   auctionhouse:

--- a/src/main/resources/pvp.yml
+++ b/src/main/resources/pvp.yml
@@ -35,6 +35,8 @@ ARENA:
   WORLD: ''
   # Where players are put when they join or respawn (world,x,y,z,yaw,pitch)
   SPAWN: ''
+  # Where the second player in a ranked 1v1 match starts. Empty puts both on SPAWN.
+  SPAWN_2: ''
   # Where players are sent on /pvp leave and after a disconnect (world,x,y,z,yaw,pitch)
   LOBBY: ''
   # The two wand corners of the arena boundary (world,x,y,z,yaw,pitch)
@@ -67,6 +69,26 @@ RESET:
   - '//paste -o -a'
   # Seconds to wait between the load command and the paste command
   PASTE_DELAY_SECONDS: 5
+
+# Ranked 1v1 matches, the queue that feeds them, and the history they leave behind
+MATCH:
+  # Enable the ranked queue, /pvp assign and the match history (true / false)
+  ENABLED: true
+  # Seconds both players stand protected at the start of a match before the fight opens
+  COUNTDOWN_SECONDS: 5
+  # Longest a match may run before it is called a draw. Accepts the same 1d10h15m format
+  # as RESET.INTERVAL. Set it to 0 to let a match run forever.
+  MAX_DURATION: '5m'
+  # Elo the winner gains
+  ELO_WIN: 20
+  # Elo the loser drops
+  ELO_LOSS: 15
+  # Elo both players take on a draw or an aborted match
+  ELO_DRAW: 0
+  # Heal both players and re-hand the kit when a match starts (true / false)
+  HEAL_ON_START: true
+  # How the date is written in the match history. Standard Java date patterns.
+  DATE_FORMAT: 'dd/MM/yyyy HH:mm'
 
 # Commands players cannot run while they are inside the arena
 BLOCKED_COMMANDS:
@@ -202,6 +224,48 @@ SCOREBOARD:
   # Shown by %pvp_arena_reset% when no reset is scheduled
   RESET_DISABLED_TEXT: '&7-'
 
+# The four menus this feature opens. Titles and sizes are yours; the layouts are fixed
+# so that a size change cannot leave a button with nowhere to sit.
+MENUS:
+  # /pvp queue - pick a kit, then confirm to join the ranked queue
+  QUEUE:
+    TITLE: '&8PvP queue'
+    SIZE: 27
+    CONFIRM:
+      MATERIAL: 'LIME_STAINED_GLASS_PANE'
+      DISPLAY-NAME: '&aCONFIRM'
+    CANCEL:
+      MATERIAL: 'RED_STAINED_GLASS_PANE'
+      DISPLAY-NAME: '&cLEAVE'
+  # /pvp leaderboard - one icon per board, each holding its own ranking
+  LEADERBOARD:
+    TITLE: '&8Leaderboards'
+    SIZE: 27
+    # How many players each board lists
+    ENTRIES: 10
+    # How one ranking row is written
+    LINE: '&7#{position} &f{player} &8- &c{value}'
+    # The icon each board uses
+    ICONS:
+      ELO: 'DIAMOND'
+      LEVEL: 'EXPERIENCE_BOTTLE'
+      KILLS: 'DIAMOND_SWORD'
+      DEATHS: 'SKELETON_SKULL'
+      STREAK: 'BLAZE_POWDER'
+      JOINS: 'IRON_DOOR'
+  # /pvp history - past ranked matches, newest first
+  HISTORY:
+    TITLE: '&8Match history &7- &f{player}'
+  # /pvp assign - put two players into a match without either of them queueing
+  ASSIGN:
+    TITLE: '&8Assign match'
+    SIZE: 27
+    CONFIRM:
+      MATERIAL: 'LIME_STAINED_GLASS_PANE'
+      DISPLAY-NAME: '&aSTART MATCH'
+    BLOCKED:
+      MATERIAL: 'RED_STAINED_GLASS_PANE'
+
 # Kit definitions. These are written by /pvp kit create and /pvp kit edit, which
 # store the real items with their enchantments, names and lore, so hand editing is
 # not expected here.
@@ -236,3 +300,15 @@ MESSAGES:
   TOP_HEADER: '&8&m--------&r &cTop PvP players &8&m--------'
   TOP_LINE: '&7#{position} &f{player} &8- &c{elo} elo &8(&7{rank}&8)'
   TOP_EMPTY: '&7Nobody has fought in the arena yet.'
+  QUEUE_JOINED: '&aYou joined the ranked queue. Waiting for an opponent...'
+  QUEUE_LEFT: '&aYou left the ranked queue.'
+  QUEUE_ALREADY_IN: '&cYou are already in the queue.'
+  QUEUE_NOT_IN: '&cYou are not in the queue.'
+  MATCH_ALREADY_IN: '&cYou are already in a ranked match.'
+  MATCH_LEAVE_ARENA_FIRST: '&cLeave the arena before queueing.'
+  MATCH_NEEDS_TWO: '&cA ranked match needs two different players.'
+  MATCH_STARTED: '&8[&cPVP&8] &f{first} &7vs &f{second}'
+  MATCH_COUNTDOWN: '&fStarting in &c{seconds}&f...'
+  MATCH_WIN: '&aYou beat &f{opponent} &8(&a{elo} elo&8, &a{hits} hits&8)'
+  MATCH_LOSS: '&cYou lost to &f{opponent} &8(&c{elo} elo&8, &c{hits} hits&8)'
+  MATCH_DRAW: '&7The match against &f{opponent} &7ended in a draw.'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
@@ -69,6 +69,44 @@ class PvpConfigurationTest {
     }
 
     @Test
+    void theRankedQueueShipsWithAScoringSpreadAndACountdown() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        assertTrue(pvp.getBoolean("MATCH.ENABLED"));
+        assertTrue(pvp.getInt("MATCH.COUNTDOWN_SECONDS") > 0, "both players need a moment before the fight opens");
+        assertTrue(pvp.getInt("MATCH.ELO_WIN") > 0);
+        assertTrue(pvp.getInt("MATCH.ELO_LOSS") > 0);
+        assertEquals(0, pvp.getInt("MATCH.ELO_DRAW"), "a draw should not move anyone by default");
+        assertFalse(pvp.getString("MATCH.DATE_FORMAT", "").isBlank());
+    }
+
+    @Test
+    void everyLeaderboardHasAnIconConfigured() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        for (String board : List.of("ELO", "LEVEL", "KILLS", "DEATHS", "STREAK", "JOINS")) {
+            assertFalse(
+                    pvp.getString("MENUS.LEADERBOARD.ICONS." + board, "").isBlank(),
+                    "expected an icon for the " + board + " leaderboard"
+            );
+        }
+        assertTrue(pvp.getInt("MENUS.LEADERBOARD.ENTRIES") > 0);
+        assertTrue(pvp.getString("MENUS.LEADERBOARD.LINE", "").contains("{player}"));
+    }
+
+    @Test
+    void everyMenuHasATitleAndAWorkableSize() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        for (String menu : List.of("QUEUE", "LEADERBOARD", "ASSIGN")) {
+            assertFalse(pvp.getString("MENUS." + menu + ".TITLE", "").isBlank(), menu + " needs a title");
+            int size = pvp.getInt("MENUS." + menu + ".SIZE");
+            assertTrue(size >= 27 && size <= 54 && size % 9 == 0, menu + " has an unusable size: " + size);
+        }
+        assertTrue(pvp.getString("MENUS.HISTORY.TITLE", "").contains("{player}"));
+    }
+
+    @Test
     void theCommandAndItsPermissionsAreRegistered() throws Exception {
         YamlConfiguration plugin = new YamlConfiguration();
         plugin.load(new File("src/main/resources/plugin.yml"));

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpMatchTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpMatchTest.java
@@ -1,0 +1,107 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PvpMatch;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The ranked match record and the two formats the history menu reads it through. */
+class PvpMatchTest {
+
+    private static final UUID FIRST = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID SECOND = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+    private static final UUID STRANGER = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+
+    private static PvpMatch match() {
+        return new PvpMatch(1L, FIRST, "SamirSpider", SECOND, "Nexf", "warrior", 1_000L);
+    }
+
+    @Test
+    void hitsAndCrystalsAreCountedPerPlayer() {
+        PvpMatch match = match();
+        match.addHit(SECOND);
+        match.addHit(SECOND);
+        match.addCrystal(FIRST);
+
+        assertEquals(0, match.getHits(FIRST));
+        assertEquals(2, match.getHits(SECOND));
+        assertEquals(1, match.getCrystals(FIRST));
+        assertEquals(0, match.getCrystals(SECOND));
+    }
+
+    @Test
+    void aStrangerCannotAddToEitherSideOfTheMatch() {
+        PvpMatch match = match();
+        match.addHit(STRANGER);
+        match.addCrystal(STRANGER);
+
+        assertEquals(0, match.getFirstHits());
+        assertEquals(0, match.getSecondHits());
+        assertEquals(0, match.getFirstCrystals());
+        assertEquals(0, match.getSecondCrystals());
+        assertFalse(match.involves(STRANGER));
+        assertNull(match.opponentOf(STRANGER));
+    }
+
+    @Test
+    void theOpponentIsWhicheverSideTheOtherPlayerIsOn() {
+        PvpMatch match = match();
+
+        assertEquals(SECOND, match.opponentOf(FIRST));
+        assertEquals(FIRST, match.opponentOf(SECOND));
+        assertTrue(match.involves(FIRST));
+        assertTrue(match.involves(SECOND));
+    }
+
+    @Test
+    void theCountdownHoldsUntilItsDeadlineAndNotAfter() {
+        PvpMatch match = match();
+        match.setCountdownEndsAt(5_000L);
+
+        assertTrue(match.isCountingDown(4_999L));
+        assertFalse(match.isCountingDown(5_000L));
+
+        // A match with no countdown set is live from the first tick.
+        assertFalse(match().isCountingDown(0L));
+    }
+
+    @Test
+    void theDurationRunsToTheEndTimeOnceThereIsOne() {
+        PvpMatch match = match();
+        assertEquals(17L, match.getDurationSeconds(18_000L));
+
+        match.setEndedAt(11_000L);
+        assertEquals(10L, match.getDurationSeconds(99_000L), "a finished match stops counting");
+    }
+
+    @Test
+    void eloDeltasAreStoredPerSideAndReadBackBySide() {
+        PvpMatch match = match();
+        match.setEloBefore(1000, 1000);
+        match.setEloDelta(-15, 20);
+
+        assertEquals(-15, match.getEloDelta(FIRST));
+        assertEquals(20, match.getEloDelta(SECOND));
+        assertEquals(1000, match.getEloBefore(FIRST));
+    }
+
+    @Test
+    void matchDurationsAreWrittenAsClockTime() {
+        assertEquals("00:17", PvpMatchManager.formatMatchDuration(17L));
+        assertEquals("05:00", PvpMatchManager.formatMatchDuration(300L));
+        assertEquals("01:00:05", PvpMatchManager.formatMatchDuration(3605L));
+        assertEquals("00:00", PvpMatchManager.formatMatchDuration(-5L));
+    }
+
+    @Test
+    void eloChangesCarryTheirSign() {
+        assertEquals("+20", PvpMatchManager.formatDelta(20));
+        assertEquals("-15", PvpMatchManager.formatDelta(-15));
+        assertEquals("0", PvpMatchManager.formatDelta(0));
+    }
+}


### PR DESCRIPTION
Follows #255, which shipped the arena itself but only gave it one menu, the kit picker. This adds the four the reference resource shows: a queue, leaderboards, match history and an assign screen for testers.

Two of those need something to describe. A history entry reads "SamirSpider vs Nexf", "Result: WIN", a duration and an Elo change per side, and Assign Mode exists to put two named people into one fight. None of that means anything against an open free-for-all, so this also adds the ranked 1v1 the menus are about.

## Ranked 1v1

`/pvp queue` puts a player in line with the kit they picked. When somebody else is waiting the two are paired, dropped on `ARENA.SPAWN` and the new `ARENA.SPAWN_2`, handed the kit and held for a countdown neither can be hurt during. The match ends on a death, a disconnect, a boundary exit, or `MATCH.MAX_DURATION`, which is a draw. Winner takes `MATCH.ELO_WIN`, loser drops `MATCH.ELO_LOSS`, both go back to the lobby.

Pairing is by wait time rather than by rating. A survival server's queue is rarely more than a handful of people, and holding a high rated player back to look for a closer opponent mostly means nobody gets a fight.

Ranked deaths route to the match instead of the open arena's per-kill rewards and respawn countdown, so a fight is scored once. Hits and crystals are counted separately, as the reference shows them. A crystal explosion names the crystal as the damager rather than whoever set it off, so in a match it is credited to the opponent, which is exact when only two people are in there.

## The menus

`/pvp queue` is the queue: kits in the middle, confirm on the right, leave on the left. The kit is picked before queueing rather than after pairing, so two matched players arrive already agreed on the loadout and the fight opens on a countdown instead of a second round of menus.

`/pvp leaderboard` is one icon per board with its ranking in the lore: elo, level, kills, deaths, best streak, arena joins. Putting the ranking in the lore rather than behind another click means the whole board reads by pointing at it. The column each board sorts on comes from an enum, so the ordering is free to change without ever building SQL from user input.

`/pvp history [player]` pages through past matches newest first. Each item carries the date, the duration, the result, and both fighters' hits, crystals and Elo change. Those come off the stored match row rather than the players' current totals, so an old entry still reads correctly after the ladder has moved on.

`/pvp assign` is the tester screen. The two player slots cycle through everyone online and the middle slot cycles the kit, which keeps the whole assignment on one screen instead of opening a picker. `/pvp assign <player> <player> [kit]` does the same from the command line, which is what running the same fixture repeatedly actually wants.

## One fix that came out of it

Losing a ranked match removes the player while they are still on the death screen, and a teleport there does not survive the respawn, so they were landing at their bed instead of the arena lobby. The lobby trip is now handed to the respawn event when the player is dead at the time they are removed.

## Notes

- New `pvp_matches` table alongside `pvp_stats`, holding both sides' hits, crystals, Elo before and Elo delta. The stored delta is what the floor and ceiling actually allowed, so history never shows a player losing points they did not have.
- New `ARENA.SPAWN_2` and `/pvp setspawn2`. Leave it unset and both fighters spawn on the same point.
- New subcommands: `queue`, `leaderboard`, `history`, `assign`, `setspawn2`, all tab completed. `assign` needs `ultimatedonutsmp.admin.pvp`; the rest are open.
- New `MATCH` and `MENUS` config blocks in `pvp.yml`, plus twelve messages. Menu titles, sizes, button materials, leaderboard icons and the ranking row format are all config; the slot layouts are fixed so a size change cannot leave a button with nowhere to sit.
- Docs: the `Ranked-PvP-Arena` and `Config-pvp.yml` pages cover the queue, the matches and all four menus, and the command tables are updated.
- 11 new tests on the match record, the two history formats and the shape of the new config. Full suite is 450 passing.
