### PR TITLE
fix(pvp): stop the queue crossing kits and free players stuck in the arena (#255)

### DIFF
--- a/docs/wiki/Config-pvp.yml.md
+++ b/docs/wiki/Config-pvp.yml.md
@@ -421,7 +421,7 @@ from the config updater so a plugin update never restores the empty default over
 | `KITS.<id>.DISPLAY` | `string` | Any text | `&f<id>` | Menu name. Set with `/pvp kit display <name> <text>`. |
 | `KITS.<id>.ICON` | `string` | A material name | `IRON_SWORD` | Menu icon. Set with `/pvp kit icon <name> <material>`. |
 | `KITS.<id>.PERMISSION` | `string` | A permission node, or empty | `''` | Empty leaves the kit open to everyone. `/pvp kit permission <name> none` clears it. |
-| `KITS.<id>.SLOT` | `int` | `0`-`26`, or `-1` | `-1` | Fixed menu slot. `-1` places the kit automatically, centred with the others. |
+| `KITS.<id>.SLOT` | `int` | `0`-`25`, or `-1` | `-1` | Fixed menu slot. `-1` places the kit automatically, centred with the others. Slot 26 belongs to the leave button, and a kit pointed at it is placed automatically instead. |
 | `KITS.<id>.CONTENTS` | `section` | Serialized items by slot | – | The 36 inventory slots. Written by the editor. |
 | `KITS.<id>.ARMOR` | `section` | Serialized items by slot | – | Boots, leggings, chestplate, helmet, in that order. |
 | `KITS.<id>.OFFHAND` | `string` | A serialized item | – | Offhand item. |
@@ -465,6 +465,7 @@ Every player-facing string the arena sends. All of them go through the plugin's 
 | `MESSAGES.MATCH_ALREADY_IN` | – | Already fighting a ranked match. |
 | `MESSAGES.MATCH_LEAVE_ARENA_FIRST` | – | Queueing while inside the open arena. |
 | `MESSAGES.MATCH_NEEDS_TWO` | – | `/pvp assign` with one player, or the same player twice. |
+| `MESSAGES.MATCH_BUSY` | `{player}` | `/pvp assign` naming somebody who is already fighting in the open arena. |
 | `MESSAGES.MATCH_STARTED` | `{first}`, `{second}` | Sent to both fighters when a match opens. |
 | `MESSAGES.MATCH_COUNTDOWN` | `{seconds}` | Sent once a second during the opening countdown. |
 | `MESSAGES.MATCH_WIN` / `MESSAGES.MATCH_LOSS` | `{opponent}`, `{elo}`, `{hits}`, `{crystals}` | The result lines. |

--- a/docs/wiki/Ranked-PvP-Arena.md
+++ b/docs/wiki/Ranked-PvP-Arena.md
@@ -82,7 +82,8 @@ The rest of a kit is set from the command line:
 ```
 
 A kit with no permission is open to everyone. A kit with no slot is placed automatically, centred in
-the menu alongside the others. `/pvp kit list` shows what exists and `/pvp kit delete <name>`
+the menu alongside the others. The bottom right slot is the leave button, so a kit pointed there is
+placed automatically instead. `/pvp kit list` shows what exists and `/pvp kit delete <name>`
 removes one.
 
 ---
@@ -133,13 +134,18 @@ BROADCASTS:
 ## Ranked 1v1 matches
 
 Alongside the open arena there is a ranked queue. `/pvp queue` opens a menu, the player picks the kit
-they want to fight with, and confirming puts them in line. As soon as a second person is waiting the
-two are paired, dropped on `ARENA.SPAWN` and `ARENA.SPAWN_2`, handed the kit, and held for a short
-countdown during which neither can be hurt.
+they want to fight with, and confirming puts them in line. As soon as somebody else is waiting for
+the same kit the two are paired, dropped on `ARENA.SPAWN` and `ARENA.SPAWN_2`, handed the kit, and
+held for a short countdown during which neither can be hurt.
 
-Pairing is by wait time, not by rating. On a survival server the queue is rarely more than a handful
-of people, and holding a high rated player back to look for a closer opponent mostly means nobody
-gets a fight at all.
+Only the same kit pairs. Both fighters use one loadout, so crossing kits would hand whoever waited
+the gear the other player picked. Within a kit, pairing is by wait time rather than by rating: on a
+survival server the queue is rarely more than a handful of people, and holding a high rated player
+back to look for a closer opponent mostly means nobody gets a fight at all.
+
+The queue and the open arena are mutually exclusive. `/pvp` refuses while you are queued, `/pvp queue`
+refuses while you are in the arena, and `/pvp assign` refuses to pull somebody out of a fight they
+are already in.
 
 The match ends when somebody dies, disconnects, leaves the arena boundary, or `MATCH.MAX_DURATION`
 runs out, which is a draw. The winner gains `MATCH.ELO_WIN`, the loser drops `MATCH.ELO_LOSS`, and

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
@@ -589,6 +589,12 @@ public class PvpManager {
             send(player, message("NO_KITS", "&cThere are no PvP kits to choose from yet."));
             return false;
         }
+        // Waiting for a ranked match and fighting in the open arena cannot both be true: the match
+        // would drop on them mid-fight and take the session out from under them.
+        if (plugin.getPvpMatchManager() != null && plugin.getPvpMatchManager().isQueued(player.getUniqueId())) {
+            send(player, message("QUEUE_ALREADY_IN", "&cYou are already in the queue."));
+            return false;
+        }
 
         PvpSession session = new PvpSession(player.getUniqueId(), System.currentTimeMillis());
         sessions.put(player.getUniqueId(), session);
@@ -881,6 +887,13 @@ public class PvpManager {
             lobbyOnRejoin.add(player.getUniqueId());
         }
         takeKitBack(player);
+
+        // Spectator is only ever a respawn countdown here, and it outlives the disconnect. Undo it
+        // now rather than on the next login: the login path is skipped entirely when the lobby
+        // return is switched off, which would leave the player a spectator for good.
+        if (player.getGameMode() == GameMode.SPECTATOR) {
+            player.setGameMode(GameMode.SURVIVAL);
+        }
     }
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
@@ -139,7 +139,7 @@ public class PvpMatchManager {
                 return false;
             }
             queue.put(player.getUniqueId(), new QueueEntry(kit.getId(), System.currentTimeMillis()));
-            opponent = findOpponent(player.getUniqueId());
+            opponent = findOpponent(player.getUniqueId(), kit.getId());
         }
 
         send(player, message("QUEUE_JOINED", "&aYou joined the ranked queue. Waiting for an opponent...")
@@ -165,15 +165,22 @@ public class PvpMatchManager {
     }
 
     /**
-     * The first other player waiting.
+     * The player who has waited longest for the same kit.
      *
-     * <p>Pairing is by wait time rather than by rating. The queue on a survival server is rarely
-     * more than a handful of people, and holding a high rated player back to look for a closer
-     * match would mostly mean nobody gets a fight at all.</p>
+     * <p>Only the same kit counts. Both fighters use one loadout, so pairing across kits would hand
+     * whoever waited the gear the other one picked, which is the opposite of what choosing a kit in
+     * the queue menu is for.</p>
+     *
+     * <p>Within a kit, pairing is by wait time rather than by rating. The queue on a survival server
+     * is rarely more than a handful of people, and holding a high rated player back to look for a
+     * closer match would mostly mean nobody gets a fight at all.</p>
      */
-    private UUID findOpponent(UUID self) {
+    private UUID findOpponent(UUID self, String kitId) {
         for (Map.Entry<UUID, QueueEntry> entry : queue.entrySet()) {
-            if (!entry.getKey().equals(self) && Bukkit.getPlayer(entry.getKey()) != null) {
+            if (entry.getKey().equals(self) || !entry.getValue().kitId().equals(kitId)) {
+                continue;
+            }
+            if (Bukkit.getPlayer(entry.getKey()) != null) {
                 return entry.getKey();
             }
         }
@@ -223,6 +230,17 @@ public class PvpMatchManager {
         }
         if (isInMatch(first.getUniqueId()) || isInMatch(second.getUniqueId())) {
             send(initiator, message("MATCH_ALREADY_IN", "&cYou are already in a ranked match."));
+            return false;
+        }
+
+        // An assigned match must not pull somebody out of an open arena fight they are in the
+        // middle of. The queue already refuses arena players, so this only bites on /pvp assign.
+        Player busy = pvp().isInArena(first.getUniqueId())
+                ? first
+                : (pvp().isInArena(second.getUniqueId()) ? second : null);
+        if (busy != null) {
+            send(initiator, message("MATCH_BUSY", "&c{player} is already in the arena.")
+                    .replace("{player}", busy.getName()));
             return false;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PvpKitMenu.java
@@ -23,8 +23,11 @@ public class PvpKitMenu extends BaseMenu {
 
     private static final List<Integer> CENTERED_SLOTS = List.of(
             13, 12, 14, 11, 15, 10, 16, 9, 17,
-            4, 22, 3, 5, 21, 23, 2, 6, 20, 24, 1, 7, 19, 25, 0, 8, 18, 26
+            4, 22, 3, 5, 21, 23, 2, 6, 20, 24, 1, 7, 19, 25, 0, 8, 18
     );
+
+    /** Reserved for the leave button, which is drawn last so a configured kit cannot cover it. */
+    private static final int LEAVE_SLOT = 26;
 
     private final Map<Integer, String> slotKits = new HashMap<>();
 
@@ -51,7 +54,9 @@ public class PvpKitMenu extends BaseMenu {
         List<PvpKit> unplaced = new ArrayList<>();
         for (PvpKit kit : kits) {
             int slot = kit.getMenuSlot();
-            if (slot >= 0 && slot < inventory.getSize() && !slotKits.containsKey(slot)) {
+            // A kit configured onto the leave button falls through to automatic placement rather
+            // than being drawn and then covered by it.
+            if (slot >= 0 && slot < inventory.getSize() && slot != LEAVE_SLOT && !slotKits.containsKey(slot)) {
                 place(slot, kit);
             } else {
                 unplaced.add(kit);
@@ -68,6 +73,24 @@ public class PvpKitMenu extends BaseMenu {
             }
             place(CENTERED_SLOTS.get(cursor), kit);
         }
+
+        buildLeaveButton();
+    }
+
+    /**
+     * The way out of the picker.
+     *
+     * <p>Closing this menu while a kit is still owed reopens it a tick later, so without a button
+     * that leaves the arena outright a player who changed their mind could only escape by
+     * disconnecting.</p>
+     */
+    private void buildLeaveButton() {
+        slotKits.remove(LEAVE_SLOT);
+        set(LEAVE_SLOT, ItemUtils.createItem(
+                Material.BARRIER,
+                "&cLeave the arena",
+                List.of("&7Click to go back to the lobby.")
+        ));
     }
 
     private void place(int slot, PvpKit kit) {
@@ -82,6 +105,12 @@ public class PvpKitMenu extends BaseMenu {
 
     @Override
     public void handleClick(int slot, Player player, ClickType clickType) {
+        if (slot == LEAVE_SLOT) {
+            player.closeInventory();
+            plugin.getPvpManager().leave(player);
+            return;
+        }
+
         String kitId = slotKits.get(slot);
         if (kitId == null) {
             return;

--- a/src/main/resources/pvp.yml
+++ b/src/main/resources/pvp.yml
@@ -307,6 +307,7 @@ MESSAGES:
   MATCH_ALREADY_IN: '&cYou are already in a ranked match.'
   MATCH_LEAVE_ARENA_FIRST: '&cLeave the arena before queueing.'
   MATCH_NEEDS_TWO: '&cA ranked match needs two different players.'
+  MATCH_BUSY: '&c{player} is already in the arena.'
   MATCH_STARTED: '&8[&cPVP&8] &f{first} &7vs &f{second}'
   MATCH_COUNTDOWN: '&fStarting in &c{seconds}&f...'
   MATCH_WIN: '&aYou beat &f{opponent} &8(&a{elo} elo&8, &a{hits} hits&8)'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
@@ -81,6 +81,20 @@ class PvpConfigurationTest {
     }
 
     @Test
+    void everyStateTheQueueAndMatchCanRefuseHasAMessage() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        for (String key : List.of(
+                "QUEUE_JOINED", "QUEUE_LEFT", "QUEUE_ALREADY_IN", "QUEUE_NOT_IN",
+                "MATCH_ALREADY_IN", "MATCH_LEAVE_ARENA_FIRST", "MATCH_NEEDS_TWO", "MATCH_BUSY",
+                "MATCH_STARTED", "MATCH_COUNTDOWN", "MATCH_WIN", "MATCH_LOSS", "MATCH_DRAW"
+        )) {
+            assertFalse(pvp.getString("MESSAGES." + key, "").isBlank(), "MESSAGES." + key + " is missing");
+        }
+        assertTrue(pvp.getString("MESSAGES.MATCH_BUSY", "").contains("{player}"));
+    }
+
+    @Test
     void everyLeaderboardHasAnIconConfigured() throws Exception {
         YamlConfiguration pvp = pvp();
 


### PR DESCRIPTION
Follows #255. Four defects found reviewing the two PvP arena PRs after they merged, all reachable on a normally configured server.

## The queue paired players across kits

`findOpponent` returned the first person waiting regardless of what they had queued for, and the match then ran on the kit the *joining* player picked. Somebody who queued for one loadout and waited got pulled into a fight holding a different one, with nothing said about it, which defeats the point of choosing a kit in the queue menu at all.

Pairing now only matches inside the same kit. Wait time still decides who gets paired within one.

## A player could get stuck in spectator

The respawn countdown puts a player in spectator for three seconds. Disconnecting inside that window left the gamemode set, and `handleQuit` never undid it. The rejoin path does undo it, but only when it runs at all: with `LOBBY_ON_REJOIN: false` the player is never registered for it, and with no lobby resolved the block is skipped. Either way they came back a spectator permanently.

Undone at the disconnect instead, where the state is actually known.

## The queue and the open arena were not exclusive

`/pvp queue` already refused a player standing in the arena, but nothing stopped the reverse. Queue up, then `/pvp` into the open arena, and when an opponent finally queued the match dropped on them mid-fight and `startSession` replaced the arena session underneath them.

`/pvp` now refuses while queued, and `/pvp assign` refuses to pull somebody out of a fight they are already in, with a new `MATCH_BUSY` message naming them.

## The kit picker had no exit

Closing the picker while a kit is still owed reopens it a tick later, which is what keeps a player from sitting in the arena as an unkillable spectator. It also meant somebody who changed their mind could not leave: the reopen lands before they can type anything, so the only way out was to disconnect.

There is a leave button in the bottom right now. Slot 26 is reserved for it, and a kit configured onto that slot is placed automatically instead of being drawn and then covered.

## Notes

- One new message, `MESSAGES.MATCH_BUSY`, and one new test asserting every refusal the queue and match code can produce has a message behind it. Full suite is 451 passing.
- The wiki pages carry the corrected pairing rule, the exclusivity, and the reserved slot.
