### PR TITLE
fix(maintenance): let setlobby clear the stored lobby server

### DIFF
--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -288,7 +288,7 @@ MAINTENANCE:
 | :--- | :--- | :--- | :--- | :--- |
 | `MAINTENANCE.BYPASS_PERMISSION` | `str` | Any permission node | `'ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS'` | Players holding this node join normally while maintenance is active and are never moved or kicked by it. |
 | `MAINTENANCE.USE_PROXY` | `bool` | `true`, `false` | `true` | `true` hands players to another server over the BungeeCord/Velocity plugin channel. `false` keeps them on this server and teleports them instead. |
-| `MAINTENANCE.LOBBY_SERVER` | `str` | Any proxy server name, or empty | `'lobby'` | Destination used when `USE_PROXY` is `true`. `/maintenance setlobby <server>` overrides it at runtime. Leave it empty on a server with no lobby: the connection is then refused during login, so players never enter the world. |
+| `MAINTENANCE.LOBBY_SERVER` | `str` | Any proxy server name, or empty | `'lobby'` | Destination used when `USE_PROXY` is `true`. `/maintenance setlobby <server>` overrides it at runtime, and `/maintenance setlobby` with no name clears that override and hands the decision back to this key. Leave it empty on a server with no lobby: the connection is then refused during login, so players never enter the world. |
 | `MAINTENANCE.LOBBY_WORLD` | `str` | Any loaded world name | `'WORLD'` | Destination used when `USE_PROXY` is `false`. When that world is not loaded the spawn location is used, and when neither resolves the connection is refused during login. |
 | `MAINTENANCE.RECONNECT_DELAY_SECONDS` | `int` | Any valid integer number | `'5'` | Countdown shown to players waiting to be sent back once the server reports itself online again over Redis. `0` sends them back straight away. |
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
@@ -61,11 +61,14 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
                 String lobby = mm.getLobbyServer();
                 sender.sendMessage(ColorUtils.toComponent("&d&lMaintenance status:"));
                 sender.sendMessage(ColorUtils.toComponent("  &fActive: " + (active ? "&aYes" : "&cNo")));
-                sender.sendMessage(ColorUtils.toComponent("  &fLobby server: &b" + lobby));
+                sender.sendMessage(ColorUtils.toComponent("  &fLobby server: " + describeLobbyServer(lobby)));
             }
             case "setlobby" -> {
-                if (args.length < 2) {
-                    sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " setlobby <server>"));
+                if (clearsLobbyServer(args)) {
+                    mm.setLobbyServer(null);
+                    sender.sendMessage(ColorUtils.toComponent(
+                            "&aLobby server cleared. network.yml decides it now: "
+                                    + describeLobbyServer(mm.getLobbyServer()) + "&a."));
                     return true;
                 }
                 String lobby = args[1];
@@ -75,6 +78,21 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
             default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <on|off|status|setlobby [server]>"));
         }
         return true;
+    }
+
+    /**
+     * Leaving the server name off clears the stored lobby, which is the only way back to the
+     * MAINTENANCE.LOBBY_SERVER value in network.yml once one has been set in game.
+     */
+    static boolean clearsLobbyServer(String[] args) {
+        return args.length < 2 || args[1].isBlank();
+    }
+
+    static String describeLobbyServer(String lobby) {
+        if (lobby == null || lobby.isBlank()) {
+            return "&7none, so players without the bypass permission cannot connect";
+        }
+        return "&b" + lobby;
     }
 
     @Override

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
@@ -97,6 +97,14 @@ public class MaintenanceManager {
         return lobbyServer != null && !lobbyServer.isBlank();
     }
 
+    /**
+     * Blank is stored as no lobby at all, so clearing it falls back to MAINTENANCE.LOBBY_SERVER
+     * rather than leaving an empty name in the state file.
+     */
+    static String normalizeLobbyServer(String lobbyServer) {
+        return isLobbyServerSet(lobbyServer) ? lobbyServer : null;
+    }
+
     public Location resolveLocalDestination() {
         World world = Bukkit.getWorld(getLobbyWorld());
         if (world != null) {
@@ -106,7 +114,7 @@ public class MaintenanceManager {
     }
 
     public void setLobbyServer(String lobbyServer) {
-        this.customLobbyServer = lobbyServer;
+        this.customLobbyServer = normalizeLobbyServer(lobbyServer);
         save();
     }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/MaintenanceSetLobbyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/MaintenanceSetLobbyTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MaintenanceSetLobbyTest {
+
+    @Test
+    void leavingTheServerNameOffClearsTheLobby() {
+        assertTrue(MaintenanceCommand.clearsLobbyServer(new String[]{"setlobby"}));
+        assertTrue(MaintenanceCommand.clearsLobbyServer(new String[]{"setlobby", ""}));
+        assertTrue(MaintenanceCommand.clearsLobbyServer(new String[]{"setlobby", "  "}));
+    }
+
+    @Test
+    void aNamedServerStillSetsIt() {
+        assertFalse(MaintenanceCommand.clearsLobbyServer(new String[]{"setlobby", "hub"}));
+    }
+
+    @Test
+    void statusSpellsOutWhatNoLobbyMeans() {
+        assertEquals("&bhub", MaintenanceCommand.describeLobbyServer("hub"));
+        assertEquals(
+                "&7none, so players without the bypass permission cannot connect",
+                MaintenanceCommand.describeLobbyServer("")
+        );
+        assertEquals(
+                "&7none, so players without the bypass permission cannot connect",
+                MaintenanceCommand.describeLobbyServer(null)
+        );
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MaintenanceLobbyDestinationTest {
@@ -31,5 +32,13 @@ class MaintenanceLobbyDestinationTest {
         assertFalse(MaintenanceManager.isLobbyServerSet(""));
         assertFalse(MaintenanceManager.isLobbyServerSet("   "));
         assertFalse(MaintenanceManager.isLobbyServerSet(null));
+    }
+
+    @Test
+    void clearingTheStoredLobbyLeavesNothingBehindInTheStateFile() {
+        assertNull(MaintenanceManager.normalizeLobbyServer(null));
+        assertNull(MaintenanceManager.normalizeLobbyServer(""));
+        assertNull(MaintenanceManager.normalizeLobbyServer("   "));
+        assertEquals("hub", MaintenanceManager.normalizeLobbyServer("hub"));
     }
 }


### PR DESCRIPTION
Follow-up to #332, which made an empty maintenance lobby mean something: instead of letting players into the world and kicking them two seconds later, the plugin now refuses the connection at login. The problem is that an admin who had ever run `/maintenance setlobby foo` could not get back to that state. The name went into `maintenance-state.yml` and was preferred over `MAINTENANCE.LOBBY_SERVER` from then on, with no in-game way to undo it. Getting rid of it meant stopping the server and editing the file by hand.

## Clearing it

`/maintenance setlobby` with no server name now clears the stored override and hands the decision back to `network.yml`. The command's own usage line already advertised `setlobby [server]` with the argument optional, so this is the shape it was describing all along. A blank argument clears too, and a stored name that is blank is normalized to nothing rather than being written back to the state file as an empty string.

The reply says where the lobby comes from now, since "cleared" on its own doesn't tell an admin whether players can still connect. If `network.yml` names a lobby they see it; if it is empty they are told that connections will be refused.

## Status

`/maintenance status` printed `Lobby server: ` with nothing after it when no lobby was set, which reads like a display bug rather than the state that decides whether anyone can join. It now spells that state out.

## Notes

Deliberately no `clear` keyword: a proxy server can legitimately be called that, and the no-argument form avoids inventing a name that collides with a real one. `MaintenanceSetLobbyTest` covers the argument shapes and both status strings, and the normalization is covered alongside the existing blank-lobby check in `MaintenanceLobbyDestinationTest`. Suite at 515.
