### PR TITLE
fix(shop): match price lore written in small caps (#293)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
@@ -13,7 +13,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 public class PurchaseShopMenu extends BaseMenu {
 
@@ -150,26 +149,10 @@ public class PurchaseShopMenu extends BaseMenu {
     }
 
     private boolean isRedundantPriceLore(String line) {
-        String plain = normalizePriceLabel(ColorUtils.strip(line));
+        String plain = ColorUtils.normalizeLabel(ColorUtils.strip(line));
         return plain.contains("buy price")
                 || plain.contains("buyprice")
                 || plain.contains("harga beli");
-    }
-
-    private String normalizePriceLabel(String value) {
-        return (value == null ? "" : value.toLowerCase(Locale.ROOT))
-                .replace('b', 'b')
-                .replace('u', 'u')
-                .replace('y', 'y')
-                .replace('p', 'p')
-                .replace('r', 'r')
-                .replace('i', 'i')
-                .replace('c', 'c')
-                .replace('e', 'e')
-                .replace('h', 'h')
-                .replace('a', 'a')
-                .replace('g', 'g')
-                .replace('l', 'l');
     }
 
     private void buildCancelButton() {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -367,7 +366,7 @@ public class ShopMenu extends BaseMenu {
                 .replace("{price}", rawPrice)
                 .replace("%price%", rawPrice);
 
-        String normalizedLine = normalizePriceLabel(line);
+        String normalizedLine = ColorUtils.normalizeLabel(line);
         if ((normalizedLine.contains("buy price:") || normalizedLine.contains("harga beli:")) && !line.contains("{price")) {
             int colonIndex = line.indexOf(':');
             if (colonIndex >= 0) {
@@ -375,22 +374,6 @@ public class ShopMenu extends BaseMenu {
             }
         }
         return result;
-    }
-
-    private String normalizePriceLabel(String value) {
-        return (value == null ? "" : value.toLowerCase(Locale.ROOT))
-                .replace('b', 'b')
-                .replace('u', 'u')
-                .replace('y', 'y')
-                .replace('p', 'p')
-                .replace('r', 'r')
-                .replace('i', 'i')
-                .replace('c', 'c')
-                .replace('e', 'e')
-                .replace('h', 'h')
-                .replace('a', 'a')
-                .replace('g', 'g')
-                .replace('l', 'l');
     }
 
     private void buildBackButton() {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
@@ -364,6 +364,16 @@ public class ColorUtils {
         return capitalizeFirstTextChar(sb.toString());
     }
 
+    // Lowercased text with small caps folded back to ASCII, so a config label typed as
+    // "ʙᴜʏ ᴘʀɪᴄᴇ:" still matches a plain lowercase needle. The fold runs first because
+    // unSmallCaps capitalizes the first letter it finds.
+    public static String normalizeLabel(String value) {
+        if (value == null) {
+            return "";
+        }
+        return unSmallCaps(value).toLowerCase(Locale.ROOT);
+    }
+
     private static String capitalizeFirstTextChar(String text) {
         if (text == null || text.isEmpty()) return text;
         int i = 0;

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
@@ -229,4 +229,13 @@ class ColorUtilsTest {
         assertEquals("Shop", ColorUtils.strip("<color:#FF0000>Shop"));
         assertEquals("give <player>", ColorUtils.strip("&7give <player>"));
     }
+
+    @Test
+    void testNormalizeLabelFoldsSmallCaps() {
+        assertTrue(ColorUtils.normalizeLabel("&fʙᴜʏ ᴘʀɪᴄᴇ: &a$250").contains("buy price:"));
+        assertTrue(ColorUtils.normalizeLabel("&fʜᴀʀɢᴀ ʙᴇʟɪ: &a$250").contains("harga beli:"));
+        assertTrue(ColorUtils.normalizeLabel("&fBuy Price: &a$250").contains("buy price:"));
+        assertEquals("", ColorUtils.normalizeLabel(null));
+        assertEquals("&5250x shards", ColorUtils.normalizeLabel("&5250x Shards"));
+    }
 }


### PR DESCRIPTION
Closes #293

The shop fills in a price for you: any lore line reading `Buy price:` (or `Harga beli:`) with no `{price}` placeholder gets everything after the colon replaced with the live formatted price. That check ran on text that was supposed to have unicode small caps folded back to ASCII first, except the folding did nothing, so a menu written in small caps kept whatever amount the config author had typed by hand.

## What was wrong

`normalizePriceLabel` lowercased its input and then ran twelve `.replace(c, c)` calls: `.replace('b', 'b')`, `.replace('u', 'u')`, and so on. Each one maps a character to itself. The twelve letters are exactly the letters in "buy price" and "harga beli", so the intent was clear enough, but not one of them changed anything.

The same dead method sat in two classes. `ShopMenu` used it for the price rewrite; `PurchaseShopMenu` used it for `isRedundantPriceLore`, which hides the duplicate price line on the confirm screen. Small caps broke both, which is why the confirm screen would show the price twice.

## The fix

`ColorUtils` has had a working small caps map since long before this, sitting in `unSmallCaps`, and neither call site used it. Both now call a new `ColorUtils.normalizeLabel`, which folds first and lowercases second. That order matters: `unSmallCaps` capitalizes the first letter it finds, so lowercasing afterwards is what cancels it out. Both duplicate private methods are deleted along with their now-unused `Locale` imports.

## Notes

Behaviour for plain ASCII lore is unchanged, since folding is a no-op there and `unSmallCaps` returns early when it sees no small caps at all.

One test in `ColorUtilsTest` covers the fold on both labels, an ASCII line, a null, and a line that is not a price label. Full suite green at 485 tests.
