### PR TITLE
fix(sell): keep selling on close when auto-sell is off (#294)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
@@ -50,7 +50,7 @@ public class SellMenu extends BaseMenu {
         this.player = player;
         FileConfiguration menus = plugin.getConfigManager().getMenus();
         String modeStr = menus.getString("SELL-MENU.MODE", "instant");
-        this.confirmMode = "confirm".equalsIgnoreCase(modeStr);
+        this.confirmMode = isConfirmMode(modeStr);
 
         clear();
         if (confirmMode) {
@@ -150,7 +150,7 @@ public class SellMenu extends BaseMenu {
     @Override
     public void onClose(Player player) {
         int sellableEnd = getSellableSlotEnd();
-        if (isAutoSellEnabled()) {
+        if (sellsOnClose(confirmMode)) {
             plugin.getShopManager().sellInventoryContents(player, inventory, 0, sellableEnd);
         }
 
@@ -235,9 +235,23 @@ public class SellMenu extends BaseMenu {
     }
 
     private boolean isAutoSellEnabled() {
-        if (confirmMode) {
-            return false;
-        }
-        return plugin.getConfigManager().getMenus().getBoolean("SELL-MENU.AUTO-SELL", true);
+        return sellsWhileOpen(
+                confirmMode,
+                plugin.getConfigManager().getMenus().getBoolean("SELL-MENU.AUTO-SELL", true)
+        );
+    }
+
+    static boolean isConfirmMode(String mode) {
+        return "confirm".equalsIgnoreCase(mode);
+    }
+
+    static boolean sellsWhileOpen(boolean confirmMode, boolean autoSell) {
+        return !confirmMode && autoSell;
+    }
+
+    // AUTO-SELL only governs selling while the menu is open, so closing it still settles the grid.
+    // Confirm mode is the exception: it has its own button, so closing cancels instead.
+    static boolean sellsOnClose(boolean confirmMode) {
+        return !confirmMode;
     }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
@@ -1,0 +1,56 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SellMenuTest {
+
+    @Test
+    void autoSellOnlyControlsSellingWhileTheMenuIsOpen() {
+        assertTrue(SellMenu.sellsWhileOpen(false, true));
+        assertFalse(
+                SellMenu.sellsWhileOpen(false, false),
+                "AUTO-SELL false must stop items selling the moment they land in the grid"
+        );
+        assertFalse(
+                SellMenu.sellsWhileOpen(true, true),
+                "confirm mode sells through its button, never on item movement"
+        );
+    }
+
+    @Test
+    void instantModeStillSellsWhenTheMenuIsClosed() {
+        assertTrue(
+                SellMenu.sellsOnClose(false),
+                "instant mode with AUTO-SELL false would otherwise have no way to sell at all"
+        );
+        assertFalse(
+                SellMenu.sellsOnClose(true),
+                "confirm mode hands items back when the player closes without confirming"
+        );
+    }
+
+    @Test
+    void modeKeyIsReadCaseInsensitively() {
+        assertTrue(SellMenu.isConfirmMode("confirm"));
+        assertTrue(SellMenu.isConfirmMode("CONFIRM"));
+        assertFalse(SellMenu.isConfirmMode("instant"));
+        assertFalse(SellMenu.isConfirmMode(null));
+    }
+
+    @Test
+    void shippedMenusYmlOpensTheSellMenuInConfirmMode() throws Exception {
+        YamlConfiguration menus = new YamlConfiguration();
+        menus.load(Path.of("src/main/resources/menus.yml").toFile());
+
+        assertTrue(
+                SellMenu.isConfirmMode(menus.getString("SELL-MENU.MODE", "instant")),
+                "menus.yml ships MODE: confirm, so the default sell menu keeps its Confirm Sell button"
+        );
+    }
+}


### PR DESCRIPTION
Closes #294

`SELL-MENU.AUTO-SELL: false` on instant mode left the sell menu with no way to sell anything. One flag gated both selling while the menu was open and selling when it closed, so turning it off quietly reduced `/sell` to a container that hands everything back. Closing the menu now settles the grid either way, and `AUTO-SELL` governs only the instant payout as items land.

## What AUTO-SELL controls now

`isAutoSellEnabled()` fed three call sites: the click handler, the drag handler, and `onClose`. Only the first two are about selling automatically. `onClose` now asks `sellsOnClose(confirmMode)`, which is true for every mode except confirm.

Confirm mode is untouched. It sells through the button at slot 53, so closing without clicking still returns the items, which is what a cancel should do.

## Config surface

No new keys. `MODE: instant` with `AUTO-SELL: false` now means "sell when I close the menu", which is what the key's name suggests and what the Discord report was asking for. The shipped `menus.yml` stays on `MODE: confirm`, so a default server sees no change.

## Notes

The mode matrix now lives in three package-private statics (`isConfirmMode`, `sellsWhileOpen`, `sellsOnClose`) so it can be checked without a live server, the same way `WorthMenu.calculateStackPrice` is covered today. `SellMenuTest` pins all four mode and flag combinations plus the shipped default. Suite is 491 tests, all green.

Closing an empty menu stays silent. `executeSale` returns early when the payout is zero, before it sends any feedback, so a player who opens `/sell` and closes it again sees nothing.
