### PR TITLE
fix(lang): apply the active language file again (#308)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/LanguageManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/LanguageManager.java
@@ -254,7 +254,17 @@ public class LanguageManager {
     }
 
     public FileConfiguration localize(String rootPath, FileConfiguration legacyConfiguration) {
-        return legacyConfiguration;
+        if (legacyConfiguration == null || !hasLanguageSection(rootPath)) {
+            return legacyConfiguration;
+        }
+        Map<String, FileConfiguration> byRoot = localizedConfigurations.computeIfAbsent(
+                legacyConfiguration,
+                ignored -> new HashMap<>()
+        );
+        return byRoot.computeIfAbsent(
+                rootPath,
+                ignored -> buildLocalizedConfiguration(rootPath, legacyConfiguration)
+        );
     }
 
     public String formatDuration(long totalSeconds, boolean includeDays) {
@@ -303,18 +313,41 @@ public class LanguageManager {
                 localized.set(key, copyValue(legacyConfiguration.get(key)));
             }
         }
-        applyLanguageSection(localized, languages.get(fallbackLocale), fallbackLocale, rootPath);
+        Set<String> customized = customizedLegacyKeys(rootPath, legacyConfiguration);
+        applyLanguageSection(localized, languages.get(fallbackLocale), fallbackLocale, rootPath, customized);
         if (!activeLocale.equals(fallbackLocale)) {
-            applyLanguageSection(localized, languages.get(activeLocale), activeLocale, rootPath);
+            applyLanguageSection(localized, languages.get(activeLocale), activeLocale, rootPath, customized);
         }
         return localized;
+    }
+
+    private Set<String> customizedLegacyKeys(String rootPath, FileConfiguration legacyConfiguration) {
+        YamlConfiguration baseline = bundledLanguages.get(fallbackLocale.toLowerCase(Locale.ROOT));
+        ConfigurationSection baselineSection = baseline != null
+                ? baseline.getConfigurationSection(rootPath)
+                : null;
+        if (baselineSection == null) {
+            return Set.of();
+        }
+        Set<String> customized = new HashSet<>();
+        for (String key : baselineSection.getKeys(true)) {
+            if (baselineSection.isConfigurationSection(key)) {
+                continue;
+            }
+            Object legacyValue = legacyConfiguration.get(key);
+            if (legacyValue != null && !legacyValue.equals(baselineSection.get(key))) {
+                customized.add(key);
+            }
+        }
+        return customized;
     }
 
     private void applyLanguageSection(
             YamlConfiguration target,
             YamlConfiguration language,
             String locale,
-            String rootPath
+            String rootPath,
+            Set<String> customizedLegacyKeys
     ) {
         if (language == null) {
             return;
@@ -331,21 +364,18 @@ public class LanguageManager {
                 continue;
             }
             Object value = section.get(key);
-            if (value instanceof String || isStringList(value)) {
-                if (target.contains(key)) {
-                    Object existingTargetValue = target.get(key);
-                    if (bundledSection != null && bundledSection.contains(key)) {
-                        Object bundledValue = bundledSection.get(key);
-                        if (existingTargetValue != null && !existingTargetValue.equals(bundledValue)) {
-                            continue;
-                        }
-                        if (value.equals(bundledValue)) {
-                            continue;
-                        }
-                    }
-                }
-                target.set(key, copyValue(value));
+            if (!(value instanceof String) && !isStringList(value)) {
+                continue;
             }
+            if (customizedLegacyKeys.contains(key)) {
+                continue;
+            }
+            if (locale.equals(fallbackLocale)
+                    && bundledSection != null
+                    && value.equals(bundledSection.get(key))) {
+                continue;
+            }
+            target.set(key, copyValue(value));
         }
     }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.managers;
 
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -7,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -15,6 +17,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LanguageManagerTest {
@@ -318,5 +321,105 @@ class LanguageManagerTest {
     private static boolean isYaml(Path path) {
         String name = path.getFileName().toString();
         return name.endsWith(".yml") || name.endsWith(".yaml");
+    }
+    @Test
+    void activeLocaleTranslationReachesLegacyMessages() throws Exception {
+        LanguageManager manager = new LanguageManager(null);
+        YamlConfiguration bundledEnglish = language("MESSAGES.SOCIAL.DISCORD", "&fJoin our discord");
+        YamlConfiguration bundledIndonesian = language("MESSAGES.SOCIAL.DISCORD", "&fGabung discord kami");
+        useLanguages(
+                manager,
+                "id_ID",
+                "en_US",
+                Map.of("en_US", bundledEnglish, "id_ID", bundledIndonesian),
+                Map.of("en_us", bundledEnglish, "id_id", bundledIndonesian)
+        );
+
+        YamlConfiguration legacy = new YamlConfiguration();
+        legacy.set("SOCIAL.DISCORD", "&fJoin our discord");
+
+        FileConfiguration localized = manager.localize("MESSAGES", legacy);
+
+        assertEquals("&fGabung discord kami", localized.getString("SOCIAL.DISCORD"));
+        assertEquals("&fJoin our discord", legacy.getString("SOCIAL.DISCORD"));
+    }
+
+    @Test
+    void customizedLegacyValueSurvivesTranslation() throws Exception {
+        LanguageManager manager = new LanguageManager(null);
+        YamlConfiguration bundledEnglish = language("MESSAGES.SOCIAL.DISCORD", "&fJoin our discord");
+        YamlConfiguration bundledIndonesian = language("MESSAGES.SOCIAL.DISCORD", "&fGabung discord kami");
+        useLanguages(
+                manager,
+                "id_ID",
+                "en_US",
+                Map.of("en_US", bundledEnglish, "id_ID", bundledIndonesian),
+                Map.of("en_us", bundledEnglish, "id_id", bundledIndonesian)
+        );
+
+        YamlConfiguration legacy = new YamlConfiguration();
+        legacy.set("SOCIAL.DISCORD", "&fJoin the Donut discord");
+
+        assertEquals(
+                "&fJoin the Donut discord",
+                manager.localize("MESSAGES", legacy).getString("SOCIAL.DISCORD")
+        );
+    }
+
+    @Test
+    void localizeLeavesConfigurationsWithoutALanguageSectionAlone() throws Exception {
+        LanguageManager manager = new LanguageManager(null);
+        YamlConfiguration bundledEnglish = language("MESSAGES.SOCIAL.DISCORD", "&fJoin our discord");
+        useLanguages(
+                manager,
+                "en_US",
+                "en_US",
+                Map.of("en_US", bundledEnglish),
+                Map.of("en_us", bundledEnglish)
+        );
+
+        YamlConfiguration legacy = new YamlConfiguration();
+        legacy.set("SOCIAL.DISCORD", "&fJoin our discord");
+
+        assertSame(legacy, manager.localize("CONFIG.SHOP", legacy));
+    }
+
+    private static YamlConfiguration language(String path, String value) {
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.set(path, value);
+        return configuration;
+    }
+
+    private static void useLanguages(
+            LanguageManager manager,
+            String activeLocale,
+            String fallbackLocale,
+            java.util.Map<String, YamlConfiguration> languages,
+            java.util.Map<String, YamlConfiguration> bundledLanguages
+    ) throws Exception {
+        replaceMap(manager, "languages", languages);
+        replaceMap(manager, "bundledLanguages", bundledLanguages);
+        setField(manager, "activeLocale", activeLocale);
+        setField(manager, "fallbackLocale", fallbackLocale);
+    }
+
+    private static void replaceMap(
+            LanguageManager manager,
+            String name,
+            java.util.Map<String, YamlConfiguration> values
+    ) throws Exception {
+        java.lang.reflect.Field field = LanguageManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, YamlConfiguration> target =
+                (java.util.Map<String, YamlConfiguration>) field.get(manager);
+        target.clear();
+        target.putAll(values);
+    }
+
+    private static void setField(LanguageManager manager, String name, String value) throws Exception {
+        java.lang.reflect.Field field = LanguageManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(manager, value);
     }
 }


### PR DESCRIPTION
Closes #308

None of the eight files under `languages/` had any effect on what players actually saw. Setting `LANGUAGE.ACTIVE` to `id_ID` logged `Language loaded: id_ID` at startup and then changed nothing, because every string served out of `messages.yml`, `menus.yml` or one of the `CONFIG.*` trees came back in whatever the legacy file said. Translating the plugin wasn't possible at all.

## The stubbed lookup

`LanguageManager.localize(...)` handed back its `legacyConfiguration` argument untouched. That left `buildLocalizedConfiguration(...)` and `hasLanguageSection(...)` with no callers anywhere, and the `localizedConfigurations` cache was only ever cleared, never filled. `ConfigManager` routes 23 getters through that one method, so the entire overlay sat dead behind it. This restores the original body, cache included.

The body was replaced in `e1497372`, a bulk import whose subject line is about ender pearls, so it reads as collateral rather than a decision. Two earlier commits were actively working on the overlay, and `docs/wiki/Placeholders-and-Integrations.md` still describes `languages/*.yml` as a live source of message templates.

## The skip guard

Restoring the lookup on its own fixed nothing, which is worth spelling out because it looks like the whole bug. `applyLanguageSection` worked out whether a key had been customized by comparing the value sitting in the target against the bundled copy of the locale it was applying. For any locale other than English those two are translations of each other, so they never matched and every key got skipped. The English pass mutating the target before the active pass ran made it worse.

`buildLocalizedConfiguration` now works the customized keys out once, before either pass, measuring the legacy config against the fallback locale's bundled values, and hands the same set to both passes. Someone who edited `messages.yml` still beats any translation. A key they left alone now picks up whatever the active locale says.

## Notes

Three tests in `LanguageManagerTest` cover it: the active locale reaching a legacy config, an edited legacy value surviving a translation, and a config with no matching language section coming back as the same instance rather than a copy. Suite is at 496.

Default installs see no behaviour change. English is both the active and the fallback locale there, `en_US.yml` is generated from `messages.yml` by the suite, and the fallback pass skips anything already equal to its bundled value, so the overlay does nothing on an untouched server.

`LANGUAGE.ACTIVE` and `LANGUAGE.FALLBACK` are read from `config.yml`, but the shipped file doesn't list either one and no wiki page mentions them. Out of scope here, raised separately.

`translateBuiltInText(...)` was flattened to `return text;` by that same import. Nothing calls it now, so nothing is broken by leaving it, and it isn't touched here.
