### PR TITLE
fix(amethyst): drop the orphan chop shard shop section (#302)

### DIFF
--- a/src/main/resources/amethyst-tools.yml
+++ b/src/main/resources/amethyst-tools.yml
@@ -299,23 +299,6 @@ AMETHYST-TOOLS:
       DEFAULT-QUANTITY: 1
       # Determines whether Hide Quantity Buttons is enabled or disabled. Available options: true, false
       HIDE-QUANTITY-BUTTONS: true
-  # Configuration section for Chop.
-  CHOP:
-    # Configuration section for Shard Shop.
-    SHARD-SHOP:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      ENABLED: false
-      # The currency this tool is sold for. Available options: SHARD, MONEY
-      CURRENCY: SHARD
-      SLOT: 18
-      # The numerical value for Min Quantity. Available options: Any valid integer
-      MIN-QUANTITY: 1
-      # The numerical value for Max Quantity. Available options: Any valid integer
-      MAX-QUANTITY: 1
-      # The numerical value for Default Quantity. Available options: Any valid integer
-      DEFAULT-QUANTITY: 1
-      # Determines whether Hide Quantity Buttons is enabled or disabled. Available options: true, false
-      HIDE-QUANTITY-BUTTONS: true
 # Configuration section for Amethyst Messages.
 AMETHYST-MESSAGES:
   # The text or value for Prefix. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystShardShopConfigurationTest.java
@@ -42,6 +42,28 @@ class AmethystShardShopConfigurationTest {
         }
     }
 
+    @Test
+    void everyShardShopSectionBelongsToAToolTheCodeReads() {
+        YamlConfiguration configuration = loadResource();
+        ConfigurationSection tools = configuration.getConfigurationSection("AMETHYST-TOOLS");
+        assertNotNull(tools, "AMETHYST-TOOLS");
+
+        Set<String> known = new HashSet<>();
+        for (AmethystToolType type : AmethystToolType.values()) {
+            known.add(type.getConfigKey());
+        }
+
+        for (String key : tools.getKeys(false)) {
+            ConfigurationSection section = tools.getConfigurationSection(key);
+            if (section == null || !section.isConfigurationSection("SHARD-SHOP")) {
+                continue;
+            }
+            // Both the loader and the validator walk AmethystToolType, so a shard shop under
+            // any other key is config nobody ever reads.
+            assertTrue(known.contains(key), "AMETHYST-TOOLS." + key + " has a SHARD-SHOP but no tool type reads it");
+        }
+    }
+
     private YamlConfiguration loadResource() {
         var file = new java.io.File("src/main/resources/amethyst-tools.yml");
         return YamlConfiguration.loadConfiguration(file);


### PR DESCRIPTION
Closes #302

`amethyst-tools.yml` shipped an `AMETHYST-TOOLS.CHOP` section holding nothing but a shard shop block, and no code path has ever read it. The six tool types are `DRILL`, `CHOPPER`, `SELL-AXE`, `SHOVEL`, `BUCKET` and `SHARD-BOOSTER`; both the menu loader and the config validator walk that list and look each section up by key, so `CHOP` was never loaded and never checked. Its `SLOT: 18` is the drill's slot, which stayed invisible only because the section was dead.

## Deleted rather than promoted

The issue left both doors open. Nothing anywhere references `CHOP`, and the one `CHOP` string in the source is `CHOP-BREAK`, which reads a message key under `AMETHYST-MESSAGES` and is untouched here. Turning it into a seventh tool would mean inventing a tool, a slot and a price nobody asked for, so it goes.

Only the bundled resource changes. The config merge never mirror-deletes, so an existing install keeps its copy of the section, as harmlessly as before.

## The guard

`AmethystShardShopConfigurationTest` now walks every section under `AMETHYST-TOOLS` that has a `SHARD-SHOP` and asserts each one maps to a real tool type. Checked against the previous file it fails with `AMETHYST-TOOLS.CHOP has a SHARD-SHOP but no tool type reads it`, so it catches this rather than passing by accident.

The existing slot-uniqueness assertion in the same class kept passing throughout, because it only ever looked at the six real tools. That is exactly why nothing noticed the duplicate slot.

## Notes

`CHOP` also collected a `CURRENCY` key in #292, when that change swept every shard shop block in the file. #297 skipped it deliberately. Both are moot now.

Full suite green at 487 tests.
