### PR TITLE
fix(worth): honour the WORTH-LORE enabled switch (#282)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -928,7 +928,9 @@ FLY-SYSTEM:
 
 ```yaml
 WORTH-LORE:
-  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  # Determines whether the worth line is shown at all. Turning this off takes the line away
+  # from everyone, whatever players picked under /settings > Worth Display.
+  # Available options: true, false
   ENABLED: true
   # The text or value for Format. Available options: Any valid string text
   FORMAT: '&7Worth: &a$%price%'
@@ -939,14 +941,16 @@ WORTH-LORE:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `WORTH-LORE.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `WORTH-LORE` system. Set to `true` to enable, `false` to disable. |
+| `WORTH-LORE.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for the worth lore line. `false` hides it from every player, overriding whatever each of them picked under `/settings` > Worth Display. Takes effect on `/uds reload`. |
 | `WORTH-LORE.FORMAT` | `str` | Any string text | `'&7Worth: &a$%price%'` | Configures the technical `FORMAT` parameter for `WORTH-LORE.FORMAT` in `config.yml`. |
 
 ### 3. Practical Setup Example
 
 ```yaml
 WORTH-LORE:
-  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  # Determines whether the worth line is shown at all. Turning this off takes the line away
+  # from everyone, whatever players picked under /settings > Worth Display.
+  # Available options: true, false
   ENABLED: true
   # The text or value for Format. Available options: Any valid string text
   FORMAT: '&7Worth: &a$%price%'

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -1074,6 +1074,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         warpManager.loadAll();
         spawnManager.load();
         worthManager.reload();
+        worthManager.resyncOnlineWorthDisplays();
         farmingMetaManager.load();
         moneyNametagManager.reload();
         shopManager.reload();

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
@@ -6,6 +6,7 @@ import com.bx.ultimateDonutSmp.models.SellCategory;
 import com.bx.ultimateDonutSmp.models.WorthResult;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -158,6 +159,14 @@ public class WorthManager {
         sellCategoryCache.clear();
         blockedMaterialsCache.clear();
         blockedMaterialsLoaded = false;
+    }
+
+    // flipping WORTH-LORE.ENABLED otherwise only reaches a player once they next touch an item,
+    // so a config reload pushes the new answer out to everyone already on the server
+    public void resyncOnlineWorthDisplays() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            syncWorthDisplay(player, true);
+        }
     }
 
     // toggled on at startup when the packet display is active, so worth is rendered per packet only
@@ -427,6 +436,11 @@ public class WorthManager {
             return item;
         }
         return updateWorthDisplay(item, isWorthDisplayEnabled(player));
+    }
+
+    // the server wide switch. off means nobody sees the line, whatever they picked in /settings
+    public boolean isWorthLoreEnabled() {
+        return plugin.getConfigManager().getConfig().getBoolean("WORTH-LORE.ENABLED", true);
     }
 
     public boolean isWorthDisplayEnabledFor(Player player) {
@@ -1179,6 +1193,10 @@ public class WorthManager {
     }
 
     private boolean isWorthDisplayEnabled(Player player) {
+        if (!isWorthLoreEnabled()) {
+            return false;
+        }
+
         PlayerData data = plugin.getPlayerDataManager().get(player);
         return data != null && data.isWorthDisplayEnabled();
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -369,7 +369,9 @@ FLY-SYSTEM:
   MAX-SPEED: 10
 # Configuration section for Worth Lore.
 WORTH-LORE:
-  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  # Determines whether the worth line is shown at all. Turning this off takes the line away
+  # from everyone, whatever players picked under /settings > Worth Display.
+  # Available options: true, false
   ENABLED: true
   # The text or value for Format. Available options: Any valid string text
   FORMAT: '&7Worth: &a$%price%'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
@@ -158,6 +158,37 @@ class WorthManagerTest {
                 playerWithOpenView(org.bukkit.event.inventory.InventoryType.CRAFTING)));
     }
 
+    @Test
+    void theBundledConfigShipsTheWorthLoreSwitchTurnedOn() throws Exception {
+        org.bukkit.configuration.file.YamlConfiguration config = new org.bukkit.configuration.file.YamlConfiguration();
+        config.load(java.nio.file.Path.of("src/main/resources", "config.yml").toFile());
+
+        assertTrue(config.isConfigurationSection("WORTH-LORE"));
+        assertTrue(config.getBoolean("WORTH-LORE.ENABLED"));
+        assertEquals("&7Worth: &a$%price%", config.getString("WORTH-LORE.FORMAT"));
+    }
+
+    @Test
+    void theWorthLoreSwitchStaysOnWhenAnAdminHasNotTouchedIt() throws Exception {
+        UltimateDonutSmp plugin = createMockPlugin(new org.bukkit.configuration.file.YamlConfiguration(), new org.bukkit.configuration.file.YamlConfiguration());
+
+        assertTrue(new WorthManager(plugin).isWorthLoreEnabled());
+    }
+
+    @Test
+    void turningTheWorthLoreSwitchOffHidesTheLineFromEveryone() throws Exception {
+        org.bukkit.configuration.file.YamlConfiguration mainConfig = new org.bukkit.configuration.file.YamlConfiguration();
+        mainConfig.set("WORTH-LORE.ENABLED", false);
+
+        UltimateDonutSmp plugin = createMockPlugin(new org.bukkit.configuration.file.YamlConfiguration(), mainConfig);
+        WorthManager worthManager = new WorthManager(plugin);
+
+        assertFalse(worthManager.isWorthLoreEnabled());
+        // the switch is read before the player's own preference, so this answers false with no
+        // player data manager behind it at all
+        assertFalse(worthManager.isWorthDisplayEnabledFor(null));
+    }
+
     private org.bukkit.entity.Player playerWithOpenView(org.bukkit.event.inventory.InventoryType type) {
         org.bukkit.inventory.Inventory topInventory = (org.bukkit.inventory.Inventory) java.lang.reflect.Proxy.newProxyInstance(
                 org.bukkit.inventory.Inventory.class.getClassLoader(),
@@ -301,6 +332,19 @@ class WorthManagerTest {
         );
 
         serverField.set(null, mockServer);
+    }
+
+    private UltimateDonutSmp createMockPlugin(
+            org.bukkit.configuration.file.YamlConfiguration worthConfig,
+            org.bukkit.configuration.file.YamlConfiguration mainConfig
+    ) throws Exception {
+        UltimateDonutSmp plugin = createMockPlugin(worthConfig);
+
+        java.lang.reflect.Field configField = ConfigManager.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(plugin.getConfigManager(), mainConfig);
+
+        return plugin;
     }
 
     private UltimateDonutSmp createMockPlugin(org.bukkit.configuration.file.YamlConfiguration worthConfig) throws Exception {


### PR DESCRIPTION
Closes #282

`config.yml` has shipped a `WORTH-LORE.ENABLED` key since the first import and nothing has ever read it. Only `WORTH-LORE.FORMAT` was, so an admin who set the switch to `false` and reloaded watched the `Worth: $x` line keep rendering for everyone. The only working off switch was per player, in `/settings`, which left a server that didn't want the line at all with no way to say so.

## The switch

`WorthManager` gets an `isWorthLoreEnabled()` reading `WORTH-LORE.ENABLED` from `config.yml`, defaulting to `true` so nothing changes for a server that leaves it alone. It sits next to `isWorthDisplayEnabledFor` for the same reason `MoneyNametagManager` puts `isEnabled()` next to `isEnabledFor()`: one is the server's answer, the other is the player's.

The per-player gate `isWorthDisplayEnabled(Player)` now checks it first and returns `false` before reading `PlayerData`. Every path that renders or strips worth lore already funnels through that one method (the packet listener via `isWorthDisplayEnabledFor`, the inventory sync, the cursor, `applyWorthDisplayForPlayer`, and the stack merge), so the switch only needed wiring in once instead of at five call sites.

## Taking effect on reload

Flipping the key would otherwise only reach a player the next time they moved an item. `resyncOnlineWorthDisplays()` walks the online players and forces a sync, and `reloadAllPluginConfigurations` calls it right after `worthManager.reload()`.

It's deliberately not inside `reload()` itself, because `FarmingMetaManager.rotate` calls that method to drop cached prices and a meta rotation has no business resyncing everybody's inventory.

## Notes

The comment on `WORTH-LORE.ENABLED` in `config.yml` used to read "Determines whether Enabled is enabled or disabled", which said nothing. It now states what the key does and that it overrides `/settings`, matching the wording `MONEY-NAMETAGS` already uses for the same relationship. `docs/wiki/Config-config.yml.md` carried that old comment in two code blocks and described the key as a global toggle it wasn't; both now match.

No new language keys, so the 8 language files are untouched.

Three tests land in `WorthManagerTest`: the bundled config still ships the switch on, an absent key reads as on, and turning it off answers `false` with no `PlayerDataManager` behind it, which is what proves the short circuit happens before the per-player read. Suite is 456 green.

One thing left alone: the issue records a second finding in the same subsystem, where `WorthPacketDisplay#isMenuInventory` treats a null inventory holder as "not a menu", so third-party GUIs built with `Bukkit.createInventory(null, ...)` get worth lore painted onto their buttons. That's a separate defect with a design question attached, and every UltimateDonutSmp menu passes a non-null holder, so the plugin's own GUIs are unaffected either way.
