### PR TITLE
fix(shop): ship a price for every amethyst shard shop entry (#297)

### DIFF
--- a/docs/wiki/Config-amethyst-tools.yml.md
+++ b/docs/wiki/Config-amethyst-tools.yml.md
@@ -88,6 +88,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 750.0
       SLOT: 18
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -121,6 +123,7 @@ AMETHYST-TOOLS:
 | `AMETHYST-TOOLS.DRILL.DURATION` | `int` | Any valid integer number | `'86400'` | Configures the technical `DURATION` parameter for `AMETHYST-TOOLS.DRILL.DURATION` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `AMETHYST-TOOLS` system. Set to `true` to enable, `false` to disable. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.CURRENCY` | `str` | `SHARD`, `MONEY` | `'SHARD'` | Currency this tool is priced in when it shows up in the shard menu. `SHARD` spends shards, `MONEY` charges the player's balance. Every tool has its own key, so a menu can mix both. |
+| `AMETHYST-TOOLS.DRILL.SHARD-SHOP.PRICE-PER-UNIT` | `float` | Any decimal number above zero | `'750.0'` | What one purchase costs, in the currency above. A tool priced at zero or below is skipped when the menu loads, leaving an empty slot, and the console says so on startup and on `/shop reload`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.SLOT` | `int` | Any valid integer number | `'18'` | Configures the technical `SLOT` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.SLOT` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MIN-QUANTITY` | `int` | Any valid integer number | `'1'` | Configures the technical `MIN-QUANTITY` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MIN-QUANTITY` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MAX-QUANTITY` | `int` | Any valid integer number | `'1'` | Configures the technical `MAX-QUANTITY` parameter for `AMETHYST-TOOLS.DRILL.SHARD-SHOP.MAX-QUANTITY` in `amethyst-tools.yml`. |

--- a/src/main/resources/amethyst-tools.yml
+++ b/src/main/resources/amethyst-tools.yml
@@ -77,6 +77,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 750.0
       SLOT: 18
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -132,6 +134,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 600.0
       SLOT: 19
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -163,6 +167,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 900.0
       SLOT: 20
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -216,6 +222,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 500.0
       SLOT: 21
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -247,6 +255,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 400.0
       SLOT: 22
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1
@@ -278,6 +288,8 @@ AMETHYST-TOOLS:
       ENABLED: false
       # The currency this tool is sold for. Available options: SHARD, MONEY
       CURRENCY: SHARD
+      # The decimal value for Price Per Unit. Available options: Any decimal number
+      PRICE-PER-UNIT: 1500.0
       SLOT: 23
       # The numerical value for Min Quantity. Available options: Any valid integer
       MIN-QUANTITY: 1

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
@@ -31,6 +31,9 @@ class AmethystShardShopConfigurationTest {
             assertNotNull(shardShop, path + ".SHARD-SHOP");
             assertFalse(shardShop.getBoolean("ENABLED"), "Default must not change the live economy");
             assertEquals("SHARD", shardShop.getString("CURRENCY"), path + ".SHARD-SHOP.CURRENCY");
+            // A tool with no usable price is skipped when the menu loads, so enabling the
+            // section would leave an empty slot behind.
+            assertTrue(shardShop.getDouble("PRICE-PER-UNIT") > 0D, path + ".SHARD-SHOP.PRICE-PER-UNIT");
             assertTrue(slots.add(shardShop.getInt("SLOT")), "Shard-shop slots must be unique");
             assertEquals(1, shardShop.getInt("MIN-QUANTITY"));
             assertEquals(1, shardShop.getInt("MAX-QUANTITY"));


### PR DESCRIPTION
Closes #297

Turning on `SHARD-SHOP` for an amethyst tool left an empty slot in the menu. The loader skips any tool priced at zero or below, and `amethyst-tools.yml` never shipped a price at all, so enabling the section could not produce an item no matter what else was set.

## Correction to the report

The issue says this failed silently. It does not: `validateAmethystShardShopConfiguration` already logs a warning naming the tool and the price, and it runs from the manager's constructor as well as `/shop reload`, so it fires on startup too. That half of the report was wrong. What was genuinely missing is the key itself and any mention of it in the docs, so this is config and documentation rather than code.

## The prices

Each of the six tools now ships a `PRICE-PER-UNIT` under its `SHARD-SHOP` block. The numbers sit inside the range the shard menu already uses, where spawners run from 250 for a pig to 1500 for an iron golem:

| Tool | Price | Why there |
|---|---|---|
| Bucket | 400 | drains 27 blocks, narrowest use |
| Shovel | 500 | 3x3 digging for a day |
| Chopper | 600 | whole trees for a day |
| Drill | 750 | 3x3 mining with fortune 3 |
| Sell axe | 900 | turns a chest into money on the spot |
| Shard booster | 1500 | 4x shards, and pricing it low would undercut the currency it pays out in |

These are a starting point rather than a balance decision anyone is stuck with. Nothing changes for a live server until an admin flips `ENABLED` to true, which is the same moment they would look at the price anyway, and existing configs receive the key through the usual merge without overwriting a value already there.

`AMETHYST-TOOLS.CHOP` deliberately got nothing. It is an orphan section no code reads, tracked in #302.

## Notes

`AmethystShardShopConfigurationTest` now asserts every tool ships a price above zero, which is the condition the loader actually checks. The wiki key table gains the row, saying what happens at zero and that the console names it.

Full suite green at 486 tests.
