### PR TITLE
fix(menus): keep rules and servers menu entries an admin edited (#333)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1941,12 +1941,16 @@ public class ConfigManager {
             return true;
         }
 
-        // Ranks menu buttons are one advert per rank a server actually sells, so a renamed or
-        // deleted bundled rank must not come back on its old slot and collide with the button
-        // that replaced it. The BUTTONS section itself stays mergeable so configs that predate
-        // the ranks menu still receive it once.
+        // Ranks menu buttons, rules pages and servers menu entries are each keyed by something
+        // the server owns rather than the plugin: a rank it sells, a rules page it wrote, a
+        // network id whose network.yml counterpart is already excluded below. A renamed or
+        // deleted entry must not come back on its old slot and collide with whatever replaced
+        // it. The sections themselves stay mergeable so configs that predate any of these menus
+        // still receive them once.
         if ("menus.yml".equals(resourceName)
-                && path.startsWith("RANKS-MENU.BUTTONS.")) {
+                && (path.startsWith("RANKS-MENU.BUTTONS.")
+                || path.startsWith("RULES-MENU.BUTTONS.")
+                || path.startsWith("SERVERS-MENU.SERVERS."))) {
             return true;
         }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -284,6 +284,95 @@ class ConfigManagerTest {
     }
 
     @Test
+    void mergeBundledDefaultsKeepsRulesButtonsAdminsRenamed() throws Exception {
+        List<String> currentLines = lines(
+                "RULES-MENU:",
+                "  TITLE: '&8Rules'",
+                "  SIZE: 27",
+                "  BUTTONS:",
+                "    HOUSE_RULES:",
+                "      MATERIAL: KNOWLEDGE_BOOK",
+                "      SLOT: 12"
+        );
+        List<String> bundledLines = lines(
+                "RULES-MENU:",
+                "  TITLE: '&8Rules'",
+                "  SIZE: 27",
+                "  BUTTONS:",
+                "    RULE_1:",
+                "      MATERIAL: KNOWLEDGE_BOOK",
+                "      SLOT: 12",
+                "    RULE_2:",
+                "      MATERIAL: KNOWLEDGE_BOOK",
+                "      SLOT: 14"
+        );
+
+        int changes = mergeBundledDefaults("menus.yml", currentLines, bundledLines);
+
+        assertEquals(0, changes);
+        assertFalse(currentLines.contains("    RULE_1:"),
+                "a renamed rules page must not come back on the slot its replacement now uses");
+        assertFalse(currentLines.contains("    RULE_2:"),
+                "a deleted rules page must not come back carrying the bundled server's rules");
+        assertTrue(currentLines.contains("    HOUSE_RULES:"));
+    }
+
+    @Test
+    void mergeBundledDefaultsKeepsServersMenuEntriesAdminsRenamed() throws Exception {
+        List<String> currentLines = lines(
+                "SERVERS-MENU:",
+                "  TITLE: '&8Ongoing Servers'",
+                "  SIZE: 27",
+                "  SERVERS:",
+                "    survival:",
+                "      SLOT: 13"
+        );
+        List<String> bundledLines = lines(
+                "SERVERS-MENU:",
+                "  TITLE: '&8Ongoing Servers'",
+                "  SIZE: 27",
+                "  SERVERS:",
+                "    crystal:",
+                "      SLOT: 13"
+        );
+
+        int changes = mergeBundledDefaults("menus.yml", currentLines, bundledLines);
+
+        assertEquals(0, changes);
+        assertFalse(currentLines.contains("    crystal:"),
+                "a renamed network id must not come back and render as a permanently offline server");
+        assertTrue(currentLines.contains("    survival:"));
+    }
+
+    @Test
+    void mergeBundledDefaultsStillInstallsTheRulesAndServersMenusOnConfigsThatPredateThem() throws Exception {
+        List<String> currentLines = lines(
+                "GLOBAL:",
+                "  ENABLED: true"
+        );
+        List<String> bundledLines = lines(
+                "GLOBAL:",
+                "  ENABLED: true",
+                "RULES-MENU:",
+                "  BUTTONS:",
+                "    RULE_1:",
+                "      SLOT: 12",
+                "SERVERS-MENU:",
+                "  SERVERS:",
+                "    crystal:",
+                "      SLOT: 13"
+        );
+
+        int changes = mergeBundledDefaults("menus.yml", currentLines, bundledLines);
+
+        assertTrue(changes > 0);
+        assertTrue(currentLines.contains("    RULE_1:"),
+                "the first install of the rules menu still needs its bundled pages");
+        assertTrue(currentLines.contains("    crystal:"),
+                "the first install of the servers menu still needs its bundled example");
+    }
+
+    @Test
     void mergeBundledDefaultsLeavesCompleteFileByteEquivalent() throws Exception {
         List<String> currentLines = lines(
                 "# admin header",


### PR DESCRIPTION
Closes #333

Two more sections of `menus.yml` are keyed by names the server picks rather than the plugin, and the config sync kept putting the bundled entries back. Same shape as the ranks menu in #327: the merge only ever adds paths a file is missing, so an entry an owner renamed or deleted counted as missing and got written back on its original slot. Whatever the owner had put on that slot then shared it with a restored entry, and the menu dropped one of the two.

## What was coming back

For the rules menu, the two bundled pages return carrying DonutSMP's own rules, `discord.gg/donutsmp` and all, so another server's Discord invite ends up in an owner's rules GUI. That happens whether or not a slot collides; renaming a page on slot 12 or 14 adds a collision on top of it.

For the servers menu it is `crystal` on slot 13. A server id with no entry in `network.yml` falls through to an offline snapshot, so the restored entry draws as a server that is permanently down and is not on their network at all. `network.yml`'s own `NETWORK-STATUS.SERVERS.` was already excluded from the merge, so the two halves of that one feature had been disagreeing with each other.

## The change

Both paths join `RANKS-MENU.BUTTONS.` in the `menus.yml` branch of `isUserManagedBundledPath`, which now reads as one rule about entries the server owns instead of three near-identical blocks. All three keep the trailing dot, so `BUTTONS` and `SERVERS` themselves stay mergeable and a config predating any of these menus still receives the whole block on its next start.

## Notes

Nothing else in either menu is affected: `TITLE`, `SIZE`, `REFRESH-TICKS`, `PLACEHOLDER-MATERIAL` and the `SERVER_STATUS` template all still merge, and neither menu cares what the keys are called, since both fall back to a prettified key or the raw id for display.

Three tests in `ConfigManagerTest`. Two rename an entry and assert nothing comes back; both fail on `main`, restoring six paths for the rules menu and two for the servers menu. The third starts from a config with neither menu present and asserts the bundled entries still arrive on a first install, which is what keeps the exclusion from reaching too far. Suite is 511 green.

Neither section appears under `docs/wiki/`, so there was nothing to correct there.
