### PR TITLE
fix(permissions): declare the admin nodes staff commands check

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -864,6 +864,11 @@ permissions:
       ultimatedonutsmp.servers: true
       ultimatedonutsmp.shards.everywhere: true
       ultimatedonutsmp.admin.ecsee: true
+      ultimatedonutsmp.admin.logs: true
+      ultimatedonutsmp.admin.maintenance: true
+      ultimatedonutsmp.admin.serverwipe: true
+      ultimatedonutsmp.admin.setup: true
+      ultimatedonutsmp.admin.features: true
   ultimatedonutsmp.servers:
     description: Access the network servers status menu
     default: false
@@ -960,6 +965,12 @@ permissions:
   ultimatedonutsmp.admin.optimize:
     description: View and reload runtime optimization controls
     default: op
+  ultimatedonutsmp.admin.setup:
+    description: Run the setup tools and set the spawn and AFK zone locations
+    default: op
+  ultimatedonutsmp.admin.features:
+    description: Manage feature toggles
+    default: op
   ultimatedonutsmp.admin.shards:
     description: Inspect Shards Everywhere eligibility and status
     default: op
@@ -977,6 +988,9 @@ permissions:
     default: op
   ultimatedonutsmp.staff.flyspeed:
     description: Adjust flying speed for yourself or another player
+    default: op
+  ultimatedonutsmp.staff.god:
+    description: Toggle god mode for yourself or another online player
     default: op
   ultimatedonutsmp.staff.heal:
     description: Restore health for yourself or another player
@@ -1020,6 +1034,7 @@ permissions:
       ultimatedonutsmp.staff.punishments.view: true
       ultimatedonutsmp.staff.punishments.create: true
       ultimatedonutsmp.staff.punishments.remove: true
+      ultimatedonutsmp.staff.god: true
   ultimatedonutsmp.staff.mode.others:
     description: Toggle staff mode for other players
     default: op
@@ -1514,6 +1529,9 @@ permissions:
   ultimatedonutsmp.command.flyspeed:
     description: Access to /flyspeed command
     default: op
+  ultimatedonutsmp.command.flyspeed.others:
+    description: Adjust another player's flying speed with /flyspeed
+    default: op
   ultimatedonutsmp.command.heal:
     description: Access to /heal command
     default: op
@@ -1719,6 +1737,9 @@ permissions:
   ultimatedonutsmp.command.logs:
     description: Access to /logs command
     default: op
+  ultimatedonutsmp.admin.logs:
+    description: Browse a player's logged shop, auction and admin activity
+    default: op
   ultimatedonutsmp.command.chatlog:
     description: Access to /chatlog command
     default: op
@@ -1770,8 +1791,14 @@ permissions:
   ultimatedonutsmp.command.maintenance:
     description: Access to /maintenance command
     default: op
+  ultimatedonutsmp.admin.maintenance:
+    description: Toggle maintenance mode and manage the allowed player list
+    default: op
   ultimatedonutsmp.command.serverwipe:
     description: Access to /serverwipe command
+    default: op
+  ultimatedonutsmp.admin.serverwipe:
+    description: Preview and run a full server data wipe
     default: op
   ultimatedonutsmp.command.playerwipe:
     description: Access to /playerwipe command


### PR DESCRIPTION
`/logs` is documented under `ultimatedonutsmp.command.logs`, but the command gates on `ultimatedonutsmp.admin.logs`, and `plugin.yml` never declared that node anywhere. A staff rank granted the documented node still got turned away, and only literal ops could run it, since an op passes any node the plugin never registered. Six other commands had the same hole.

## Why the code side was right

Bukkit already enforces whatever `permission:` a command declares, so an in-code check is always a second, separate node rather than a repeat of the first. Nothing in the plugin re-checks its own `command.*` node. `/chatlog` shows the intended shape: `command.chatlog` guards the command, `admin.chatlog` guards what it opens, and both are declared, with `admin.chatlog` listed under the `ultimatedonutsmp.admin` umbrella. `/logs` was missing that second half, so the fix belongs in the declarations rather than in the command.

## What this actually broke

`ultimatedonutsmp.admin` is the node described as full admin access, and it hands out every `admin.*` node through its children list. A node missing from that list is not granted by it, which is what pushed this past a missing description: staff ranks holding `ultimatedonutsmp.admin` still could not run any of these.

- `admin.logs` for `/logs`
- `admin.maintenance` for `/maintenance` and `/uds maintenance`
- `admin.serverwipe` for `/serverwipe`
- `admin.setup` for the fallback branch in `/setspawn`, `/setafk`, `/spawn` and `/afk`, plus `/uds setup`
- `admin.features` for `/uds features`
- `staff.god` for `/god`, where the command block itself points at a node the permissions block never defined
- `command.flyspeed.others` for changing another player's speed with `/flyspeed`

## Notes

Declarations only. All seven get a description and `default: op`, each placed beside the sibling it belongs with. Six are wired into the umbrella that should have been granting them already: the `admin.*` ones under `ultimatedonutsmp.admin`, and `staff.god` under `ultimatedonutsmp.staff.mode`. `command.flyspeed.others` stays out of both on purpose, because it escalates the base `/flyspeed` permission to cover other players, and the `command.*` children block does not list flyspeed at all.

No Java changed, and nobody who could already reach these commands loses anything. 451 tests pass.
