### PR TITLE
feat(sell): add a close mode that sells when the menu is closed (#295)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1607,6 +1607,8 @@ PROGRESS-MENU:
 SELL-MENU:
   TITLE: '&8Place Items In Here To Sell'
   MULTIPLIER-TITLE: '&8Sell Multipliers'
+  AUTO-SELL: true
+  MODE: 'confirm'
   CROPS-BUTTON:
     MATERIAL: WHEAT
     TITLE: '&#6BF18DCrops'
@@ -1692,6 +1694,8 @@ SELL-MENU:
 | :--- | :--- | :--- | :--- | :--- |
 | `SELL-MENU.TITLE` | `str` | Any string text | `'&8Place Items In Here To Sell'` | Configures the technical `TITLE` parameter for `SELL-MENU.TITLE` in `menus.yml`. |
 | `SELL-MENU.MULTIPLIER-TITLE` | `str` | Any string text | `'&8Sell Multipliers'` | Configures the technical `MULTIPLIER-TITLE` parameter for `SELL-MENU.MULTIPLIER-TITLE` in `menus.yml`. |
+| `SELL-MENU.MODE` | `str` | `confirm`, `close`, `instant` | `'confirm'` | Decides when the menu takes payment. `confirm` shows the Confirm Sell button and gives items back if the player closes without clicking it. `close` sells the whole grid the moment the menu is shut. `instant` pays out item by item as things land, and still settles whatever is left on close. An unrecognised value falls back to `instant`. |
+| `SELL-MENU.AUTO-SELL` | `bool` | `true`, `false` | `true` | Only applies to `MODE: instant`. Leave it `true` for the item-by-item payout as things land in the grid; set it `false` and instant mode holds everything until the player shuts the menu, the same as `MODE: close`. Both `confirm` and `close` ignore it. |
 | `SELL-MENU.CROPS-BUTTON.MATERIAL` | `str` | Any string text | `'WHEAT'` | Configures the technical `MATERIAL` parameter for `SELL-MENU.CROPS-BUTTON.MATERIAL` in `menus.yml`. |
 | `SELL-MENU.CROPS-BUTTON.TITLE` | `str` | Any string text | `'&#6BF18DCrops'` | Configures the technical `TITLE` parameter for `SELL-MENU.CROPS-BUTTON.TITLE` in `menus.yml`. |
 | `SELL-MENU.CROPS-BUTTON.LORE` | `list` | List of configured items/strings | `[&7Sell crops and farming materials to, &7upgrade your sell multiplier!, ...]` | Configures the technical `LORE` parameter for `SELL-MENU.CROPS-BUTTON.LORE` in `menus.yml`. |
@@ -1726,6 +1730,8 @@ SELL-MENU:
 SELL-MENU:
   TITLE: '&8Place Items In Here To Sell'
   MULTIPLIER-TITLE: '&8Sell Multipliers'
+  AUTO-SELL: true
+  MODE: 'confirm'
   CROPS-BUTTON:
     MATERIAL: WHEAT
     TITLE: '&#6BF18DCrops'

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
@@ -35,6 +35,7 @@ public class SellMenu extends BaseMenu {
     );
 
     private boolean processScheduled;
+    private String mode = "instant";
     private boolean confirmMode;
     private Player player;
 
@@ -49,8 +50,8 @@ public class SellMenu extends BaseMenu {
     public void build(Player player) {
         this.player = player;
         FileConfiguration menus = plugin.getConfigManager().getMenus();
-        String modeStr = menus.getString("SELL-MENU.MODE", "instant");
-        this.confirmMode = isConfirmMode(modeStr);
+        this.mode = menus.getString("SELL-MENU.MODE", "instant");
+        this.confirmMode = isConfirmMode(mode);
 
         clear();
         if (confirmMode) {
@@ -150,7 +151,7 @@ public class SellMenu extends BaseMenu {
     @Override
     public void onClose(Player player) {
         int sellableEnd = getSellableSlotEnd();
-        if (sellsOnClose(confirmMode)) {
+        if (sellsOnClose(mode)) {
             plugin.getShopManager().sellInventoryContents(player, inventory, 0, sellableEnd);
         }
 
@@ -236,7 +237,7 @@ public class SellMenu extends BaseMenu {
 
     private boolean isAutoSellEnabled() {
         return sellsWhileOpen(
-                confirmMode,
+                mode,
                 plugin.getConfigManager().getMenus().getBoolean("SELL-MENU.AUTO-SELL", true)
         );
     }
@@ -245,13 +246,18 @@ public class SellMenu extends BaseMenu {
         return "confirm".equalsIgnoreCase(mode);
     }
 
-    static boolean sellsWhileOpen(boolean confirmMode, boolean autoSell) {
-        return !confirmMode && autoSell;
+    static boolean isCloseMode(String mode) {
+        return "close".equalsIgnoreCase(mode);
+    }
+
+    // Close mode ignores AUTO-SELL outright: waiting for the close is the whole point of it.
+    static boolean sellsWhileOpen(String mode, boolean autoSell) {
+        return !isConfirmMode(mode) && !isCloseMode(mode) && autoSell;
     }
 
     // AUTO-SELL only governs selling while the menu is open, so closing it still settles the grid.
     // Confirm mode is the exception: it has its own button, so closing cancels instead.
-    static boolean sellsOnClose(boolean confirmMode) {
-        return !confirmMode;
+    static boolean sellsOnClose(String mode) {
+        return !isConfirmMode(mode);
     }
 }

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1222,6 +1222,10 @@ PROGRESS-MENU:
 SELL-MENU:
   TITLE: '&8Place Items In Here To Sell'
   MULTIPLIER-TITLE: '&8Sell Multipliers'
+  # MODE decides when the menu takes payment. 'confirm' shows the Confirm Sell button and gives
+  # items back if the player closes without clicking it. 'close' sells the whole grid the moment
+  # the menu is shut. 'instant' pays out item by item as things land, and AUTO-SELL only applies
+  # there: set it false and instant behaves like 'close'.
   AUTO-SELL: true
   MODE: "confirm"
   CONFIRM-BUTTON:

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
@@ -12,35 +12,59 @@ class SellMenuTest {
 
     @Test
     void autoSellOnlyControlsSellingWhileTheMenuIsOpen() {
-        assertTrue(SellMenu.sellsWhileOpen(false, true));
+        assertTrue(SellMenu.sellsWhileOpen("instant", true));
         assertFalse(
-                SellMenu.sellsWhileOpen(false, false),
+                SellMenu.sellsWhileOpen("instant", false),
                 "AUTO-SELL false must stop items selling the moment they land in the grid"
         );
         assertFalse(
-                SellMenu.sellsWhileOpen(true, true),
+                SellMenu.sellsWhileOpen("confirm", true),
                 "confirm mode sells through its button, never on item movement"
+        );
+    }
+
+    @Test
+    void closeModeHoldsEverythingUntilTheMenuIsShut() {
+        assertFalse(
+                SellMenu.sellsWhileOpen("close", true),
+                "close mode waits for the close even with AUTO-SELL left on"
+        );
+        assertFalse(SellMenu.sellsWhileOpen("close", false));
+        assertTrue(
+                SellMenu.sellsOnClose("close"),
+                "close mode has no other way to pay the player"
         );
     }
 
     @Test
     void instantModeStillSellsWhenTheMenuIsClosed() {
         assertTrue(
-                SellMenu.sellsOnClose(false),
+                SellMenu.sellsOnClose("instant"),
                 "instant mode with AUTO-SELL false would otherwise have no way to sell at all"
         );
         assertFalse(
-                SellMenu.sellsOnClose(true),
+                SellMenu.sellsOnClose("confirm"),
                 "confirm mode hands items back when the player closes without confirming"
         );
     }
 
     @Test
-    void modeKeyIsReadCaseInsensitively() {
+    void modeNamesAreReadCaseInsensitively() {
         assertTrue(SellMenu.isConfirmMode("confirm"));
         assertTrue(SellMenu.isConfirmMode("CONFIRM"));
         assertFalse(SellMenu.isConfirmMode("instant"));
         assertFalse(SellMenu.isConfirmMode(null));
+
+        assertTrue(SellMenu.isCloseMode("close"));
+        assertTrue(SellMenu.isCloseMode("Close"));
+        assertFalse(SellMenu.isCloseMode("instant"));
+        assertFalse(SellMenu.isCloseMode(null));
+    }
+
+    @Test
+    void anUnknownModeFallsBackToInstant() {
+        assertTrue(SellMenu.sellsWhileOpen("colse", true), "a typo must not silently disable selling");
+        assertTrue(SellMenu.sellsOnClose("colse"));
     }
 
     @Test


### PR DESCRIPTION
Closes #295

`SELL-MENU.MODE` takes a third value, `close`, which holds everything a player drops into the grid until they shut the menu and then sells the lot. That is the "drop items in, close to sell" flow the request asked for, and until now there was no way to write it down as an intent.

## Part of this already shipped

#294 made closing the menu settle the grid in every mode except confirm, so `MODE: instant` with `AUTO-SELL: false` has behaved this way since that merge. What was missing is the name. Asking a server owner to express "sell when I close" by switching off a key called `AUTO-SELL` is a bad trade, and it reads as a workaround rather than a setting.

`close` says it outright and ignores `AUTO-SELL` entirely, since waiting for the close is the whole point of the mode. The old spelling keeps working, so nobody who already found it has to change anything.

## The mode set

`confirm` shows the Confirm Sell button at slot 53 and gives items back if the player closes without clicking. `close` sells the grid when the menu shuts. `instant` pays out item by item as things land, and still settles whatever is left on close.

Layout for `close` matches instant: no confirm button, sellable slots 0 to 44, category buttons along the bottom row. An unrecognised value still falls back to instant, so a typo in the config cannot leave the menu unable to sell.

## Notes

The mode gates now take the configured string rather than a `confirmMode` boolean, which is what lets a third value exist at all. `SellMenuTest` covers each mode against both `AUTO-SELL` settings, the case-insensitive names, the typo fallback, and the shipped default. Suite is 493 tests, all green.

`menus.yml` gains a comment above the pair explaining what each value does, and the `SELL-MENU` section of `docs/wiki/Config-menus.yml.md` gains rows for `MODE` and `AUTO-SELL`. Neither key had ever been documented there, so both were invisible to anyone reading the wiki rather than the source.
