### PR TITLE
feat(discord): add ranked sync stats leaderboards and match results (#255)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dependency-reduced-pom.xml
 *.jar
 *.zip
 *.log
+node_modules/
+discord-bot-example/data/links.db
+discord-bot-example/data/links.db-shm
+discord-bot-example/data/links.db-wal

--- a/discord-bot-example/.env.example
+++ b/discord-bot-example/.env.example
@@ -24,3 +24,18 @@ MONGODB_PLAYERS_COLLECTION=players
 
 # Skin render provider. %uuid_no_dash% is replaced automatically.
 SKIN_BUST_URL=https://crafatar.com/renders/body/%uuid_no_dash%
+
+# Ranked PvP arena.
+# Where the bot stores Discord account links and how far the match watcher has read.
+# This is the bot's own file. It never writes to the plugin database.
+LINKS_FILE=data/links.db
+
+# Channel that finished ranked matches are posted into. Leave it empty to post nothing.
+PVP_MATCH_CHANNEL_ID=
+
+# How often the bot checks for finished matches, in seconds. Minimum 5.
+PVP_MATCH_POLL_SECONDS=15
+
+# The rank ladder, lowest first. Keep this in step with RANKS in the plugin's pvp.yml:
+# it only decides what Discord prints, never what the server awards.
+PVP_RANKS=LT5:0,LT4:100,LT3:200,LT2:300,LT1:400,HT5:600,HT4:800,HT3:1000,HT2:1200,HT1:1500

--- a/discord-bot-example/README.md
+++ b/discord-bot-example/README.md
@@ -1,6 +1,11 @@
 # UltimateDonutSmp Discord Bot Example
 
-Example discord.js bot for `/stats` and `/leaderboard`. This replaces stats and leaderboard webhook delivery with real slash commands.
+Example discord.js bot that reads the plugin database. It covers survival stats and leaderboards,
+and the ranked PvP arena: account linking, competitive stats, tier leaderboards, and a match result
+posted into a channel every time a ranked fight finishes.
+
+The bot only ever reads the plugin database. Everything it owns, meaning Discord account links and
+how far the match watcher has read, lives in its own SQLite file.
 
 ## Setup
 
@@ -23,20 +28,68 @@ npm install
 npm start
 ```
 
-Slash commands are registered automatically every time the bot starts. You can still deploy manually without starting the bot:
+Slash commands are registered automatically every time the bot starts. You can still deploy manually
+without starting the bot:
 
 ```bash
 npm run deploy
 ```
 
-`DISCORD_CLIENT_ID` and `DISCORD_GUILD_ID` must be numeric Discord snowflake IDs. Do not leave placeholder values such as `your_test_server_id` in `.env`.
+`DISCORD_CLIENT_ID` and `DISCORD_GUILD_ID` must be numeric Discord snowflake IDs. Do not leave
+placeholder values such as `your_test_server_id` in `.env`.
 
 ## Commands
 
 ```txt
 /stats player:<minecraft username or uuid>
 /leaderboard type:<money|shards|kills|deaths|playtime|...> limit:<1-10>
+
+/sync code:<code from /pvp sync in game>
+/unsync
+/mystats
+/tier stats player:<minecraft username or uuid>
+/tier leaderboard type:<elo|level|kills|deaths|streak|killstreak|wins|losses> limit:<1-10>
 ```
+
+## Linking an account
+
+A player runs `/pvp sync` in game. The plugin gives them a short one-time code and writes it to the
+`pvp_sync_codes` table. They then run `/sync code:<that code>` in Discord, and the bot checks the
+code, confirms it has not expired or been spent, and records the link on its own side.
+
+The plugin never learns anybody's Discord id, which is why the bot can keep the plugin database
+read-only. Codes expire after ten minutes by default, and asking for a new one in game replaces the
+old one. Every `/sync` and `/unsync` reply is ephemeral so a live code never sits in a public
+channel.
+
+`/mystats` uses that link. `/tier stats` takes a username instead and needs no link at all.
+
+## Match results
+
+Set `PVP_MATCH_CHANNEL_ID` and the bot posts a result embed after every ranked match, showing the
+winner, the duration, and both fighters' rank, Elo change, hits, crystals and final health.
+
+The plugin writes one `pvp_matches` row when a match ends, and the bot polls for rows past the last
+one it posted. The first run does not backfill: a server that has been up for months would otherwise
+dump its whole history into the channel the moment the bot starts. After that, a restart resumes
+where it stopped rather than losing what happened while it was down.
+
+```env
+PVP_MATCH_CHANNEL_ID=123456789012345678
+PVP_MATCH_POLL_SECONDS=15
+```
+
+## Ranks
+
+The rank each Elo score maps to comes from `PVP_RANKS`, which mirrors the `RANKS` section of the
+plugin's `pvp.yml`:
+
+```env
+PVP_RANKS=LT5:0,LT4:100,LT3:200,LT2:300,LT1:400,HT5:600,HT4:800,HT3:1000,HT2:1200,HT1:1500
+```
+
+Keep the two in step. This list only decides what Discord prints; the server awards ranks from
+`pvp.yml` regardless of what is set here.
 
 ## Database Notes
 
@@ -75,10 +128,31 @@ MONGODB_DATABASE=ultimatedonutsmp
 MONGODB_PLAYERS_COLLECTION=players
 ```
 
-The plugin stores MongoDB snapshots in collections named after SQL tables, so this bot reads the `players` collection by default.
+The plugin stores MongoDB snapshots in collections named after SQL tables, so this bot reads the
+`players`, `pvp_stats`, `pvp_matches` and `pvp_sync_codes` collections.
 
-The bot reads the plugin `players` table. Live in-memory player values may only appear after the plugin saves/autosaves them to the database.
+The survival commands read the plugin `players` table and the ranked commands read `pvp_stats` and
+`pvp_matches`. Live in-memory player values may only appear after the plugin saves or autosaves them
+to the database. The ranked tables are written as matches finish, so those are current.
+
+A server that has never enabled the ranked arena has no `pvp_*` tables at all. The ranked commands
+answer with "nobody has fought a ranked match yet" in that case rather than failing.
+
+## Tests
+
+```bash
+npm test
+```
+
+The tests build a throwaway database with the plugin's real schema and run every query the bot makes
+against it, so a column renamed on the plugin side fails here instead of in a live channel. There is
+also a syntax check over every source file:
+
+```bash
+npm run check
+```
 
 ## Discord.js References
 
-This example follows the discord.js v14 slash command pattern with `REST`, `Routes`, `Client`, `GatewayIntentBits`, and `SlashCommandBuilder`.
+This example follows the discord.js v14 slash command pattern with `REST`, `Routes`, `Client`,
+`GatewayIntentBits`, and `SlashCommandBuilder`.

--- a/discord-bot-example/package.json
+++ b/discord-bot-example/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "deploy": "node src/deploy-commands.js",
     "start": "node src/index.js",
-    "check": "node --check src/index.js && node --check src/deploy-commands.js && node --check src/register-commands.js && node --check src/database.js && node --check src/embeds.js && node --check src/format.js"
+    "test": "node --test \"test/**/*.test.mjs\"",
+    "check": "node --check src/index.js && node --check src/deploy-commands.js && node --check src/register-commands.js && node --check src/commands.js && node --check src/database.js && node --check src/embeds.js && node --check src/format.js && node --check src/pvp.js && node --check src/pvp-embeds.js && node --check src/links.js && node --check src/ranks.js && node --check src/match-watcher.js"
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",

--- a/discord-bot-example/src/commands.js
+++ b/discord-bot-example/src/commands.js
@@ -1,7 +1,13 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { leaderboardTypes } from './database.js';
+import { tierLeaderboardTypes } from './pvp.js';
 
 const leaderboardChoices = Object.entries(leaderboardTypes).map(([value, definition]) => ({
+  name: definition.label,
+  value
+}));
+
+const tierChoices = Object.entries(tierLeaderboardTypes).map(([value, definition]) => ({
   name: definition.label,
   value
 }));
@@ -32,5 +38,53 @@ export const commands = [
         .setDescription('Number of entries to show')
         .setMinValue(1)
         .setMaxValue(10)
+    ),
+  new SlashCommandBuilder()
+    .setName('mystats')
+    .setDescription('View your own competitive statistics.'),
+  new SlashCommandBuilder()
+    .setName('sync')
+    .setDescription('Sync your Minecraft account with Discord.')
+    .addStringOption(option =>
+      option
+        .setName('code')
+        .setDescription('The code /pvp sync gave you in game')
+        .setRequired(true)
+    ),
+  new SlashCommandBuilder()
+    .setName('unsync')
+    .setDescription('Unlink your Minecraft account.'),
+  new SlashCommandBuilder()
+    .setName('tier')
+    .setDescription('Ranked arena commands.')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('leaderboard')
+        .setDescription('View the top players.')
+        .addStringOption(option =>
+          option
+            .setName('type')
+            .setDescription('Leaderboard type')
+            .setRequired(true)
+            .addChoices(...tierChoices)
+        )
+        .addIntegerOption(option =>
+          option
+            .setName('limit')
+            .setDescription('Number of entries to show')
+            .setMinValue(1)
+            .setMaxValue(10)
+        )
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('stats')
+        .setDescription('View the competitive statistics of another player.')
+        .addStringOption(option =>
+          option
+            .setName('player')
+            .setDescription('Minecraft username or UUID')
+            .setRequired(true)
+        )
     )
 ].map(command => command.toJSON());

--- a/discord-bot-example/src/index.js
+++ b/discord-bot-example/src/index.js
@@ -1,7 +1,11 @@
 import 'dotenv/config';
-import { Client, Events, GatewayIntentBits } from 'discord.js';
+import { Client, Events, GatewayIntentBits, MessageFlags } from 'discord.js';
 import { createPlayerRepository, leaderboardTypes } from './database.js';
+import { createPvpRepository, tierLeaderboardTypes } from './pvp.js';
+import { createLinkStore } from './links.js';
 import { createLeaderboardEmbed, createStatsEmbed } from './embeds.js';
+import { createCompetitiveStatsEmbed, createTierLeaderboardEmbed } from './pvp-embeds.js';
+import { createMatchWatcher } from './match-watcher.js';
 import { registerCommands } from './register-commands.js';
 
 const token = process.env.DISCORD_TOKEN;
@@ -11,12 +15,16 @@ if (!token) {
 }
 
 const repository = await createPlayerRepository();
+const pvp = await createPvpRepository();
+const links = createLinkStore();
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+const matchWatcher = createMatchWatcher({ client, repository: pvp, links });
 
 await registerCommands();
 
-client.once(Events.ClientReady, readyClient => {
+client.once(Events.ClientReady, async readyClient => {
   console.log(`Logged in as ${readyClient.user.tag}.`);
+  await matchWatcher.start();
 });
 
 client.on(Events.InteractionCreate, async interaction => {
@@ -25,13 +33,26 @@ client.on(Events.InteractionCreate, async interaction => {
   }
 
   try {
-    if (interaction.commandName === 'stats') {
-      await handleStats(interaction);
-      return;
-    }
-
-    if (interaction.commandName === 'leaderboard') {
-      await handleLeaderboard(interaction);
+    switch (interaction.commandName) {
+      case 'stats':
+        await handleStats(interaction);
+        return;
+      case 'leaderboard':
+        await handleLeaderboard(interaction);
+        return;
+      case 'mystats':
+        await handleMyStats(interaction);
+        return;
+      case 'sync':
+        await handleSync(interaction);
+        return;
+      case 'unsync':
+        await handleUnsync(interaction);
+        return;
+      case 'tier':
+        await handleTier(interaction);
+        return;
+      default:
     }
   } catch (error) {
     console.error(error);
@@ -39,7 +60,7 @@ client.on(Events.InteractionCreate, async interaction => {
     if (interaction.deferred || interaction.replied) {
       await interaction.editReply({ content: message, embeds: [] });
     } else {
-      await interaction.reply({ content: message });
+      await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
     }
   }
 });
@@ -78,8 +99,118 @@ async function handleLeaderboard(interaction) {
   await interaction.editReply({ embeds: [createLeaderboardEmbed(typeKey, entries, interaction.user.username)] });
 }
 
+// ── Ranked arena ─────────────────────────────────────────────────────────────
+
+async function handleMyStats(interaction) {
+  await interaction.deferReply();
+
+  const link = links.getLink(interaction.user.id);
+  if (!link) {
+    await interaction.editReply(
+      'Your Discord account is not linked yet. Run `/pvp sync` in game, then `/sync` here with the code it gives you.'
+    );
+    return;
+  }
+
+  await replyWithCompetitiveStats(interaction, link.player_uuid, link.player_name);
+}
+
+async function handleTier(interaction) {
+  const subcommand = interaction.options.getSubcommand();
+  if (subcommand === 'stats') {
+    await interaction.deferReply();
+    await replyWithCompetitiveStats(interaction, interaction.options.getString('player', true));
+    return;
+  }
+
+  const typeKey = interaction.options.getString('type', true);
+  const limit = interaction.options.getInteger('limit') ?? 10;
+  await interaction.deferReply();
+
+  if (!tierLeaderboardTypes[typeKey]) {
+    await interaction.editReply(`Unknown leaderboard type: \`${typeKey}\`.`);
+    return;
+  }
+
+  const entries = (await pvp.getTierLeaderboard(typeKey, limit)).filter(Boolean);
+  if (entries.length === 0) {
+    await interaction.editReply('Nobody has fought a ranked match yet.');
+    return;
+  }
+
+  await interaction.editReply({
+    embeds: [createTierLeaderboardEmbed(typeKey, entries, interaction.user.username)]
+  });
+}
+
+async function replyWithCompetitiveStats(interaction, lookup, fallbackName) {
+  const stats = await pvp.findStats(lookup);
+  if (!stats) {
+    await interaction.editReply(`No ranked record found for \`${fallbackName ?? lookup}\`.`);
+    return;
+  }
+
+  const record = await pvp.getRecord(stats.uuid);
+  await interaction.editReply({
+    embeds: [createCompetitiveStatsEmbed(stats, record, interaction.user.username)]
+  });
+}
+
+/**
+ * Claims a Minecraft account with a code issued in game.
+ *
+ * The reply is ephemeral throughout: a code that is still valid should not stay readable in a
+ * public channel, and neither should the failure that tells somebody a code was wrong.
+ */
+async function handleSync(interaction) {
+  const code = interaction.options.getString('code', true).trim().toLowerCase();
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const entry = await pvp.findSyncCode(code);
+  if (!entry) {
+    await interaction.editReply('That sync code is not valid. Run `/pvp sync` in game for a new one.');
+    return;
+  }
+  if (entry.expiresAt > 0 && entry.expiresAt < Date.now()) {
+    await interaction.editReply('That sync code has expired. Run `/pvp sync` in game for a new one.');
+    return;
+  }
+  if (links.isCodeUsed(code)) {
+    await interaction.editReply('That sync code has already been used. Run `/pvp sync` in game for a new one.');
+    return;
+  }
+
+  const taken = links.getLinkByUuid(entry.uuid);
+  if (taken && taken.discord_id !== interaction.user.id) {
+    await interaction.editReply(
+      'That Minecraft account is already linked to another Discord user. They need to `/unsync` first.'
+    );
+    return;
+  }
+
+  const name = entry.name ?? (await pvp.findStats(entry.uuid))?.username ?? 'your account';
+  links.link(interaction.user.id, entry.uuid, name, code);
+  await interaction.editReply(`Sync successful! You are now linked with **${name}**.`);
+}
+
+async function handleUnsync(interaction) {
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const link = links.getLink(interaction.user.id);
+  if (!link) {
+    await interaction.editReply('Your Discord account is not linked to a Minecraft account.');
+    return;
+  }
+
+  links.unlink(interaction.user.id);
+  await interaction.editReply(`Unlinked from **${link.player_name ?? link.player_uuid}**.`);
+}
+
 function shutdown() {
+  matchWatcher.stop();
   repository.close?.();
+  pvp.close?.();
+  links.close?.();
   client.destroy();
 }
 

--- a/discord-bot-example/src/links.js
+++ b/discord-bot-example/src/links.js
@@ -1,0 +1,98 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Where the bot keeps what it owns: Discord account links and how far the match watcher has read.
+ *
+ * This is deliberately the bot's own SQLite file rather than a second writer on the plugin
+ * database. The plugin issues sync codes and never has to know a Discord id, so the bot can stay
+ * a read-only reader of the server's data and still own the half of the relationship that is
+ * genuinely its own.
+ */
+export function createLinkStore() {
+  const configured = process.env.LINKS_FILE || 'data/links.db';
+  const file = path.isAbsolute(configured) ? configured : path.resolve(projectRoot, configured);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+
+  const database = new Database(file);
+  database.pragma('journal_mode = WAL');
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS links (
+      discord_id TEXT PRIMARY KEY,
+      player_uuid TEXT NOT NULL UNIQUE,
+      player_name TEXT,
+      code TEXT,
+      linked_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS state (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS links_code ON links(code);
+  `);
+
+  return {
+    getLink(discordId) {
+      return database
+        .prepare('SELECT discord_id, player_uuid, player_name, linked_at FROM links WHERE discord_id = ?')
+        .get(String(discordId)) ?? null;
+    },
+
+    getLinkByUuid(uuid) {
+      return database
+        .prepare('SELECT discord_id, player_uuid, player_name, linked_at FROM links WHERE player_uuid = ?')
+        .get(String(uuid)) ?? null;
+    },
+
+    /** True once a code has been spent, so the same one cannot be claimed twice. */
+    isCodeUsed(code) {
+      return Boolean(
+        database.prepare('SELECT 1 FROM links WHERE code = ?').get(String(code).toLowerCase())
+      );
+    },
+
+    /**
+     * Claims an account for a Discord user.
+     *
+     * One row per Discord id and one per Minecraft account, so relinking either side replaces the
+     * old pair instead of leaving two rows that disagree about who owns what.
+     */
+    link(discordId, uuid, name, code) {
+      const now = Date.now();
+      const write = database.transaction(() => {
+        database.prepare('DELETE FROM links WHERE discord_id = ? OR player_uuid = ?')
+          .run(String(discordId), String(uuid));
+        database.prepare(`
+          INSERT INTO links (discord_id, player_uuid, player_name, code, linked_at)
+          VALUES (?, ?, ?, ?, ?)
+        `).run(String(discordId), String(uuid), name ?? null, String(code).toLowerCase(), now);
+      });
+      write();
+      return { discord_id: String(discordId), player_uuid: String(uuid), player_name: name, linked_at: now };
+    },
+
+    unlink(discordId) {
+      return database.prepare('DELETE FROM links WHERE discord_id = ?').run(String(discordId)).changes > 0;
+    },
+
+    getState(key, fallback = null) {
+      const row = database.prepare('SELECT value FROM state WHERE key = ?').get(String(key));
+      return row ? row.value : fallback;
+    },
+
+    setState(key, value) {
+      database.prepare(`
+        INSERT INTO state (key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `).run(String(key), String(value));
+    },
+
+    close() {
+      database.close();
+    }
+  };
+}

--- a/discord-bot-example/src/match-watcher.js
+++ b/discord-bot-example/src/match-watcher.js
@@ -1,0 +1,83 @@
+import { createMatchResultEmbed } from './pvp-embeds.js';
+
+const stateKey = 'last_match_id';
+const maxPerPoll = 10;
+
+/**
+ * Posts every finished ranked match into a channel.
+ *
+ * The plugin writes one `pvp_matches` row when a match ends, so the bot polls for rows past the
+ * last one it posted rather than needing the server to call out to it. The high-water mark lives
+ * in the bot's own database, which means a restart resumes where it stopped instead of either
+ * replaying the whole history or losing the matches that happened while it was down.
+ */
+export function createMatchWatcher({ client, repository, links }) {
+  const channelId = String(process.env.PVP_MATCH_CHANNEL_ID || '').trim();
+  const intervalSeconds = Math.max(5, Number(process.env.PVP_MATCH_POLL_SECONDS || 15));
+  let timer = null;
+  let running = false;
+
+  async function seed() {
+    if (links.getState(stateKey) !== null) {
+      return;
+    }
+    // First run posts nothing: a server that has been up for months would otherwise dump its
+    // entire match history into the channel the moment the bot is switched on.
+    const latest = await repository.getLatestMatchId();
+    links.setState(stateKey, String(latest));
+    console.log(`Match watcher starting from match #${latest}.`);
+  }
+
+  async function poll() {
+    if (running) {
+      return;
+    }
+    running = true;
+
+    try {
+      const lastId = Number(links.getState(stateKey, '0'));
+      const matches = await repository.getMatchesAfter(lastId, maxPerPoll);
+      if (matches.length === 0) {
+        return;
+      }
+
+      const channel = await client.channels.fetch(channelId).catch(() => null);
+      if (!channel?.isTextBased?.()) {
+        console.warn(`PVP_MATCH_CHANNEL_ID ${channelId} is not a text channel the bot can post in.`);
+        // The id stays unadvanced on purpose, so fixing the channel replays what was missed.
+        return;
+      }
+
+      for (const match of matches) {
+        await channel.send({ embeds: [createMatchResultEmbed(match)] });
+        links.setState(stateKey, String(match.id));
+      }
+    } catch (error) {
+      console.error('Match watcher poll failed.', error);
+    } finally {
+      running = false;
+    }
+  }
+
+  return {
+    async start() {
+      if (!channelId) {
+        console.log('PVP_MATCH_CHANNEL_ID is not set, so finished matches will not be posted.');
+        return;
+      }
+
+      await seed();
+      await poll();
+      timer = setInterval(poll, intervalSeconds * 1000);
+      timer.unref?.();
+      console.log(`Match watcher polling every ${intervalSeconds}s into channel ${channelId}.`);
+    },
+
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+  };
+}

--- a/discord-bot-example/src/pvp-embeds.js
+++ b/discord-bot-example/src/pvp-embeds.js
@@ -1,0 +1,164 @@
+import { EmbedBuilder } from 'discord.js';
+import { tierLeaderboardTypes } from './pvp.js';
+import { rankName } from './ranks.js';
+import { formatKdr, formatNumber } from './format.js';
+
+const competitiveColor = 0x5865f2;
+const winColor = 0x22c55e;
+const drawColor = 0xeab308;
+
+export function createCompetitiveStatsEmbed(stats, record, requestedBy) {
+  return new EmbedBuilder()
+    .setColor(competitiveColor)
+    .setTitle(`${escape(stats.username)}'s Stats`)
+    .setDescription(`> Viewed by **${escape(requestedBy)}**`)
+    .setThumbnail(skinBustUrl(stats.uuid))
+    .addFields(
+      {
+        name: ':trophy: Competitive',
+        value: [
+          `Rank: **${rankName(stats.elo)}**`,
+          `ELO: **${formatNumber(stats.elo)}**`,
+          `Level: **${formatNumber(stats.level)}**`
+        ].join('\n'),
+        inline: false
+      },
+      {
+        name: ':crossed_swords: Stats',
+        value: [
+          `Kills: **${formatNumber(stats.kills)}**`,
+          `Deaths: **${formatNumber(stats.deaths)}**`,
+          `K/D: **${formatKdr(stats.kills, stats.deaths)}**`,
+          `Kill Streak: **${formatNumber(stats.streak)}**`,
+          `Highest Kill Streak: **${formatNumber(stats.bestStreak)}**`
+        ].join('\n'),
+        inline: false
+      },
+      {
+        name: ':scroll: Record',
+        value: `Wins: **${formatNumber(record.wins)}** | Losses: **${formatNumber(record.losses)}** | Draws: **${formatNumber(record.draws)}**`,
+        inline: false
+      },
+      {
+        name: ':information_source: Information',
+        value: [
+          `Arena joins: **${formatNumber(stats.arenaJoins)}**`,
+          `Last active: **${formatRelative(stats.updatedAt)}**`
+        ].join('\n'),
+        inline: false
+      }
+    )
+    .setFooter({ text: 'UltimateDonutSmp ranked stats' })
+    .setTimestamp();
+}
+
+export function createTierLeaderboardEmbed(typeKey, entries, requestedBy) {
+  const type = tierLeaderboardTypes[typeKey];
+  const top = entries[0];
+  const showRank = typeKey === 'elo';
+
+  const lines = entries.map((entry, index) => {
+    const suffix = showRank ? ` (${rankName(entry.value)})` : '';
+    return `**#${index + 1}** ${escape(entry.username)} » \`${formatNumber(entry.value)}\`${suffix}`;
+  });
+
+  return new EmbedBuilder()
+    .setColor(competitiveColor)
+    .setTitle(`:trophy: Top ${type.label}`)
+    .setDescription(lines.join('\n'))
+    .setThumbnail(skinBustUrl(top.uuid))
+    .setFooter({ text: `UltimateDonutSmp leaderboards · requested by ${requestedBy}` })
+    .setTimestamp();
+}
+
+/**
+ * The snapshot posted after a ranked match ends.
+ *
+ * Both fighters get an inline column so the two sides sit side by side and can be compared without
+ * scrolling, which is the whole point of posting the result rather than just the winner.
+ */
+export function createMatchResultEmbed(match) {
+  const decided = match.result === 'DECIDED' && match.winnerUuid;
+  const winnerName = decided
+    ? (match.winnerUuid === match.first.uuid ? match.first.name : match.second.name)
+    : null;
+
+  return new EmbedBuilder()
+    .setColor(decided ? winColor : drawColor)
+    .setTitle(`:crossed_swords: Match Result: ${escape(match.first.name)} vs ${escape(match.second.name)}`)
+    .setThumbnail(skinBustUrl(decided ? match.winnerUuid : match.first.uuid))
+    .addFields(
+      {
+        name: 'Winner',
+        value: decided ? `**${escape(winnerName)}**` : `**${match.result === 'DRAW' ? 'Draw' : 'No result'}**`,
+        inline: true
+      },
+      {
+        name: 'Duration',
+        value: `**${formatDuration(match.durationSeconds)}**`,
+        inline: true
+      },
+      { name: '​', value: '​', inline: true },
+      fighterField(match, match.first),
+      fighterField(match, match.second),
+      { name: '​', value: '​', inline: true }
+    )
+    .setFooter({ text: match.kitId ? `Match snapshot · ${match.kitId} kit` : 'Match snapshot' })
+    .setTimestamp(match.endedAt > 0 ? new Date(match.endedAt) : new Date());
+}
+
+function fighterField(match, fighter) {
+  return {
+    name: `${escape(fighter.name)} Stats`,
+    value: [
+      `Rank: **${rankName(fighter.eloBefore + fighter.eloDelta)}**`,
+      `ELO: **${formatNumber(fighter.eloBefore + fighter.eloDelta)}** ${formatDelta(fighter.eloDelta)}`,
+      '',
+      `Hits: **${formatNumber(fighter.hits)}**`,
+      `Crystals: **${formatNumber(fighter.crystals)}**`,
+      `Final HP: **${fighter.finalHealth.toFixed(1)} / ${match.maxHealth.toFixed(1)}**`
+    ].join('\n'),
+    inline: true
+  };
+}
+
+function formatDelta(delta) {
+  if (delta > 0) {
+    return `(+${delta})`;
+  }
+  return delta < 0 ? `(${delta})` : '(0)';
+}
+
+export function formatDuration(totalSeconds) {
+  const seconds = Math.max(0, Math.floor(Number(totalSeconds || 0)));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) {
+    return `${minutes}m ${remainder}s`;
+  }
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m ${remainder}s`;
+}
+
+/** Discord renders this itself, so the reader always sees it in their own timezone. */
+function formatRelative(epochMillis) {
+  const value = Number(epochMillis || 0);
+  if (value <= 0) {
+    return 'never';
+  }
+  return `<t:${Math.floor(value / 1000)}:R>`;
+}
+
+function skinBustUrl(uuid) {
+  const template = process.env.SKIN_BUST_URL || 'https://visage.surgeplay.com/bust/384/%uuid_no_dash%';
+  return template
+    .replaceAll('%uuid%', String(uuid))
+    .replaceAll('%uuid_no_dash%', String(uuid).replaceAll('-', ''));
+}
+
+/** Player names are server-controlled text, so they are neutralised before going into markdown. */
+function escape(value) {
+  return String(value ?? '').replace(/[\\`*_~|>]/g, character => `\\${character}`);
+}

--- a/discord-bot-example/src/pvp.js
+++ b/discord-bot-example/src/pvp.js
@@ -1,0 +1,518 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { MongoClient } from 'mongodb';
+import mysql from 'mysql2/promise';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const defaultSqliteFile = '../plugins/UltimateDonutSmp/data/data.db';
+
+/**
+ * The ranked boards. `column` types sort a column of `pvp_stats`; `derived` types are counted out
+ * of `pvp_matches`, because a win is a property of a match rather than of a player row.
+ */
+export const tierLeaderboardTypes = {
+  elo: { label: 'ELO', column: 'elo' },
+  level: { label: 'Level', column: 'pvp_level' },
+  kills: { label: 'Kills', column: 'kills' },
+  deaths: { label: 'Deaths', column: 'deaths' },
+  streak: { label: 'Streak', column: 'streak' },
+  killstreak: { label: 'Highest Kill Streak', column: 'best_streak' },
+  wins: { label: 'Wins', derived: 'wins' },
+  losses: { label: 'Losses', derived: 'losses' }
+};
+
+const statsColumns = `
+  s.player_uuid AS uuid,
+  p.username AS username,
+  s.elo AS elo,
+  s.pvp_level AS pvp_level,
+  s.pvp_xp AS pvp_xp,
+  s.kills AS kills,
+  s.deaths AS deaths,
+  s.streak AS streak,
+  s.best_streak AS best_streak,
+  s.arena_joins AS arena_joins,
+  s.updated_at AS updated_at
+`;
+
+const matchColumns = `
+  id, player_one_uuid, player_one_name, player_two_uuid, player_two_name, kit_id,
+  winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals, two_crystals,
+  one_elo_before, two_elo_before, one_elo_delta, two_elo_delta,
+  one_final_health, two_final_health, max_health
+`;
+
+export async function createPvpRepository() {
+  const type = (process.env.DB_TYPE || 'sqlite').toLowerCase();
+  if (type === 'mysql') {
+    return createMysqlPvpRepository();
+  }
+  if (type === 'mongodb' || type === 'mongo') {
+    return createMongoPvpRepository();
+  }
+  return createSqlitePvpRepository();
+}
+
+// ── SQLite ───────────────────────────────────────────────────────────────────
+
+function createSqlitePvpRepository() {
+  const configured = process.env.SQLITE_FILE || defaultSqliteFile;
+  const file = resolveSqlitePath(configured);
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      [
+        `SQLite database file was not found: ${file}`,
+        `SQLITE_FILE is currently set to: ${configured}`,
+        'Point SQLITE_FILE at the plugin database, usually plugins/UltimateDonutSmp/data/data.db.'
+      ].join('\n')
+    );
+  }
+
+  const database = new Database(file, { readonly: true, fileMustExist: true });
+  const has = table => tableExists(() =>
+    database.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(table)
+  );
+
+  return {
+    ready: has('pvp_stats'),
+
+    async findStats(input) {
+      if (!has('pvp_stats')) {
+        return null;
+      }
+      return normalizeStats(database.prepare(`
+        SELECT ${statsColumns}
+        FROM pvp_stats s LEFT JOIN players p ON p.uuid = s.player_uuid
+        WHERE LOWER(p.username) = LOWER(?) OR s.player_uuid = ?
+        LIMIT 1
+      `).get(input, input));
+    },
+
+    async getRecord(uuid) {
+      if (!has('pvp_matches')) {
+        return emptyRecord();
+      }
+      const row = database.prepare(`
+        SELECT
+          SUM(CASE WHEN result = 'DECIDED' AND winner_uuid = ? THEN 1 ELSE 0 END) AS wins,
+          SUM(CASE WHEN result = 'DECIDED' AND winner_uuid IS NOT NULL AND winner_uuid <> ? THEN 1 ELSE 0 END) AS losses,
+          SUM(CASE WHEN result <> 'DECIDED' THEN 1 ELSE 0 END) AS draws
+        FROM pvp_matches
+        WHERE player_one_uuid = ? OR player_two_uuid = ?
+      `).get(uuid, uuid, uuid, uuid);
+      return normalizeRecord(row);
+    },
+
+    async getTierLeaderboard(typeKey, limit) {
+      const type = tierLeaderboardTypes[typeKey];
+      if (!type) {
+        return [];
+      }
+      if (type.derived) {
+        if (!has('pvp_matches')) {
+          return [];
+        }
+        return database.prepare(derivedLeaderboardSql(type.derived)).all(limit).map(normalizeEntry);
+      }
+      if (!has('pvp_stats')) {
+        return [];
+      }
+      return database.prepare(`
+        SELECT s.player_uuid AS uuid, p.username AS username, s.${type.column} AS value
+        FROM pvp_stats s LEFT JOIN players p ON p.uuid = s.player_uuid
+        ORDER BY value DESC, LOWER(COALESCE(p.username, s.player_uuid)) ASC
+        LIMIT ?
+      `).all(limit).map(normalizeEntry);
+    },
+
+    async getLatestMatchId() {
+      if (!has('pvp_matches')) {
+        return 0;
+      }
+      const row = database.prepare('SELECT MAX(id) AS id FROM pvp_matches').get();
+      return Number(row?.id || 0);
+    },
+
+    async getMatchesAfter(afterId, limit) {
+      if (!has('pvp_matches')) {
+        return [];
+      }
+      return database.prepare(`
+        SELECT ${matchColumns} FROM pvp_matches WHERE id > ? ORDER BY id ASC LIMIT ?
+      `).all(afterId, limit).map(normalizeMatch);
+    },
+
+    async findSyncCode(code) {
+      if (!has('pvp_sync_codes')) {
+        return null;
+      }
+      const row = database.prepare(`
+        SELECT code, player_uuid, player_name, expires_at FROM pvp_sync_codes WHERE LOWER(code) = LOWER(?)
+      `).get(code);
+      return normalizeSyncCode(row);
+    },
+
+    close() {
+      database.close();
+    }
+  };
+}
+
+function resolveSqlitePath(configured) {
+  const value = String(configured || defaultSqliteFile).trim();
+  if (value.startsWith('file://')) {
+    return fileURLToPath(value);
+  }
+  return path.isAbsolute(value) ? value : path.resolve(projectRoot, value);
+}
+
+function tableExists(lookup) {
+  try {
+    return Boolean(lookup());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wins and losses counted over matches.
+ *
+ * A loss is any decided match a player was in and did not win, which needs both sides of the row
+ * flattened into one column first. That is what the union is doing.
+ */
+function derivedLeaderboardSql(kind) {
+  if (kind === 'wins') {
+    return `
+      SELECT m.winner_uuid AS uuid, p.username AS username, COUNT(*) AS value
+      FROM pvp_matches m LEFT JOIN players p ON p.uuid = m.winner_uuid
+      WHERE m.result = 'DECIDED' AND m.winner_uuid IS NOT NULL
+      GROUP BY m.winner_uuid, p.username
+      ORDER BY value DESC
+      LIMIT ?
+    `;
+  }
+
+  return `
+    SELECT t.uuid AS uuid, p.username AS username, COUNT(*) AS value
+    FROM (
+      SELECT player_one_uuid AS uuid, winner_uuid, result FROM pvp_matches
+      UNION ALL
+      SELECT player_two_uuid AS uuid, winner_uuid, result FROM pvp_matches
+    ) t
+    LEFT JOIN players p ON p.uuid = t.uuid
+    WHERE t.result = 'DECIDED' AND t.winner_uuid IS NOT NULL AND t.uuid <> t.winner_uuid
+    GROUP BY t.uuid, p.username
+    ORDER BY value DESC
+    LIMIT ?
+  `;
+}
+
+// ── MySQL ────────────────────────────────────────────────────────────────────
+
+async function createMysqlPvpRepository() {
+  const pool = mysql.createPool({
+    host: process.env.MYSQL_HOST || 'localhost',
+    port: Number(process.env.MYSQL_PORT || 3306),
+    database: process.env.MYSQL_DATABASE || 'ultimatedonutsmp',
+    user: process.env.MYSQL_USER || 'root',
+    password: process.env.MYSQL_PASSWORD || '',
+    waitForConnections: true,
+    connectionLimit: 5
+  });
+
+  const query = async (sql, params = []) => {
+    try {
+      const [rows] = await pool.execute(sql, params);
+      return rows;
+    } catch (error) {
+      if (error?.code === 'ER_NO_SUCH_TABLE') {
+        return [];
+      }
+      throw error;
+    }
+  };
+
+  return {
+    ready: true,
+
+    async findStats(input) {
+      const rows = await query(`
+        SELECT ${statsColumns}
+        FROM pvp_stats s LEFT JOIN players p ON p.uuid = s.player_uuid
+        WHERE LOWER(p.username) = LOWER(?) OR s.player_uuid = ?
+        LIMIT 1
+      `, [input, input]);
+      return normalizeStats(rows[0]);
+    },
+
+    async getRecord(uuid) {
+      const rows = await query(`
+        SELECT
+          SUM(CASE WHEN result = 'DECIDED' AND winner_uuid = ? THEN 1 ELSE 0 END) AS wins,
+          SUM(CASE WHEN result = 'DECIDED' AND winner_uuid IS NOT NULL AND winner_uuid <> ? THEN 1 ELSE 0 END) AS losses,
+          SUM(CASE WHEN result <> 'DECIDED' THEN 1 ELSE 0 END) AS draws
+        FROM pvp_matches
+        WHERE player_one_uuid = ? OR player_two_uuid = ?
+      `, [uuid, uuid, uuid, uuid]);
+      return normalizeRecord(rows[0]);
+    },
+
+    async getTierLeaderboard(typeKey, limit) {
+      const type = tierLeaderboardTypes[typeKey];
+      if (!type) {
+        return [];
+      }
+      if (type.derived) {
+        return (await query(derivedLeaderboardSql(type.derived), [limit])).map(normalizeEntry);
+      }
+      const rows = await query(`
+        SELECT s.player_uuid AS uuid, p.username AS username, s.${type.column} AS value
+        FROM pvp_stats s LEFT JOIN players p ON p.uuid = s.player_uuid
+        ORDER BY value DESC, LOWER(COALESCE(p.username, s.player_uuid)) ASC
+        LIMIT ?
+      `, [limit]);
+      return rows.map(normalizeEntry);
+    },
+
+    async getLatestMatchId() {
+      const rows = await query('SELECT MAX(id) AS id FROM pvp_matches');
+      return Number(rows[0]?.id || 0);
+    },
+
+    async getMatchesAfter(afterId, limit) {
+      const rows = await query(
+        `SELECT ${matchColumns} FROM pvp_matches WHERE id > ? ORDER BY id ASC LIMIT ?`,
+        [afterId, limit]
+      );
+      return rows.map(normalizeMatch);
+    },
+
+    async findSyncCode(code) {
+      const rows = await query(
+        'SELECT code, player_uuid, player_name, expires_at FROM pvp_sync_codes WHERE LOWER(code) = LOWER(?)',
+        [code]
+      );
+      return normalizeSyncCode(rows[0]);
+    },
+
+    close() {
+      return pool.end();
+    }
+  };
+}
+
+// ── MongoDB ──────────────────────────────────────────────────────────────────
+
+async function createMongoPvpRepository() {
+  const client = new MongoClient(process.env.MONGODB_URI || 'mongodb://localhost:27017');
+  await client.connect();
+
+  const database = client.db(process.env.MONGODB_DATABASE || 'ultimatedonutsmp');
+  const stats = database.collection('pvp_stats');
+  const matches = database.collection('pvp_matches');
+  const codes = database.collection('pvp_sync_codes');
+  const players = database.collection(process.env.MONGODB_PLAYERS_COLLECTION || 'players');
+
+  const usernameFor = async uuid => {
+    const player = await players.findOne({ uuid }, { projection: { username: 1 } });
+    return player?.username ?? null;
+  };
+
+  const withUsernames = async rows => {
+    return Promise.all(rows.map(async row => ({
+      ...row,
+      username: row.username ?? await usernameFor(row.uuid)
+    })));
+  };
+
+  return {
+    ready: true,
+
+    async findStats(input) {
+      const player = await players.findOne(
+        { username: { $regex: `^${escapeRegex(input)}$`, $options: 'i' } },
+        { projection: { uuid: 1, username: 1 } }
+      );
+      const uuid = player?.uuid ?? input;
+      const row = await stats.findOne({ player_uuid: uuid });
+      if (!row) {
+        return null;
+      }
+      return normalizeStats({ ...row, uuid: row.player_uuid, username: player?.username ?? await usernameFor(uuid) });
+    },
+
+    async getRecord(uuid) {
+      const rows = await matches
+        .find({ $or: [{ player_one_uuid: uuid }, { player_two_uuid: uuid }] })
+        .project({ result: 1, winner_uuid: 1 })
+        .toArray();
+
+      let wins = 0;
+      let losses = 0;
+      let draws = 0;
+      for (const row of rows) {
+        if (row.result !== 'DECIDED') {
+          draws += 1;
+        } else if (row.winner_uuid === uuid) {
+          wins += 1;
+        } else if (row.winner_uuid) {
+          losses += 1;
+        }
+      }
+      return { wins, losses, draws };
+    },
+
+    async getTierLeaderboard(typeKey, limit) {
+      const type = tierLeaderboardTypes[typeKey];
+      if (!type) {
+        return [];
+      }
+
+      if (type.derived) {
+        const pipeline = type.derived === 'wins'
+          ? [
+            { $match: { result: 'DECIDED', winner_uuid: { $ne: null } } },
+            { $group: { _id: '$winner_uuid', value: { $sum: 1 } } }
+          ]
+          : [
+            { $match: { result: 'DECIDED', winner_uuid: { $ne: null } } },
+            { $project: { uuid: ['$player_one_uuid', '$player_two_uuid'], winner_uuid: 1 } },
+            { $unwind: '$uuid' },
+            { $match: { $expr: { $ne: ['$uuid', '$winner_uuid'] } } },
+            { $group: { _id: '$uuid', value: { $sum: 1 } } }
+          ];
+        pipeline.push({ $sort: { value: -1 } }, { $limit: limit });
+
+        const rows = await matches.aggregate(pipeline).toArray();
+        return withUsernames(rows.map(row => ({ uuid: row._id, value: row.value }))).then(all => all.map(normalizeEntry));
+      }
+
+      const rows = await stats
+        .find({})
+        .sort({ [type.column]: -1 })
+        .limit(limit)
+        .toArray();
+      return withUsernames(rows.map(row => ({ uuid: row.player_uuid, value: row[type.column] })))
+        .then(all => all.map(normalizeEntry));
+    },
+
+    async getLatestMatchId() {
+      const row = await matches.find({}).sort({ id: -1 }).limit(1).next();
+      return Number(row?.id || 0);
+    },
+
+    async getMatchesAfter(afterId, limit) {
+      const rows = await matches.find({ id: { $gt: afterId } }).sort({ id: 1 }).limit(limit).toArray();
+      return rows.map(normalizeMatch);
+    },
+
+    async findSyncCode(code) {
+      const row = await codes.findOne({ code: String(code).toLowerCase() });
+      return normalizeSyncCode(row);
+    },
+
+    close() {
+      return client.close();
+    }
+  };
+}
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ── Row shaping ──────────────────────────────────────────────────────────────
+
+function normalizeStats(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    uuid: String(row.uuid ?? row.player_uuid),
+    username: row.username || 'Unknown',
+    elo: Number(row.elo || 0),
+    level: Number(row.pvp_level || 1),
+    xp: Number(row.pvp_xp || 0),
+    kills: Number(row.kills || 0),
+    deaths: Number(row.deaths || 0),
+    streak: Number(row.streak || 0),
+    bestStreak: Number(row.best_streak || 0),
+    arenaJoins: Number(row.arena_joins || 0),
+    updatedAt: Number(row.updated_at || 0)
+  };
+}
+
+function normalizeEntry(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    uuid: String(row.uuid),
+    username: row.username || String(row.uuid).slice(0, 8),
+    value: Number(row.value || 0)
+  };
+}
+
+function normalizeRecord(row) {
+  if (!row) {
+    return emptyRecord();
+  }
+  return {
+    wins: Number(row.wins || 0),
+    losses: Number(row.losses || 0),
+    draws: Number(row.draws || 0)
+  };
+}
+
+function emptyRecord() {
+  return { wins: 0, losses: 0, draws: 0 };
+}
+
+function normalizeSyncCode(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    code: String(row.code).toLowerCase(),
+    uuid: String(row.player_uuid),
+    name: row.player_name || null,
+    expiresAt: Number(row.expires_at || 0)
+  };
+}
+
+function normalizeMatch(row) {
+  if (!row) {
+    return null;
+  }
+  const maxHealth = Number(row.max_health || 20);
+  return {
+    id: Number(row.id || 0),
+    kitId: row.kit_id || null,
+    result: row.result || 'ABORTED',
+    winnerUuid: row.winner_uuid || null,
+    startedAt: Number(row.started_at || 0),
+    endedAt: Number(row.ended_at || 0),
+    durationSeconds: Math.max(0, Math.floor((Number(row.ended_at || 0) - Number(row.started_at || 0)) / 1000)),
+    maxHealth,
+    first: {
+      uuid: String(row.player_one_uuid),
+      name: row.player_one_name || 'Unknown',
+      hits: Number(row.one_hits || 0),
+      crystals: Number(row.one_crystals || 0),
+      eloBefore: Number(row.one_elo_before || 0),
+      eloDelta: Number(row.one_elo_delta || 0),
+      finalHealth: Number(row.one_final_health || 0)
+    },
+    second: {
+      uuid: String(row.player_two_uuid),
+      name: row.player_two_name || 'Unknown',
+      hits: Number(row.two_hits || 0),
+      crystals: Number(row.two_crystals || 0),
+      eloBefore: Number(row.two_elo_before || 0),
+      eloDelta: Number(row.two_elo_delta || 0),
+      finalHealth: Number(row.two_final_health || 0)
+    }
+  };
+}

--- a/discord-bot-example/src/ranks.js
+++ b/discord-bot-example/src/ranks.js
@@ -1,0 +1,73 @@
+const defaultLadder = 'LT5:0,LT4:100,LT3:200,LT2:300,LT1:400,HT5:600,HT4:800,HT3:1000,HT2:1200,HT1:1500';
+
+let cached = null;
+
+/**
+ * The rank ladder, lowest requirement first.
+ *
+ * The plugin keeps the real ladder in `pvp.yml`. The bot cannot read that file reliably from
+ * wherever it happens to run, so it takes the same list through `PVP_RANKS` instead. Keep the two
+ * in step: an edit in `pvp.yml` that is not mirrored here only changes what Discord prints, never
+ * what the server actually awards.
+ */
+export function getRankLadder() {
+  if (cached) {
+    return cached;
+  }
+
+  const raw = String(process.env.PVP_RANKS || defaultLadder).trim() || defaultLadder;
+  const ladder = raw
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => {
+      const separator = entry.lastIndexOf(':');
+      if (separator < 0) {
+        return null;
+      }
+      const id = entry.slice(0, separator).trim();
+      const elo = Number(entry.slice(separator + 1).trim());
+      if (!id || !Number.isFinite(elo)) {
+        return null;
+      }
+      return { id, elo };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.elo - b.elo);
+
+  cached = ladder.length > 0 ? ladder : parseLadder(defaultLadder);
+  return cached;
+}
+
+function parseLadder(raw) {
+  return raw.split(',').map(entry => {
+    const [id, elo] = entry.split(':');
+    return { id: id.trim(), elo: Number(elo) };
+  });
+}
+
+/**
+ * The rank an Elo score holds: the highest one it still meets.
+ *
+ * Below the cheapest rank the player keeps that cheapest rank rather than having none, which is
+ * the same floor the plugin applies.
+ */
+export function resolveRank(elo) {
+  const ladder = getRankLadder();
+  if (ladder.length === 0) {
+    return null;
+  }
+
+  let current = ladder[0];
+  for (const rank of ladder) {
+    if (Number(elo) >= rank.elo) {
+      current = rank;
+    }
+  }
+  return current;
+}
+
+export function rankName(elo) {
+  const rank = resolveRank(elo);
+  return rank ? rank.id : '-';
+}

--- a/discord-bot-example/test/pvp.test.mjs
+++ b/discord-bot-example/test/pvp.test.mjs
@@ -1,0 +1,206 @@
+// Builds a throwaway database with the plugin's real schema and drives every query the bot makes
+// against it. A column renamed on the plugin side fails here rather than in a live channel.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test, { after, before } from 'node:test';
+import Database from 'better-sqlite3';
+
+const ALICE = '11111111-1111-1111-1111-111111111111';
+const BOB = '22222222-2222-2222-2222-222222222222';
+
+let scratch;
+let pvp;
+let links;
+let modules;
+
+before(async () => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'uds-bot-test-'));
+  const databaseFile = path.join(scratch, 'data.db');
+  seedDatabase(databaseFile);
+
+  process.env.DB_TYPE = 'sqlite';
+  process.env.SQLITE_FILE = databaseFile;
+  process.env.LINKS_FILE = path.join(scratch, 'links.db');
+  delete process.env.PVP_RANKS;
+
+  modules = {
+    pvp: await import('../src/pvp.js'),
+    links: await import('../src/links.js'),
+    ranks: await import('../src/ranks.js'),
+    embeds: await import('../src/pvp-embeds.js')
+  };
+
+  pvp = await modules.pvp.createPvpRepository();
+  links = modules.links.createLinkStore();
+});
+
+after(() => {
+  pvp?.close?.();
+  links?.close?.();
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+function seedDatabase(file) {
+  const database = new Database(file);
+  database.exec(`
+    CREATE TABLE players (uuid TEXT PRIMARY KEY, username TEXT);
+    CREATE TABLE pvp_stats (player_uuid TEXT PRIMARY KEY, elo INTEGER DEFAULT 0,
+      pvp_level INTEGER DEFAULT 1, pvp_xp INTEGER DEFAULT 0, kills INTEGER DEFAULT 0,
+      deaths INTEGER DEFAULT 0, streak INTEGER DEFAULT 0, best_streak INTEGER DEFAULT 0,
+      arena_joins INTEGER DEFAULT 0, updated_at INTEGER DEFAULT 0);
+    CREATE TABLE pvp_matches (id INTEGER PRIMARY KEY AUTOINCREMENT, player_one_uuid TEXT NOT NULL,
+      player_one_name TEXT, player_two_uuid TEXT NOT NULL, player_two_name TEXT, kit_id TEXT,
+      winner_uuid TEXT, result TEXT, started_at INTEGER DEFAULT 0, ended_at INTEGER DEFAULT 0,
+      one_hits INTEGER DEFAULT 0, two_hits INTEGER DEFAULT 0, one_crystals INTEGER DEFAULT 0,
+      two_crystals INTEGER DEFAULT 0, one_elo_before INTEGER DEFAULT 0, two_elo_before INTEGER DEFAULT 0,
+      one_elo_delta INTEGER DEFAULT 0, two_elo_delta INTEGER DEFAULT 0, one_final_health REAL DEFAULT 0,
+      two_final_health REAL DEFAULT 0, max_health REAL DEFAULT 20);
+    CREATE TABLE pvp_sync_codes (code TEXT PRIMARY KEY, player_uuid TEXT NOT NULL, player_name TEXT,
+      created_at INTEGER DEFAULT 0, expires_at INTEGER DEFAULT 0);
+  `);
+
+  const now = Date.now();
+  database.prepare('INSERT INTO players (uuid, username) VALUES (?,?)').run(ALICE, 'SamirSpider');
+  database.prepare('INSERT INTO players (uuid, username) VALUES (?,?)').run(BOB, 'Nexf');
+  const insertStats = database.prepare(`
+    INSERT INTO pvp_stats (player_uuid, elo, pvp_level, kills, deaths, streak, best_streak, arena_joins, updated_at)
+    VALUES (?,?,?,?,?,?,?,?,?)
+  `);
+  insertStats.run(ALICE, 970, 3, 4, 9, 0, 2, 11, now);
+  insertStats.run(BOB, 1040, 7, 9, 4, 3, 5, 14, now);
+  database.prepare(`
+    INSERT INTO pvp_matches (player_one_uuid, player_one_name, player_two_uuid, player_two_name, kit_id,
+      winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals, two_crystals,
+      one_elo_before, two_elo_before, one_elo_delta, two_elo_delta, one_final_health, two_final_health, max_health)
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+  `).run(ALICE, 'SamirSpider', BOB, 'Nexf', 'warrior', BOB, 'DECIDED', 1000, 9000,
+    0, 5, 0, 0, 985, 1020, -15, 20, 0, 7, 20);
+  database.prepare(`
+    INSERT INTO pvp_sync_codes (code, player_uuid, player_name, created_at, expires_at)
+    VALUES (?,?,?,?,?)
+  `).run('ouw5rp', BOB, 'Nexf', now, now + 600_000);
+  database.close();
+}
+
+test('stats resolve by username and by uuid', async () => {
+  const byName = await pvp.findStats('nexf');
+  assert.equal(byName.username, 'Nexf');
+  assert.equal(byName.elo, 1040);
+  assert.equal(byName.level, 7);
+
+  assert.equal((await pvp.findStats(ALICE)).username, 'SamirSpider');
+  assert.equal(await pvp.findStats('nobody'), null);
+});
+
+test('the record counts wins and losses from the match rows', async () => {
+  const winner = await pvp.getRecord(BOB);
+  assert.deepEqual(winner, { wins: 1, losses: 0, draws: 0 });
+
+  const loser = await pvp.getRecord(ALICE);
+  assert.deepEqual(loser, { wins: 0, losses: 1, draws: 0 });
+});
+
+test('every leaderboard type runs against the real schema', async () => {
+  for (const typeKey of Object.keys(modules.pvp.tierLeaderboardTypes)) {
+    const rows = await pvp.getTierLeaderboard(typeKey, 10);
+    assert.ok(Array.isArray(rows), `${typeKey} did not return rows`);
+  }
+});
+
+test('leaderboards are ordered and name the right player', async () => {
+  assert.equal((await pvp.getTierLeaderboard('elo', 10))[0].username, 'Nexf');
+  assert.equal((await pvp.getTierLeaderboard('wins', 10))[0].username, 'Nexf');
+  assert.equal((await pvp.getTierLeaderboard('losses', 10))[0].username, 'SamirSpider');
+});
+
+test('the match watcher reads forward from an id and stops', async () => {
+  assert.equal(await pvp.getLatestMatchId(), 1);
+  assert.equal((await pvp.getMatchesAfter(0, 10)).length, 1);
+  assert.equal((await pvp.getMatchesAfter(1, 10)).length, 0);
+});
+
+test('a match row keeps both sides apart', async () => {
+  const [match] = await pvp.getMatchesAfter(0, 10);
+
+  assert.equal(match.durationSeconds, 8);
+  assert.equal(match.first.eloDelta, -15);
+  assert.equal(match.second.eloDelta, 20);
+  assert.equal(match.second.hits, 5);
+  assert.equal(match.first.finalHealth, 0);
+  assert.equal(match.second.finalHealth, 7);
+  assert.equal(match.maxHealth, 20);
+});
+
+test('sync codes are looked up without case mattering', async () => {
+  const entry = await pvp.findSyncCode('OUW5RP');
+  assert.equal(entry.uuid, BOB);
+  assert.equal(entry.name, 'Nexf');
+  assert.ok(entry.expiresAt > Date.now());
+
+  assert.equal(await pvp.findSyncCode('zzzzzz'), null);
+});
+
+test('a rank is the highest one the elo reaches', () => {
+  const { rankName } = modules.ranks;
+
+  assert.equal(rankName(0), 'LT5');
+  assert.equal(rankName(-10), 'LT5', 'below the floor still ranks');
+  assert.equal(rankName(399), 'LT2');
+  assert.equal(rankName(400), 'LT1');
+  assert.equal(rankName(970), 'HT4');
+  assert.equal(rankName(1040), 'HT3');
+  assert.equal(rankName(99_999), 'HT1');
+});
+
+test('links are one per Discord user and one per account', () => {
+  assert.equal(links.getLink('discord-1'), null);
+
+  links.link('discord-1', BOB, 'Nexf', 'ouw5rp');
+  assert.equal(links.getLink('discord-1').player_uuid, BOB);
+  assert.equal(links.isCodeUsed('OUW5RP'), true, 'a spent code cannot be claimed again');
+  assert.equal(links.isCodeUsed('abc123'), false);
+
+  links.link('discord-2', BOB, 'Nexf', 'newcode');
+  assert.equal(links.getLink('discord-1'), null, 'relinking moves the account rather than duplicating it');
+  assert.equal(links.getLink('discord-2').player_uuid, BOB);
+
+  assert.equal(links.unlink('discord-2'), true);
+  assert.equal(links.unlink('discord-2'), false);
+});
+
+test('watcher state survives a read back', () => {
+  links.setState('last_match_id', '7');
+  assert.equal(links.getState('last_match_id'), '7');
+  assert.equal(links.getState('never_set', '0'), '0');
+});
+
+test('the embeds carry what the screenshots show', async () => {
+  const stats = await pvp.findStats('nexf');
+  const record = await pvp.getRecord(BOB);
+  const [match] = await pvp.getMatchesAfter(0, 10);
+  const board = await pvp.getTierLeaderboard('elo', 10);
+
+  const statsEmbed = modules.embeds.createCompetitiveStatsEmbed(stats, record, 'Hugster').toJSON();
+  assert.equal(statsEmbed.title, "Nexf's Stats");
+  assert.match(JSON.stringify(statsEmbed.fields), /HT3/);
+
+  const boardEmbed = modules.embeds.createTierLeaderboardEmbed('elo', board, 'Hugster').toJSON();
+  assert.match(boardEmbed.description, /Nexf/);
+  assert.match(boardEmbed.description, /SamirSpider/);
+
+  const matchEmbed = modules.embeds.createMatchResultEmbed(match).toJSON();
+  assert.match(matchEmbed.title, /SamirSpider vs Nexf/);
+  assert.match(matchEmbed.fields[0].value, /Nexf/);
+  assert.match(matchEmbed.fields[1].value, /8s/);
+  assert.match(JSON.stringify(matchEmbed.fields), /7\.0 \/ 20\.0/);
+  assert.match(JSON.stringify(matchEmbed.fields), /\(\+20\)/);
+});
+
+test('durations read as clock time', () => {
+  assert.equal(modules.embeds.formatDuration(8), '8s');
+  assert.equal(modules.embeds.formatDuration(65), '1m 5s');
+  assert.equal(modules.embeds.formatDuration(3725), '1h 2m 5s');
+  assert.equal(modules.embeds.formatDuration(-3), '0s');
+});

--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -48,7 +48,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/leave` | `/leave` | None | Leave active duel or FFA instance | `ultimatedonutsmp.command.leave` |
 | `/ffa` | `/ffa [join]` | None | Join instanced FFA arena | `ultimatedonutsmp.command.ffa` |
 | `/ffastats` | `/ffastats [player]` | None | View FFA kill/death/streak stats | `ultimatedonutsmp.command.ffastats` |
-| `/pvp` | `/pvp [join\|leave\|kit\|stats\|top\|queue\|leaderboard\|history]` | None | Join the ranked PvP arena, queue for a 1v1, or browse leaderboards and match history | `ultimatedonutsmp.command.pvp` |
+| `/pvp` | `/pvp [join\|leave\|kit\|stats\|top\|queue\|leaderboard\|history\|sync]` | None | Join the ranked PvP arena, queue for a 1v1, browse leaderboards and match history, or get a Discord sync code | `ultimatedonutsmp.command.pvp` |
 | `/bounty` | `/bounty [place\|list]` | None | Place or view player bounties | `ultimatedonutsmp.command.bounty` |
 | `/leaderboard` | `/leaderboard [type]` | `/lb`, `/top`, `/leaderboards`, `/baltop` | Open leaderboard menus; `/baltop` opens the money leaderboard directly | `ultimatedonutsmp.command.leaderboard` |
 | `/voicechatconsent` | `/voicechatconsent [revoke]` | `/vcconsent`, `/voiceconsent` | Open the voice chat consent menu, or withdraw an answer already given with `revoke` | `ultimatedonutsmp.command.voicechatconsent` |

--- a/docs/wiki/Config-pvp.yml.md
+++ b/docs/wiki/Config-pvp.yml.md
@@ -193,6 +193,34 @@ nowhere to sit.
 
 ---
 
+## Section: `SYNC`
+
+One-time codes players use to link their Minecraft account to the Discord bot. The bot reads this
+table, checks the code and stores the link on its own side, so the plugin never has to know anybody's
+Discord id and the bot never has to write to the server database.
+
+### 1. Commented Setup Code Example
+
+```yaml
+SYNC:
+  # Enable /pvp sync (true / false)
+  ENABLED: true
+  # How many characters a code has
+  CODE_LENGTH: 6
+  # How long a code stays valid
+  EXPIRES: '10m'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SYNC.ENABLED` | `bool` | `true`, `false` | `true` | Turns `/pvp sync` on. Off, the command answers with `MESSAGES.SYNC_DISABLED`. |
+| `SYNC.CODE_LENGTH` | `int` | `4`-`16` | `6` | Characters per code. The alphabet leaves out characters that read as each other, so a player copying one out of chat by eye does not get it wrong. |
+| `SYNC.EXPIRES` | `string` | Same format as `RESET.INTERVAL` | `'10m'` | How long a code stays claimable. Asking for another replaces the one before it. |
+
+---
+
 ## Section: `BLOCKED_COMMANDS`
 
 ### 1. Commented Setup Code Example
@@ -466,6 +494,11 @@ Every player-facing string the arena sends. All of them go through the plugin's 
 | `MESSAGES.MATCH_LEAVE_ARENA_FIRST` | – | Queueing while inside the open arena. |
 | `MESSAGES.MATCH_NEEDS_TWO` | – | `/pvp assign` with one player, or the same player twice. |
 | `MESSAGES.MATCH_BUSY` | `{player}` | `/pvp assign` naming somebody who is already fighting in the open arena. |
+| `MESSAGES.SYNC_DISABLED` | – | `/pvp sync` while `SYNC.ENABLED` is off. |
+| `MESSAGES.SYNC_FAILED` | – | `/pvp sync` when the code could not be stored. |
+| `MESSAGES.SYNC_HEADER` | – | First line of the sync code message. |
+| `MESSAGES.SYNC_CODE` | `{code}` | The code itself. |
+| `MESSAGES.SYNC_HINT` | `{code}` | What to do with it on Discord. |
 | `MESSAGES.MATCH_STARTED` | `{first}`, `{second}` | Sent to both fighters when a match opens. |
 | `MESSAGES.MATCH_COUNTDOWN` | `{seconds}` | Sent once a second during the opening countdown. |
 | `MESSAGES.MATCH_WIN` / `MESSAGES.MATCH_LOSS` | `{opponent}`, `{elo}`, `{hits}`, `{crystals}` | The result lines. |

--- a/docs/wiki/Placeholders-and-Integrations.md
+++ b/docs/wiki/Placeholders-and-Integrations.md
@@ -122,6 +122,11 @@ A typical TAB nametag format:
 %pvp_rank% | %luckperms-prefix% %player%
 ```
 
+The bundled [Discord bot example](https://github.com/BeestoXd/UltimateDonutSMP/tree/main/discord-bot-example)
+reads the same ranked data straight from the database rather than through placeholders, and adds
+`/mystats`, `/tier stats`, `/tier leaderboard`, `/sync` and `/unsync` along with a match result
+posted after every ranked fight. See [Ranked PvP Arena](Ranked-PvP-Arena) for the linking flow.
+
 ---
 
 ### 6. Punishment & Expiry Message Placeholders

--- a/docs/wiki/Ranked-PvP-Arena.md
+++ b/docs/wiki/Ranked-PvP-Arena.md
@@ -191,6 +191,31 @@ which is exact because a match only ever has two people in it.
 
 ---
 
+## Discord
+
+The bundled [Discord bot example](https://github.com/BeestoXd/UltimateDonutSMP/tree/main/discord-bot-example)
+reads the ranked tables and adds `/mystats`, `/tier stats`, `/tier leaderboard`, `/sync` and
+`/unsync`, plus a result posted into a channel after every ranked match showing the winner, the
+duration, and both fighters' rank, Elo change, hits, crystals and final health.
+
+Linking works from the game outward. A player runs `/pvp sync`, the plugin gives them a short
+one-time code, and they hand that code to the bot with `/sync <code>` on Discord. The bot verifies
+the code and stores the link on its own side, so the plugin never learns anybody's Discord id and
+the bot never needs to write to the server database.
+
+```yaml
+SYNC:
+  ENABLED: true
+  CODE_LENGTH: 6
+  EXPIRES: '10m'
+```
+
+Codes are drawn from an alphabet with no characters that read as each other, since a player has to
+copy one out of chat by eye. Asking for another replaces the one before it, so a code somebody read
+over a shoulder stops working as soon as its owner asks again.
+
+---
+
 ## Kill farming
 
 Killing the same player over and over stops paying:
@@ -302,6 +327,7 @@ it.
 | `/pvp queue leave` | Leave the queue |
 | `/pvp leaderboard` | Open the leaderboards |
 | `/pvp history [player]` | Browse ranked match history |
+| `/pvp sync` | Get a one-time code to link a Discord account |
 
 See [Config-pvp.yml](Config-pvp.yml) for every option, and
 [Placeholders & Integrations](Placeholders-and-Integrations) for the `%pvp_*%` catalog.

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PvpCommand.java
@@ -34,7 +34,7 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
 
     private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("0.00");
     private static final List<String> PLAYER_SUBCOMMANDS = List.of(
-            "join", "leave", "kit", "stats", "top", "queue", "leaderboard", "history"
+            "join", "leave", "kit", "stats", "top", "queue", "leaderboard", "history", "sync"
     );
     private static final List<String> ADMIN_SUBCOMMANDS = List.of(
             "wand", "create", "setspawn", "setspawn2", "setlobby", "setboundary",
@@ -74,6 +74,7 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
             case "queue" -> handleQueue(sender, args);
             case "leaderboard", "lb" -> requirePlayer(sender, p -> new PvpLeaderboardMenu(plugin).open(p));
             case "history" -> handleHistory(sender, args);
+            case "sync" -> handleSync(sender);
             case "assign" -> handleAssign(sender, args);
             case "wand" -> handleWand(sender);
             case "create" -> handleCreate(sender, args);
@@ -344,6 +345,28 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         return requirePlayer(sender, player -> new PvpAssignMatchMenu(plugin, first, null).open(player));
     }
 
+    /** Hands the player a code to type into the Discord bot. */
+    private boolean handleSync(CommandSender sender) {
+        return requirePlayer(sender, player -> {
+            PvpManager pvp = plugin.getPvpManager();
+            if (!pvp.isSyncEnabled()) {
+                send(player, pvp.message("SYNC_DISABLED", "&cAccount syncing is switched off."));
+                return;
+            }
+
+            String code = pvp.createSyncCode(player);
+            if (code == null) {
+                send(player, pvp.message("SYNC_FAILED", "&cCould not create a sync code right now."));
+                return;
+            }
+
+            send(player, pvp.message("SYNC_HEADER", "&e&lTier Sync"));
+            send(player, pvp.message("SYNC_CODE", "&fYour sync code: &e{code}").replace("{code}", code));
+            send(player, pvp.message("SYNC_HINT", "&7Use &f/sync {code} &7on our Discord to link your account.")
+                    .replace("{code}", code));
+        });
+    }
+
     // ── Admin subcommands ─────────────────────────────────────────────────────
 
     private boolean handleWand(CommandSender sender) {
@@ -508,6 +531,7 @@ public class PvpCommand implements CommandExecutor, TabCompleter {
         send(sender, "&e/" + label + " queue &7- join the ranked 1v1 queue");
         send(sender, "&e/" + label + " leaderboard &7- open the leaderboards");
         send(sender, "&e/" + label + " history [player] &7- browse ranked matches");
+        send(sender, "&e/" + label + " sync &7- get a code to link your Discord account");
         if (!admin) {
             return;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpManager.java
@@ -956,6 +956,73 @@ public class PvpManager {
         }
     }
 
+    // ── Discord account sync ──────────────────────────────────────────────────
+
+    public boolean isSyncEnabled() {
+        return config().getBoolean("SYNC.ENABLED", true);
+    }
+
+    /**
+     * Issues a one-time code a player types into the Discord bot to claim this account.
+     *
+     * <p>Any code the player already had is replaced, so the newest one is the only one that
+     * works and a code read over someone's shoulder stops being useful as soon as they ask for
+     * another. The bot verifies the code and stores the link on its own side; nothing here needs
+     * to know a Discord id.</p>
+     *
+     * @return the code, or null when syncing is off or the database is unavailable
+     */
+    public String createSyncCode(Player player) {
+        Connection connection = connection();
+        if (player == null || connection == null || !isSyncEnabled()) {
+            return null;
+        }
+
+        long ttl = parseDuration(config().getString("SYNC.EXPIRES", "10m"));
+        long now = System.currentTimeMillis();
+        String code = generateSyncCode(Math.max(4, Math.min(16, config().getInt("SYNC.CODE_LENGTH", 6))));
+
+        try (PreparedStatement clear = connection.prepareStatement(
+                "delete from pvp_sync_codes where player_uuid = ? or expires_at < ?")) {
+            clear.setString(1, player.getUniqueId().toString());
+            clear.setLong(2, now);
+            clear.executeUpdate();
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to clear old PvP sync codes", exception);
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "insert into pvp_sync_codes (code, player_uuid, player_name, created_at, expires_at)"
+                        + " values (?,?,?,?,?)")) {
+            ps.setString(1, code);
+            ps.setString(2, player.getUniqueId().toString());
+            ps.setString(3, player.getName());
+            ps.setLong(4, now);
+            ps.setLong(5, ttl > 0 ? now + ttl : now + 600_000L);
+            ps.executeUpdate();
+            return code;
+        } catch (SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to store a PvP sync code", exception);
+            return null;
+        }
+    }
+
+    /**
+     * Builds a code from an alphabet with no characters that read as each other.
+     *
+     * <p>The player has to copy this out of chat by eye, so 0/o/O, 1/l/I and their neighbours are
+     * left out rather than turned into a support question.</p>
+     */
+    private static String generateSyncCode(int length) {
+        String alphabet = "abcdefghjkmnpqrstuvwxyz23456789";
+        java.security.SecureRandom random = new java.security.SecureRandom();
+        StringBuilder code = new StringBuilder(length);
+        for (int index = 0; index < length; index++) {
+            code.append(alphabet.charAt(random.nextInt(alphabet.length())));
+        }
+        return code.toString();
+    }
+
     // ── Anti kill-farming ─────────────────────────────────────────────────────
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PvpMatchManager.java
@@ -354,6 +354,7 @@ public class PvpMatchManager {
         active.remove(match.getFirstUuid());
         active.remove(match.getSecondUuid());
         match.setEndedAt(System.currentTimeMillis());
+        captureFinalHealth(match);
         match.setWinnerUuid(winner);
         match.setResult(result);
 
@@ -398,6 +399,26 @@ public class PvpMatchManager {
         if (second != null) {
             pvp().removeFromArena(second, silent);
         }
+    }
+
+    /**
+     * Reads the health both fighters ended on, before either is cleaned up.
+     *
+     * <p>A player who is offline or already gone counts as zero, which is what a disconnect
+     * forfeit should look like in the record.</p>
+     */
+    private void captureFinalHealth(PvpMatch match) {
+        Player first = Bukkit.getPlayer(match.getFirstUuid());
+        Player second = Bukkit.getPlayer(match.getSecondUuid());
+        match.setFinalHealth(healthOf(first), healthOf(second));
+        Player reference = first != null ? first : second;
+        if (reference != null) {
+            match.setMaxHealth(com.bx.ultimateDonutSmp.utils.AttributeUtils.getMaxHealth(reference));
+        }
+    }
+
+    private double healthOf(Player player) {
+        return player == null || player.isDead() ? 0.0D : player.getHealth();
     }
 
     private void announceResult(PvpMatch match, Player player) {
@@ -475,7 +496,8 @@ public class PvpMatchManager {
         try (PreparedStatement ps = connection.prepareStatement(
                 "select id, player_one_uuid, player_one_name, player_two_uuid, player_two_name, kit_id,"
                         + " winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals,"
-                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta"
+                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta,"
+                        + " one_final_health, two_final_health, max_health"
                         + " from pvp_matches where player_one_uuid = ? or player_two_uuid = ?"
                         + " order by ended_at desc limit ? offset ?")) {
             ps.setString(1, uuid.toString());
@@ -516,6 +538,8 @@ public class PvpMatchManager {
         match.setCrystals(rs.getInt("one_crystals"), rs.getInt("two_crystals"));
         match.setEloBefore(rs.getInt("one_elo_before"), rs.getInt("two_elo_before"));
         match.setEloDelta(rs.getInt("one_elo_delta"), rs.getInt("two_elo_delta"));
+        match.setFinalHealth(rs.getDouble("one_final_health"), rs.getDouble("two_final_health"));
+        match.setMaxHealth(rs.getDouble("max_health"));
         try {
             match.setResult(PvpMatch.Result.valueOf(rs.getString("result")));
         } catch (IllegalArgumentException | NullPointerException exception) {
@@ -625,12 +649,38 @@ public class PvpMatchManager {
                       one_elo_before INTEGER DEFAULT 0,
                       two_elo_before INTEGER DEFAULT 0,
                       one_elo_delta INTEGER DEFAULT 0,
-                      two_elo_delta INTEGER DEFAULT 0
+                      two_elo_delta INTEGER DEFAULT 0,
+                      one_final_health REAL DEFAULT 0,
+                      two_final_health REAL DEFAULT 0,
+                      max_health REAL DEFAULT 20
                     )
                     """);
+            plugin.getDatabaseManager().executeSchema(st, """
+                    CREATE TABLE IF NOT EXISTS pvp_sync_codes (
+                      code TEXT PRIMARY KEY,
+                      player_uuid TEXT NOT NULL,
+                      player_name TEXT,
+                      created_at INTEGER DEFAULT 0,
+                      expires_at INTEGER DEFAULT 0
+                    )
+                    """);
+
+            // The match table shipped before the health columns existed, so a server updating from
+            // that build gets them added rather than a create that quietly does nothing.
+            addColumn(st, "one_final_health", "REAL DEFAULT 0");
+            addColumn(st, "two_final_health", "REAL DEFAULT 0");
+            addColumn(st, "max_health", "REAL DEFAULT 20");
         } catch (SQLException exception) {
             plugin.getLogger().log(Level.WARNING, "Failed to create the PvP match tables", exception);
         }
+    }
+
+    private void addColumn(Statement statement, String column, String definition) throws SQLException {
+        if (plugin.getDatabaseManager().hasColumn("pvp_matches", column)) {
+            return;
+        }
+        statement.execute(plugin.getDatabaseManager().adaptSchemaSql(
+                "ALTER TABLE pvp_matches ADD COLUMN " + column + " " + definition));
     }
 
     private void insertMatch(PvpMatch match) {
@@ -642,8 +692,9 @@ public class PvpMatchManager {
         try (PreparedStatement ps = connection.prepareStatement(
                 "insert into pvp_matches (player_one_uuid, player_one_name, player_two_uuid, player_two_name,"
                         + " kit_id, winner_uuid, result, started_at, ended_at, one_hits, two_hits, one_crystals,"
-                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta)"
-                        + " values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")) {
+                        + " two_crystals, one_elo_before, two_elo_before, one_elo_delta, two_elo_delta,"
+                        + " one_final_health, two_final_health, max_health)"
+                        + " values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")) {
             ps.setString(1, match.getFirstUuid().toString());
             ps.setString(2, match.getFirstName());
             ps.setString(3, match.getSecondUuid().toString());
@@ -661,6 +712,9 @@ public class PvpMatchManager {
             ps.setInt(15, match.getSecondEloBefore());
             ps.setInt(16, match.getFirstEloDelta());
             ps.setInt(17, match.getSecondEloDelta());
+            ps.setDouble(18, match.getFirstFinalHealth());
+            ps.setDouble(19, match.getSecondFinalHealth());
+            ps.setDouble(20, match.getMaxHealth());
             ps.executeUpdate();
         } catch (SQLException exception) {
             plugin.getLogger().log(Level.WARNING, "Failed to store a PvP match", exception);

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PvpMatch.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PvpMatch.java
@@ -39,6 +39,9 @@ public class PvpMatch {
     private int secondEloBefore;
     private int firstEloDelta;
     private int secondEloDelta;
+    private double firstFinalHealth;
+    private double secondFinalHealth;
+    private double maxHealth = 20.0D;
 
     public PvpMatch(
             long id,
@@ -230,5 +233,32 @@ public class PvpMatch {
     public void setEloDelta(int first, int second) {
         this.firstEloDelta = first;
         this.secondEloDelta = second;
+    }
+
+    /** Health each fighter was left on. The loser is on zero; the winner is what survived. */
+    public double getFinalHealth(UUID uuid) {
+        return isFirst(uuid) ? firstFinalHealth : secondFinalHealth;
+    }
+
+    public double getFirstFinalHealth() {
+        return firstFinalHealth;
+    }
+
+    public double getSecondFinalHealth() {
+        return secondFinalHealth;
+    }
+
+    public void setFinalHealth(double first, double second) {
+        this.firstFinalHealth = Math.max(0.0D, first);
+        this.secondFinalHealth = Math.max(0.0D, second);
+    }
+
+    /** The scale the two health values are on, so a server with modified max health still reads right. */
+    public double getMaxHealth() {
+        return maxHealth;
+    }
+
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth <= 0.0D ? 20.0D : maxHealth;
     }
 }

--- a/src/main/resources/pvp.yml
+++ b/src/main/resources/pvp.yml
@@ -90,6 +90,18 @@ MATCH:
   # How the date is written in the match history. Standard Java date patterns.
   DATE_FORMAT: 'dd/MM/yyyy HH:mm'
 
+# One-time codes players use to link their Minecraft account to the Discord bot.
+# The bot reads this table, verifies the code and stores the link on its own side, so the
+# plugin never has to know anybody's Discord id.
+SYNC:
+  # Enable /pvp sync (true / false)
+  ENABLED: true
+  # How many characters a code has. The alphabet leaves out characters that read as each
+  # other, so a player copying it out of chat by eye does not get it wrong.
+  CODE_LENGTH: 6
+  # How long a code stays valid. Accepts the same 1d10h15m format as RESET.INTERVAL.
+  EXPIRES: '10m'
+
 # Commands players cannot run while they are inside the arena
 BLOCKED_COMMANDS:
   # Enable command blocking inside the arena (true / false)
@@ -308,6 +320,11 @@ MESSAGES:
   MATCH_LEAVE_ARENA_FIRST: '&cLeave the arena before queueing.'
   MATCH_NEEDS_TWO: '&cA ranked match needs two different players.'
   MATCH_BUSY: '&c{player} is already in the arena.'
+  SYNC_DISABLED: '&cAccount syncing is switched off.'
+  SYNC_FAILED: '&cCould not create a sync code right now.'
+  SYNC_HEADER: '&e&lTier Sync'
+  SYNC_CODE: '&fYour sync code: &e{code}'
+  SYNC_HINT: '&7Use &f/sync {code} &7on our Discord to link your account.'
   MATCH_STARTED: '&8[&cPVP&8] &f{first} &7vs &f{second}'
   MATCH_COUNTDOWN: '&fStarting in &c{seconds}&f...'
   MATCH_WIN: '&aYou beat &f{opponent} &8(&a{elo} elo&8, &a{hits} hits&8)'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PvpConfigurationTest.java
@@ -95,6 +95,21 @@ class PvpConfigurationTest {
     }
 
     @Test
+    void discordSyncShipsOnWithAShortLivedCode() throws Exception {
+        YamlConfiguration pvp = pvp();
+
+        assertTrue(pvp.getBoolean("SYNC.ENABLED"));
+        assertTrue(pvp.getInt("SYNC.CODE_LENGTH") >= 4, "a code short enough to guess is not a code");
+        assertFalse(pvp.getString("SYNC.EXPIRES", "").isBlank(), "a code that never expires stays claimable forever");
+
+        for (String key : List.of("SYNC_DISABLED", "SYNC_FAILED", "SYNC_HEADER", "SYNC_CODE", "SYNC_HINT")) {
+            assertFalse(pvp.getString("MESSAGES." + key, "").isBlank(), "MESSAGES." + key + " is missing");
+        }
+        assertTrue(pvp.getString("MESSAGES.SYNC_CODE", "").contains("{code}"));
+        assertTrue(pvp.getString("MESSAGES.SYNC_HINT", "").contains("{code}"));
+    }
+
+    @Test
     void everyLeaderboardHasAnIconConfigured() throws Exception {
         YamlConfiguration pvp = pvp();
 


### PR DESCRIPTION
Follows #255. Brings the bundled Discord bot example up to what the ranked arena can now report: account linking, competitive stats, tier leaderboards, and a match result posted after every ranked fight.

## Commands

```txt
/sync code:<code from /pvp sync in game>
/unsync
/mystats
/tier stats player:<username or uuid>
/tier leaderboard type:<elo|level|kills|deaths|streak|killstreak|wins|losses> limit:<1-10>
```

Wins and losses are counted over `pvp_matches` rather than read off a column, because a win belongs to a match, not to a player row. The other boards sort `pvp_stats` directly. All three database backends are implemented, including a Mongo aggregation for the derived boards.

## Linking

A player runs `/pvp sync`, the plugin writes a short one-time code, and they give that code to the bot with `/sync`. The bot checks it and records the link **on its own side**, in its own SQLite file.

That split is the point. The plugin never learns anybody's Discord id, so the bot keeps the plugin database strictly read-only and still owns the half of the relationship that is genuinely its own. Codes expire after ten minutes, asking for a new one in game replaces the old one, a code the bot has already spent is refused, and an account already claimed by another Discord user is refused too. Every `/sync` and `/unsync` reply is ephemeral so a live code never sits in a public channel.

Codes come from an alphabet with no characters that read as each other, since a player has to copy one out of chat by eye.

## Match results

`PVP_MATCH_CHANNEL_ID` turns on a watcher that posts each finished match: winner, duration, and both fighters' rank, Elo change, hits, crystals and final health, in two side-by-side columns.

It polls `pvp_matches` for rows past the last one it posted rather than needing the server to call out. The first run deliberately backfills nothing, since a server that has been up for months would otherwise dump its whole history into the channel the moment the bot is switched on. After that the high-water mark lives in the bot's database, so a restart resumes instead of losing what happened while it was down. A channel it cannot post in leaves the mark unadvanced, so fixing the channel replays what was missed.

## Plugin side

Two things the bot cannot do alone:

- **Sync codes.** New `pvp_sync_codes` table, a `SYNC` config block, and `/pvp sync` to issue one. Without this there is no way for the bot to know a Discord user owns a Minecraft account.
- **Final health.** `pvp_matches` gains `one_final_health`, `two_final_health` and `max_health`, captured at the moment a match ends and before either fighter is cleaned up. A server updating from the previous build gets the columns added rather than a `CREATE TABLE IF NOT EXISTS` that quietly does nothing.

## Notes

- The bot gained a test suite: `npm test` builds a throwaway database with the plugin's real schema and runs every query the bot makes against it. That is not ceremony, it caught two wrong assumptions while I was writing it, and it is the only thing standing between a column rename on the plugin side and a broken command in a live channel. 12 tests.
- `npm run check` now covers the new files too.
- `node_modules/` and the bot's own `links.db` are gitignored; the repository had no ignore for either.
- One new Java test on the `SYNC` config block. Full Java suite is 451 passing.
- A server that never enabled the arena has no `pvp_*` tables. The ranked commands answer with "nobody has fought a ranked match yet" rather than failing.
