### PR TITLE
fix(config): strip generator comment text from shipped message values (#313)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1392,10 +1392,7 @@ SHARDS:
         # The text or value for Reward Message. Available options: Any valid string text
         REWARD-MESSAGE: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
         # The text or value for Boosted Reward Message. Available options: Any valid string text
-        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7)
-          # The text or value for # The Text Or Mode For &7(Total. Available Options. Available options: Any valid string text
-          # The text or mode for &7(Total. Available options: Any string text &7(Total:
-          &#A303F9%total%&7)'
+        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total: &#A303F9%total%&7)'
         # The text or value for Leave Message. Available options: Any valid string text
         LEAVE-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
         # The numerical value for Afk Time. Available options: Any valid integer

--- a/docs/wiki/Config-hide.yml.md
+++ b/docs/wiki/Config-hide.yml.md
@@ -389,21 +389,12 @@ MESSAGES:
   # The text or value for Status Active. Available options: Any valid string text
   STATUS-ACTIVE: '&7hide status: &a{mode} &8- &f{alias}'
   # The text or value for Check. Available options: Any valid string text
-  CHECK: '&bhide check
-
-    # The text or value for # The Text Or Mode For &7Ʀeal name. Available Options. Available options: Any valid string text
-    # The text or mode for &7Ʀeal name. Available options: Any string text &7real
-    # The text or value for name. Available options: Any valid string text
-    name: &f{real}
-
-    # The text or value for # The Text Or Mode For &7alias. Available Options. Available options: Any valid string text
-    # The text or mode for &7alias. Available options: Any string text &7alias: &f{alias}
-
-    # The text or value for # The Text Or Mode For &7mode. Available Options. Available options: Any valid string text
-    # The text or mode for &7mode. Available options: Any string text &7mode: &f{mode}
-
-    # The text or value for # The Text Or Mode For &7Ѕkin. Available Options. Available options: Any valid string text
-    # The text or mode for &7Ѕkin. Available options: Any string text &7skin: &f{skin}'
+  CHECK: |-
+    &bhide check
+    &7real name: &f{real}
+    &7alias: &f{alias}
+    &7mode: &f{mode}
+    &7skin: &f{skin}
   # The text or value for Permission Removed. Available options: Any valid string text
   PERMISSION-REMOVED: '&cyour hide state was removed because its permission is no
     longer available.'

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1078,10 +1078,7 @@ SHARDS:
         # The text or value for Reward Message. Available options: Any valid string text
         REWARD-MESSAGE: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
         # The text or value for Boosted Reward Message. Available options: Any valid string text
-        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7)
-          # The text or value for # The Text Or Mode For &7(Total. Available Options. Available options: Any valid string text
-          # The text or mode for &7(Total. Available options: Any string text &7(Total:
-          &#A303F9%total%&7)'
+        BOOSTED-REWARD-MESSAGE: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total: &#A303F9%total%&7)'
         # The text or value for Leave Message. Available options: Any valid string text
         LEAVE-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
         # The numerical value for Afk Time. Available options: Any valid integer
@@ -1127,11 +1124,7 @@ SHARDS:
     # The text or value for Received. Available options: Any valid string text
     RECEIVED: '&#A303F9You received %amount% Shard &8[Everywhere] &7(Total: &#A303F9%total%&7)'
     # The text or value for Received Boosted. Available options: Any valid string text
-    RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7)
-      # The text or value for # The Text Or Mode For &8[Everywhere] &7(Total. Available Options. Available options: Any valid string text
-      # The text or mode for &8[Everywhere] &7(Total. Available options: Any string
-      # The text or value for Text &8[Everywhere] &7(Total. Available options: Any valid string text
-      text &8[Everywhere] &7(Total: &#A303F9%total%&7)'
+    RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &8[Everywhere] &7(Total: &#A303F9%total%&7)'
     # Configuration section for Excluded Worlds.
     EXCLUDED-WORLDS:
     - duels
@@ -1495,32 +1488,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FF0000'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':hammer: **Punishment Type:** Ban
+      DESCRIPTION: |-
+        :hammer: **Punishment Type:** Ban
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -1535,32 +1521,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FFFF00'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':mute: **Punishment Type:** Mute
+      DESCRIPTION: |-
+        :mute: **Punishment Type:** Mute
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Duration. Available Options. Available options: Any valid string text
-        # The text or mode for **Duration. Available options: Any string text **Duration:**
+        **Duration:**
         %duration%
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -1575,28 +1554,22 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FFA500'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':warning: **Punishment Type:** Warning
+      DESCRIPTION: |-
+        :warning: **Punishment Type:** Warning
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
-
-        '
+        **ID:** `%id%`
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -1611,25 +1584,20 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#FF6347'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':boot: **Punishment Type:** Kick
+      DESCRIPTION: |-
+        :boot: **Punishment Type:** Kick
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
-
-        '
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text
@@ -1644,32 +1612,25 @@ WEBHOOKS:
       # The text or value for Color. Available options: Any valid string text
       COLOR: '#000000'
       # The text or value for Description. Available options: Any valid string text
-      DESCRIPTION: ':no_entry: **PERMANENT NETWORK BAN**
+      DESCRIPTION: |-
+        :no_entry: **PERMANENT NETWORK BAN**
 
-        # The text or value for # The Text Or Mode For **Player. Available Options. Available options: Any valid string text
-        # The text or mode for **Player. Available options: Any string text **Player:**
+        **Player:**
         %player%
 
-        # The text or value for # The Text Or Mode For **Staff. Available Options. Available options: Any valid string text
-        # The text or mode for **Staff. Available options: Any string text **Staff:**
+        **Staff:**
         %staff%
 
-        # The text or value for # The Text Or Mode For **Reason. Available Options. Available options: Any valid string text
-        # The text or mode for **Reason. Available options: Any string text **Reason:**
+        **Reason:**
         ||%reason%||
 
-        # The text or value for # The Text Or Mode For **Date. Available Options. Available options: Any valid string text
-        # The text or mode for **Date. Available options: Any string text **Date:**
+        **Date:**
         %date%
 
-        # The text or value for # The Text Or Mode For **Id. Available Options. Available options: Any valid string text
-        # The text or mode for **Id. Available options: Any string text **ID:** `%id%`
+        **ID:** `%id%`
 
-        # The text or value for # The Text Or Mode For . Available Options. Available options: Any valid string text
-        # The text or mode for . Available options: Any string text :exclamation:
+        :exclamation:
         This is a permanent network-wide ban
-
-        '
       # The text or value for Thumbnail. Available options: Any valid string text
       THUMBNAIL: '%skin_bust%'
       # The text or value for Author Name. Available options: Any valid string text

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -578,11 +578,7 @@ SHARDS:
     # The text or value for Received. Available options: Any valid string text
     RECEIVED: '&#A303F9You received %amount% Shard &8[Everywhere] &7(Total: &#A303F9%total%&7)'
     # The text or value for Received Boosted. Available options: Any valid string text
-    RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7)
-      # The text or value for # The Text Or Mode For &8[Everywhere] &7(Total. Available Options. Available options: Any valid string text
-      # The text or mode for &8[Everywhere] &7(Total. Available options: Any string
-      # The text or value for Text &8[Everywhere] &7(Total. Available options: Any valid string text
-      text &8[Everywhere] &7(Total: &#A303F9%total%&7)'
+    RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &8[Everywhere] &7(Total: &#A303F9%total%&7)'
     # Configuration section for Excluded Worlds.
     EXCLUDED-WORLDS:
     - duels

--- a/src/main/resources/hide.yml
+++ b/src/main/resources/hide.yml
@@ -118,21 +118,12 @@ MESSAGES:
   # The text or value for Status Active. Available options: Any valid string text
   STATUS-ACTIVE: '&7hide status: &a{mode} &8- &f{alias}'
   # The text or value for Check. Available options: Any valid string text
-  CHECK: '&bhide check
-
-    # The text or value for # The Text Or Mode For &7Ʀeal name. Available Options. Available options: Any valid string text
-    # The text or mode for &7Ʀeal name. Available options: Any string text &7real
-    # The text or value for name. Available options: Any valid string text
-    name: &f{real}
-
-    # The text or value for # The Text Or Mode For &7alias. Available Options. Available options: Any valid string text
-    # The text or mode for &7alias. Available options: Any string text &7alias: &f{alias}
-
-    # The text or value for # The Text Or Mode For &7mode. Available Options. Available options: Any valid string text
-    # The text or mode for &7mode. Available options: Any string text &7mode: &f{mode}
-
-    # The text or value for # The Text Or Mode For &7Ѕkin. Available Options. Available options: Any valid string text
-    # The text or mode for &7Ѕkin. Available options: Any string text &7skin: &f{skin}'
+  CHECK: |-
+    &bhide check
+    &7real name: &f{real}
+    &7alias: &f{alias}
+    &7mode: &f{mode}
+    &7skin: &f{skin}
   # The text or value for Permission Removed. Available options: Any valid string text
   PERMISSION-REMOVED: '&cyour hide state was removed because its permission is no
     longer available.'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -489,10 +489,7 @@ BILLFORD:
   FULL-INVENTORY: '&cYour inventory is full! Free up a slot before confirming the
     trade.'
   # The text or value for Trade Completed. Available options: Any valid string text
-  TRADE-COMPLETED: '&aTrade complete! You received &f{reward}&a. &7Shards: &#A303F9{shard_bonus}&7,
-    # The text or value for # The Text Or Mode For Money. Available Options. Available options: Any valid string text
-    # The text or mode for Money. Available options: Any string text Money: &a${money_bonus}&7.
-    &8Next refresh in &f{next_rotation}&8.'
+  TRADE-COMPLETED: '&aTrade complete! You received &f{reward}&a. &7Shards: &#A303F9{shard_bonus}&7, Money: &a${money_bonus}&7. &8Next refresh in &f{next_rotation}&8.'
   # The text or value for Limit Reached. Available options: Any valid string text
   LIMIT-REACHED: '&cYou''ve reached the trade limit for this rotation. Come back after
     the next trade change!'
@@ -540,10 +537,7 @@ BALANCE:
     REMOVE-MONEY-SUCCESS: '&aRemoved &f${amount} &afrom &b{player}&a. New balance:
       &f${balance}&a.'
     # The text or value for Remove Money Received. Available options: Any valid string text
-    REMOVE-MONEY-RECEIVED: '&c{admin} removed &f${amount} &cfrom your balance. New
-      # The text or value for # The Text Or Mode For Balance. Available Options. Available options: Any valid string text
-      # The text or mode for Balance. Available options: Any string text balance:
-      &f${balance}&c.'
+    REMOVE-MONEY-RECEIVED: '&c{admin} removed &f${amount} &cfrom your balance. New balance: &f${balance}&c.'
     # The text or value for Set Money Success. Available options: Any valid string text
     SET-MONEY-SUCCESS: '&aSet &b{player}&a''s balance to &f${amount}&a. Previous balance:
       &f${previous_balance}&a.'
@@ -675,108 +669,48 @@ PUNISHMENTS:
   # The text or value for Muted Chat. Available options: Any valid string text
   MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
   # The text or value for Ban Kick. Available options: Any valid string text
-  BAN-KICK: '&cYou are banned from this server.
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f{reason}
-
-    # The text or value for # The Text Or Mode For &7Expires. Available Options. Available options: Any valid string text
-    # The text or mode for &7Expires. Available options: Any string text &7Expires:
-    &f{expires}'
+  BAN-KICK: |-
+    &cYou are banned from this server.
+    &7Reason: &f{reason}
+    &7Expires: &f{expires}
   # The text or value for Blacklist Kick. Available options: Any valid string text
-  BLACKLIST-KICK: '&cYou are blacklisted from this server.
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f{reason}'
+  BLACKLIST-KICK: |-
+    &cYou are blacklisted from this server.
+    &7Reason: &f{reason}
   # The text or value for Ban. Available options: Any valid string text
-  BAN: '&c&lYou have been banned!
-
+  BAN: |
+    &c&lYou have been banned!
     &8&m----------------------------
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f%reason%
-
-    # The text or value for # The Text Or Mode For &7Expires. Available Options. Available options: Any valid string text
-    # The text or mode for &7Expires. Available options: Any string text &7Expires:
-    &f%nicest_expiration%
-
-    # The text or value for # The Text Or Mode For &7Banned By. Available Options. Available options: Any valid string text
-    # The text or mode for &7Banned By. Available options: Any string text &7Banned
-    # The text or value for By. Available options: Any valid string text
-    by: &f%issuer%
-
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Banned by: &f%issuer%
     &8&m----------------------------
-
-    # The text or value for # The Text Or Mode For &7Appeal At. Available Options. Available options: Any valid string text
-    # The text or mode for &7Appeal At. Available options: Any string text &7Appeal
-    # The text or value for At. Available options: Any valid string text
-    at: &fdiscord.example.space
-
-    '
+    &7Appeal at: &fdiscord.example.space
   # The text or value for Kick. Available options: Any valid string text
-  KICK: '&c&lYou have been kicked!
-
+  KICK: |
+    &c&lYou have been kicked!
     &8&m----------------------------
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f%reason%
-
-    # The text or value for # The Text Or Mode For &7Kicked By. Available Options. Available options: Any valid string text
-    # The text or mode for &7Kicked By. Available options: Any string text &7Kicked
-    # The text or value for By. Available options: Any valid string text
-    by: &f%issuer%
-
+    &7Reason: &f%reason%
+    &7Kicked by: &f%issuer%
     &8&m----------------------------
-
     &7You may reconnect
-
-    '
   # The text or value for Mute. Available options: Any valid string text
-  MUTE: '&c&lYou have been muted!
-
+  MUTE: |
+    &c&lYou have been muted!
     &8&m----------------------------
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f%reason%
-
-    # The text or value for # The Text Or Mode For &7Expires. Available Options. Available options: Any valid string text
-    # The text or mode for &7Expires. Available options: Any string text &7Expires:
-    &f%nicest_expiration%
-
-    # The text or value for # The Text Or Mode For &7Muted By. Available Options. Available options: Any valid string text
-    # The text or mode for &7Muted By. Available options: Any string text &7Muted
-    # The text or value for By. Available options: Any valid string text
-    by: &f%issuer%
-
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Muted by: &f%issuer%
     &8&m----------------------------
-
     &7You cannot speak in chat
-
-    '
   # The text or value for Blacklist. Available options: Any valid string text
-  BLACKLIST: '&4&lYOU HAVE BEEN BLACKLISTED!
-
+  BLACKLIST: |
+    &4&lYOU HAVE BEEN BLACKLISTED!
     &8&m----------------------------
-
-    # The text or value for # The Text Or Mode For &7Reason. Available Options. Available options: Any valid string text
-    # The text or mode for &7Reason. Available options: Any string text &7Reason:
-    &f%reason%
-
-    # The text or value for # The Text Or Mode For &7Blacklisted By. Available Options. Available options: Any valid string text
-    # The text or mode for &7Blacklisted By. Available options: Any string text &7Blacklisted
-    # The text or value for By. Available options: Any valid string text
-    by: &f%issuer%
-
+    &7Reason: &f%reason%
+    &7Blacklisted by: &f%issuer%
     &8&m----------------------------
-
     &4You cannot join the server
-
-    '
 # Configuration section for Social.
 SOCIAL:
   # Configuration section for Discord.
@@ -821,10 +755,7 @@ AUCTION_HOUSE:
   # The text or value for Max Listings Reached. Available options: Any valid string text
   MAX_LISTINGS_REACHED: '&cYou have reached your active listing limit.'
   # The text or value for Listing Created. Available options: Any valid string text
-  LISTING_CREATED: '&aListing created! &7#{listing_id} &f{item} &7for &a${price}&7.
-    # The text or value for # The Text Or Mode For Fee. Available Options. Available options: Any valid string text
-    # The text or mode for Fee. Available options: Any string text Fee: &a${fee}&7.
-    Expires in &f{expires}&7.'
+  LISTING_CREATED: '&aListing created! &7#{listing_id} &f{item} &7for &a${price}&7. Fee: &a${fee}&7. Expires in &f{expires}&7.'
   # The text or value for Listing Cancelled. Available options: Any valid string text
   LISTING_CANCELLED: '&eListing #{listing_id} &f({item}) &ehas been moved to your
     claim queue.'
@@ -843,11 +774,7 @@ AUCTION_HOUSE:
   # The text or value for Purchase Success. Available options: Any valid string text
   PURCHASE_SUCCESS: '&aPurchased &f{item} &afor &a${price} &afrom &f{seller}&a.'
   # The text or value for Item Sold. Available options: Any valid string text
-  ITEM_SOLD: '&aYour listing sold! &f{buyer} &abought &f{item} &afor &a${price}&a.
-    # The text or value for # The Text Or Mode For Claimable Payout. Available Options. Available options: Any valid string text
-    # The text or mode for Claimable Payout. Available options: Any string text Claimable
-    # The text or value for Payout. Available options: Any valid string text
-    payout: &a${payout}&a.'
+  ITEM_SOLD: '&aYour listing sold! &f{buyer} &abought &f{item} &afor &a${price}&a. Claimable payout: &a${payout}&a.'
   # The text or value for Claim Not Found. Available options: Any valid string text
   CLAIM_NOT_FOUND: '&cThat claim no longer exists.'
   # The text or value for Not Your Claim. Available options: Any valid string text
@@ -895,11 +822,7 @@ ORDERS:
   # The text or value for Max Active Reached. Available options: Any valid string text
   MAX_ACTIVE_REACHED: '&cYou have reached your active order limit.'
   # The text or value for Created. Available options: Any valid string text
-  CREATED: '&aOrder created! &7#{order_id} &ffor &e{quantity} {item}&7 at &a${price_each}
-    # The text or value for # The Text Or Mode For &7Each. Budget Locked. Available Options. Available options: Any valid string text
-    # The text or mode for &7Each. Budget Locked. Available options: Any string text
-    # The text or value for &7Each. Budget Locked. Available options: Any valid string text
-    &7each. Budget locked: &a${budget}&7.'
+  CREATED: '&aOrder created! &7#{order_id} &ffor &e{quantity} {item}&7 at &a${price_each} &7each. Budget locked: &a${budget}&7.'
   # The text or value for Order Not Found. Available options: Any valid string text
   ORDER_NOT_FOUND: '&cThat order no longer exists.'
   # The text or value for Order Not Active. Available options: Any valid string text


### PR DESCRIPTION
Closes #313

The documentation comment generator wrote its `#` lines inside quoted YAML scalars wherever a value wrapped or already spanned lines. YAML only treats `#` as a comment between tokens, so inside a quoted scalar those lines are ordinary text and get folded into the value. Players have been reading them. Anyone banned from the server saw generator boilerplate sitting in the middle of the ban screen.

## What was wrong

13 values across `messages.yml`, `config.yml` and `hide.yml`. The punishment screens (`BAN`, `KICK`, `MUTE`, `BLACKLIST`) are the ones people actually see; the rest are trade, balance, auction and order messages.

#83 fixed the same damage in `discord.yml` and added `sanitizeDescription` as a guard, but that guard only covers webhook descriptions. Nothing sanitises these three files at runtime, so the data itself had to be cleaned.

## How the values were rebuilt

Deleting the comment lines is not enough. In several places the generator welded real content onto the end of its own boilerplate, so a line like `# The text or mode for &7Reason. Available options: Any string text &7Reason:` carries the message's own `&7Reason:` label on its tail. Dropping the whole line loses it. The rule that holds is the one #83 used: strip from the `#` up to and including the `Available options: Any ... string text` marker, and keep whatever follows it.

Every rebuilt value was then checked against `src/main/resources/languages/en_US.yml`, which still holds clean copies. 12 of the 13 matched exactly once case and spacing were normalised.

The 13th is `SHARDS.EVERYWHERE.RECEIVED-BOOSTED`, which has no counterpart in the language files, and it is also the one value damaged past a clean strip: the marker text `Any string text` was itself split across the wrap, leaving a stray `text` inside the message. It was rebuilt instead from its two clean siblings, `SHARDS.EVERYWHERE.RECEIVED` and `SHARDS.RECEIVED-BOOSTED`.

Multi-line values become block literals, matching both #83 and what `en_US.yml` already uses: `|` where the original value ended in a newline, `|-` where it did not.

## Wiki

`Config-config.yml.md`, `Config-hide.yml.md` and `Configuration-Reference.md` carried the same broken examples, and `Configuration-Reference.md` was still showing the pre-#83 Discord descriptions. All nine blocks now come from the real config files rather than being rebuilt separately, so the pages and the shipped defaults agree.

## Notes

The generator is not in the repository, so there is nothing to fix upstream of the data. `CONTRIBUTING.md` treats `docs/wiki/` as hand-maintained.

The eight language files were already clean and are untouched. `mvn test` leaves `en_US.yml` alone after this change, which is a second confirmation that the rebuilt values are what the language generator expects. Suite is green at 499 tests.

The boilerplate strings still in `DiscordWebhookManagerTest` are deliberate. They are the fixture proving the #83 sanitiser strips them.
