### PR TITLE
refactor(config): drop the unused YAML node removal helpers

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1722,23 +1722,6 @@ public class ConfigManager {
         return index;
     }
 
-    private void removeYamlNodeBlock(List<String> lines, YamlPathLine node) {
-        int start = attachedCommentStart(lines, node.lineIndex);
-        int end = findYamlNodeEnd(lines, node);
-        lines.subList(start, end).clear();
-        collapseBlankLinesAt(lines, Math.max(0, start - 1));
-    }
-
-    private void collapseBlankLinesAt(List<String> lines, int aroundIndex) {
-        int index = Math.max(1, Math.min(aroundIndex + 1, lines.size() - 1));
-        while (index < lines.size()
-                && index > 0
-                && lines.get(index).trim().isEmpty()
-                && lines.get(index - 1).trim().isEmpty()) {
-            lines.remove(index);
-        }
-    }
-
     private void appendYamlTopLevelBlock(List<String> target, List<String> block) {
         List<String> cleanBlock = trimYamlBlock(block);
         if (cleanBlock.isEmpty()) {


### PR DESCRIPTION
The config sync only ever inserts. `mergeBundledDefaults` adds bundled paths a file is missing and never takes anything out, which is the behaviour `mergeBundledDefaultsPreservesUnknownAndRemovedPaths` pins down. `removeYamlNodeBlock` is left over from a shape where the sync could prune as well, and nothing calls it.

## What went

`removeYamlNodeBlock` and `collapseBlankLinesAt`, seventeen lines between them. `collapseBlankLinesAt` had exactly one caller, `removeYamlNodeBlock`, so it goes with it.

`attachedCommentStart` and `findYamlNodeEnd` stay. Both are still used by `extractYamlNodeBlock` and by the sibling lookup that decides where a newly merged block gets inserted.

## How I checked it was unreachable

Grepping the repository for `removeYamlNodeBlock` outside `target/` returns one line, its own declaration. The tests do reach private methods reflectively, so the method names they look up matter too: that list is `applyLineSpigot`, `createTables`, `findSafeSplit`, `getLoadedNormalWorldName`, `hasLegacyButtons`, `isBan`, `lines`, `mergeCurrentResourceText`, `pollPreCachedLocation`, `prepare`, `punishmentPlaceholders` and `readTextFile`. Neither removed method appears in it, and no name is built dynamically.

`git log -S removeYamlNodeBlock` returns a single commit, the initial source import, and nothing since has changed the occurrence count. It arrived with one occurrence and it still had one, so it has never had a caller in this repository.

## Notes

No behaviour change, and nothing new to test. The suite is 511 green, the same count as before the deletion, which is what you would expect from code no test could reach.
