### PR TITLE
fix(amethyst): take the shard booster from the hand it was drunk from (#320)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
@@ -45,6 +45,9 @@ import java.util.Set;
 
 public class AmethystToolsListener implements Listener {
 
+    /** PlayerInventory keeps the off hand at slot 40; the main hand moves with the hotbar cursor. */
+    private static final int OFF_HAND_SLOT = 40;
+
     private final UltimateDonutSmp plugin;
     private final AmethystToolsManager manager;
     private final ThreadLocal<Boolean> isProcessingAoe = ThreadLocal.withInitial(() -> false);
@@ -66,6 +69,16 @@ public class AmethystToolsListener implements Listener {
     /** Breaking a block in creative drops nothing in vanilla, so neither does an amethyst tool. */
     static boolean shouldDropAoeLoot(GameMode gameMode) {
         return gameMode != GameMode.CREATIVE;
+    }
+
+    /**
+     * Where a consumed item actually sat. Drinking is not always main-hand - a potion in the off
+     * hand is used whenever the main-hand item has no use of its own - so the slot has to come from
+     * the hand the event reports rather than from whatever the hotbar cursor happens to be on.
+     * A null hand falls back to the held slot, which is what the pre-1.19.2 event assumed.
+     */
+    static int consumedSlot(EquipmentSlot hand, int heldSlot) {
+        return hand == EquipmentSlot.OFF_HAND ? OFF_HAND_SLOT : heldSlot;
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -107,7 +120,7 @@ public class AmethystToolsListener implements Listener {
             return;
         }
 
-        if (!canUseTool(player, item, type, false, true)) {
+        if (!canUseTool(player, item, type, false, true, EquipmentSlot.HAND)) {
             event.setCancelled(true);
             player.sendBlockChange(event.getBlock().getLocation(), event.getBlock().getBlockData());
             return;
@@ -314,7 +327,7 @@ public class AmethystToolsListener implements Listener {
                 if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
                     return;
                 }
-                if (!canUseTool(player, item, type, true, true)) {
+                if (!canUseTool(player, item, type, true, true, EquipmentSlot.HAND)) {
                     event.setCancelled(true);
                     return;
                 }
@@ -325,7 +338,7 @@ public class AmethystToolsListener implements Listener {
                 if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
                     return;
                 }
-                if (!canUseTool(player, item, type, true, true)) {
+                if (!canUseTool(player, item, type, true, true, EquipmentSlot.HAND)) {
                     event.setCancelled(true);
                     return;
                 }
@@ -417,7 +430,7 @@ public class AmethystToolsListener implements Listener {
                 manager.getMessage("BUCKET-DRAIN", "{count}", String.valueOf(waterBlocks.size()))));
     }
 
-    private void handleShardBooster(Player player) {
+    private void handleShardBooster(Player player, EquipmentSlot hand) {
         manager.suppressVisualSync(player.getUniqueId());
         ShardManager shardManager = plugin.getShardManager();
         long durationMillis = manager.getShardBoosterDurationSeconds() * 1000L;
@@ -427,7 +440,7 @@ public class AmethystToolsListener implements Listener {
             return;
         }
 
-        int slot = player.getInventory().getHeldItemSlot();
+        int slot = consumedSlot(hand, player.getInventory().getHeldItemSlot());
         player.getInventory().setItem(slot, null);
         SoundUtils.play(player, manager.getSound("ACTIVATE"));
         manager.spawnAmethystParticles(player.getLocation().add(0, 1, 0));
@@ -442,6 +455,8 @@ public class AmethystToolsListener implements Listener {
             return;
         }
 
+        EquipmentSlot hand = event.getHand();
+
         if (shouldManageInventory(player.getGameMode())) {
             manager.ensureIdentity(item, player.getUniqueId(), false);
         }
@@ -450,12 +465,12 @@ public class AmethystToolsListener implements Listener {
             return;
         }
 
-        if (!canUseTool(player, item, type, false, true)) {
+        if (!canUseTool(player, item, type, false, true, hand)) {
             event.setCancelled(true);
             return;
         }
 
-        handleShardBooster(player);
+        handleShardBooster(player, hand);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -646,7 +661,7 @@ public class AmethystToolsListener implements Listener {
         itemEntity.setItemStack(stack);
     }
 
-    private boolean canUseTool(Player player, ItemStack item, AmethystToolType type, boolean checkCooldown, boolean sendFeedback) {
+    private boolean canUseTool(Player player, ItemStack item, AmethystToolType type, boolean checkCooldown, boolean sendFeedback, EquipmentSlot hand) {
         if (!manager.hasValidSignature(item)) {
             return false;
         }
@@ -659,7 +674,7 @@ public class AmethystToolsListener implements Listener {
         }
 
         if (manager.isExpired(item)) {
-            manager.expireHeldItem(player);
+            manager.expireItemInSlot(player, consumedSlot(hand, player.getInventory().getHeldItemSlot()));
             return false;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsManager.java
@@ -569,8 +569,8 @@ public class AmethystToolsManager {
         }
     }
 
-    public void expireHeldItem(Player player) {
-        int slot = player.getInventory().getHeldItemSlot();
+    /** Expires whatever amethyst tool sits in the given slot, main hand or off hand alike. */
+    public void expireItemInSlot(Player player, int slot) {
         ItemStack item = player.getInventory().getItem(slot);
         if (isAmethystTool(item)) {
             expireItem(player, slot, item, true);

--- a/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListenerTest.java
@@ -1,8 +1,10 @@
 package com.bx.ultimateDonutSmp.amethyst;
 
 import org.bukkit.GameMode;
+import org.bukkit.inventory.EquipmentSlot;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,5 +23,19 @@ class AmethystToolsListenerTest {
         assertFalse(AmethystToolsListener.shouldDropAoeLoot(GameMode.CREATIVE));
         assertTrue(AmethystToolsListener.shouldDropAoeLoot(GameMode.SURVIVAL));
         assertTrue(AmethystToolsListener.shouldDropAoeLoot(GameMode.ADVENTURE));
+    }
+
+    @Test
+    void aDrunkBoosterComesFromTheHandThatDrankIt() {
+        // Slot 40 is the off hand. Clearing the held slot instead would delete whatever the player
+        // happened to be holding while they drank.
+        assertEquals(40, AmethystToolsListener.consumedSlot(EquipmentSlot.OFF_HAND, 3));
+        assertEquals(3, AmethystToolsListener.consumedSlot(EquipmentSlot.HAND, 3));
+        assertEquals(8, AmethystToolsListener.consumedSlot(EquipmentSlot.HAND, 8));
+    }
+
+    @Test
+    void anAbsentHandFallsBackToTheHeldSlot() {
+        assertEquals(5, AmethystToolsListener.consumedSlot(null, 5));
     }
 }


### PR DESCRIPTION
Closes #320

Drinking a Shard Booster out of the off-hand used to delete whatever the player was holding in their main hand. The consume handler never asked which hand the drink came from, and the booster handler then cleared the selected hotbar slot on the assumption that the booster must have been sitting there. Vanilla ate the off-hand potion separately, so the player still got their booster while an unrelated item quietly vanished.

## Reading the hand

`PlayerItemConsumeEvent` has carried the hand since 1.19.2, and the constructor that leaves it out is deprecated for removal. The consume handler now takes `getHand()` and threads it down to the two places that were guessing.

Which slot that means lives in a small static helper, next to `shouldManageInventory` and `shouldDropAoeLoot`:

```java
static int consumedSlot(EquipmentSlot hand, int heldSlot) {
    return hand == EquipmentSlot.OFF_HAND ? OFF_HAND_SLOT : heldSlot;
}
```

Keeping it pure is the only reason any of this is testable. The event itself can't be driven from the suite, so the slot arithmetic is the part worth pinning, and a null hand still falls through to the held slot the way the old event assumed.

## The expiry path

`canUseTool` had the same guess in it: an expired booster called `expireHeldItem`, which also went for the main hand. That one was less dangerous, since it checked the slot held an amethyst tool before clearing it, so the worst case was an expired off-hand booster surviving while a main-hand tool vanished instead. It takes the hand now too. `expireHeldItem` had exactly one caller and became `expireItemInSlot(player, slot)` rather than sitting around unused; nothing outside this package referenced it.

The three call sites that genuinely are main-hand pass `EquipmentSlot.HAND` explicitly. Block breaking is main-hand by definition, and the interact handler already returns early on anything else.

## Notes

Found by an audit sweep rather than a player report, so there's no repro thread behind it. Everything provable was proved off the source and the API jar: the event reports a hand, the listener ignored it, the handler cleared the main hand unconditionally, and `AmethystToolsTask` has been maintaining amethyst items in slot 40 all along, which is what makes a booster in the off-hand an ordinary thing rather than a stunt. What I could not do here is watch it happen on a live server; there isn't one, and the suite has no Bukkit mock to fake the event with.

I left the `Bukkit.getScheduler()` calls further down this same file alone. Those belong to #318, and there was no reason to collide with it.

Suite is 500 tests, all green.
