### PR TITLE
fix(spawner): let players use info and split without leaking details (#300)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -96,7 +96,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/ffaarena` | `/ffaarena <create\|delete\|setpos\|enable>` | Instanced FFA arena management | `ultimatedonutsmp.admin.ffaarena` |
 | `/pvp` | `/pvp <wand\|create\|setspawn\|setspawn2\|setlobby\|setboundary\|kit\|schematic\|assign\|reset\|reload>` | Ranked PvP arena setup, kit editing, assigned matches, and schematic resets | `ultimatedonutsmp.admin.pvp` |
 | `/crate` | `/crate <create\|delete\|key\|keyall\|bind\|edit>` | Crate & virtual key administration | `ultimatedonutsmp.admin.crate` |
-| `/spawner` | `/spawner [give\|info\|panel\|reload\|remove\|split]` | Custom spawner stack administration. `info` and `split` need only `ultimatedonutsmp.command.spawner` | `ultimatedonutsmp.admin.spawner` |
+| `/spawner` | `/spawner [give\|info\|panel\|reload\|remove\|split]` | Custom spawner stack administration. `info` and `split` are open to every player; the rest needs the admin node | `ultimatedonutsmp.admin.spawner` |
 | `/addmoney` | `/addmoney <player> <amount>` | Add money to player balance | `ultimatedonutsmp.admin.addmoney` |
 | `/removemoney` | `/removemoney <player> <amount>` | Deduct money from player balance | `ultimatedonutsmp.admin.removemoney` |
 | `/setmoney` | `/setmoney <player> <amount>` | Set player money balance | `ultimatedonutsmp.admin.setmoney` |
@@ -138,6 +138,8 @@ The refusal message is `PUNISHMENTS.TARGET-EXEMPT` in `messages.yml`.
 | Permission Node | Default | Description |
 | :--- | :--- | :--- |
 | `ultimatedonutsmp.spawner.bypass` | `false` | Break spawners without a Silk Touch pickaxe while `SETTINGS.REQUIRE_SILK_TOUCH` is enabled in `spawners.yml`. Registered with `default: false`, so operators do not receive it automatically. Assign it explicitly via LuckPerms. |
+| `ultimatedonutsmp.command.spawner` | `true` | Reach `/spawner` at all. Every player has it, which is what makes `/spawner info` and `/spawner split` usable; the admin subcommands stay behind their own node. |
+| `ultimatedonutsmp.admin.spawner` | `op` | Run `/spawner give`, `panel`, `reload`, `remove` and `forcebreak`, and see the full `/spawner info` breakdown on any spawner regardless of who owns it. |
 
 ---
 

--- a/docs/wiki/Crates-and-Spawners.md
+++ b/docs/wiki/Crates-and-Spawners.md
@@ -32,7 +32,7 @@ UltimateDonutSMP includes custom mob spawners engineered for high-performance mo
 - **Break Safeguards**: Requires Silk Touch or admin bypass permissions to break stacked spawners without losing count.
 
 ### Player Spawner Commands (`/spawner`):
-- `/spawner info` – Inspect the spawner block you are looking at.
+- `/spawner info` – Inspect the spawner block you are looking at. Owner, stack size, stored loot and coordinates only show on spawners you are allowed to access: your own, a teammate's under `OWNER_AND_TEAM`, any of them under `PUBLIC` or while `ALLOW_SPAWNER_STEAL` is on. Anyone else sees the mob type and nothing further.
 - `/spawner split <amount>` – Split the spawner item in your hand into a smaller stack.
 
 ### Admin Spawner Commands (`/spawner`):
@@ -41,7 +41,7 @@ UltimateDonutSMP includes custom mob spawners engineered for high-performance mo
 - `/spawner remove` – Remove the spawner block you are looking at. `/spawner forcebreak` does the same thing.
 - `/spawner reload` – Reload `spawners.yml`.
 
-The admin entries need `ultimatedonutsmp.admin.spawner`, and the command itself is gated by `ultimatedonutsmp.command.spawner`.
+The admin entries need `ultimatedonutsmp.admin.spawner`, which also unlocks the full `/spawner info` breakdown on any spawner. The command itself is gated by `ultimatedonutsmp.command.spawner`, and every player holds that one by default.
 
 ---
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/SpawnerCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/SpawnerCommand.java
@@ -135,6 +135,10 @@ public class SpawnerCommand implements CommandExecutor {
 
         player.sendMessage(ColorUtils.toComponent("&8&m----------- &bSpawner Info &8&m-----------"));
         player.sendMessage(ColorUtils.toComponent("&7Type: &f" + plugin.getSpawnerManager().getPlainTypeDisplayName(instance.getMobTypeKey())));
+        if (!plugin.getSpawnerManager().canOpen(player, instance)) {
+            player.sendMessage(ColorUtils.toComponent("&7The rest is hidden on spawners you cannot access."));
+            return true;
+        }
         player.sendMessage(ColorUtils.toComponent("&7Owner: &f" + instance.getOwnerNameSnapshot()));
         player.sendMessage(ColorUtils.toComponent("&7Stack: &f" + NumberUtils.format(instance.getStackAmount())));
         player.sendMessage(ColorUtils.toComponent("&7Stored Loot: &f" + NumberUtils.format(instance.getTotalStoredItems())));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1729,7 +1729,7 @@ permissions:
     default: true
   ultimatedonutsmp.command.spawner:
     description: Access to /spawner command
-    default: op
+    default: true
   ultimatedonutsmp.command.clearlag:
     description: Access to /clearlag command
     default: op

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/SpawnerCommandPermissionTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/SpawnerCommandPermissionTest.java
@@ -1,0 +1,24 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpawnerCommandPermissionTest {
+
+    @Test
+    void spawnerCommandIsReachableByPlayersWhileAdminWorkStaysOp() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        // Permission nodes are dotted keys, so path traversal has to walk on something else.
+        plugin.options().pathSeparator('/');
+        plugin.load(new File("src/main/resources/plugin.yml"));
+
+        // /spawner info and /spawner split carry no admin check of their own, so the command
+        // node has to reach ordinary players or both of them are unusable.
+        assertEquals("true", plugin.getString("permissions/ultimatedonutsmp.command.spawner/default"));
+        assertEquals("op", plugin.getString("permissions/ultimatedonutsmp.admin.spawner/default"));
+    }
+}


### PR DESCRIPTION
Closes #300

`/spawner info` and `/spawner split` were written for ordinary players: neither carries a permission check, and the tab completer offers exactly those two to anybody without the admin node. They were unreachable anyway, because `/spawner` itself sat behind an operator-only node. Meanwhile the one of them that did run gave away more than it should.

## The permission

`ultimatedonutsmp.command.spawner` now defaults to `true`, which is what every comparable command node already does: `shop`, `spawn`, `rtp`, `home`, `sethome`, `tpa`, `balance` and `billford` are all `default: true`. The only bundle containing it, `ultimatedonutsmp.command.*`, is operator-only itself, so nothing shipped was handing it out.

The admin subcommands are unaffected. `give`, `panel`, `reload`, `remove` and `forcebreak` each check `ultimatedonutsmp.admin.spawner` inside the command, and so does the bare `/spawner` panel, so opening the node up does not widen any of them.

## The disclosure

`/spawner info` printed owner, stack count, stored loot and coordinates for whatever managed spawner the player looked at, with no access check. On a server where players raid each other, stack size and stored loot are the two numbers worth hiding, and nothing else in the plugin gives them out. Anti-ESP does not help here: it already reveals the block to anyone within the reveal radius, and the command reaches 6 blocks, so concealment was never what stopped this.

The command now prints the mob type and then stops unless `SpawnerManager.canOpen` accepts the viewer. That is deliberately the same rule that decides who may open the spawner GUI, rather than a second access rule invented for one command, so it follows `ACCESS_MODE` and `ALLOW_SPAWNER_STEAL` the way the rest of the system does. Owner, teammates under `OWNER_AND_TEAM`, everyone under `PUBLIC`, and admins keep the full breakdown.

## Notes

`SpawnerCommandPermissionTest` pins both defaults so neither drifts back by accident. Permission keys are dotted, so the test walks the file with a different path separator rather than pretending `ultimatedonutsmp.command.spawner` is four nested sections.

Both wiki pages that describe these commands are updated, including two new rows in the spawner permission table.

Servers that deliberately kept `/spawner` away from players will want to negate `ultimatedonutsmp.command.spawner` for the default group after updating. Full suite green at 486 tests.
