### PR TITLE
docs(config): ship and document the language selection keys

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -5,6 +5,48 @@ Each section details the exact commented setup code block, allowed option values
 
 ---
 
+## Section: `LANGUAGE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+LANGUAGE:
+  # The language players see, taken from the matching file in the languages folder
+  # Bundled locales: en_US, es_ES, id_ID, pt_BR, de_DE, fr_FR, ru_RU, zh_CN
+  # Names such as Bahasa Indonesia, Spanish or pt-BR resolve to those, and a custom
+  # file dropped into the languages folder can be selected by its file name
+  # Available options: Any valid string text
+  ACTIVE: en_US
+  # Supplies any message the active language is missing
+  # Available options: Any valid string text
+  FALLBACK: en_US
+# Configuration section for Locations.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `LANGUAGE.ACTIVE` | `str` | Any bundled locale, a locale alias, or the file name of a custom language file | `en_US` | Selects the language file under `languages/` that supplies player-facing text. Aliases such as `Bahasa Indonesia`, `Spanish` and `pt-BR` resolve to the bundled locales. Anything you have edited yourself in `messages.yml` still takes priority over the translation. |
+| `LANGUAGE.FALLBACK` | `str` | Same values as `LANGUAGE.ACTIVE` | `en_US` | Supplies any key the active language file does not define, so a partial translation still shows text rather than a missing key. |
+
+### 3. Practical Setup Example
+
+```yaml
+LANGUAGE:
+  # The language players see, taken from the matching file in the languages folder
+  # Bundled locales: en_US, es_ES, id_ID, pt_BR, de_DE, fr_FR, ru_RU, zh_CN
+  # Names such as Bahasa Indonesia, Spanish or pt-BR resolve to those, and a custom
+  # file dropped into the languages folder can be selected by its file name
+  # Available options: Any valid string text
+  ACTIVE: en_US
+  # Supplies any message the active language is missing
+  # Available options: Any valid string text
+  FALLBACK: en_US
+# Configuration section for Locations.
+```
+
+---
 ## Section: `LOCATIONS`
 
 ### 1. Commented Setup Code Example

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,14 @@
+# Configuration section for Language.
+LANGUAGE:
+  # The language players see, taken from the matching file in the languages folder
+  # Bundled locales: en_US, es_ES, id_ID, pt_BR, de_DE, fr_FR, ru_RU, zh_CN
+  # Names such as Bahasa Indonesia, Spanish or pt-BR resolve to those, and a custom
+  # file dropped into the languages folder can be selected by its file name
+  # Available options: Any valid string text
+  ACTIVE: en_US
+  # Supplies any message the active language is missing
+  # Available options: Any valid string text
+  FALLBACK: en_US
 # Configuration section for Locations.
 LOCATIONS:
   # The text or value for Spawn Location. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LanguageManagerTest.java
@@ -323,6 +323,14 @@ class LanguageManagerTest {
         return name.endsWith(".yml") || name.endsWith(".yaml");
     }
     @Test
+    void bundledConfigShipsTheLocaleSelectionKeys() throws Exception {
+        YamlConfiguration config = loadResource("config.yml");
+
+        assertEquals(LanguageManager.DEFAULT_LOCALE, config.getString("LANGUAGE.ACTIVE"));
+        assertEquals(LanguageManager.DEFAULT_LOCALE, config.getString("LANGUAGE.FALLBACK"));
+    }
+
+    @Test
     void activeLocaleTranslationReachesLegacyMessages() throws Exception {
         LanguageManager manager = new LanguageManager(null);
         YamlConfiguration bundledEnglish = language("MESSAGES.SOCIAL.DISCORD", "&fJoin our discord");


### PR DESCRIPTION
`LANGUAGE.ACTIVE` and `LANGUAGE.FALLBACK` have been read out of `config.yml` for a long time, but the shipped file never listed either one and no wiki page mentioned them. The only `LANGUAGE` entry in the config documentation is the chat alphabet filter, which is a different setting entirely. Anyone wanting to run the plugin in another language had to guess the key existed.

That gap was invisible until #309 landed, because until then the language files did nothing whatever you set. Now that picking a locale actually changes what players read, the setting needs to be findable.

## What changed

`config.yml` gains a `LANGUAGE` block at the top with both keys defaulting to `en_US`, and a comment naming the eight bundled locales. The wiki page for `config.yml` gains a matching section in the same shape as the others, covering the aliases (`Bahasa Indonesia`, `Spanish`, `pt-BR` and friends all resolve) and the fact that a custom file dropped into `languages/` can be selected by its own file name.

Behaviour is unchanged. Both keys already defaulted to `en_US` in code, so a server that never touches the block reads exactly as it did before. Existing servers pick the block up through the usual bundled-default merge on the next start.

## The language-merge question

New player-facing config text normally has to be carried into all eight language files, so I checked whether this block needed the same treatment or an exclusion. It needs neither, for two independent reasons: `ConfigManager.getConfig()` hands back the raw configuration rather than going through `localized(...)`, so `config.yml` is never overlaid by a language file, and `mergeCurrentResourceText` in `LanguageManagerTest` has no entry for `config.yml`, so its text never travels into one either. Running the suite confirms it: `en_US.yml` comes back unmodified.

No entry was added to `ConfigManager.isUserManagedBundledPath` either. That list is for trees holding live server content that must survive a config update, and these are ordinary settings that should merge into an existing config like any other new key.

## Notes

One test in `LanguageManagerTest` asserts the shipped `config.yml` defines both keys as `en_US`, matching `DEFAULT_LOCALE`. It is there so the file and the code cannot drift apart again quietly, which is how this gap opened. Suite is at 497.
