### PR TITLE
fix(maintenance): refuse logins when maintenance has no lobby to send players to (#328)

### DIFF
--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -253,6 +253,54 @@ NETWORK-STATUS:
       SOURCE:
         TYPE: LOCAL
 ```
-
 ---
 
+## Section: `MAINTENANCE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Maintenance mode behaviour (/maintenance on|off|status|setlobby)
+MAINTENANCE:
+  # Permission node that lets a player join while maintenance mode is active
+  BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
+
+  # Move players to another server through the proxy (true) or keep them on this one (false)
+  USE_PROXY: true
+
+  # Proxy server players are moved to while maintenance is active, used when USE_PROXY is true.
+  # Leave it empty when this server has no lobby to hand players to: maintenance then refuses
+  # the connection at login instead of letting players in and kicking them a moment later
+  LOBBY_SERVER: lobby
+
+  # World players are teleported to while maintenance is active, used when USE_PROXY is false.
+  # Falls back to the spawn location when that world is not loaded, and refuses the connection
+  # at login when neither one resolves
+  LOBBY_WORLD: WORLD
+
+  # Countdown in seconds shown before players are sent back once the server returns
+  RECONNECT_DELAY_SECONDS: 5
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `MAINTENANCE.BYPASS_PERMISSION` | `str` | Any permission node | `'ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS'` | Players holding this node join normally while maintenance is active and are never moved or kicked by it. |
+| `MAINTENANCE.USE_PROXY` | `bool` | `true`, `false` | `true` | `true` hands players to another server over the BungeeCord/Velocity plugin channel. `false` keeps them on this server and teleports them instead. |
+| `MAINTENANCE.LOBBY_SERVER` | `str` | Any proxy server name, or empty | `'lobby'` | Destination used when `USE_PROXY` is `true`. `/maintenance setlobby <server>` overrides it at runtime. Leave it empty on a server with no lobby: the connection is then refused during login, so players never enter the world. |
+| `MAINTENANCE.LOBBY_WORLD` | `str` | Any loaded world name | `'WORLD'` | Destination used when `USE_PROXY` is `false`. When that world is not loaded the spawn location is used, and when neither resolves the connection is refused during login. |
+| `MAINTENANCE.RECONNECT_DELAY_SECONDS` | `int` | Any valid integer number | `'5'` | Countdown shown to players waiting to be sent back once the server reports itself online again over Redis. `0` sends them back straight away. |
+
+### 3. Practical Setup Example
+
+A single server with no lobby to hand players to. `/maintenance on` refuses every connection except staff holding the bypass node:
+
+```yaml
+MAINTENANCE:
+  BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
+  USE_PROXY: true
+  LOBBY_SERVER: ''
+```
+
+---

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -17,7 +17,6 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import com.bx.ultimateDonutSmp.models.PlayerData;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
@@ -43,6 +42,18 @@ public class PlayerJoinQuitListener implements Listener {
                     ColorUtils.colorize(plugin.getServerWipeManager().getMaintenanceMessage())
             );
             return;
+        }
+        if (plugin.getMaintenanceManager() != null) {
+            String bypassPerm = plugin.getConfigManager().getNetwork().getString("MAINTENANCE.BYPASS_PERMISSION", "ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS");
+            if (deniesMaintenanceLogin(
+                    plugin.getMaintenanceManager().isMaintenanceActive(),
+                    event.getPlayer().hasPermission(bypassPerm),
+                    plugin.getMaintenanceManager().hasLobbyDestination()
+            )) {
+                String kickMessage = plugin.getConfigManager().getNetwork().getString("MAINTENANCE.MESSAGES.KICK_FALLBACK", "&cThis server is in maintenance and no lobby is available.");
+                event.disallow(PlayerLoginEvent.Result.KICK_OTHER, ColorUtils.colorize(kickMessage));
+                return;
+            }
         }
         if (event.getResult() != PlayerLoginEvent.Result.ALLOWED) {
             return;
@@ -114,12 +125,11 @@ public class PlayerJoinQuitListener implements Listener {
                         }
                     }
 
-                    String lobbyWorld = plugin.getConfigManager().getNetwork().getString("MAINTENANCE.LOBBY_WORLD", "WORLD");
-                    org.bukkit.World world = Bukkit.getWorld(lobbyWorld);
-                    if (world != null) {
+                    Location destination = plugin.getMaintenanceManager().resolveLocalDestination();
+                    if (destination != null) {
                         plugin.getSpigotScheduler().runEntityLater(player, () -> {
                             if (player.isOnline()) {
-                                plugin.getSpigotScheduler().teleport(player, world.getSpawnLocation());
+                                plugin.getSpigotScheduler().teleport(player, destination);
                             }
                         }, 1L);
                     }
@@ -322,6 +332,10 @@ public class PlayerJoinQuitListener implements Listener {
 
     static long firstJoinSpawnDelayTicks(long configured) {
         return Math.max(1L, Math.min(MAX_FIRST_JOIN_SPAWN_DELAY_TICKS, configured));
+    }
+
+    static boolean deniesMaintenanceLogin(boolean maintenanceActive, boolean hasBypass, boolean hasLobbyDestination) {
+        return maintenanceActive && !hasBypass && !hasLobbyDestination;
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
@@ -82,6 +82,29 @@ public class MaintenanceManager {
         return plugin.getConfigManager().getNetwork().getString("MAINTENANCE.LOBBY_WORLD", "WORLD");
     }
 
+    /**
+     * Whether maintenance has somewhere to put a player. When it does not, the player is refused at
+     * login instead of being allowed into the world and kicked a couple of seconds later.
+     */
+    public boolean hasLobbyDestination() {
+        if (isUseProxy()) {
+            return isLobbyServerSet(getLobbyServer());
+        }
+        return resolveLocalDestination() != null;
+    }
+
+    static boolean isLobbyServerSet(String lobbyServer) {
+        return lobbyServer != null && !lobbyServer.isBlank();
+    }
+
+    public Location resolveLocalDestination() {
+        World world = Bukkit.getWorld(getLobbyWorld());
+        if (world != null) {
+            return world.getSpawnLocation();
+        }
+        return plugin.getSpawnManager().resolveCommandDestination(SpawnManager.AreaType.SPAWN);
+    }
+
     public void setLobbyServer(String lobbyServer) {
         this.customLobbyServer = lobbyServer;
         save();
@@ -137,15 +160,9 @@ public class MaintenanceManager {
             if (useProxy) {
                 sendToLobby(player, lobby);
             } else {
-                String worldName = getLobbyWorld();
-                World world = Bukkit.getWorld(worldName);
-                if (world != null) {
-                    plugin.getSpigotScheduler().teleport(player, world.getSpawnLocation());
-                } else {
-                    Location defaultSpawn = plugin.getSpawnManager().resolveCommandDestination(SpawnManager.AreaType.SPAWN);
-                    if (defaultSpawn != null) {
-                        plugin.getSpigotScheduler().teleport(player, defaultSpawn);
-                    }
+                Location destination = resolveLocalDestination();
+                if (destination != null) {
+                    plugin.getSpigotScheduler().teleport(player, destination);
                 }
             }
         }

--- a/src/main/resources/network.yml
+++ b/src/main/resources/network.yml
@@ -111,3 +111,24 @@ NETWORK-STATUS:
       DISPLAY: Crystal
       SOURCE:
         TYPE: LOCAL
+
+# Maintenance mode behaviour (/maintenance on|off|status|setlobby)
+MAINTENANCE:
+  # Permission node that lets a player join while maintenance mode is active
+  BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
+
+  # Move players to another server through the proxy (true) or keep them on this one (false)
+  USE_PROXY: true
+
+  # Proxy server players are moved to while maintenance is active, used when USE_PROXY is true.
+  # Leave it empty when this server has no lobby to hand players to: maintenance then refuses
+  # the connection at login instead of letting players in and kicking them a moment later
+  LOBBY_SERVER: lobby
+
+  # World players are teleported to while maintenance is active, used when USE_PROXY is false.
+  # Falls back to the spawn location when that world is not loaded, and refuses the connection
+  # at login when neither one resolves
+  LOBBY_WORLD: WORLD
+
+  # Countdown in seconds shown before players are sent back once the server returns
+  RECONNECT_DELAY_SECONDS: 5

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/MaintenanceLoginGateTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/MaintenanceLoginGateTest.java
@@ -1,0 +1,21 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MaintenanceLoginGateTest {
+
+    @Test
+    void maintenanceWithNowhereToSendThemRefusesTheLogin() {
+        assertTrue(PlayerJoinQuitListener.deniesMaintenanceLogin(true, false, false));
+    }
+
+    @Test
+    void everyoneElseIsStillLetThrough() {
+        assertFalse(PlayerJoinQuitListener.deniesMaintenanceLogin(false, false, false));
+        assertFalse(PlayerJoinQuitListener.deniesMaintenanceLogin(true, true, false));
+        assertFalse(PlayerJoinQuitListener.deniesMaintenanceLogin(true, false, true));
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MaintenanceLobbyDestinationTest {
+
+    @Test
+    void bundledConfigShipsTheMaintenanceSection() {
+        YamlConfiguration network = YamlConfiguration.loadConfiguration(new File("src/main/resources/network.yml"));
+        assertTrue(network.contains("MAINTENANCE.LOBBY_SERVER"));
+        assertTrue(network.getBoolean("MAINTENANCE.USE_PROXY"));
+        assertEquals("lobby", network.getString("MAINTENANCE.LOBBY_SERVER"));
+        assertEquals("WORLD", network.getString("MAINTENANCE.LOBBY_WORLD"));
+        assertEquals(5, network.getInt("MAINTENANCE.RECONNECT_DELAY_SECONDS"));
+        assertEquals(
+                "ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS",
+                network.getString("MAINTENANCE.BYPASS_PERMISSION")
+        );
+    }
+
+    @Test
+    void anEmptyLobbyServerCountsAsNoDestination() {
+        assertTrue(MaintenanceManager.isLobbyServerSet("lobby"));
+        assertFalse(MaintenanceManager.isLobbyServerSet(""));
+        assertFalse(MaintenanceManager.isLobbyServerSet("   "));
+        assertFalse(MaintenanceManager.isLobbyServerSet(null));
+    }
+}


### PR DESCRIPTION
Closes #328

Maintenance mode only ran its check once the player had already spawned in, on `PlayerJoinEvent`. Behind a proxy that's fine: the plugin fires a Connect packet and the proxy pulls them across, with a fallback kick two seconds later for anyone the transfer missed. On a server with no lobby to hand them to, nothing catches them until that fallback fires, so they get a couple of seconds inside a server that's supposed to be closed. On a single server with `USE_PROXY` off and no world matching `LOBBY_WORLD` there was no fallback at all, and the player simply stayed.

## The login gate

The check now also runs on `PlayerLoginEvent`, before the player reaches the world. Maintenance active, no bypass node, and nowhere to put them means the plugin refuses the connection with `MAINTENANCE.MESSAGES.KICK_FALLBACK`. "Nowhere to put them" is a blank `LOBBY_SERVER` in proxy mode, or neither the lobby world nor a spawn location resolving in local mode. Servers with a lobby configured keep exactly what they had, fallback kick included, since a Spigot server can't know in advance whether the proxy will accept a Connect packet.

## The missing config section

`network.yml` shipped with no `MAINTENANCE` section at all, so every key ran on its hardcoded default and "no lobby set" wasn't something an admin could express in the first place; `getLobbyServer()` invented `lobby` whether or not such a server existed. The section is in the file now, carrying the same values the code was already falling back to, so nothing changes for anyone on upgrade. Emptying `LOBBY_SERVER` is the switch that turns the refusal on.

## Notes

One method resolves local destinations now, `MaintenanceManager.resolveLocalDestination`, and both the join path and `/maintenance on` call it, so the two can no longer disagree about where a player ends up. `MaintenanceLoginGateTest` covers the login decision and `MaintenanceLobbyDestinationTest` covers the blank-lobby check plus the bundled config; the suite sits at 506.
