### PR TITLE
docs(spawner): correct the documented subcommand list (#291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/shop` | - | `/shop [reload]` | `ultimatedonutsmp.command.shop` |
 | `/social` | `/media` | `/social` | `ultimatedonutsmp.command.social` |
 | `/spawn` | - | `/spawn` | `ultimatedonutsmp.command.spawn` |
-| `/spawner` | `/spawners` | `/spawner [give\|info\|panel\|reload\|remove]` | `ultimatedonutsmp.command.spawner` |
+| `/spawner` | `/spawners` | `/spawner [give\|info\|panel\|reload\|remove\|split]` | `ultimatedonutsmp.command.spawner` |
 | `/spawnstash` | `/stash` | `/spawnstash [type\|spawn\|list\|remove\|reload]` | `ultimatedonutsmp.command.spawnstash` |
 | `/staffchat` | `/sc` | `/staffchat <message>` | `ultimatedonutsmp.command.staffchat` |
 | `/stafflist` | - | `/stafflist` | `ultimatedonutsmp.command.stafflist` |

--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -96,7 +96,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/ffaarena` | `/ffaarena <create\|delete\|setpos\|enable>` | Instanced FFA arena management | `ultimatedonutsmp.admin.ffaarena` |
 | `/pvp` | `/pvp <wand\|create\|setspawn\|setspawn2\|setlobby\|setboundary\|kit\|schematic\|assign\|reset\|reload>` | Ranked PvP arena setup, kit editing, assigned matches, and schematic resets | `ultimatedonutsmp.admin.pvp` |
 | `/crate` | `/crate <create\|delete\|key\|keyall\|bind\|edit>` | Crate & virtual key administration | `ultimatedonutsmp.admin.crate` |
-| `/spawner` | `/spawner <give\|set\|type\|stack>` | Custom spawner stack administration | `ultimatedonutsmp.admin.spawner` |
+| `/spawner` | `/spawner [give\|info\|panel\|reload\|remove\|split]` | Custom spawner stack administration. `info` and `split` need only `ultimatedonutsmp.command.spawner` | `ultimatedonutsmp.admin.spawner` |
 | `/addmoney` | `/addmoney <player> <amount>` | Add money to player balance | `ultimatedonutsmp.admin.addmoney` |
 | `/removemoney` | `/removemoney <player> <amount>` | Deduct money from player balance | `ultimatedonutsmp.admin.removemoney` |
 | `/setmoney` | `/setmoney <player> <amount>` | Set player money balance | `ultimatedonutsmp.admin.setmoney` |

--- a/docs/wiki/Crates-and-Spawners.md
+++ b/docs/wiki/Crates-and-Spawners.md
@@ -31,12 +31,17 @@ UltimateDonutSMP includes custom mob spawners engineered for high-performance mo
 - **Upgrade System**: Upgrade spawner rate, spawn count, and mob drop multipliers via GUI.
 - **Break Safeguards**: Requires Silk Touch or admin bypass permissions to break stacked spawners without losing count.
 
+### Player Spawner Commands (`/spawner`):
+- `/spawner info` – Inspect the spawner block you are looking at.
+- `/spawner split <amount>` – Split the spawner item in your hand into a smaller stack.
+
 ### Admin Spawner Commands (`/spawner`):
-- `/spawner give <player> <entity_type> <amount>` – Give stacked spawner item to player.
-- `/spawner set <entity_type>` – Change targeted spawner type.
-- `/spawner type <entity_type>` – Change spawner type in hand.
-- `/spawner stack <amount>` – Set stack count of targeted spawner block.
+- `/spawner` or `/spawner panel` – Open the spawner admin panel.
+- `/spawner give <player> <entity_type> [amount]` – Give a stacked spawner item to a player.
+- `/spawner remove` – Remove the spawner block you are looking at. `/spawner forcebreak` does the same thing.
 - `/spawner reload` – Reload `spawners.yml`.
+
+The admin entries need `ultimatedonutsmp.admin.spawner`, and the command itself is gated by `ultimatedonutsmp.command.spawner`.
 
 ---
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -646,7 +646,7 @@ commands:
     permission-message: "&cYou do not have permission to use /billford."
   spawner:
     description: Manage Donut-style spawners
-    usage: /spawner [give|info|panel|reload|remove]
+    usage: /spawner [give|info|panel|reload|remove|split]
     aliases:
     - spawners
     permission: ultimatedonutsmp.command.spawner


### PR DESCRIPTION
Closes #291

The wiki documented three `/spawner` subcommands that the plugin has never had. Anyone following it would type `/spawner set`, get the help screen back, and have no way to tell whether they mistyped it or the feature was missing. That is how this surfaced: a server owner went looking for a way to turn a natural dungeon spawner into a plugin-managed one, found `set` in the wiki, and it did nothing.

## What the command actually accepts

`give`, `info`, `panel`, `split`, `reload`, and `remove` with `forcebreak` as an alias. `info` and `split` carry no admin gate; everything else needs `ultimatedonutsmp.admin.spawner`, and the command as a whole sits behind `ultimatedonutsmp.command.spawner`. The in-game help in `SpawnerCommand.sendUsage` already listed the right set, so it is untouched.

## Docs

`Crates-and-Spawners.md` drops `set`, `type` and `stack`, and picks up the entries it never listed. Because two of the subcommands are not admin-only, the page now separates player and admin lists instead of filing everything under "Admin Spawner Commands".

`Commands-and-Permissions.md` carried the same phantom list in its usage column and now shows the real one, with a note on which parts need nothing beyond the command node.

## Usage strings

`plugin.yml` and the README command table both listed everything except `split`, so it goes into both. `git log -S` over `SpawnerCommand.java` turns up no commit that ever added `set`, `type` or `stack`; they were documented rather than implemented and later dropped.

## Notes

Documentation plus one usage string, no behaviour change. Full suite green at 483 tests.
