### PR TITLE
fix(deaths): show death messages to every player again (#337)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1019,8 +1019,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
-    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
+    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
+    #                     the death feed is server wide, so the button only mutes it.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted
@@ -1147,8 +1148,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
-    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
+    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
+    #                     the death feed is server wide, so the button only mutes it.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted
@@ -1195,9 +1197,9 @@ documented above.
 **Which values a setting accepts.** On/off buttons take `true` or `false` (`on`/`off`, `yes`/`no`
 and `enabled`/`disabled` are accepted too). The privacy buttons — `PRIVATE_MESSAGES`,
 `TPA_REQUESTS`, `TPA_HERE_REQUESTS`, `PAYMENTS`, `ADVANCEMENT_MESSAGES` and
-`JOIN_LEAVE_MESSAGES` — take `ANYONE`, `FRIENDS_FOLLOWED` or `OFF`, and `DEATH_MESSAGES` takes
-`FRIENDS_FOLLOWED` or `OFF`. On those buttons `true` is shorthand for `ANYONE`
-(`FRIENDS_FOLLOWED` for `DEATH_MESSAGES`) and `false` is shorthand for `OFF`. `DISABLE_MOB_SPAWN`
+`JOIN_LEAVE_MESSAGES` — take `ANYONE`, `FRIENDS_FOLLOWED` or `OFF`. On those buttons `true` is
+shorthand for `ANYONE` and `false` is shorthand for `OFF`. `DEATH_MESSAGES` is a plain on/off
+button: the death feed goes to the whole server, so the setting only mutes it. `DISABLE_MOB_SPAWN`
 and `DISABLE_PHANTOM_SPAWN` follow the button label, so `DEFAULT: true` means the prevention is
 on and the mobs stop spawning. An unusable value is ignored and logged as a console warning.
 

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerDeathListener.java
@@ -4,7 +4,6 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.FeatureManager;
 import com.bx.ultimateDonutSmp.managers.ShardManager;
 import com.bx.ultimateDonutSmp.models.PlayerData;
-import com.bx.ultimateDonutSmp.models.TwoChoice;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -136,29 +135,27 @@ public class PlayerDeathListener implements Listener {
                 .getBoolean("MESSAGES.ENABLED", true)) {
             final String finalDeathMsg = deathMsg;
             plugin.getSpigotScheduler().forEachOnlinePlayer(p -> {
-                if (shouldReceiveDeathMessage(p, victim)) {
+                if (shouldReceiveDeathMessage(plugin.getPlayerDataManager().get(p))) {
                     p.sendMessage(ColorUtils.toComponent(finalDeathMsg));
                 }
             });
+            // Clearing the vanilla message above also takes the death out of the server log, which
+            // is where an owner looks when nobody was online to read the chat line.
+            org.bukkit.Bukkit.getConsoleSender().sendMessage(finalDeathMsg);
         }
 
         plugin.getCombatManager().clearTag(victim.getUniqueId());
         plugin.getRtpZoneManager().clearState(victim);
     }
 
-    private boolean shouldReceiveDeathMessage(Player receiver, Player victim) {
-        PlayerData receiverData = plugin.getPlayerDataManager().get(receiver);
-        if (receiverData == null) {
-            return true;
-        }
-        TwoChoice choice = receiverData.getDeathMessagesChoice();
-        if (choice == TwoChoice.OFF) {
-            return false;
-        }
-        if (choice == TwoChoice.FRIENDS_FOLLOWED) {
-            return plugin.getFriendsManager() != null && plugin.getFriendsManager().isFollowing(receiver.getUniqueId(), victim.getUniqueId());
-        }
-        return true;
+    /**
+     * Everyone online reads the death feed unless they muted it, and a player the store has no row
+     * for yet is treated as not having muted it. Narrowing the feed to players who follow the
+     * victim, the way join and leave messages are narrowed, emptied it completely: a fresh server
+     * has nobody following anybody, and the victim does not follow themselves either.
+     */
+    static boolean shouldReceiveDeathMessage(PlayerData receiverData) {
+        return receiverData == null || receiverData.isDeathMessagesEnabled();
     }
 
     private String buildDeathMessage(PlayerDeathEvent event, Player victim, Player killer) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -281,7 +281,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
             }
             case "DEATH_MESSAGES" -> {
                 data.setDeathMessagesChoice(nextTwoChoice(data.getDeathMessagesChoice()));
-                sendChoiceMessage(player, "Death Messages", formatTwoChoice(data.getDeathMessagesChoice()));
+                sendToggleMessage(player, "Death Messages", data.isDeathMessagesEnabled());
             }
             case "ADVANCEMENT_MESSAGES" -> toggle(player, "Advancement Messages",
                     !data.isAdvancementMessagesEnabled(), data::setAdvancementMessagesEnabled);
@@ -446,7 +446,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "TEAM_CHAT" -> state(plugin.getTeamManager().isTeamChatEnabled(player.getUniqueId()));
             case "DESTROY_PEARL_ON_DEATH" -> state(data.isDestroyPearlOnDeath());
             case "RANDOMIZED_COORDS" -> state(data.isRandomizedCoords());
-            case "DEATH_MESSAGES" -> new ButtonState(formatTwoChoice(data.getDeathMessagesChoice()), true);
+            case "DEATH_MESSAGES" -> state(data.isDeathMessagesEnabled());
             case "ADVANCEMENT_MESSAGES" -> state(data.isAdvancementMessagesEnabled());
             case "JOIN_LEAVE_MESSAGES" -> new ButtonState(formatTwoChoice(data.getJoinLeaveMessagesChoice()), true);
             case "TELEPORT_ALERTS" -> state(data.isTeleportAlertsEnabled());

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -915,6 +915,15 @@ public class PlayerData {
         dirty = true;
     }
 
+    /**
+     * Death lines go to the whole server, so this setting is only a mute switch. The value is
+     * stored as a {@link TwoChoice} because join and leave messages share the type, and there the
+     * second value narrows the feed to followed players.
+     */
+    public boolean isDeathMessagesEnabled() {
+        return deathMessagesChoice != TwoChoice.OFF;
+    }
+
     public boolean isAdvancementMessagesEnabled() {
         return advancementMessagesEnabled;
     }

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -650,8 +650,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and DEATH_MESSAGES and
-    #                     JOIN_LEAVE_MESSAGES take FRIENDS_FOLLOWED or OFF.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
+    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
+    #                     the death feed is server wide, so the button only mutes it.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/DeathMessageAudienceTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/DeathMessageAudienceTest.java
@@ -1,0 +1,68 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.TwoChoice;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PlayerDeathListener clears the vanilla death message and posts its own line to each player it
+ * decides may see it, so anything that narrows that audience silently removes the death feed from
+ * chat and from the server log at once. These pin the audience to "everyone who did not mute it".
+ */
+class DeathMessageAudienceTest {
+
+    @Test
+    void aPlayerWhoNeverTouchedTheSettingSeesDeathMessages() {
+        assertTrue(PlayerDeathListener.shouldReceiveDeathMessage(newPlayer()));
+    }
+
+    @Test
+    void mutingTheSettingStopsThem() {
+        PlayerData data = newPlayer();
+        data.setDeathMessagesChoice(TwoChoice.OFF);
+        assertFalse(PlayerDeathListener.shouldReceiveDeathMessage(data));
+    }
+
+    /**
+     * The stored value doubles as the join and leave choice, where FRIENDS_FOLLOWED means "only
+     * players I follow". Reading it that way for deaths left the feed empty, because a server
+     * where nobody has followed anybody has no receiver that passes the check.
+     */
+    @Test
+    void theOnValueDoesNotNarrowTheFeedToFollowedPlayers() {
+        PlayerData data = newPlayer();
+        data.setDeathMessagesChoice(TwoChoice.FRIENDS_FOLLOWED);
+        assertTrue(PlayerDeathListener.shouldReceiveDeathMessage(data));
+    }
+
+    @Test
+    void aPlayerWithNoStoredRowStillSeesThem() {
+        assertTrue(PlayerDeathListener.shouldReceiveDeathMessage(null));
+    }
+
+    @Test
+    void bundledDeathMessagesShipEnabled() {
+        var stream = DeathMessageAudienceTest.class.getClassLoader()
+                .getResourceAsStream("death-messages.yml");
+        assertNotNull(stream);
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(
+                new InputStreamReader(stream, StandardCharsets.UTF_8)
+        );
+        assertTrue(config.isBoolean("MESSAGES.ENABLED"));
+        assertTrue(config.getBoolean("MESSAGES.ENABLED"));
+    }
+
+    private static PlayerData newPlayer() {
+        return new PlayerData(UUID.randomUUID(), "Tester");
+    }
+}


### PR DESCRIPTION
Closes #337

Death and kill messages stopped reaching anyone. `PlayerDeathListener` clears the vanilla message so it can send its own coloured line to each player, but the per-player check it hands off to only let a message through when the receiver followed the victim, and that is false for everybody on a server where nobody has followed anybody yet. The victim doesn't follow themselves either, so they didn't even see their own death. Clearing the vanilla message also took the line out of the server log, which is why the reporter saw nothing in console.

## Where it came from

0231fba0, the settings GUI rework in July, swapped `event.setDeathMessage(deathMsg)` for `event.setDeathMessage(null)` plus a manual send. That manual send needed a per-player check so the new mute switch in `/settings` would work, and it copied the one join and leave messages use, where `FRIENDS_FOLLOWED` genuinely does mean "only people I follow". Deaths are different: nobody is following the player who just died, least of all that player.

The stored value is a `TwoChoice`, and that enum has exactly two members: `OFF` and `FRIENDS_FOLLOWED`. No third "everyone" value exists, so `FRIENDS_FOLLOWED` is really just the on state; `PlayerSettingDefaults.parseTwoChoice` maps `true`, `on` and `enabled` straight onto it. An admin who wrote `DEFAULT: true` under `DEATH_MESSAGES` in `menus.yml` was asking for death messages and getting silence.

## The change

`shouldReceiveDeathMessage` now asks one question: did this player mute death messages? Anything other than `OFF` gets the line, and the follow lookup is gone along with the `FriendsManager` call in that path. Join and leave messages keep their own filter; whether they should is a separate question and not this issue.

The console line comes back too. It goes to the console sender after the broadcast rather than through the event, since the event message stays null.

## Settings menu

Leaving the button alone would have made it lie. It rendered "Currently: Friends/Followed". Now it reads Enabled or Disabled, matching the other notification toggles on that row. How the value is stored didn't change, so existing players keep whatever they last picked and nothing needs migrating.

## Notes

No new config or language keys. The comment block in `menus.yml` and the two copies of it quoted in `docs/wiki/Config-menus.yml.md` claimed `DEATH_MESSAGES` takes `FRIENDS_FOLLOWED` or `OFF`; they now say it is on or off, because the death feed is server wide and the button only mutes it.

`DeathMessageAudienceTest` is new and covers the untouched default, an explicit mute, the on value, a player the store has no row for, and that the bundled `death-messages.yml` still ships `MESSAGES.ENABLED: true`. Putting the old follow-gated behaviour back fails two of them. Suite sits at 520 tests, all passing.
