### PR TITLE
feat(ranks): add a ranks menu and ranks command

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/punishments` | `/phistory` | `/punishments <player>` | `ultimatedonutsmp.command.punishments` |
 | `/queue` | - | `/queue [join\|leave] [map]` | `ultimatedonutsmp.command.queue` |
 | `/randomteleport` | `/randomtp` | `/randomteleport` | `ultimatedonutsmp.command.randomteleport` |
+| `/ranks` | `/rank` | `/ranks` | `ultimatedonutsmp.command.ranks` |
 | `/removemoney` | - | `/removemoney <player> <amount>` | `ultimatedonutsmp.command.removemoney` |
 | `/removeshards` | - | `/removeshards <player> <amount>` | `ultimatedonutsmp.command.removeshards` |
 | `/rename` | - | `/rename <name...\|reset>` | `ultimatedonutsmp.command.rename` |

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -728,6 +728,79 @@ MEDIA-MENU:
 
 ---
 
+## Section: `RANKS-MENU`
+
+Opened with `/ranks` (alias `/rank`). Every button is a rank advert: the icon plus its lore lists what
+that rank unlocks, so players can compare ranks without leaving the game.
+
+### 1. Commented Setup Code Example
+
+```yaml
+RANKS-MENU:
+  TITLE: '&8Ranks'
+  SIZE: 27
+  BUTTONS:
+    # Each key under BUTTONS is one rank. Add or delete keys freely.
+    DEFAULT:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 11
+      DISPLAY-NAME: '&fDefault'
+      LORE:
+      - '&73 Homes'
+      - '&718 Auction Slots'
+      - '&718 Order Slots'
+      # Leave COMMAND empty for a button that only shows perks.
+      COMMAND: ''
+    DONUT_PLUS:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 13
+      DISPLAY-NAME: '&fDonut&#00A4FC+'
+      LORE:
+      - '&79 Homes'
+      - '&745 Auction Slots'
+      - '&745 Order Slots'
+      COMMAND: ''
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RANKS-MENU.TITLE` | `str` | Any string text | `'&8Ranks'` | Inventory title shown at the top of the menu. |
+| `RANKS-MENU.SIZE` | `int` | `9`, `18`, `27`, `36`, `45`, `54` | `27` | Inventory size. Anything else falls back to `27` with a console warning. |
+| `RANKS-MENU.FILLER-MATERIAL` | `str` | Any valid material name | unset | Optional. Fills the slots no rank uses, e.g. `BLACK_STAINED_GLASS_PANE`. Unset leaves them empty. |
+| `RANKS-MENU.BUTTONS.<RANK>.MATERIAL` | `str` | Any valid material name | `PLAYER_HEAD` | Icon material. A button with a missing or invalid material is skipped. |
+| `RANKS-MENU.BUTTONS.<RANK>.SLOT` | `int` | `0` to `SIZE - 1` | - | Slot the rank renders in. Out-of-range and duplicate slots are skipped. |
+| `RANKS-MENU.BUTTONS.<RANK>.DISPLAY-NAME` | `str` | Any string text | Prettified button key | Icon name. `NAME` also works for consistency with the other menus. |
+| `RANKS-MENU.BUTTONS.<RANK>.LORE` | `list` | List of strings | `[]` | The perk list shown under the rank name. |
+| `RANKS-MENU.BUTTONS.<RANK>.HEAD-TEXTURE` | `str` | Skin URL or base64 texture | `''` | Optional. Applied when `MATERIAL` is `PLAYER_HEAD` so a rank can use a custom head. |
+| `RANKS-MENU.BUTTONS.<RANK>.COMMAND` | `str` | Any command, with or without `/` | `''` | Run as the player on click. Empty keeps the button informational. |
+
+### 3. Practical Setup Example
+
+Custom heads plus a click that sends the player to the store page:
+
+```yaml
+RANKS-MENU:
+  TITLE: '&8Ranks'
+  SIZE: 27
+  BUTTONS:
+    DONUT_PLUS:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 13
+      DISPLAY-NAME: '&fDonut&#00A4FC+'
+      HEAD-TEXTURE: 'https://textures.minecraft.net/texture/d875eb45aca34a4d24c3dc1395fc020ccf37f825a17b054a22fd24b189c24c'
+      LORE:
+      - '&79 Homes'
+      - '&745 Auction Slots'
+      - '&745 Order Slots'
+      - ''
+      - '&7Click to open the store'
+      COMMAND: 'store'
+```
+
+---
+
 ## Section: `STATS-MENU`
 
 ### 1. Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -769,6 +769,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         setExecutor("social", socialCmd, FeatureManager.Feature.SOCIAL);
 
         setExecutor("rules", new RulesCommand(this), FeatureManager.Feature.RULES);
+        setExecutor("ranks", new RanksCommand(this), FeatureManager.Feature.RANKS);
         setExecutor("safety", new SafetyCommand(this), FeatureManager.Feature.SAFETY);
         setExecutor("voicechatconsent", new VoiceChatConsentCommand(this),
                 FeatureManager.Feature.VOICE_CHAT);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/HelpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/HelpCommand.java
@@ -55,6 +55,7 @@ public class HelpCommand implements CommandExecutor {
         sendHelpLine(player, "social", "&b/discord &7- discord link");
         sendHelpLine(player, "social", "&b/media &7- view media rank requirements");
         sendHelpLine(player, "rules", "&b/rules &7- view server rules");
+        sendHelpLine(player, "ranks", "&b/ranks &7- view rank perks");
         player.sendMessage(ColorUtils.toComponent("&7&m---------------------"));
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/RanksCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/RanksCommand.java
@@ -1,0 +1,36 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.menus.RanksMenu;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class RanksCommand implements CommandExecutor {
+
+    private final UltimateDonutSmp plugin;
+
+    public RanksCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player player)) { sender.sendMessage("Player only."); return true; }
+        if (!plugin.getConfigManager().isCommandEnabled("RANKS")) {
+            player.sendMessage(ColorUtils.toComponent("&cRanks command is currently disabled."));
+            return true;
+        }
+
+        RanksMenu menu = new RanksMenu(plugin);
+        if (!menu.hasValidButtons()) {
+            player.sendMessage(ColorUtils.toComponent("&cThe ranks menu has no usable buttons configured."));
+            return true;
+        }
+
+        menu.open(player);
+        return true;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -457,7 +457,7 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
                     "spawn", "afk", "home", "homes", "sethome", "delhome", "renamehome",
                     "rtp", "warp", "tpa", "tpahere", "tpaccept", "tpadeny", "tpacancel",
                     "settings", "stats", "ping", "playtime", "social", "discord", "twitter",
-                    "store", "rules", "help", "servers"
+                    "store", "rules", "ranks", "help", "servers"
             );
             case "economy" -> List.of(
                     "balance", "pay", "addmoney", "removemoney", "setmoney", "shards", "shardpay",

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -99,7 +99,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
             case "rename" -> singleArg(args, List.of("reset", "clear", "remove"));
             case "randomteleport", "leave", "draw", "pm", "spawn", "afk", "sell", "sellall", "sellhistory",
                     "stafflist", "vanish", "tpauto", "tpahereauto", "nightvision", "phantom", "settings",
-                    "discord", "twitter", "store", "social", "rules", "help", "servers", "billford",
+                    "discord", "twitter", "store", "social", "rules", "ranks", "help", "servers", "billford",
                     "clearlag", "crates", "keys" -> List.of();
             case "teleport" -> completeTeleport(sender, label, args);
             case "invsee" -> completePlayerOrReload(sender, args, "ultimatedonutsmp.admin.invsee", false);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FeatureManager.java
@@ -63,6 +63,7 @@ public class FeatureManager {
         FIND_PLAYER("FIND_PLAYER", "find player", "staff find player command.", "SPYGLASS", "FINDPLAYER"),
         CRATES("CRATES", "crates", "crate commands, menus, key-all, and visual effects.", "TRIPWIRE_HOOK", "CRATE"),
         RULES("RULES", "rules", "rules command and rules menu.", "BOOKSHELF", "RULES"),
+        RANKS("RANKS", "ranks", "ranks command and ranks menu.", "PLAYER_HEAD", "RANKS"),
         HELP("HELP", "help", "help command and server info menu.", "KNOWLEDGE_BOOK", "HELP"),
         NETWORK_SERVERS("NETWORK_SERVERS", "network servers", "network server status command and menu.", "NETHER_STAR", "SERVERS"),
         SCOREBOARD("SCOREBOARD", "scoreboard", "sidebar scoreboard task and display.", "MAP", null),
@@ -254,6 +255,7 @@ public class FeatureManager {
             case "settings" -> new Feature[]{Feature.SETTINGS};
             case "discord", "twitter", "store", "social" -> new Feature[]{Feature.SOCIAL};
             case "rules" -> new Feature[]{Feature.RULES};
+            case "ranks", "rank" -> new Feature[]{Feature.RANKS};
             case "help" -> new Feature[]{Feature.HELP};
             case "servers" -> new Feature[]{Feature.NETWORK_SERVERS};
             case "billford" -> new Feature[]{Feature.BILLFORD};

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/RanksMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/RanksMenu.java
@@ -1,0 +1,247 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class RanksMenu extends BaseMenu {
+
+    private static final String MENU_PATH = "RANKS-MENU";
+    private static final String BUTTONS_PATH = MENU_PATH + ".BUTTONS";
+    private static final String CLICK_SOUND_PATH = "MENUS.BUTTON-CLICK";
+
+    private final List<RankButton> buttons;
+    private final Map<Integer, RankButton> slotButtons = new HashMap<>();
+
+    public RanksMenu(UltimateDonutSmp plugin) {
+        super(plugin, configuredTitle(plugin), configuredSize(plugin));
+        this.buttons = loadButtons(plugin, inventory.getSize());
+    }
+
+    public boolean hasValidButtons() {
+        return !buttons.isEmpty();
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        // The bundled layout leaves the empty slots empty; owners who want a border set a filler.
+        Material filler = configuredFiller(plugin);
+        if (filler != null) {
+            fill(filler);
+        }
+        slotButtons.clear();
+
+        for (RankButton button : buttons) {
+            if (slotButtons.containsKey(button.slot())) {
+                plugin.getLogger().warning("skipping duplicate ranks menu slot " + button.slot()
+                        + " for button " + button.key() + ".");
+                continue;
+            }
+
+            set(button.slot(), createIcon(button));
+            slotButtons.put(button.slot(), button);
+        }
+
+        if (slotButtons.isEmpty()) {
+            set(inventory.getSize() / 2, ItemUtils.createItem(
+                    Material.BARRIER,
+                    "&cNo usable rank buttons",
+                    List.of("&7Fix " + BUTTONS_PATH + " in menus.yml to use the GUI.")
+            ));
+        }
+    }
+
+    @Override
+    public void handleClick(int slot, Player player) {
+        RankButton button = slotButtons.get(slot);
+        if (button == null) {
+            return;
+        }
+
+        SoundUtils.play(player, plugin.getConfigManager().getSound(CLICK_SOUND_PATH));
+
+        // The bundled ranks ship without a command because their buttons only advertise perks.
+        if (button.command() == null) {
+            return;
+        }
+
+        player.closeInventory();
+        plugin.getSpigotScheduler().runEntity(player, () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+
+            if (!player.performCommand(button.command())) {
+                player.sendMessage(ColorUtils.toComponent("&cThat action is unavailable right now."));
+            }
+        });
+    }
+
+    private ItemStack createIcon(RankButton button) {
+        if (button.material() == Material.PLAYER_HEAD && button.headTexture() != null) {
+            return ItemUtils.createHeadFromSkinUrl(button.headTexture(), button.displayName(), button.lore());
+        }
+        return ItemUtils.createItem(button.material(), button.displayName(), button.lore());
+    }
+
+    private static List<RankButton> loadButtons(UltimateDonutSmp plugin, int inventorySize) {
+        FileConfiguration menus = plugin.getConfigManager().getMenus();
+        ConfigurationSection buttonsSection = menus.getConfigurationSection(BUTTONS_PATH);
+        List<RankButton> loadedButtons = new ArrayList<>();
+
+        if (buttonsSection == null || buttonsSection.getKeys(false).isEmpty()) {
+            plugin.getLogger().warning("no buttons found at " + BUTTONS_PATH + ".");
+            return loadedButtons;
+        }
+
+        for (String key : buttonsSection.getKeys(false)) {
+            ConfigurationSection buttonSection = buttonsSection.getConfigurationSection(key);
+            if (buttonSection == null) {
+                plugin.getLogger().warning("Skipping " + BUTTONS_PATH + "." + key
+                        + " because it is not a section.");
+                continue;
+            }
+
+            int slot = buttonSection.getInt("SLOT", -1);
+            if (slot < 0 || slot >= inventorySize) {
+                plugin.getLogger().warning("Skipping " + buttonSection.getCurrentPath()
+                        + " because slot " + slot + " is outside menu size " + inventorySize + ".");
+                continue;
+            }
+
+            String rawMaterial = buttonSection.getString("MATERIAL");
+            if (rawMaterial == null || rawMaterial.isBlank()) {
+                plugin.getLogger().warning("Skipping " + buttonSection.getCurrentPath()
+                        + " because MATERIAL is missing.");
+                continue;
+            }
+
+            Material material = Material.matchMaterial(rawMaterial.trim().toUpperCase(Locale.ROOT));
+            if (material == null) {
+                plugin.getLogger().warning("Skipping " + buttonSection.getCurrentPath()
+                        + " because material '" + rawMaterial + "' is invalid.");
+                continue;
+            }
+
+            String displayName = firstNonBlank(
+                    buttonSection.getString("DISPLAY-NAME"),
+                    buttonSection.getString("NAME"),
+                    prettifyKey(key)
+            );
+
+            loadedButtons.add(new RankButton(
+                    key,
+                    slot,
+                    material,
+                    plugin.getCurrencyManager().applyStaticPlaceholders(displayName),
+                    plugin.getCurrencyManager().applyStaticPlaceholders(buttonSection.getStringList("LORE")),
+                    blankToNull(buttonSection.getString("HEAD-TEXTURE")),
+                    sanitizeCommand(buttonSection.getString("COMMAND"))
+            ));
+        }
+
+        loadedButtons.sort(Comparator.comparingInt(RankButton::slot));
+        return loadedButtons;
+    }
+
+    private static String configuredTitle(UltimateDonutSmp plugin) {
+        return plugin.getConfigManager().getMenus().getString(MENU_PATH + ".TITLE", "&8Ranks");
+    }
+
+    private static int configuredSize(UltimateDonutSmp plugin) {
+        int rawSize = plugin.getConfigManager().getMenus().getInt(MENU_PATH + ".SIZE", 27);
+        if (rawSize >= 9 && rawSize <= 54 && rawSize % 9 == 0) {
+            return rawSize;
+        }
+
+        plugin.getLogger().warning("invalid " + MENU_PATH + ".SIZE value '" + rawSize
+                + "'. Falling back to 27.");
+        return 27;
+    }
+
+    private static Material configuredFiller(UltimateDonutSmp plugin) {
+        String rawMaterial = blankToNull(plugin.getConfigManager().getMenus()
+                .getString(MENU_PATH + ".FILLER-MATERIAL"));
+        if (rawMaterial == null) {
+            return null;
+        }
+
+        Material material = Material.matchMaterial(rawMaterial.toUpperCase(Locale.ROOT));
+        if (material == null) {
+            plugin.getLogger().warning("invalid " + MENU_PATH + ".FILLER-MATERIAL value '" + rawMaterial
+                    + "'. Leaving the empty slots empty.");
+        }
+        return material;
+    }
+
+    static String sanitizeCommand(String rawCommand) {
+        String command = blankToNull(rawCommand);
+        if (command == null) {
+            return null;
+        }
+
+        if (command.startsWith("/")) {
+            command = command.substring(1);
+        }
+        return blankToNull(command);
+    }
+
+    private static String blankToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? null : trimmed;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    static String prettifyKey(String key) {
+        String[] parts = key.toLowerCase(Locale.ROOT).split("_");
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (!builder.isEmpty()) {
+                builder.append(' ');
+            }
+            builder.append(Character.toUpperCase(part.charAt(0)));
+            if (part.length() > 1) {
+                builder.append(part.substring(1));
+            }
+        }
+        return builder.isEmpty() ? "Rank" : builder.toString();
+    }
+
+    private record RankButton(
+            String key,
+            int slot,
+            Material material,
+            String displayName,
+            List<String> lore,
+            String headTexture,
+            String command
+    ) {}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1092,6 +1092,8 @@ COMMANDS:
   CRATE: true
   # Determines whether Shardpay is enabled or disabled. Available options: true, false
   SHARDPAY: false
+  # Determines whether Ranks is enabled or disabled. Available options: true, false
+  RANKS: true
   # Determines whether Rules is enabled or disabled. Available options: true, false
   RULES: true
   # Determines whether Help is enabled or disabled. Available options: true, false

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1668,6 +1668,33 @@ MENUS:
       DISPLAY-NAME: '&cDecline'
       LORE:
       - '&fVoice chat will stay disabled'
+  RANKS-MENU:
+    TITLE: '&8Ranks'
+    BUTTONS:
+      DEFAULT:
+        DISPLAY-NAME: '&fDefault'
+        LORE:
+        - '&73 Homes'
+        - '&718 Auction Slots'
+        - '&718 Order Slots'
+      DONUT_PLUS:
+        DISPLAY-NAME: '&fDonut&#00A4FC+'
+        LORE:
+        - '&79 Homes'
+        - '&745 Auction Slots'
+        - '&745 Order Slots'
+      DONUT_PLUS_PLUS:
+        DISPLAY-NAME: '&fDonut&#00A4FC++'
+        LORE:
+        - '&727 Homes'
+        - '&790 Auction Slots'
+        - '&790 Order Slots'
+      DONUT_PLUS_PLUS_PLUS:
+        DISPLAY-NAME: '&fDonut&#00A4FC+++'
+        LORE:
+        - '&790 Homes'
+        - '&790 Auction Slots'
+        - '&790 Order Slots'
 CONFIG:
   AUCTION_HOUSE:
     GUI:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -519,6 +519,9 @@ MEDIA-MENU:
 RANKS-MENU:
   TITLE: '&8Ranks'
   SIZE: 27
+  # Every button takes an optional HEAD-TEXTURE, used when its MATERIAL is PLAYER_HEAD. It accepts a
+  # skin url or a base64 texture value. Uncomment the line inside a button to give that rank its own
+  # head; leaving it commented renders a plain player head.
   BUTTONS:
     DEFAULT:
       MATERIAL: PLAYER_HEAD
@@ -528,6 +531,7 @@ RANKS-MENU:
       - '&73 Homes'
       - '&718 Auction Slots'
       - '&718 Order Slots'
+      # HEAD-TEXTURE: 'https://textures.minecraft.net/texture/<texture id>'
       COMMAND: ''
     DONUT_PLUS:
       MATERIAL: PLAYER_HEAD
@@ -537,6 +541,7 @@ RANKS-MENU:
       - '&79 Homes'
       - '&745 Auction Slots'
       - '&745 Order Slots'
+      # HEAD-TEXTURE: 'https://textures.minecraft.net/texture/<texture id>'
       COMMAND: ''
     DONUT_PLUS_PLUS:
       MATERIAL: PLAYER_HEAD
@@ -546,6 +551,7 @@ RANKS-MENU:
       - '&727 Homes'
       - '&790 Auction Slots'
       - '&790 Order Slots'
+      # HEAD-TEXTURE: 'https://textures.minecraft.net/texture/<texture id>'
       COMMAND: ''
     DONUT_PLUS_PLUS_PLUS:
       MATERIAL: PLAYER_HEAD
@@ -555,6 +561,7 @@ RANKS-MENU:
       - '&790 Homes'
       - '&790 Auction Slots'
       - '&790 Order Slots'
+      # HEAD-TEXTURE: 'https://textures.minecraft.net/texture/<texture id>'
       COMMAND: ''
 STATS-MENU:
   TITLE: '&8{username} Stats'

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -516,6 +516,46 @@ MEDIA-MENU:
     - '&8- &7Create ticket in discord for the rank'
     - '&8- &7It lasts 90 days and has all top ranks perks'
     - ''
+RANKS-MENU:
+  TITLE: '&8Ranks'
+  SIZE: 27
+  BUTTONS:
+    DEFAULT:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 11
+      DISPLAY-NAME: '&fDefault'
+      LORE:
+      - '&73 Homes'
+      - '&718 Auction Slots'
+      - '&718 Order Slots'
+      COMMAND: ''
+    DONUT_PLUS:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 13
+      DISPLAY-NAME: '&fDonut&#00A4FC+'
+      LORE:
+      - '&79 Homes'
+      - '&745 Auction Slots'
+      - '&745 Order Slots'
+      COMMAND: ''
+    DONUT_PLUS_PLUS:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 14
+      DISPLAY-NAME: '&fDonut&#00A4FC++'
+      LORE:
+      - '&727 Homes'
+      - '&790 Auction Slots'
+      - '&790 Order Slots'
+      COMMAND: ''
+    DONUT_PLUS_PLUS_PLUS:
+      MATERIAL: PLAYER_HEAD
+      SLOT: 15
+      DISPLAY-NAME: '&fDonut&#00A4FC+++'
+      LORE:
+      - '&790 Homes'
+      - '&790 Auction Slots'
+      - '&790 Order Slots'
+      COMMAND: ''
 STATS-MENU:
   TITLE: '&8{username} Stats'
   SIZE: 36

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -617,6 +617,13 @@ commands:
     - media
     permission: ultimatedonutsmp.command.social
     permission-message: "&cYou do not have permission to use /social."
+  ranks:
+    description: View rank perks
+    usage: /ranks
+    aliases:
+    - rank
+    permission: ultimatedonutsmp.command.ranks
+    permission-message: "&cYou do not have permission to use /ranks."
   rules:
     description: View server rules
     usage: /rules
@@ -1335,6 +1342,7 @@ permissions:
       ultimatedonutsmp.command.twitter: true
       ultimatedonutsmp.command.store: true
       ultimatedonutsmp.command.social: true
+      ultimatedonutsmp.command.ranks: true
       ultimatedonutsmp.command.rules: true
       ultimatedonutsmp.command.help: true
       ultimatedonutsmp.command.servers: true
@@ -1697,6 +1705,9 @@ permissions:
     default: true
   ultimatedonutsmp.command.social:
     description: Access to /social command
+    default: true
+  ultimatedonutsmp.command.ranks:
+    description: Access to /ranks command
     default: true
   ultimatedonutsmp.command.rules:
     description: Access to /rules command

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/RanksMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/RanksMenuTest.java
@@ -1,0 +1,114 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RanksMenu renders straight off menus.yml, so a bad slot, a missing material, or a button the
+ * player cannot see is a config problem the bundled defaults have to avoid.
+ */
+class RanksMenuTest {
+
+    private static final String MENU_PATH = "RANKS-MENU";
+    private static final String BUTTONS_PATH = MENU_PATH + ".BUTTONS";
+
+    @Test
+    void bundledMenuShipsATitleAndAUsableSize() throws Exception {
+        YamlConfiguration menus = loadMenus();
+
+        assertFalse(
+                menus.getString(MENU_PATH + ".TITLE", "").isBlank(),
+                "menus.yml must ship " + MENU_PATH + ".TITLE or the menu opens with an empty title"
+        );
+
+        int size = menus.getInt(MENU_PATH + ".SIZE", -1);
+        assertTrue(size >= 9 && size <= 54 && size % 9 == 0,
+                MENU_PATH + ".SIZE must be a multiple of 9 between 9 and 54 but was " + size);
+    }
+
+    @Test
+    void bundledButtonsAreRenderable() throws Exception {
+        YamlConfiguration menus = loadMenus();
+        int size = menus.getInt(MENU_PATH + ".SIZE", 27);
+        ConfigurationSection buttons = menus.getConfigurationSection(BUTTONS_PATH);
+        assertNotNull(buttons, "menus.yml must ship " + BUTTONS_PATH + " or the menu renders a barrier");
+
+        List<Integer> usedSlots = new ArrayList<>();
+        for (String key : buttons.getKeys(false)) {
+            ConfigurationSection button = buttons.getConfigurationSection(key);
+            assertNotNull(button, BUTTONS_PATH + "." + key + " must be a section");
+
+            int slot = button.getInt("SLOT", -1);
+            assertTrue(slot >= 0 && slot < size,
+                    button.getCurrentPath() + " slot " + slot + " is outside menu size " + size);
+            assertFalse(usedSlots.contains(slot),
+                    button.getCurrentPath() + " reuses slot " + slot + ", so one button never renders");
+            usedSlots.add(slot);
+
+            String material = button.getString("MATERIAL", "");
+            assertFalse(material.isBlank(), button.getCurrentPath() + " must ship a MATERIAL");
+            assertNotNull(org.bukkit.Material.getMaterial(material.trim().toUpperCase(java.util.Locale.ROOT)),
+                    button.getCurrentPath() + " material '" + material + "' is not a valid material");
+
+            assertFalse(button.getString("DISPLAY-NAME", "").isBlank(),
+                    button.getCurrentPath() + " must ship a DISPLAY-NAME");
+            assertFalse(button.getStringList("LORE").isEmpty(),
+                    button.getCurrentPath() + " must ship LORE or the rank lists no perks");
+        }
+
+        assertFalse(usedSlots.isEmpty(), BUTTONS_PATH + " must ship at least one button");
+    }
+
+    @Test
+    void blankCommandsStayInformational() {
+        assertNull(RanksMenu.sanitizeCommand(null));
+        assertNull(RanksMenu.sanitizeCommand(""));
+        assertNull(RanksMenu.sanitizeCommand("   "));
+        assertNull(RanksMenu.sanitizeCommand("/"));
+        assertEquals("shop", RanksMenu.sanitizeCommand("/shop"));
+        assertEquals("shop ranks", RanksMenu.sanitizeCommand("  shop ranks  "));
+    }
+
+    @Test
+    void buttonKeysFallBackToAReadableName() {
+        assertEquals("Donut Plus Plus", RanksMenu.prettifyKey("DONUT_PLUS_PLUS"));
+        assertEquals("Default", RanksMenu.prettifyKey("DEFAULT"));
+        assertEquals("Rank", RanksMenu.prettifyKey("_"));
+    }
+
+    @Test
+    void commandAndPermissionAreRegistered() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        plugin.load(Path.of("src/main/resources/plugin.yml").toFile());
+
+        assertTrue(plugin.isConfigurationSection("commands.ranks"),
+                "plugin.yml must declare the ranks command or the executor never binds");
+        assertEquals("ultimatedonutsmp.command.ranks", plugin.getString("commands.ranks.permission"));
+        assertTrue(plugin.isConfigurationSection("permissions.ultimatedonutsmp.command.ranks"),
+                "plugin.yml must declare the ranks permission node");
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.options().parseComments(true);
+        config.load(Path.of("src/main/resources/config.yml").toFile());
+        assertTrue(config.contains("COMMANDS.RANKS"),
+                "config.yml must ship COMMANDS.RANKS so the feature toggle can disable the menu");
+    }
+
+    private static YamlConfiguration loadMenus() throws Exception {
+        YamlConfiguration menus = new YamlConfiguration();
+        menus.options().parseComments(true);
+        menus.load(Path.of("src/main/resources/menus.yml").toFile());
+        return menus;
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/RanksMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/RanksMenuTest.java
@@ -4,6 +4,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +70,22 @@ class RanksMenuTest {
         }
 
         assertFalse(usedSlots.isEmpty(), BUTTONS_PATH + " must ship at least one button");
+    }
+
+    @Test
+    void theCommentedHeadTextureHintSurvivesAConfigRewrite() throws Exception {
+        String bundled = Files.readString(Path.of("src/main/resources/menus.yml"), StandardCharsets.UTF_8);
+        assertTrue(bundled.contains("# HEAD-TEXTURE:"),
+                "menus.yml must keep the commented HEAD-TEXTURE hint so owners can find the option");
+
+        // The plugin rewrites menus.yml whenever it merges bundled defaults, so the hint has to
+        // survive a load and save the same way ConfigManager does them.
+        String rewritten = loadMenus().saveToString();
+        assertEquals(
+                4,
+                rewritten.split("# HEAD-TEXTURE:", -1).length - 1,
+                "all four rank buttons must keep their commented HEAD-TEXTURE hint after a rewrite"
+        );
     }
 
     @Test


### PR DESCRIPTION
Adds `/ranks` (alias `/rank`), a config-driven menu that lists what each rank unlocks so players can compare them in game.

The layout lives under `RANKS-MENU` in `menus.yml` and follows the same rules as the rules and server info menus: slot, material, name and lore all come from config, and a button with a bad slot or an invalid material is skipped with a console warning instead of breaking the menu.

Two choices worth calling out:

- The four bundled buttons ship with an empty `COMMAND`, so clicking one only plays the menu click sound. Set a command and it runs as the player.
- There is no glass pane filler by default, since the ranks sit on empty slots. `RANKS-MENU.FILLER-MATERIAL` adds one for anyone who wants it.

Each button also takes an optional `HEAD-TEXTURE` (skin URL or base64) so a rank can use a custom head instead of a blank one.

`/ranks` is gated by `ultimatedonutsmp.command.ranks` and by the new RANKS feature toggle, so `/uds features disable ranks` and `COMMANDS.RANKS` in `config.yml` both turn it off. The command also shows up in `/help`, the tab completer, and the starter list in `/uds setup commands`.

`mvn test`: 462 tests, no failures. `RanksMenuTest` covers the bundled layout, the blank command handling, and the plugin.yml and config.yml registration.
