### PR TITLE
feat(shop): let amethyst shard shop entries pick their currency (#292)

### DIFF
--- a/docs/wiki/Config-amethyst-tools.yml.md
+++ b/docs/wiki/Config-amethyst-tools.yml.md
@@ -86,6 +86,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 18
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -118,6 +120,7 @@ AMETHYST-TOOLS:
 | `AMETHYST-TOOLS.DRILL.DISABLED-BLOCKS` | `list` | List of configured items/strings | `[DIRT, GRASS_BLOCK, COARSE_DIRT...]` | Configures the technical `DISABLED-BLOCKS` parameter for `AMETHYST-TOOLS.DRILL.DISABLED-BLOCKS` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.DURATION` | `int` | Any valid integer number | `'86400'` | Configures the technical `DURATION` parameter for `AMETHYST-TOOLS.DRILL.DURATION` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `AMETHYST-TOOLS` system. Set to `true` to enable, `false` to disable. |
+| `AMETHYST-TOOLS.DRILL.SHARD-SHOP.CURRENCY` | `str` | `SHARD`, `MONEY` | `'SHARD'` | Currency this tool is priced in when it shows up in the shard menu. `SHARD` spends shards, `MONEY` charges the player's balance. Every tool has its own key, so a menu can mix both. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.SLOT` | `int` | Any valid integer number | `'18'` | Configures the technical `SLOT` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.SLOT` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MIN-QUANTITY` | `int` | Any valid integer number | `'1'` | Configures the technical `MIN-QUANTITY` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MIN-QUANTITY` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MAX-QUANTITY` | `int` | Any valid integer number | `'1'` | Configures the technical `MAX-QUANTITY` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MAX-QUANTITY` in `amethyst-tools.yml`. |

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -643,7 +643,7 @@ public class ShopManager {
                     lore,
                     shopSection.getInt("SLOT", 0),
                     price,
-                    Currency.SHARD,
+                    parseCurrency(shopSection.getString("CURRENCY", Currency.SHARD.name())),
                     "",
                     true,
                     shopSection.getString("PERMISSION", ""),
@@ -978,7 +978,7 @@ public class ShopManager {
         );
     }
 
-    private Currency parseCurrency(String currencyName) {
+    static Currency parseCurrency(String currencyName) {
         if (currencyName == null || currencyName.isBlank()) {
             return Currency.MONEY;
         }

--- a/src/main/resources/amethyst-tools.yml
+++ b/src/main/resources/amethyst-tools.yml
@@ -75,6 +75,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 18
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -128,6 +130,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 19
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -157,6 +161,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 20
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -208,6 +214,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 21
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -237,6 +245,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 22
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -266,6 +276,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 23
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -281,6 +293,8 @@ AMETHYST-TOOLS:
     SHARD-SHOP:
       # Determines whether Enabled is enabled or disabled. Available options: true, false
       ENABLED: false
+      # The currency this tool is sold for. Available options: SHARD, MONEY
+      CURRENCY: SHARD
       SLOT: 18
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
@@ -30,6 +30,7 @@ class AmethystShardShopConfigurationTest {
             ConfigurationSection shardShop = tool.getConfigurationSection("SHARD-SHOP");
             assertNotNull(shardShop, path + ".SHARD-SHOP");
             assertFalse(shardShop.getBoolean("ENABLED"), "Default must not change the live economy");
+            assertEquals("SHARD", shardShop.getString("CURRENCY"), path + ".SHARD-SHOP.CURRENCY");
             assertTrue(slots.add(shardShop.getInt("SLOT")), "Shard-shop slots must be unique");
             assertEquals(1, shardShop.getInt("MIN-QUANTITY"));
             assertEquals(1, shardShop.getInt("MAX-QUANTITY"));

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
@@ -123,6 +123,16 @@ class ShopManagerTest {
         assertNull(ShopManager.parsePriceTag("[PRICE] "));
     }
 
+    @Test
+    void readsCurrencyNames() {
+        assertEquals(ShopManager.Currency.SHARD, ShopManager.parseCurrency("SHARD"));
+        assertEquals(ShopManager.Currency.SHARD, ShopManager.parseCurrency("shards"));
+        assertEquals(ShopManager.Currency.MONEY, ShopManager.parseCurrency("MONEY"));
+        assertEquals(ShopManager.Currency.MONEY, ShopManager.parseCurrency("gold bars"));
+        assertEquals(ShopManager.Currency.MONEY, ShopManager.parseCurrency(""));
+        assertEquals(ShopManager.Currency.MONEY, ShopManager.parseCurrency(null));
+    }
+
     private AuctionListing listing(
             long id,
             UUID seller,


### PR DESCRIPTION
Closes #292

Amethyst tools sold through the shard menu were priced in shards and nothing else, because the currency came from a literal in the loader. A server that moved that menu onto money ended up with tools still asking for shards in the middle of a money shop, and no key to change it.

## The change

`loadAmethystShardShopItems` now reads a `CURRENCY` key from each tool's `SHARD-SHOP` section, defaulting to `SHARD` so nothing moves for setups that already run it. The key sits per tool rather than per menu, so one menu can mix both.

Nothing else needed touching. Validation, the withdraw, the refund after a failed reward delivery, the money-spent counter, the price lore and the purchase menu all branch on the item's currency rather than on whether the item is an amethyst reward, so they picked the change up as-is.

## Config

`amethyst-tools.yml` gains `CURRENCY: SHARD` in all seven `SHARD-SHOP` sections. `amethyst-tools.yml` is not in the user-managed exclusion list in `ConfigManager`, so existing configs receive the key on update instead of quietly running without it. The wiki key table gets the matching row.

## Notes

`parseCurrency` is now package-private static so a test can call it, which puts it beside `parsePriceTag` and `shouldDeliverConfiguredItem` in the same class. Two tests cover the change: the bundled default stays `SHARD` for every tool, and the name parsing maps shard and shards onto shards with everything else falling back to money.

One thing this does not fix: enabling `SHARD-SHOP` still produces an empty slot, because the loader skips any tool without a `PRICE-PER-UNIT` and the bundled config defines none anywhere. That is #297.

Full suite green at 484 tests.
