### PR TITLE
fix(config): restore the missing sell axe failure message (#317)

### DIFF
--- a/docs/wiki/Config-amethyst-tools.yml.md
+++ b/docs/wiki/Config-amethyst-tools.yml.md
@@ -184,6 +184,8 @@ AMETHYST-MESSAGES:
   SELL-SUCCESS: '{prefix}&#BDC3C7Sold all chest contents for &a${amount}&7.'
   # The text or value for Sell Empty. Available options: Any valid string text
   SELL-EMPTY: '{prefix}&#BDC3C7That chest is empty or has no sellable items.'
+  # The text or value for Sell Failed. Available options: Any valid string text
+  SELL-FAILED: '{prefix}&#BDC3C7The sale failed. no items were removed.'
   # The text or value for Sell No Chest. Available options: Any valid string text
   SELL-NO-CHEST: '{prefix}&#BDC3C7You must right-click a chest.'
   # The text or value for Bucket Drain. Available options: Any valid string text
@@ -221,6 +223,7 @@ AMETHYST-MESSAGES:
 | `AMETHYST-MESSAGES.CHOP-BREAK` | `str` | Any string text | `'{prefix}&#BDC3C7&dAmethyst Tree Cho...'` | Configures the technical `CHOP-BREAK` parameter for `AMETHYST-MESSAGES.CHOP-BREAK` in `amethyst-tools.yml`. |
 | `AMETHYST-MESSAGES.SELL-SUCCESS` | `str` | Any string text | `'{prefix}&#BDC3C7Sold all chest cont...'` | Configures the technical `SELL-SUCCESS` parameter for `AMETHYST-MESSAGES.SELL-SUCCESS` in `amethyst-tools.yml`. |
 | `AMETHYST-MESSAGES.SELL-EMPTY` | `str` | Any string text | `'{prefix}&#BDC3C7That chest is empty...'` | Configures the technical `SELL-EMPTY` parameter for `AMETHYST-MESSAGES.SELL-EMPTY` in `amethyst-tools.yml`. |
+| `AMETHYST-MESSAGES.SELL-FAILED` | `str` | Any string text | `'{prefix}&#BDC3C7The sale failed. no...'` | Configures the technical `SELL-FAILED` parameter for `AMETHYST-MESSAGES.SELL-FAILED` in `amethyst-tools.yml`. |
 | `AMETHYST-MESSAGES.SELL-NO-CHEST` | `str` | Any string text | `'{prefix}&#BDC3C7You must right-clic...'` | Configures the technical `SELL-NO-CHEST` parameter for `AMETHYST-MESSAGES.SELL-NO-CHEST` in `amethyst-tools.yml`. |
 | `AMETHYST-MESSAGES.BUCKET-DRAIN` | `str` | Any string text | `'{prefix}&#BDC3C7Drained &d{count} &...'` | Configures the technical `BUCKET-DRAIN` parameter for `AMETHYST-MESSAGES.BUCKET-DRAIN` in `amethyst-tools.yml`. |
 | `AMETHYST-MESSAGES.BUCKET-NO-WATER` | `str` | Any string text | `'{prefix}&#BDC3C7No water blocks fou...'` | Configures the technical `BUCKET-NO-WATER` parameter for `AMETHYST-MESSAGES.BUCKET-NO-WATER` in `amethyst-tools.yml`. |

--- a/src/main/resources/amethyst-tools.yml
+++ b/src/main/resources/amethyst-tools.yml
@@ -315,6 +315,8 @@ AMETHYST-MESSAGES:
   SELL-SUCCESS: '{prefix}&#BDC3C7Sold all chest contents for &a${amount}&7.'
   # The text or value for Sell Empty. Available options: Any valid string text
   SELL-EMPTY: '{prefix}&#BDC3C7That chest is empty or has no sellable items.'
+  # The text or value for Sell Failed. Available options: Any valid string text
+  SELL-FAILED: '{prefix}&#BDC3C7The sale failed. no items were removed.'
   # The text or value for Sell No Chest. Available options: Any valid string text
   SELL-NO-CHEST: '{prefix}&#BDC3C7You must right-click a chest.'
   # The text or value for Bucket Drain. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystMessageKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AmethystMessageKeyTest.java
@@ -1,0 +1,67 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AmethystMessageKeyTest {
+
+    private static final Pattern GET_MESSAGE = Pattern.compile("getMessage\\(\"([A-Z0-9-]+)\"");
+
+    @Test
+    void everyMessageKeyTheCodeReadsIsShipped() throws IOException {
+        ConfigurationSection messages = YamlConfiguration
+                .loadConfiguration(new java.io.File("src/main/resources/amethyst-tools.yml"))
+                .getConfigurationSection("AMETHYST-MESSAGES");
+        assertNotNull(messages, "AMETHYST-MESSAGES");
+
+        Set<String> missing = new TreeSet<>();
+        for (String key : readMessageKeys()) {
+            if (!messages.isString(key)) {
+                missing.add(key);
+            }
+        }
+
+        // getMessage falls back to the key itself, so a key the config never ships is
+        // sent to the player as raw text instead of a message.
+        assertTrue(missing.isEmpty(), "AMETHYST-MESSAGES is missing keys the code reads: " + missing);
+    }
+
+    private Set<String> readMessageKeys() throws IOException {
+        Set<String> keys = new TreeSet<>();
+        try (Stream<Path> files = Files.walk(Path.of("src/main/java/com/bx/ultimateDonutSmp/amethyst"))) {
+            files.filter(path -> path.toString().endsWith(".java")).forEach(path -> collect(path, keys));
+        }
+        // The command reads the same AMETHYST-MESSAGES section from outside the package.
+        collect(Path.of("src/main/java/com/bx/ultimateDonutSmp/commands/AmethystToolCommand.java"), keys);
+        return keys;
+    }
+
+    private void collect(Path path, Set<String> keys) {
+        Matcher matcher = GET_MESSAGE.matcher(read(path));
+        while (matcher.find()) {
+            keys.add(matcher.group(1));
+        }
+    }
+
+    private String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #317

The sell axe has a failure branch nobody could read. When a payout gets rejected the listener sends `AMETHYST-MESSAGES.SELL-FAILED`, except that key vanished from `amethyst-tools.yml` during the YAML overhaul in 55f753a9, and `getMessage` answers a missing key by handing back the key name. So a player whose sale failed saw the literal string `SELL-FAILED` in chat.

## The missing key

The key goes back under `AMETHYST-MESSAGES` with the wording all eight language files already carry:

```yaml
SELL-FAILED: '{prefix}&#BDC3C7The sale failed. no items were removed.'
```

Nothing else moved. `languages/en_US.yml` already had the same value, so `mvn test` had nothing to merge and left the file alone.

The language files look like they should have covered this on their own. They don't, because `applyLanguageSection` drops any fallback-locale value that still matches the bundled one, on the theory that an unedited value isn't a customization. A default server has both `LANGUAGE.ACTIVE` and `LANGUAGE.FALLBACK` sitting at `en_US`, so that branch fired every time and the key never reached the config. Servers on another locale took the second pass and did get the message, which is why this only ever showed up in English.

## Regression test

`AmethystMessageKeyTest` walks the amethyst package plus `AmethystToolCommand`, pulls out every `getMessage("...")` literal, and checks each one against the shipped `AMETHYST-MESSAGES` section. Against the old config it fails with `missing keys the code reads: [SELL-FAILED]`. It'll catch the next key that gets regenerated away.

## Docs

`docs/wiki/Config-amethyst-tools.yml.md` mirrors the shipped file, so it was short the same key in its sample block and in its reference table. This updates both. The truncated second sample further down stops before this key, so it stays as it is.

## Notes

No new keys anywhere. This puts back one that all eight translations already shipped, so nobody's existing config changes shape on update. Suite is 498 tests, all green.
