### PR TITLE
fix(menus): stop restoring rank buttons an admin renamed or deleted (#327)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1941,6 +1941,15 @@ public class ConfigManager {
             return true;
         }
 
+        // Ranks menu buttons are one advert per rank a server actually sells, so a renamed or
+        // deleted bundled rank must not come back on its old slot and collide with the button
+        // that replaced it. The BUTTONS section itself stays mergeable so configs that predate
+        // the ranks menu still receive it once.
+        if ("menus.yml".equals(resourceName)
+                && path.startsWith("RANKS-MENU.BUTTONS.")) {
+            return true;
+        }
+
         // Network server entries can be expanded per deployment.
         if ("network.yml".equals(resourceName)
                 && path.startsWith("NETWORK-STATUS.SERVERS.")) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -223,6 +223,67 @@ class ConfigManagerTest {
     }
 
     @Test
+    void mergeBundledDefaultsKeepsRanksMenuButtonsAdminsRenamed() throws Exception {
+        List<String> currentLines = lines(
+                "RANKS-MENU:",
+                "  TITLE: '&8Ranks'",
+                "  SIZE: 27",
+                "  BUTTONS:",
+                "    OWNER:",
+                "      MATERIAL: PLAYER_HEAD",
+                "      SLOT: 11",
+                "    MVP:",
+                "      MATERIAL: PLAYER_HEAD",
+                "      SLOT: 13"
+        );
+        List<String> bundledLines = lines(
+                "RANKS-MENU:",
+                "  TITLE: '&8Ranks'",
+                "  SIZE: 27",
+                "  BUTTONS:",
+                "    DEFAULT:",
+                "      MATERIAL: PLAYER_HEAD",
+                "      SLOT: 11",
+                "    DONUT_PLUS:",
+                "      MATERIAL: PLAYER_HEAD",
+                "      SLOT: 13"
+        );
+
+        int changes = mergeBundledDefaults("menus.yml", currentLines, bundledLines);
+
+        assertEquals(0, changes);
+        assertFalse(currentLines.contains("    DEFAULT:"),
+                "a renamed bundled rank must not come back on the slot its replacement now uses");
+        assertFalse(currentLines.contains("    DONUT_PLUS:"));
+        assertTrue(currentLines.contains("    OWNER:"));
+        assertTrue(currentLines.contains("    MVP:"));
+    }
+
+    @Test
+    void mergeBundledDefaultsStillInstallsTheRanksMenuOnConfigsThatPredateIt() throws Exception {
+        List<String> currentLines = lines(
+                "GLOBAL:",
+                "  ENABLED: true"
+        );
+        List<String> bundledLines = lines(
+                "GLOBAL:",
+                "  ENABLED: true",
+                "RANKS-MENU:",
+                "  TITLE: '&8Ranks'",
+                "  BUTTONS:",
+                "    DEFAULT:",
+                "      SLOT: 11"
+        );
+
+        int changes = mergeBundledDefaults("menus.yml", currentLines, bundledLines);
+
+        assertTrue(changes > 0);
+        assertTrue(currentLines.contains("RANKS-MENU:"));
+        assertTrue(currentLines.contains("    DEFAULT:"),
+                "the first install of the ranks menu still needs its bundled buttons");
+    }
+
+    @Test
     void mergeBundledDefaultsLeavesCompleteFileByteEquivalent() throws Exception {
         List<String> currentLines = lines(
                 "# admin header",


### PR DESCRIPTION
Closes #327

A server running its own set of ranks has to rename the four buttons bundled in `RANKS-MENU`, and until now every restart put them back. The config sync only ever adds bundled paths that are missing from a file, so once `DONUT_PLUS` no longer existed it counted as missing and got re-inserted on slot 13, right on top of whatever the owner had put there. `RanksMenu` drops the second button it finds on an occupied slot, logs a line about it and carries on, so the rank the owner actually sells disappears from the GUI while the bundled one they deleted is the one players see.

## Why the merge was restoring them

`isUserManagedBundledPath` already carves out every tree that belongs to the server rather than to the plugin: crate definitions, Billford trades, duel arenas, shop categories, staff-mode items, and the permission maps in `rtp.yml` and `ender-chest.yml` that are keyed by a server's own rank names. The ranks menu buttons are the same shape and were the one list missing from it. Each key under `RANKS-MENU.BUTTONS` is one rank a server sells, and nothing in the code cares what those keys are called; `prettifyKey` exists so an unfamiliar key still renders a readable name.

The exclusion covers `RANKS-MENU.BUTTONS.` with the trailing dot, so `BUTTONS` itself still merges. A config written before the ranks menu shipped picks up the whole `RANKS-MENU` block on the next start, buttons included; only entries inside a section that's already there stay as the owner left them. `TITLE`, `SIZE` and `FILLER-MATERIAL` merge as before.

## Notes

Adding a fifth rank was never broken by itself. A new key at a free slot below `SIZE` already survived the merge untouched, and I checked that before changing anything; what breaks is editing the four that ship, which is how anyone with five ranks ends up there.

The change adds no config keys and touches no language files. Two tests in `ConfigManagerTest` cover it: one renames the bundled ranks and asserts nothing comes back, the other starts from a config with no `RANKS-MENU` at all and asserts the buttons still arrive on a first install. The first fails on `main` with six paths restored. The full suite runs 504 green.

`SERVERS-MENU.SERVERS` and `RULES-MENU.BUTTONS` have the same admin-keyed shape and the same gap, left alone here since this issue didn't report them.
