### PR TITLE
fix(folia): stop item-drop listeners using the removed Bukkit scheduler (#318)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolsListener.java
@@ -602,7 +602,7 @@ public class AmethystToolsListener implements Listener {
         if (!manager.hasValidSignature(item) || item.getAmount() > 1) {
             event.setCancelled(true);
             manager.sanitizeHeldItem(player, false);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }
@@ -613,7 +613,7 @@ public class AmethystToolsListener implements Listener {
         if (manager.isExpired(item)) {
             event.setCancelled(true);
             manager.sanitizeHeldItem(player, true);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
@@ -285,7 +285,7 @@ public class DuelListener implements Listener {
                 || (plugin.getDuelManager().isInDuel(uuid)
                 && !plugin.getDuelManager().hasArenaSetting(uuid, DuelManager.ArenaSetting.ALLOW_ITEM_DROP))) {
             event.setCancelled(true);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/FfaListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/FfaListener.java
@@ -172,7 +172,7 @@ public class FfaListener implements Listener {
                 || plugin.getFfaManager().isInMatch(uuid)
                 || plugin.getFfaManager().isTransitioning(uuid)) {
             event.setCancelled(true);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/FreezeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/FreezeListener.java
@@ -142,7 +142,7 @@ public class FreezeListener implements Listener {
         org.bukkit.entity.Player player = event.getPlayer();
         if (deny(player)) {
             event.setCancelled(true);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/ItemDropListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/ItemDropListener.java
@@ -53,7 +53,7 @@ public class ItemDropListener implements Listener {
 
         if (block) {
             event.setCancelled(true);
-            org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+            plugin.getSpigotScheduler().runEntity(player, () -> {
                 if (player.isOnline()) {
                     player.updateInventory();
                 }

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/StaffModeListener.java
@@ -87,7 +87,7 @@ public class StaffModeListener implements Listener {
         }
 
         event.setCancelled(true);
-        org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
+        plugin.getSpigotScheduler().runEntity(player, () -> {
             if (player.isOnline()) {
                 player.updateInventory();
             }

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/StaffModeListenerTest.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.listeners;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.StaffModeManager;
 import com.bx.ultimateDonutSmp.staff.StaffToolType;
+import com.bx.ultimateDonutSmp.utils.SpigotScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -130,6 +131,12 @@ class StaffModeListenerTest {
         Field smmField = UltimateDonutSmp.class.getDeclaredField("staffModeManager");
         smmField.setAccessible(true);
         smmField.set(mockPlugin, mockStaffModeManager);
+
+        // Blocked drops schedule the inventory refresh through SpigotScheduler, so the mock plugin
+        // needs one; off Folia it routes straight back to the mock server's scheduler.
+        Field schedulerField = UltimateDonutSmp.class.getDeclaredField("SpigotScheduler");
+        schedulerField.setAccessible(true);
+        schedulerField.set(mockPlugin, new SpigotScheduler(mockPlugin));
 
         staffModeManager = mockStaffModeManager;
         listener = new StaffModeListener(mockPlugin);

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/FoliaSchedulerUsageTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/FoliaSchedulerUsageTest.java
@@ -1,0 +1,58 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * plugin.yml declares folia-supported: true. On Folia the legacy BukkitScheduler is gone and
+ * Bukkit.getScheduler().runTask(...) throws UnsupportedOperationException, so every scheduling
+ * call has to go through SpigotScheduler, which picks the global / entity / region scheduler.
+ */
+class FoliaSchedulerUsageTest {
+
+    private static final Path SOURCE_ROOT = Path.of("src", "main", "java");
+    private static final Path SCHEDULER_WRAPPER =
+            SOURCE_ROOT.resolve(Path.of("com", "bx", "ultimateDonutSmp", "utils", "SpigotScheduler.java"));
+
+    @Test
+    void pluginDeclaresFoliaSupport() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        plugin.load(new File("src/main/resources/plugin.yml"));
+        assertTrue(plugin.getBoolean("folia-supported"),
+                "This test only matters while the plugin claims Folia support");
+    }
+
+    @Test
+    void nothingOutsideSpigotSchedulerTouchesTheLegacyBukkitScheduler() throws Exception {
+        List<String> offenders = new ArrayList<>();
+
+        try (Stream<Path> sources = Files.walk(SOURCE_ROOT)) {
+            for (Path source : sources.filter(Files::isRegularFile).toList()) {
+                if (!source.toString().endsWith(".java") || source.equals(SCHEDULER_WRAPPER)) {
+                    continue;
+                }
+                List<String> lines = Files.readAllLines(source, StandardCharsets.UTF_8);
+                for (int i = 0; i < lines.size(); i++) {
+                    if (lines.get(i).contains("Bukkit.getScheduler()")) {
+                        offenders.add(SOURCE_ROOT.relativize(source) + ":" + (i + 1)
+                                + " -> " + lines.get(i).trim());
+                    }
+                }
+            }
+        }
+
+        assertEquals(List.of(), offenders,
+                "These call sites throw UnsupportedOperationException on Folia; use SpigotScheduler instead");
+    }
+}


### PR DESCRIPTION
Closes #318

Folia dropped the old global BukkitScheduler, so `Bukkit.getScheduler().runTask(...)` throws `UnsupportedOperationException` there instead of queueing anything. Seven handlers still called it, and all seven sat in the same place: immediately after cancelling a `PlayerDropItemEvent`, to push a fresh inventory back to the client on the next tick. On Folia that line killed the handler, so the player kept looking at a ghost copy of the item they were not allowed to drop.

## The seven call sites

`AmethystToolsListener` (twice, both inside `onDrop`), `DuelListener`, `FfaListener`, `FreezeListener`, `ItemDropListener` and `StaffModeListener` now go through `plugin.getSpigotScheduler().runEntity(player, ...)`. That is already what the listeners sitting next to them do; `EnderChestListener`, `PlayerRespawnListener`, `SpawnerBlockListener` and `WorthDisplayListener` all use the same call, and these seven slipped past when 038c870e turned on `folia-supported`.

`runEntity` rather than `runGlobal`, because `updateInventory()` touches the player, and on Folia a player belongs to a region rather than to the global tick.

Two of the sites did more damage than a ghost item. In `ItemDropListener` the throw landed before the `PREVENT-ITEM-DROP.MESSAGE` send, and in `StaffModeListener` before `sendToolLockedMessage`, so a Folia server refused the drop and then told the player nothing at all.

## Notes

Paper and Spigot behave exactly as before. Off Folia, `SpigotScheduler.runEntity` falls back to `runGlobal`, which is the same `Bukkit.getScheduler().runTask` these lines were making directly.

`FoliaSchedulerUsageTest` keeps it from coming back. One test asserts `plugin.yml` still claims Folia support, so the check retires itself if that ever changes; the other walks `src/main/java` and fails if anything outside `SpigotScheduler` reaches for `Bukkit.getScheduler()`. Run against `main` it printed all seven lines.

`StaffModeListenerTest` needed a real `SpigotScheduler` on its mock plugin, since the reflection-built `UltimateDonutSmp` carries a null one and the blocked-drop test now walks straight through that call. Suite sits at 502 green.
