### PR TITLE
fix(auction): stop the sell menu returning the item after confirm (#277)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellGui.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellGui.java
@@ -150,6 +150,9 @@ public final class SellGui extends BaseMenu {
 
     @Override
     public void handleClick(int slot, Player player, ClickType clickType) {
+        if (submitted) {
+            return;
+        }
         List<Integer> durations = plugin.getAuctionHouseManager().getAllowedDurations();
         int durationStart = plugin.getConfigManager().getAuctionHouse()
                 .getInt("GUI.SELL.DURATION_START_SLOT", 18);


### PR DESCRIPTION
Closes #277

The auction house sell screen could hand a player their item back while the listing for that same item was still being written. Clicking Confirm and then Cancel before the database transaction finished left them holding the stack and owning an active listing for it.

## The guard

`SellGui.handleClick` already tracked whether the menu had been acted on through the `submitted` flag, but only the confirm branch tested it. The cancel branch sits above that test and called `returnEscrow` unconditionally, so a second click after Confirm released the escrowed stack even though the listing was already on its way into the database.

Confirm now makes the whole menu inert instead of only blocking a second Confirm. One check at the top of `handleClick` covers cancel along with the duration and category buttons, and keeping it in a single place is harder to undo by accident than a second copy of the same condition inside the cancel branch. The existing test in the confirm branch stays where it is, so the listing still cannot be submitted twice even if the top guard is ever moved.

The window lasts as long as the insert does, since `createListing` runs its transaction on the storage executor and the menu is never closed before the callback lands. On MySQL over a network that is long enough to click twice by hand.

## Notes

The same guard closes the smaller version of this on the failure path, where a rejected listing restores the escrow itself and a Cancel click could have added a second copy. That window was roughly one tick.

No config or language keys changed. There is no unit test for this one: the menu tests here cover static helpers and shipped config, and building a `SellGui` would need hand-rolled proxies for the plugin and several managers, which is a lot of scaffolding around a three-line guard. The full suite still passes at 453 tests.
