### PR TITLE
docs(config): ship the shard region RADIUS and correct the wand item (#311)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1378,6 +1378,11 @@ SHARDS:
         CUBOID: ''
         # The text or value for World. Available options: Any valid string text
         WORLD: world
+        # Radius in blocks for the point-based fallbacks. LOCATION gets a sphere this wide
+        # that pays shards alongside CUBOID, and the AFK point gets one that counts as the
+        # AFK area when no AFK cuboid is bound. One number covers both. Set 0 to switch the
+        # shard sphere off and leave the AFK sphere at its built-in 16.
+        RADIUS: 16
         # The numerical value for Interval. Available options: Any valid integer
         INTERVAL: 60
         # The numerical value for Amount. Available options: Any valid integer
@@ -1444,6 +1449,7 @@ SHARDS:
 | `SHARDS.CUBOIDS.REGIONS.spawn.PRIORITY` | `int` | Any valid integer number | `'100'` | Configures the technical `PRIORITY` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.PRIORITY` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.CUBOID` | `str` | Any string text | `''` | Configures the technical `CUBOID` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.CUBOID` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.WORLD` | `str` | Any string text | `'world'` | Configures the technical `WORLD` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.WORLD` in `config.yml`. |
+| `SHARDS.CUBOIDS.REGIONS.spawn.RADIUS` | `int` | Any valid integer number | `'16'` | Radius in blocks for the point-based fallbacks. `LOCATION` gets a sphere this wide that pays shards alongside `CUBOID`, and the AFK point gets one that counts as the AFK area when no AFK cuboid is bound. One number covers both. Set `0` to switch the shard sphere off and leave the AFK sphere at its built-in 16. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.INTERVAL` | `int` | Any valid integer number | `'60'` | Configures the technical `INTERVAL` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.INTERVAL` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.AMOUNT` | `int` | Any valid integer number | `'1'` | Configures the technical `AMOUNT` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.AMOUNT` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.COUNTDOWN-MESSAGE` | `str` | Any string text | `'&7Next shard in &#A303F9%time%'` | Configures the technical `COUNTDOWN-MESSAGE` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.COUNTDOWN-MESSAGE` in `config.yml`. |

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1064,6 +1064,11 @@ SHARDS:
         CUBOID: ''
         # The text or value for World. Available options: Any valid string text
         WORLD: world
+        # Radius in blocks for the point-based fallbacks. LOCATION gets a sphere this wide
+        # that pays shards alongside CUBOID, and the AFK point gets one that counts as the
+        # AFK area when no AFK cuboid is bound. One number covers both. Set 0 to switch the
+        # shard sphere off and leave the AFK sphere at its built-in 16.
+        RADIUS: 16
         # The numerical value for Interval. Available options: Any valid integer
         INTERVAL: 60
         # The numerical value for Amount. Available options: Any valid integer
@@ -1156,6 +1161,7 @@ SHARDS:
 | `SHARDS.CUBOIDS.REGIONS.spawn.PRIORITY` | `int` | Any valid integer | `100` | Configures `PRIORITY` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.CUBOID` | `str` | Any string text | `` | Configures `CUBOID` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.WORLD` | `str` | Any string text | `world` | Configures `WORLD` for `SHARDS`. |
+| `SHARDS.CUBOIDS.REGIONS.spawn.RADIUS` | `int` | Any valid integer | `16` | Radius in blocks for the point-based fallbacks. `LOCATION` gets a sphere this wide that pays shards alongside `CUBOID`, and the AFK point gets one that counts as the AFK area when no AFK cuboid is bound. One number covers both. Set `0` to switch the shard sphere off and leave the AFK sphere at its built-in 16. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.INTERVAL` | `int` | Any valid integer | `60` | Configures `INTERVAL` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.AMOUNT` | `int` | Any valid integer | `1` | Configures `AMOUNT` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.COUNTDOWN-MESSAGE` | `str` | Any string text | `&7Next shard in &#A303F9%time%` | Configures `COUNTDOWN-MESSAGE` for `SHARDS`. |

--- a/docs/wiki/Cuboids-and-Portals.md
+++ b/docs/wiki/Cuboids-and-Portals.md
@@ -7,7 +7,7 @@ The **Cuboid** system in UltimateDonutSMP provides lightweight, high-performance
 ## Cuboid Management (`/cuboid`)
 
 ### 1. Selection Wand
-Get the selection tool (Golden Hoe or Wooden Axe):
+Get the selection tool (a golden shovel):
 ```bash
 /cuboid wand
 ```

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -519,6 +519,11 @@ SHARDS:
         CUBOID: ''
         # The text or value for World. Available options: Any valid string text
         WORLD: world
+        # Radius in blocks for the point-based fallbacks. LOCATION gets a sphere this wide
+        # that pays shards alongside CUBOID, and the AFK point gets one that counts as the
+        # AFK area when no AFK cuboid is bound. One number covers both. Set 0 to switch the
+        # shard sphere off and leave the AFK sphere at its built-in 16.
+        RADIUS: 16
         # The numerical value for Interval. Available options: Any valid integer
         INTERVAL: 60
         # The numerical value for Amount. Available options: Any valid integer


### PR DESCRIPTION
Closes #311

Two settings around the AFK and shard areas could only be found by reading the source. Someone asking how to resize the AFK area had no key to point them at, and the wiki sent them looking for a tool the plugin never hands out.

## The shard region radius now ships with a default

`SHARDS.CUBOIDS.REGIONS.spawn.RADIUS` has always been read by the loader, but it was never written into `config.yml`. Every other key in that section ships with a value and a comment; this one lived only in `ShardManager.loadShardCuboidConfigs`, and the sole writer was `SpawnManager.configureSetupShardRegion`, on the spawn path alone. A server that never ran that setup step had nothing to find. The startup warning made it worse by telling operators about a RADIUS fallback that appeared in no config file and no wiki page.

It ships now as `RADIUS: 16`, with a comment saying what the one number actually covers: the sphere around `LOCATION` that pays shards alongside `CUBOID`, and the sphere around the AFK point that counts as the AFK area when no AFK cuboid is bound.

Shipping the value changes nothing at runtime. `ShardCuboidConfig.isInAfkZone` already fell back to a hardcoded `16D` when the key was absent, so the AFK sphere keeps the size it has always had. `isInsideRewardRadius` needs `rewardLocation` to be non-null, and the shipped region carries no `LOCATION` key at all, so the reward sphere stays off until somebody sets a point on purpose.

## The wand is a golden shovel

`Cuboids-and-Portals.md` called the selection tool a Golden Hoe or Wooden Axe. `CuboidCommand.giveWand` builds it from `Material.GOLDEN_SHOVEL`, and has since the initial import. The wooden axe in the docs looks like it came from `FeatureManager`, where `WOODEN_AXE` is the menu icon for the cuboids feature rather than the item players are handed.

## Notes

Both reference pages mirror `config.yml`, so `RADIUS` went into `Config-config.yml.md` and `Configuration-Reference.md` alike, in the YAML block and in the key table.

One admin config key, no player-facing message keys, so the eight language files are untouched and the suite does not rewrite `en_US.yml`. Green at 499 tests across 91 classes.
