### PR TITLE
docs(platforms): document Purpur and Pufferfish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <h1 align="center">UltimateDonutSmp</h1>
 
 <p align="center">
-  Free Paper, Spigot, and Folia plugin for DonutSMP-style Minecraft servers.
+  Free Paper, Purpur, Pufferfish, Spigot, and Folia plugin for DonutSMP-style Minecraft servers.
   Economy, PvP, marketplace, staff tools, menus, and network utilities in one production-focused plugin.
 </p>
 
 <p align="center">
   <img alt="Java 21" src="https://img.shields.io/badge/Java-21-007396?style=for-the-badge&logo=openjdk&logoColor=white">
-  <img alt="Platform" src="https://img.shields.io/badge/Platform-Paper%20%7C%20Spigot%20%7C%20Folia-2ea44f?style=for-the-badge">
+  <img alt="Platform" src="https://img.shields.io/badge/Platform-Paper%20%7C%20Purpur%20%7C%20Pufferfish%20%7C%20Spigot%20%7C%20Folia-2ea44f?style=for-the-badge">
   <img alt="Free" src="https://img.shields.io/badge/Distribution-Free-green?style=for-the-badge">
   <img alt="License" src="https://img.shields.io/badge/License-Proprietary-red?style=for-the-badge">
 </p>
@@ -44,7 +44,7 @@ This README is the quick reference. The full documentation set lives in [`docs/w
 
 | Area | Included systems |
 | --- | --- |
-| Platforms | Separate Paper/Spigot and Folia builds with compatibility checks against the latest published APIs |
+| Platforms | Separate Paper/Purpur/Pufferfish/Spigot and Folia builds with compatibility checks against the latest published APIs |
 | Economy | Money, shards, player payments, Vault provider, shop, sell workflows, sell multipliers, worth browser, and sell history |
 | Marketplaces | Auction House, Orders board, Billford rotating trades, category filters, claims, delivery, and search |
 | Player systems | Teams, friends/follows, homes, warps, private messages, ignore lists, profiles, settings, and custom Ender Chests |
@@ -86,7 +86,7 @@ Gameplay clips:
 | --- | --- |
 | Plugin version | `1.5` |
 | Java | Bytecode targets Java 21. Use the Java version required by the selected Minecraft server; Minecraft 26.1+ requires Java 25. |
-| Paper / Spigot | Minecraft `1.21.10` through `26.2` |
+| Paper / Purpur / Pufferfish / Spigot | Minecraft `1.21.10` through `26.2` |
 | Folia | Minecraft `1.21.11` through `26.2` |
 | Hard dependencies | PlaceholderAPI and ProtocolLib (declared under `depend` in `plugin.yml`; the plugin will not load without them) |
 | Default storage | SQLite, bundled through the shaded JDBC driver |
@@ -124,7 +124,7 @@ Or run Maven directly:
 mvn clean package
 ```
 
-The build compiles the codebase against the target API and packages a single unified JAR that automatically detects and adapts to Paper, Spigot, or Folia at runtime.
+The build compiles the codebase against the target API and packages a single unified JAR that automatically detects and adapts to Paper, Purpur, Pufferfish, Spigot, or Folia at runtime.
 
 Generated artifact is saved to the `target/` directory:
 
@@ -612,7 +612,7 @@ Copyright (c) 2026 UltimateDonutSmp. All rights reserved.
 When reporting an issue, include:
 
 - Plugin version and jar file name
-- Server software and version (Paper, Spigot, or Folia)
+- Server software and version (Paper, Purpur, Pufferfish, Spigot, or Folia)
 - Java version
 - Relevant configuration snippets with secrets removed
 - Console errors or stack traces

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # Welcome to the UltimateDonutSMP Wiki
 
-Welcome to the official wiki documentation for **UltimateDonutSMP**, an all-in-one, high-performance Paper, Spigot, and Folia plugin designed for DonutSMP-style Minecraft survival networks.
+Welcome to the official wiki documentation for **UltimateDonutSMP**, an all-in-one, high-performance Paper, Purpur, Pufferfish, Spigot, and Folia plugin designed for DonutSMP-style Minecraft survival networks.
 
 UltimateDonutSMP replaces dozens of separate plugins by integrating economy, marketplaces, team systems, teleportation, PvP duels, FFA and ranked arenas, custom spawners, crates, staff utilities, security tools, and multi-server network syncing into a single, cohesive plugin.
 
@@ -11,8 +11,8 @@ UltimateDonutSMP replaces dozens of separate plugins by integrating economy, mar
 | Property | Details |
 | :--- | :--- |
 | **Plugin Version** | `1.4.1` |
-| **Supported Server Engines** | Paper, Spigot, Folia |
-| **Supported Minecraft Versions** | Paper/Spigot: `1.21.10` – `26.2`<br>Folia: `1.21.11` – `26.2` |
+| **Supported Server Engines** | Paper, Purpur, Pufferfish, Spigot, Folia |
+| **Supported Minecraft Versions** | Paper/Purpur/Pufferfish/Spigot: `1.21.10` – `26.2`<br>Folia: `1.21.11` – `26.2` |
 | **Java Requirement** | Java 21+ (Java 25 for MC 26.1+) |
 | **Storage Engines** | SQLite (Default), MySQL, MongoDB |
 | **Network Sync Layer** | Redis (Cross-server staff chat, alerts, maintenance) |

--- a/docs/wiki/Installation-and-Setup.md
+++ b/docs/wiki/Installation-and-Setup.md
@@ -9,7 +9,7 @@ This guide provides step-by-step instructions for installing and configuring **U
 | Requirement | Minimum / Supported | Notes |
 | :--- | :--- | :--- |
 | **Java Version** | Java 21+ | Minecraft 26.1 / 26.2 requires Java 25 |
-| **Server Engine** | Paper, Spigot, **Folia 26.2+** | Native multi-threaded region scheduling on Folia |
+| **Server Engine** | Paper, Purpur, Pufferfish, Spigot, **Folia 26.2+** | Purpur and other Paper forks run the Paper/Spigot path; native multi-threaded region scheduling on Folia |
 | **Minecraft Versions** | `1.21.10` – `26.2` | Folia: `1.21.11` – `26.2` |
 | **Build Tools** | Maven (`mvn`), Windows PowerShell | Tested on Windows / Linux environments |
 
@@ -35,7 +35,7 @@ This guide provides step-by-step instructions for installing and configuring **U
 
 ## Folia 26.2 Engine Compatibility & Multi-Threaded Architecture
 
-UltimateDonutSMP is built from the ground up to support **Folia 26.2+** multi-threaded region ticking servers alongside Paper and Spigot.
+UltimateDonutSMP is built from the ground up to support **Folia 26.2+** multi-threaded region ticking servers alongside Paper, Purpur, Pufferfish, and Spigot.
 
 ### Key Architecture Features under Folia:
 - **Region-Aware Schedulers**: Uses Paper/Folia `RegionScheduler`, `EntityScheduler`, `GlobalRegionScheduler`, and `AsyncScheduler` to ensure that region cuboids, portal triggers, Fast Crystal placements, and spawner ticks run safely on their respective region threads without throwing `ConcurrentModificationException` or thread safety errors.

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,2 +1,2 @@
 ---
-*UltimateDonutSMP Documentation v1.4.1 | Built for Paper, Spigot, and Folia Minecraft Networks.*
+*UltimateDonutSMP Documentation v1.4.1 | Built for Paper, Purpur, Pufferfish, Spigot, and Folia Minecraft Networks.*


### PR DESCRIPTION
The plugin already runs on Purpur and Pufferfish. `isPaperLikeServer()` matches both names alongside Paper, and the startup gate only checks the Minecraft version and whether the Folia classes are present, never the server brand. The docs never said so, so anyone on Purpur or Pufferfish had no way to find out except by trying it.

This updates the platform lists in the README (tagline, badge, feature table, requirements row, build note, bug report checklist) and in three wiki pages (Home, Installation and Setup, Footer). The Notes column in Installation and Setup now states that Purpur and other Paper forks run the Paper/Spigot path, so a future fork is covered without editing the list again.

No code changes.
