### PR TITLE
docs(shop): explain how price lore is filled in

### DIFF
--- a/docs/wiki/Config-shop.yml.md
+++ b/docs/wiki/Config-shop.yml.md
@@ -1209,3 +1209,37 @@ Rather than writing `ITEM-DATA` by hand, run `/shopedit <menu>` (for example `/s
 Clicking a filled slot with nothing selected removes that entry. Changes are saved to `shop.yml` as you make them, so no reload is needed.
 
 ---
+
+## Prices in Item Lore
+
+You do not keep the price in an item's `LORE` in step with `PRICE-PER-UNIT` by hand. Every lore line on a shop item runs through a substitution pass first, and the amount you typed there is a placeholder rather than the number players see.
+
+### Placeholders
+
+| Placeholder | What it renders |
+|---|---|
+| `{price_formatted}`, `%price_formatted%`, `${price_formatted}`, `${price}` | The full price with its symbol, colour and currency name: `$25,000.00` under `MONEY`, `★ 250 Shards` under `SHARD` |
+| `{price}`, `%price%` | The bare number, `25,000.00`, with no symbol and no colour of its own |
+
+Both follow the item's own `CURRENCY`, so an entry moved from `SHARD` to `MONEY` re-renders itself with no lore edit.
+
+These describe the currency rather than this item's price, and work on any lore line: `{money_symbol}`, `{money_symbol_color}`, `{money_symbol_colored}`, `{money_name}`, `{money_name_singular}`, `{money_name_plural}`, `{money_color}`, and the same seven with a `shards_` prefix.
+
+### The `Buy price:` line fills itself in
+
+A lore line containing `Buy price:` that carries no `{price` placeholder has everything after its first colon replaced with the live formatted price. `Harga beli:` does the same on Indonesian menus. Capitalisation does not matter, a colour code in front of the label does not interfere, and a label typed in unicode small caps is recognised too.
+
+So the amount written here never reaches anybody:
+
+```yaml
+    LORE:
+    - '&fBuy price: &a$1'
+```
+
+That is also why the confirm screen does not show the line twice. Any lore line reading `Buy price`, `buyprice` or `Harga beli` is dropped there, because the purchase menu prints the total itself.
+
+### What you do still maintain
+
+Wording you invented stays yours. A line like `&7Effect: Strength II`, or a menu `TITLE` that mentions shards, is untouched by any of the above and needs editing by hand when the item or the currency changes.
+
+---

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -365,3 +365,17 @@ SPLASH-STRENGTH-POTION:
 2. Locate your target menu section (e.g., `GEAR-MENU` or create a new `POTION-MENU`).
 3. Paste the potion configuration entry into the `ITEMS:` section.
 4. Save `shop.yml` and run `/uds reload` in-game or from console.
+
+---
+
+## 15. Keeping `Buy price:` Lore in Step With `PRICE-PER-UNIT` (`shop.yml`)
+
+### Question: I changed a shop item's price, or moved a menu from shards to money. Do I have to rewrite every `Buy price:` lore line by hand?
+
+No. A lore line that reads `Buy price:` and carries no `{price` placeholder has everything after its first colon replaced with the live price, in that item's own currency, every time the menu is drawn. The amount sitting in the file is never shown, so `'&fBuy price: &a$1'` still displays the real figure. `Harga beli:` behaves the same way on Indonesian menus, and the confirm screen hides the duplicate line rather than printing the price twice.
+
+If you would rather write the label yourself, `{price_formatted}` renders the price with its symbol and colour anywhere in the line, and `{price}` renders the bare number.
+
+The full list of placeholders, and what the auto-filled line does with colour codes and small caps, is on the [`shop.yml` configuration page](Config-shop.yml).
+
+Wording you invented is still yours to maintain: effect lines, menu titles and anything else that mentions a currency by name does not update itself.


### PR DESCRIPTION
The shop rewrites the price into item lore by itself, and nothing said so. Every page that shows a shop entry prints sample lore like `'&fBuy price: &a$500'` with no hint that the amount is a placeholder, so the reasonable reading is that it is literal text an admin has to keep in step with `PRICE-PER-UNIT`, and that switching a menu from shards to money means rewriting every line by hand. Neither is true, and somebody asked exactly that in support.

## What is now written down

`Config-shop.yml.md` gains a section covering the whole behaviour:

- the six price placeholders, split into the four that render the full symbol, colour and currency name, and the two that render the bare number
- that both follow the item's own `CURRENCY`, so a menu moved to money re-renders itself
- the currency placeholders that describe the currency rather than the price, `{money_*}` and `{shards_*}`
- the `Buy price:` line rewriting itself, its Indonesian counterpart `Harga beli:`, and the fact that case, a leading colour code and small caps labels all still match
- why the confirm screen shows the price once rather than twice
- what an admin does still maintain by hand, so the section does not read as a promise that lore never needs editing

The FAQ gains an entry phrased the way the question actually arrived, pointing at that section.

## Notes

Documentation only, no behaviour change. The small caps half of the matching became true in #293, and this describes the state after it.

Full suite green at 486 tests.
