### PR TITLE
fix(pvp): hand out the ranked kit after the arena teleport (#275)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
@@ -674,8 +674,9 @@ public class PvpManager {
     /**
      * Opens a session for a player the ranked queue is about to drop into a match.
      *
-     * <p>Unlike {@link #join(Player)} there is no kit menu: the match already decided the kit, and
-     * the pair have to arrive holding it at the same moment.</p>
+     * <p>Unlike {@link #join(Player)} there is no kit menu: the match already decided the kit. It
+     * still arrives later than the session does, because the match waits for the teleport into the
+     * arena before handing it over, so the session opens awaiting a kit like any other.</p>
      */
     public void startSession(Player player) {
         if (player == null) {
@@ -683,11 +684,27 @@ public class PvpManager {
         }
 
         PvpSession session = new PvpSession(player.getUniqueId(), System.currentTimeMillis());
-        session.setAwaitingKit(false);
-        session.setSpawnedAt(System.currentTimeMillis());
         sessions.put(player.getUniqueId(), session);
         updateStats(player.getUniqueId(), getStats(player.getUniqueId()).recordArenaJoin());
         player.setGameMode(GameMode.SURVIVAL);
+    }
+
+    /**
+     * Records that a ranked fighter has landed in the arena holding the match kit.
+     *
+     * <p>Kept apart from {@link #startSession(Player)} because the two no longer happen together.
+     * Between them the player is still on their way in, and a session that says it is awaiting a
+     * kit is what keeps them out of the damage and boundary checks until they arrive.</p>
+     */
+    public void markKitGiven(Player player, PvpKit kit) {
+        PvpSession session = player == null ? null : getSession(player.getUniqueId());
+        if (session == null || kit == null) {
+            return;
+        }
+
+        session.setKitId(kit.getId());
+        session.setAwaitingKit(false);
+        session.setSpawnedAt(System.currentTimeMillis());
     }
 
     public void openKitMenu(Player player) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
@@ -291,13 +291,34 @@ public class PvpMatchManager {
     /** Drops a player onto their side of the arena with the match kit in hand. */
     private void prepare(Player player, PvpKit kit, Location spawn) {
         pvp().startSession(player);
-        if (spawn != null) {
-            plugin.getSpigotScheduler().teleport(player, spawn);
+        if (spawn == null) {
+            equip(player, kit);
+            return;
+        }
+
+        // The kit has to land after the teleport rather than beside it. Moving a player is
+        // asynchronous, so handing the kit over here writes it into the inventory they are still
+        // standing in - the survival one - and whatever keeps inventories apart per world then
+        // files the kit away as everything they queued with.
+        plugin.getSpigotScheduler().teleport(player, spawn).thenRun(() ->
+                plugin.getSpigotScheduler().runEntity(player, () -> equip(player, kit)));
+    }
+
+    /**
+     * Hands the match kit over once the player is standing in the arena.
+     *
+     * <p>The match can already be over by the time the teleport lands - a disconnect during those
+     * few ticks ends it - so this checks it is still running before clearing anything.</p>
+     */
+    private void equip(Player player, PvpKit kit) {
+        if (player == null || !player.isOnline() || !isInMatch(player.getUniqueId())) {
+            return;
         }
         if (config().getBoolean("MATCH.HEAL_ON_START", true)) {
             pvp().healPlayer(player);
         }
         pvp().giveKit(player, kit);
+        pvp().markKitGiven(player, kit);
     }
 
     /** Called when a player in a ranked match dies. The other one wins. */

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpMatchPrepareTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpMatchPrepareTest.java
@@ -1,0 +1,230 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PvpKit;
+import com.bx.ultimateDonutSmp.models.PvpMatch;
+import com.bx.ultimateDonutSmp.utils.SpigotScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sun.reflect.ReflectionFactory;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The order a ranked match assembles a fighter in.
+ *
+ * <p>The kit overwrites whatever the player is carrying, so it must not land until the teleport
+ * into the arena has. Handing it over beside the teleport writes it into the survival inventory
+ * the player is still standing in, and everything they queued with goes down with it.</p>
+ */
+class PvpMatchPrepareTest {
+
+    private static final List<String> CALLS = new ArrayList<>();
+
+    private static final UUID PLAYER = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID OPPONENT = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    private Server originalServer;
+    private World arenaWorld;
+    private Location arenaSpawn;
+    private AtomicBoolean teleportRequested;
+    private CompletableFuture<Boolean> arrival;
+
+    private UltimateDonutSmp plugin;
+    private PvpMatchManager matches;
+    private Map<UUID, PvpMatch> active;
+    private Player player;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        CALLS.clear();
+        originalServer = Bukkit.getServer();
+        installServer();
+
+        plugin = build(UltimateDonutSmp.class);
+        set(plugin, "configManager", arenaConfig());
+        set(plugin, "SpigotScheduler", new SpigotScheduler(plugin));
+        set(plugin, "pvpManager", build(RecordingPvpManager.class));
+
+        matches = build(PvpMatchManager.class);
+        set(matches, "plugin", plugin);
+        active = new ConcurrentHashMap<>();
+        set(matches, "active", active);
+        active.put(PLAYER, new PvpMatch(1L, PLAYER, "Tester", OPPONENT, "Rival", "warrior", 0L));
+
+        teleportRequested = new AtomicBoolean();
+        arrival = new CompletableFuture<>();
+        arenaWorld = proxy(World.class, (method, args) -> "getName".equals(method.getName()) ? "arena" : null);
+        arenaSpawn = new Location(arenaWorld, 0.0D, 64.0D, 0.0D);
+        player = proxy(Player.class, AsyncTeleport.class, (method, args) -> switch (method.getName()) {
+            case "getUniqueId" -> PLAYER;
+            case "getName" -> "Tester";
+            case "isOnline" -> true;
+            case "teleportAsync" -> {
+                teleportRequested.set(true);
+                yield arrival;
+            }
+            default -> null;
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        setServer(originalServer);
+    }
+
+    @Test
+    void theKitIsHeldBackUntilTheTeleportIntoTheArenaLands() throws Exception {
+        prepare();
+
+        assertTrue(teleportRequested.get(), "the fighter has to be sent to the arena");
+        assertEquals(List.of("startSession"), CALLS,
+                "nothing may touch the inventory while the player is still standing in survival");
+
+        arrival.complete(true);
+
+        assertEquals(List.of("startSession", "heal", "giveKit", "markKitGiven"), CALLS,
+                "the kit belongs on the arena side of the teleport");
+    }
+
+    @Test
+    void aFighterWhoseMatchEndedMidTeleportIsLeftAlone() throws Exception {
+        prepare();
+        active.clear();
+
+        arrival.complete(true);
+
+        assertEquals(List.of("startSession"), CALLS,
+                "a match that ended during the teleport must not clear anyone out");
+    }
+
+    private void prepare() throws Exception {
+        Method prepare = PvpMatchManager.class
+                .getDeclaredMethod("prepare", Player.class, PvpKit.class, Location.class);
+        prepare.setAccessible(true);
+        prepare.invoke(matches, player, new PvpKit("warrior"), arenaSpawn);
+    }
+
+    // ── Harness ───────────────────────────────────────────────────────────────
+
+    /** The asynchronous teleport Paper and Purpur hand back, which spigot-api does not declare. */
+    public interface AsyncTeleport {
+        CompletableFuture<Boolean> teleportAsync(Location location, PlayerTeleportEvent.TeleportCause cause);
+    }
+
+    /** An arena manager that only writes down what the match asked it to do. */
+    public static class RecordingPvpManager extends PvpManager {
+
+        public RecordingPvpManager() {
+            super(null);
+        }
+
+        @Override
+        public void startSession(Player player) {
+            CALLS.add("startSession");
+        }
+
+        @Override
+        public void healPlayer(Player player) {
+            CALLS.add("heal");
+        }
+
+        @Override
+        public void giveKit(Player player, PvpKit kit) {
+            CALLS.add("giveKit");
+        }
+
+        @Override
+        public void markKitGiven(Player player, PvpKit kit) {
+            CALLS.add("markKitGiven");
+        }
+    }
+
+    private ConfigManager arenaConfig() throws Exception {
+        ConfigManager configManager = build(ConfigManager.class);
+        YamlConfiguration pvp = new YamlConfiguration();
+        pvp.load(new File("src/main/resources/pvp.yml"));
+        set(configManager, "pvp", pvp);
+        return configManager;
+    }
+
+    /** Builds an instance without running any constructor, so nothing reaches for a live server. */
+    @SuppressWarnings("unchecked")
+    private static <T> T build(Class<T> type) throws Exception {
+        Constructor<?> constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(type, Object.class.getConstructor());
+        return (T) constructor.newInstance();
+    }
+
+    private static void set(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private interface Handler {
+        Object handle(Method method, Object[] args) throws Throwable;
+    }
+
+    private static <T> T proxy(Class<T> type, Handler handler) {
+        return proxy(type, null, handler);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, Class<?> extra, Handler handler) {
+        Class<?>[] interfaces = extra == null ? new Class<?>[]{type} : new Class<?>[]{type, extra};
+        return (T) Proxy.newProxyInstance(
+                PvpMatchPrepareTest.class.getClassLoader(),
+                interfaces,
+                (instance, method, args) -> switch (method.getName()) {
+                    case "hashCode" -> System.identityHashCode(instance);
+                    case "equals" -> instance == args[0];
+                    case "toString" -> type.getSimpleName() + "-stub";
+                    default -> handler.handle(method, args);
+                }
+        );
+    }
+
+    private void installServer() throws Exception {
+        BukkitScheduler scheduler = proxy(BukkitScheduler.class, (method, args) -> {
+            if ("runTask".equals(method.getName()) && args[1] instanceof Runnable runnable) {
+                runnable.run();
+            }
+            return null;
+        });
+        setServer(proxy(Server.class, (method, args) -> switch (method.getName()) {
+            case "getScheduler" -> scheduler;
+            case "getLogger" -> java.util.logging.Logger.getLogger("PvpMatchPrepareTest");
+            default -> null;
+        }));
+    }
+
+    private static void setServer(Server server) throws Exception {
+        Field field = Bukkit.class.getDeclaredField("server");
+        field.setAccessible(true);
+        field.set(null, server);
+    }
+}


### PR DESCRIPTION
Closes #275

Queueing for a ranked match wiped whatever the player was carrying. The match sent them to the arena and handed them the kit in the same breath, but the teleport is asynchronous, so the kit landed in the inventory they were still standing in back in survival, and everything they queued with went with it. Now the kit waits for the teleport to finish.

## What was going wrong

`prepare` in `PvpMatchManager` did three things in a row: open the session, ask for a teleport to the arena spawn, hand over the kit. That last step opens with `PlayerInventory.clear()`, and it ran on the same tick as the teleport request rather than after it. On Paper and Purpur the move goes through `teleportAsync` and finishes a tick or more later, so by the time the player actually arrived their survival inventory already held the kit, and whatever keeps inventories apart per world then filed that away as the survival one.

Every other way in and out of the arena already gets this right. `PvpManager.join` chains the kit menu off `teleport(...).thenRun(...)`, and `removeFromArena` empties the kit before the trip back to the lobby. The ranked queue was the only path that touched an inventory the arena never handed out, which is the opposite of what `docs/wiki/Ranked-PvP-Arena.md` promises.

## The fix

`prepare` now chains the kit off the teleport future and runs it back on the player's own thread, the way `join` does. The heal moves with it, so a fighter gets patched up on arrival instead of on their way out of survival.

`equip` checks the match is still running before it clears anything. A disconnect during those few ticks ends the match, and without that check the kit would land on somebody who is no longer in one.

## Awaiting a kit

`startSession` used to mark the session as already holding its kit and start the spawn protection clock. That was true while the kit arrived on the same tick; it isn't now. So the session opens awaiting a kit like any other, and the new `markKitGiven` flips it once the gear is actually in their hands.

That flag is what `PvpListener` reads to cancel damage and what the arena tick reads to skip the boundary sweep, so a fighter who is still mid-teleport cannot be hit and will not be dragged out for standing outside the arena.

## Notes

No new config or language keys, and nothing under `docs/wiki` changed. The arena still keeps its promise of not snapshotting a survival inventory; it just stops clearing one it never handed out.

`PvpMatchPrepareTest` covers both halves of this: it holds the teleport future open and checks the kit stays put, then ends the match mid-teleport and checks nobody gets cleared. Both cases fail against the old ordering. The suite is at 453 tests.
