### PR TITLE
docs(config): mark the top-level shard keys as fallbacks (#315)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1347,18 +1347,26 @@ LUNAR-CLIENT:
 
 ```yaml
 SHARDS:
-  # The numerical value for Every. Available options: Any valid integer
+  # EVERY down to CANCELLED-MESSAGE are a fallback for servers that have no shard region
+  # at all. They are read only when CUBOIDS.REGIONS below is empty, and this file ships a
+  # 'spawn' region, so on a normal install they do nothing. The settings that actually run
+  # are the ones inside CUBOIDS.REGIONS.<region>. RESET-ON-LEAVE is not part of this group:
+  # it stays live as the default for the matching per-region key.
+  # Minutes between rewards in the fallback zone. Watch the unit, because the per-region
+  # INTERVAL is in seconds and this one is multiplied by 60.
   EVERY: 1
-  # The numerical value for Amount. Available options: Any valid integer
+  # Shards paid out each time the fallback timer runs down.
   AMOUNT: 1
-  # The text or value for Countdown. Available options: Any valid string text
+  # Countdown shown on the action bar in the fallback zone. %time% is the time remaining,
+  # %seconds% the same thing as a plain number.
   COUNTDOWN: '&7Next shard in &#A303F9%time%'
-  # The text or value for Received. Available options: Any valid string text
+  # Shown when a fallback reward lands. %amount% is the payout and %total% the new balance.
   RECEIVED: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
-  # The text or value for Received Boosted. Available options: Any valid string text
+  # Replaces RECEIVED while a shard booster is running. %multiplier% is the boost.
   RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total:
     &#A303F9%total%&7)'
-  # The text or value for Cancelled Message. Available options: Any valid string text
+  # Shown when a player leaves the fallback zone before the timer finishes. %cuboid% is the
+  # zone name. There is no %total% here, since nothing was paid out.
   CANCELLED-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
   # Determines whether Reset On Leave is enabled or disabled. Available options: true, false
   RESET-ON-LEAVE: true
@@ -1434,12 +1442,12 @@ SHARDS:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `SHARDS.EVERY` | `int` | Any valid integer number | `'1'` | Configures the technical `EVERY` parameter for `SHARDS.EVERY` in `config.yml`. |
-| `SHARDS.AMOUNT` | `int` | Any valid integer number | `'1'` | Configures the technical `AMOUNT` parameter for `SHARDS.AMOUNT` in `config.yml`. |
-| `SHARDS.COUNTDOWN` | `str` | Any string text | `'&7Next shard in &#A303F9%time%'` | Configures the technical `COUNTDOWN` parameter for `SHARDS.COUNTDOWN` in `config.yml`. |
-| `SHARDS.RECEIVED` | `str` | Any string text | `'&#A303F9You received %amount% Shard...'` | Configures the technical `RECEIVED` parameter for `SHARDS.RECEIVED` in `config.yml`. |
-| `SHARDS.RECEIVED-BOOSTED` | `str` | Any string text | `'&#A303F9You received %amount% Shard...'` | Configures the technical `RECEIVED-BOOSTED` parameter for `SHARDS.RECEIVED-BOOSTED` in `config.yml`. |
-| `SHARDS.CANCELLED-MESSAGE` | `str` | Any string text | `'&cShard reward cancelled &7(Left %c...'` | Configures the technical `CANCELLED-MESSAGE` parameter for `SHARDS.CANCELLED-MESSAGE` in `config.yml`. |
+| `SHARDS.EVERY` | `int` | Any valid integer number | `'1'` | Fallback only, read when `SHARDS.CUBOIDS.REGIONS` has no entries. Minutes between rewards in the fallback zone; the per-region `INTERVAL` is in seconds instead. |
+| `SHARDS.AMOUNT` | `int` | Any valid integer number | `'1'` | Fallback only. Shards paid out each time the fallback timer runs down. The setting that runs on a normal install is `SHARDS.CUBOIDS.REGIONS.<region>.AMOUNT`. |
+| `SHARDS.COUNTDOWN` | `str` | Any string text | `'&7Next shard in &#A303F9%time%'` | Fallback only. Action bar countdown in the fallback zone, supporting `%time%` and `%seconds%`. |
+| `SHARDS.RECEIVED` | `str` | Any string text | `'&#A303F9You received %amount% Shard...'` | Fallback only. Shown when a fallback reward lands, supporting `%amount%` and `%total%`. |
+| `SHARDS.RECEIVED-BOOSTED` | `str` | Any string text | `'&#A303F9You received %amount% Shard...'` | Fallback only. Replaces `SHARDS.RECEIVED` while a shard booster is running, adding `%multiplier%`. |
+| `SHARDS.CANCELLED-MESSAGE` | `str` | Any string text | `'&cShard reward cancelled &7(Left %c...'` | Fallback only. Shown when a player leaves the fallback zone before the timer finishes, supporting `%cuboid%`. |
 | `SHARDS.RESET-ON-LEAVE` | `bool` | `true`, `false` | `true` | Configures the technical `RESET-ON-LEAVE` parameter for `SHARDS.RESET-ON-LEAVE` in `config.yml`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `SHARDS` system. Set to `true` to enable, `false` to disable. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.BOUND` | `bool` | `true`, `false` | `false` | Configures the technical `BOUND` parameter for `SHARDS.CUBOIDS.REGIONS.spawn.BOUND` in `config.yml`. |
@@ -1473,18 +1481,26 @@ SHARDS:
 
 ```yaml
 SHARDS:
-  # The numerical value for Every. Available options: Any valid integer
+  # EVERY down to CANCELLED-MESSAGE are a fallback for servers that have no shard region
+  # at all. They are read only when CUBOIDS.REGIONS below is empty, and this file ships a
+  # 'spawn' region, so on a normal install they do nothing. The settings that actually run
+  # are the ones inside CUBOIDS.REGIONS.<region>. RESET-ON-LEAVE is not part of this group:
+  # it stays live as the default for the matching per-region key.
+  # Minutes between rewards in the fallback zone. Watch the unit, because the per-region
+  # INTERVAL is in seconds and this one is multiplied by 60.
   EVERY: 1
-  # The numerical value for Amount. Available options: Any valid integer
+  # Shards paid out each time the fallback timer runs down.
   AMOUNT: 1
-  # The text or value for Countdown. Available options: Any valid string text
+  # Countdown shown on the action bar in the fallback zone. %time% is the time remaining,
+  # %seconds% the same thing as a plain number.
   COUNTDOWN: '&7Next shard in &#A303F9%time%'
-  # The text or value for Received. Available options: Any valid string text
+  # Shown when a fallback reward lands. %amount% is the payout and %total% the new balance.
   RECEIVED: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
-  # The text or value for Received Boosted. Available options: Any valid string text
+  # Replaces RECEIVED while a shard booster is running. %multiplier% is the boost.
   RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total:
     &#A303F9%total%&7)'
-  # The text or value for Cancelled Message. Available options: Any valid string text
+  # Shown when a player leaves the fallback zone before the timer finishes. %cuboid% is the
+  # zone name. There is no %total% here, since nothing was paid out.
   CANCELLED-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
   # Determines whether Reset On Leave is enabled or disabled. Available options: true, false
   RESET-ON-LEAVE: true

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1033,18 +1033,26 @@ RESPAWN-RTP:
 ### Fully Commented Setup Code Example
 ```yaml
 SHARDS:
-  # The numerical value for Every. Available options: Any valid integer
+  # EVERY down to CANCELLED-MESSAGE are a fallback for servers that have no shard region
+  # at all. They are read only when CUBOIDS.REGIONS below is empty, and this file ships a
+  # 'spawn' region, so on a normal install they do nothing. The settings that actually run
+  # are the ones inside CUBOIDS.REGIONS.<region>. RESET-ON-LEAVE is not part of this group:
+  # it stays live as the default for the matching per-region key.
+  # Minutes between rewards in the fallback zone. Watch the unit, because the per-region
+  # INTERVAL is in seconds and this one is multiplied by 60.
   EVERY: 1
-  # The numerical value for Amount. Available options: Any valid integer
+  # Shards paid out each time the fallback timer runs down.
   AMOUNT: 1
-  # The text or value for Countdown. Available options: Any valid string text
+  # Countdown shown on the action bar in the fallback zone. %time% is the time remaining,
+  # %seconds% the same thing as a plain number.
   COUNTDOWN: '&7Next shard in &#A303F9%time%'
-  # The text or value for Received. Available options: Any valid string text
+  # Shown when a fallback reward lands. %amount% is the payout and %total% the new balance.
   RECEIVED: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
-  # The text or value for Received Boosted. Available options: Any valid string text
+  # Replaces RECEIVED while a shard booster is running. %multiplier% is the boost.
   RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total:
     &#A303F9%total%&7)'
-  # The text or value for Cancelled Message. Available options: Any valid string text
+  # Shown when a player leaves the fallback zone before the timer finishes. %cuboid% is the
+  # zone name. There is no %total% here, since nothing was paid out.
   CANCELLED-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
   # Determines whether Reset On Leave is enabled or disabled. Available options: true, false
   RESET-ON-LEAVE: true
@@ -1142,12 +1150,12 @@ SHARDS:
 ### Key Options & Setup Breakdown
 | Key / Option Path | Data Type | Allowed Values / Options | Default | Functional Behavior & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `SHARDS.EVERY` | `int` | Any valid integer | `1` | Configures `EVERY` for `SHARDS`. |
-| `SHARDS.AMOUNT` | `int` | Any valid integer | `1` | Configures `AMOUNT` for `SHARDS`. |
-| `SHARDS.COUNTDOWN` | `str` | Any string text | `&7Next shard in &#A303F9%time%` | Configures `COUNTDOWN` for `SHARDS`. |
-| `SHARDS.RECEIVED` | `str` | Any string text | `&#A303F9You received %amount% Shard &...` | Configures `RECEIVED` for `SHARDS`. |
-| `SHARDS.RECEIVED-BOOSTED` | `str` | Any string text | `&#A303F9You received %amount% Shards ...` | Configures `RECEIVED-BOOSTED` for `SHARDS`. |
-| `SHARDS.CANCELLED-MESSAGE` | `str` | Any string text | `&cShard reward cancelled &7(Left %cub...` | Configures `CANCELLED-MESSAGE` for `SHARDS`. |
+| `SHARDS.EVERY` | `int` | Any valid integer | `1` | Fallback only, read when `SHARDS.CUBOIDS.REGIONS` has no entries. Minutes between rewards in the fallback zone; the per-region `INTERVAL` is in seconds instead. |
+| `SHARDS.AMOUNT` | `int` | Any valid integer | `1` | Fallback only. Shards paid out each time the fallback timer runs down. The setting that runs on a normal install is `SHARDS.CUBOIDS.REGIONS.<region>.AMOUNT`. |
+| `SHARDS.COUNTDOWN` | `str` | Any string text | `&7Next shard in &#A303F9%time%` | Fallback only. Action bar countdown in the fallback zone, supporting `%time%` and `%seconds%`. |
+| `SHARDS.RECEIVED` | `str` | Any string text | `&#A303F9You received %amount% Shard &...` | Fallback only. Shown when a fallback reward lands, supporting `%amount%` and `%total%`. |
+| `SHARDS.RECEIVED-BOOSTED` | `str` | Any string text | `&#A303F9You received %amount% Shards ...` | Fallback only. Replaces `SHARDS.RECEIVED` while a shard booster is running, adding `%multiplier%`. |
+| `SHARDS.CANCELLED-MESSAGE` | `str` | Any string text | `&cShard reward cancelled &7(Left %cub...` | Fallback only. Shown when a player leaves the fallback zone before the timer finishes, supporting `%cuboid%`. |
 | `SHARDS.RESET-ON-LEAVE` | `bool` | true, false | `True` | Configures `RESET-ON-LEAVE` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.ENABLED` | `bool` | true, false | `False` | Configures `ENABLED` for `SHARDS`. |
 | `SHARDS.CUBOIDS.REGIONS.spawn.BOUND` | `bool` | true, false | `False` | Configures `BOUND` for `SHARDS`. |

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -488,18 +488,26 @@ LUNAR-CLIENT:
     UPDATE: 20
 # Configuration section for Shards.
 SHARDS:
-  # The numerical value for Every. Available options: Any valid integer
+  # EVERY down to CANCELLED-MESSAGE are a fallback for servers that have no shard region
+  # at all. They are read only when CUBOIDS.REGIONS below is empty, and this file ships a
+  # 'spawn' region, so on a normal install they do nothing. The settings that actually run
+  # are the ones inside CUBOIDS.REGIONS.<region>. RESET-ON-LEAVE is not part of this group:
+  # it stays live as the default for the matching per-region key.
+  # Minutes between rewards in the fallback zone. Watch the unit, because the per-region
+  # INTERVAL is in seconds and this one is multiplied by 60.
   EVERY: 1
-  # The numerical value for Amount. Available options: Any valid integer
+  # Shards paid out each time the fallback timer runs down.
   AMOUNT: 1
-  # The text or value for Countdown. Available options: Any valid string text
+  # Countdown shown on the action bar in the fallback zone. %time% is the time remaining,
+  # %seconds% the same thing as a plain number.
   COUNTDOWN: '&7Next shard in &#A303F9%time%'
-  # The text or value for Received. Available options: Any valid string text
+  # Shown when a fallback reward lands. %amount% is the payout and %total% the new balance.
   RECEIVED: '&#A303F9You received %amount% Shard &7(Total: &#A303F9%total%&7)'
-  # The text or value for Received Boosted. Available options: Any valid string text
+  # Replaces RECEIVED while a shard booster is running. %multiplier% is the boost.
   RECEIVED-BOOSTED: '&#A303F9You received %amount% Shards &7(&ax%multiplier%&7) &7(Total:
     &#A303F9%total%&7)'
-  # The text or value for Cancelled Message. Available options: Any valid string text
+  # Shown when a player leaves the fallback zone before the timer finishes. %cuboid% is the
+  # zone name. There is no %total% here, since nothing was paid out.
   CANCELLED-MESSAGE: '&cShard reward cancelled &7(Left %cuboid% zone)'
   # Determines whether Reset On Leave is enabled or disabled. Available options: true, false
   RESET-ON-LEAVE: true


### PR DESCRIPTION
Closes #315

Someone on Discord couldn't get their spawn zone to pay out more than one shard a minute. They'd been editing `SHARDS.EVERY` and `SHARDS.AMOUNT`, which is the obvious move given what the file says about them, and nothing happened. The plugin only reads those two, and the four message keys under them, when `SHARDS.CUBOIDS.REGIONS` has no entries at all; the shipped config carries a `spawn` region, so that never happens on a normal install. Nothing here changes behaviour, it just writes the split down where someone editing the file will actually see it.

## config.yml

The six fallback keys carried the generated placeholder text ("The numerical value for Every. Available options: Any valid integer"), which reads exactly like a live setting. They now say what they actually are and where the live settings sit, plus which placeholders each message accepts.

The unit difference gets its own line, because it's a second trap sitting behind the first: `EVERY` is multiplied by 60, so it counts minutes, while the per-region `INTERVAL` a few lines below counts seconds.

`RESET-ON-LEAVE` sits in the same block and stays as it was, deliberately. The plugin reads it twice, once for the fallback and once as the default for the per-region key, so it stays live either way; the new comment names where the fallback group ends so nobody lumps it in.

## Wiki

Both reference pages carry those six rows plus an embedded copy of the shipped comments, so all of it moved together. `Config-config.yml.md` holds two of those snippets, the commented example and the practical one, and both were stale.

## Notes

Comments and table prose only. No key was added, renamed or removed, no default changed, and the parsed YAML is identical before and after. Suite green at 497 tests.
