### PR TITLE
fix(punishments): stop staff punishing exempt players (#289)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -109,6 +109,30 @@ This page contains the complete reference guide for all commands, aliases, synta
 
 ---
 
+## Punishment Exemption Permissions
+
+Holding `/offend`, `/ban` or `/mute` says nothing about who the command may be used on, so a rank
+handed one of those nodes can otherwise punish anybody on the server, the owner included. Give a rank
+the exempt node and staff who lack the bypass are turned away instead.
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.admin.punishments.exempt` | `op` | The player cannot be punished. `/offend`, `/ban`, `/tempban`, `/mute`, `/tempmute`, `/warn`, `/kick` and `/blacklist` all refuse to touch them. |
+| `ultimatedonutsmp.admin.punishments.exempt.bypass` | `op` | Punish players who hold the exempt node anyway. Give it to the ranks that are allowed to act on each other. |
+
+Both nodes sit under `ultimatedonutsmp.admin.` rather than beside the other punishment nodes on
+purpose. A server that hands its moderators `ultimatedonutsmp.staff.punishments.*` would otherwise
+make every one of them unpunishable. `ultimatedonutsmp.admin.*` grants both, so an admin rank keeps
+its protection and can still act on other admins.
+
+The check reads the target's permissions off the player, which only works while they are online.
+Punishing someone who is offline goes through as it always has, so an exempt player can still be
+banned in absentia.
+
+The refusal message is `PUNISHMENTS.TARGET-EXEMPT` in `messages.yml`.
+
+---
+
 ## Spawner Permissions
 
 | Permission Node | Default | Description |

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -73,6 +73,27 @@ Passing a player name opens that player's history on its own, with the same stat
 - Both views require `ultimatedonutsmp.staff.punishments.view`.
 - Both are styled from `PUNISHMENTS-LIST-MENU` and `PUNISHMENT-HISTORY-MENU` in `menus.yml`.
 
+### 3. Protecting Ranks From Punishment
+
+A punishment permission carries no notion of who it may be used on. A rank given
+`ultimatedonutsmp.staff.punishments.offend` so it can hand out preset offenses can point `/offend` at
+the owner just as easily as at a rule breaker, and the same goes for `/ban`, `/mute`, `/warn`,
+`/kick` and `/blacklist`.
+
+Give the ranks you want protected `ultimatedonutsmp.admin.punishments.exempt`. Staff below them are
+told they cannot punish that player and nothing is recorded. Ranks that should still be able to act
+on each other get `ultimatedonutsmp.admin.punishments.exempt.bypass` as well — `ultimatedonutsmp.admin.*`
+covers both, so an admin group keeps its protection without losing the ability to punish other admins.
+
+Both nodes default to `op`, so operators are protected from non-operator staff out of the box and can
+still punish one another. The console is never blocked.
+
+Keep the nodes out of `ultimatedonutsmp.staff.punishments.*`. A wildcard over that branch is a normal
+way to set up a moderator rank, and it would hand the exemption to every moderator on the server.
+
+Permissions are read off the player, so the check only applies while the target is online. Banning an
+exempt player while they are offline still works.
+
 ---
 
 ## Chat & Anvil Moderation

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
@@ -11,6 +11,7 @@ import com.bx.ultimateDonutSmp.models.PunishmentType;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import com.bx.ultimateDonutSmp.utils.PunishmentExemptPolicy;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -58,6 +59,14 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
         }
 
         Player onlineTarget = Bukkit.getPlayer(target.uuid());
+        if (!PunishmentExemptPolicy.canPunish(sender, onlineTarget)) {
+            sendMessage(sender, plugin.getConfigManager().getMessageOrDefault(
+                    "PUNISHMENTS.TARGET-EXEMPT",
+                    "&cYou cannot punish that player."
+            ));
+            return true;
+        }
+
         OffenseManager offenseManager = plugin.getOffenseManager();
         Optional<OffenseManager.OffenseRule> ruleOpt = offenseManager.getOffenseRule(reasonKeyInput);
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
@@ -1,6 +1,7 @@
 package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import com.bx.ultimateDonutSmp.utils.PunishmentExemptPolicy;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.PunishmentManager;
@@ -133,6 +134,14 @@ public class PunishmentCommand implements CommandExecutor {
             send(sender, plugin.getConfigManager().getMessageOrDefault(
                     "PUNISHMENTS.TARGET-OFFLINE",
                     "&cThat player is not online."
+            ));
+            return true;
+        }
+
+        if (!PunishmentExemptPolicy.canPunish(sender, onlineTarget)) {
+            send(sender, plugin.getConfigManager().getMessageOrDefault(
+                    "PUNISHMENTS.TARGET-EXEMPT",
+                    "&cYou cannot punish that player."
             ));
             return true;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PunishmentExemptPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PunishmentExemptPolicy.java
@@ -1,0 +1,39 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.permissions.Permissible;
+
+/**
+ * Decides whether one player is allowed to punish another.
+ *
+ * <p>The permission that grants a punishment says nothing about who it may be used on, so a rank
+ * handed {@code ultimatedonutsmp.staff.punishments.offend} could ban the owner. A protected player
+ * carries {@link #EXEMPT_PERMISSION}, and only somebody holding {@link #BYPASS_PERMISSION} can
+ * still punish them.
+ *
+ * <p>Both nodes deliberately sit under {@code ultimatedonutsmp.admin.} rather than beside the other
+ * punishment nodes. A server that hands its moderators {@code ultimatedonutsmp.staff.punishments.*}
+ * would otherwise make every one of them exempt, which is the opposite of the point.
+ */
+public final class PunishmentExemptPolicy {
+
+    public static final String EXEMPT_PERMISSION = "ultimatedonutsmp.admin.punishments.exempt";
+    public static final String BYPASS_PERMISSION = "ultimatedonutsmp.admin.punishments.exempt.bypass";
+
+    private PunishmentExemptPolicy() {
+    }
+
+    public static boolean isExempt(Permissible target) {
+        return PermissionUtils.has(target, EXEMPT_PERMISSION);
+    }
+
+    /**
+     * A null target is an offline player. Their permissions cannot be read without them being on
+     * the server, so an offline punishment goes through as it always has.
+     */
+    public static boolean canPunish(Permissible issuer, Permissible target) {
+        if (target == null || !isExempt(target)) {
+            return true;
+        }
+        return PermissionUtils.has(issuer, BYPASS_PERMISSION);
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2683,6 +2683,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine:
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2995,6 +2995,7 @@ MESSAGES:
       &7Blacklisted by: &f%issuer%
       &8&m----------------------------
       &4You cannot join the server
+    TARGET-EXEMPT: '&cYou cannot punish that player.'
   SOCIAL:
     DISCORD:
     - ''

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2548,6 +2548,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine:
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2548,6 +2548,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage : /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine :
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2681,6 +2681,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player dan is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine:
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2549,6 +2549,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine:
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2546,6 +2546,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found."
     TARGET-OFFLINE: "&cThat player is not online."
+    TARGET-EXEMPT: "&cYou cannot punish that player."
     INVALID-DURATION: "&cInvalid time. use values like 30s, 15m, 2h, 5d, or combine:
       5d 15m 30s."
     CREATE-FAILED: "&cFailed to create punishment record."

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2536,6 +2536,7 @@ MESSAGES:
     USAGE-UNBLACKLIST: "&cUsage: /unblacklist <player> [reason]"
     NOT-FOUND: "&cPlayer not found。"
     TARGET-OFFLINE: "&cThatplayerisnotonline。"
+    TARGET-EXEMPT: "&cYou cannot punish that player。"
     INVALID-DURATION: "&cInvalidtime。 use values like 30s、15m、2h、5d、or combine：5d
       15m 30s。"
     CREATE-FAILED: "&cFailedtocreatepunishmentrecord。"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -651,6 +651,8 @@ PUNISHMENTS:
   NOT-FOUND: '&cPlayer not found.'
   # The text or value for Target Offline. Available options: Any valid string text
   TARGET-OFFLINE: '&cThat player is not online.'
+  # The text or value for Target Exempt. Available options: Any valid string text
+  TARGET-EXEMPT: '&cYou cannot punish that player.'
   # The text or value for Invalid Duration. Available options: Any valid string text
   INVALID-DURATION: '&cInvalid time. Use values like 30s, 15m, 2h, 5d, or combine:
     5d 15m 30s.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1146,6 +1146,12 @@ permissions:
   ultimatedonutsmp.staff.punishments.delete:
     description: Delete punishment history records from the GUI
     default: op
+  ultimatedonutsmp.admin.punishments.exempt:
+    description: Cannot be punished by staff who lack the exempt bypass
+    default: op
+  ultimatedonutsmp.admin.punishments.exempt.bypass:
+    description: Punish players who are exempt from being punished
+    default: op
   ultimatedonutsmp.shards.everywhere:
     description: Receive passive Shards Everywhere rewards
     default: false

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/PunishmentExemptPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/PunishmentExemptPolicyTest.java
@@ -1,0 +1,164 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rank handed the offend or ban permission used to be able to punish anybody on the server, the
+ * owner included.
+ */
+class PunishmentExemptPolicyTest {
+
+    private static final String OFFEND = "ultimatedonutsmp.staff.punishments.offend";
+
+    @Test
+    void staffCannotPunishAnExemptPlayer() {
+        TestPermissible staff = new TestPermissible().grant(OFFEND);
+        TestPermissible owner = new TestPermissible().grant(PunishmentExemptPolicy.EXEMPT_PERMISSION);
+
+        assertFalse(PunishmentExemptPolicy.canPunish(staff, owner));
+    }
+
+    @Test
+    void staffCanStillPunishEveryoneElse() {
+        TestPermissible staff = new TestPermissible().grant(OFFEND);
+
+        assertTrue(PunishmentExemptPolicy.canPunish(staff, new TestPermissible()));
+    }
+
+    @Test
+    void theBypassGetsThroughTheExemption() {
+        TestPermissible admin = new TestPermissible()
+                .grant(OFFEND)
+                .grant(PunishmentExemptPolicy.BYPASS_PERMISSION);
+        TestPermissible owner = new TestPermissible().grant(PunishmentExemptPolicy.EXEMPT_PERMISSION);
+
+        assertTrue(PunishmentExemptPolicy.canPunish(admin, owner));
+    }
+
+    @Test
+    void theStaffPunishmentWildcardDoesNotHandOutTheExemption() {
+        TestPermissible staff = new TestPermissible().grant("ultimatedonutsmp.staff.punishments.*");
+        TestPermissible owner = new TestPermissible().grant(PunishmentExemptPolicy.EXEMPT_PERMISSION);
+
+        assertFalse(PunishmentExemptPolicy.isExempt(staff),
+                "a wildcard over the staff nodes must not make every moderator unpunishable");
+        assertFalse(PunishmentExemptPolicy.canPunish(staff, owner));
+    }
+
+    @Test
+    void anAdminWildcardCarriesBothNodes() {
+        TestPermissible admin = new TestPermissible().grant("ultimatedonutsmp.admin.*");
+        TestPermissible owner = new TestPermissible().grant(PunishmentExemptPolicy.EXEMPT_PERMISSION);
+
+        assertTrue(PunishmentExemptPolicy.isExempt(admin));
+        assertTrue(PunishmentExemptPolicy.canPunish(admin, owner));
+    }
+
+    @Test
+    void anOfflineTargetIsLeftAlone() {
+        TestPermissible staff = new TestPermissible().grant(OFFEND);
+
+        assertTrue(PunishmentExemptPolicy.canPunish(staff, null),
+                "an offline player has no permissions to read, so the punishment goes through");
+    }
+
+    @Test
+    void pluginMetadataDeclaresBothNodes() {
+        YamlConfiguration pluginYaml = YamlConfiguration.loadConfiguration(
+                new java.io.File("src/main/resources/plugin.yml"));
+
+        assertEquals("op", pluginYaml.getString(
+                "permissions." + PunishmentExemptPolicy.EXEMPT_PERMISSION + ".default"));
+        assertEquals("op", pluginYaml.getString(
+                "permissions." + PunishmentExemptPolicy.BYPASS_PERMISSION + ".default"));
+    }
+
+    private static final class TestPermissible implements Permissible {
+        private final Set<PermissionAttachmentInfo> effectivePermissions = new LinkedHashSet<>();
+        private boolean op;
+
+        private TestPermissible grant(String permission) {
+            effectivePermissions.add(new PermissionAttachmentInfo(this, permission, null, true));
+            return this;
+        }
+
+        @Override
+        public boolean isPermissionSet(String name) {
+            return effectivePermissions.stream()
+                    .anyMatch(info -> info.getPermission().equalsIgnoreCase(name));
+        }
+
+        @Override
+        public boolean isPermissionSet(Permission permission) {
+            return permission != null && isPermissionSet(permission.getName());
+        }
+
+        @Override
+        public boolean hasPermission(String name) {
+            return effectivePermissions.stream()
+                    .anyMatch(info -> info.getValue() && info.getPermission().equalsIgnoreCase(name));
+        }
+
+        @Override
+        public boolean hasPermission(Permission permission) {
+            return permission != null && hasPermission(permission.getName());
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, String name, boolean value, int ticks) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PermissionAttachment addAttachment(Plugin plugin, int ticks) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeAttachment(PermissionAttachment attachment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void recalculatePermissions() {
+        }
+
+        @Override
+        public Set<PermissionAttachmentInfo> getEffectivePermissions() {
+            return effectivePermissions;
+        }
+
+        @Override
+        public boolean isOp() {
+            return op;
+        }
+
+        @Override
+        public void setOp(boolean value) {
+            op = value;
+        }
+    }
+}


### PR DESCRIPTION
Closes #289

A rank handed `ultimatedonutsmp.staff.punishments.offend` could point `/offend` at anybody on the server. The command checked that the sender was allowed to create punishments, then went straight to writing the record and kicking the target, so an alt with the offend node was enough to ban the owner. Nothing anywhere looked at who the command was aimed at. `/ban`, `/tempban`, `/mute`, `/tempmute`, `/warn`, `/kick` and `/blacklist` had the same hole.

## The exemption

Two new nodes, both registered with `default: op`:

- `ultimatedonutsmp.admin.punishments.exempt` for the player who cannot be punished
- `ultimatedonutsmp.admin.punishments.exempt.bypass` for the staff allowed to punish them anyway

`PunishmentExemptPolicy.canPunish` reads the exempt node off the target and, when it is there, requires the bypass from whoever ran the command. Staff without it get `PUNISHMENTS.TARGET-EXEMPT` and the command stops before it writes anything. Console holds every permission, so it never gets blocked.

Both nodes sit under `ultimatedonutsmp.admin.` rather than beside the other punishment nodes, which is deliberate. Setting a moderator rank up with `ultimatedonutsmp.staff.punishments.*` is a normal thing to do, and a wildcard over that branch would have made every moderator on the server unpunishable. `ultimatedonutsmp.admin.*` picks up both nodes instead, which is what an admin group wants: protected from moderators, still able to act on other admins. Defaulting them to `op` also covers operators on a fresh install without anyone editing a config file.

## Where the check sits

`OffendCommand` runs it once the target is resolved, before the offense tier lookup, so refusing costs nothing beyond the permission read. `PunishmentCommand.handleCreate` runs it after the online-only check, so `/kick` aimed at somebody offline still says they are offline rather than refusing for the wrong reason.

Nothing changed on the removal side. `/unban` and `/unmute` still work on an exempt player, since blocking those would only strand people.

## Notes

The check reads permissions off the `Player`, so it needs the target online. An offline target goes through as before; asking a permission plugin about somebody who is not on the server would mean depending on one.

New message key `PUNISHMENTS.TARGET-EXEMPT` in `messages.yml` and all 8 language files. Both wiki pages that cover punishments picked up a section on the nodes.

Seven tests in `PunishmentExemptPolicyTest` cover the block, the bypass, an offline target, and the two wildcards that matter here: `ultimatedonutsmp.staff.punishments.*` must not hand out the exemption, `ultimatedonutsmp.admin.*` must hand out both. Suite is at 483.
