### PR TITLE
fix(spawn): stop setup rewriting a shard zone bound to a cuboid (#325)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
@@ -555,15 +555,18 @@ public class SpawnManager {
             return;
         }
 
-        String regionLocationPath = SETUP_SHARD_REGION_PATH + "."
-                + (type == AreaType.SPAWN ? MENU_LOCATION_KEY : "AFK-LOCATION");
-        if (!setupOwnsShardRegion(config.getString(regionLocationPath), previousSetupLocation)) {
-            return;
-        }
-
         String cuboidName = trimToNull(menus.getString(target.path() + ".CUBOID"));
         if (cuboidName == null) {
             cuboidName = defaultCuboidName(type, parsePositiveInt(target.areaId(), 1));
+        }
+
+        String regionLocationPath = SETUP_SHARD_REGION_PATH + "."
+                + (type == AreaType.SPAWN ? MENU_LOCATION_KEY : "AFK-LOCATION");
+        String regionCuboidPath = SETUP_SHARD_REGION_PATH + "."
+                + (type == AreaType.SPAWN ? "CUBOID" : "AFK-CUBOID");
+        if (!setupOwnsShardRegion(config.getString(regionLocationPath), previousSetupLocation)
+                || !setupOwnsShardCuboid(config.getString(regionCuboidPath), cuboidName)) {
+            return;
         }
 
         config.set(SETUP_SHARD_REGION_PATH + ".ENABLED", true);
@@ -596,6 +599,23 @@ public class SpawnManager {
 
         String previous = previousSetupLocation == null ? "" : previousSetupLocation.trim();
         return current.equalsIgnoreCase(previous);
+    }
+
+    /**
+     * The bound cuboid half of the same question. A region setup filled in names the cuboid setup
+     * would pick for the area being saved, so that name is still setup's to move. Any other name got
+     * there from /cuboid bind, which sets the cuboid without ever writing a LOCATION, so the check
+     * above still reads the region as empty and this is the only thing keeping a bound shard zone
+     * from being pointed back at spawn.
+     */
+    static boolean setupOwnsShardCuboid(String regionCuboid, String setupCuboidName) {
+        String current = regionCuboid == null ? "" : regionCuboid.trim();
+        if (current.isEmpty()) {
+            return true;
+        }
+
+        String setupName = setupCuboidName == null ? "" : setupCuboidName.trim();
+        return current.equalsIgnoreCase(setupName);
     }
 
     private SetupAreaTarget findNextSetupAreaTarget(AreaType type) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/SetupShardRegionOwnershipTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/SetupShardRegionOwnershipTest.java
@@ -9,6 +9,8 @@ class SetupShardRegionOwnershipTest {
 
     private static final String SPAWN_BUILD = "worlds_spawn1,13.0,-3.0,-31.0,45.0,-5.0";
     private static final String WORLD_ORIGIN = "worlds_spawn1,0.5,0.0,0.5,90.0,0.0";
+    private static final String SETUP_CUBOID = "spawn1";
+    private static final String OWNER_CUBOID = "shardzone";
 
     @Test
     void aRegionWithNoLocationYetIsBootstrapped() {
@@ -33,5 +35,34 @@ class SetupShardRegionOwnershipTest {
     void aRegionConfiguredBeforeAnySetupRunIsLeftAlone() {
         assertFalse(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, ""));
         assertFalse(SpawnManager.setupOwnsShardRegion(SPAWN_BUILD, null));
+    }
+
+    @Test
+    void aRegionWithNoCuboidYetIsBootstrapped() {
+        assertTrue(SpawnManager.setupOwnsShardCuboid(null, SETUP_CUBOID));
+        assertTrue(SpawnManager.setupOwnsShardCuboid("", SETUP_CUBOID));
+        assertTrue(SpawnManager.setupOwnsShardCuboid("   ", SETUP_CUBOID));
+    }
+
+    @Test
+    void aRegionStillNamingTheSetupCuboidMovesWithTheNewLocation() {
+        assertTrue(SpawnManager.setupOwnsShardCuboid(SETUP_CUBOID, SETUP_CUBOID));
+        assertTrue(SpawnManager.setupOwnsShardCuboid("  " + SETUP_CUBOID + "  ", SETUP_CUBOID));
+        assertTrue(SpawnManager.setupOwnsShardCuboid(SETUP_CUBOID.toUpperCase(), SETUP_CUBOID));
+    }
+
+    @Test
+    void aCuboidTheOwnerBoundIsLeftAlone() {
+        assertFalse(SpawnManager.setupOwnsShardCuboid(OWNER_CUBOID, SETUP_CUBOID));
+        assertFalse(SpawnManager.setupOwnsShardCuboid(OWNER_CUBOID, ""));
+        assertFalse(SpawnManager.setupOwnsShardCuboid(OWNER_CUBOID, null));
+    }
+
+    @Test
+    void aShardZoneBoundToACuboidSurvivesTheNextSetupRun() {
+        // /cuboid bind <name> shard true names the cuboid and never writes a LOCATION, so the
+        // location check on its own still hands the region back to setup.
+        assertTrue(SpawnManager.setupOwnsShardRegion("", SPAWN_BUILD));
+        assertFalse(SpawnManager.setupOwnsShardCuboid(OWNER_CUBOID, SETUP_CUBOID));
     }
 }


### PR DESCRIPTION
Closes #325

Binding a shard zone with `/cuboid bind <name> shard true` used to survive only until the next `/setspawn`. Saving a spawn point would quietly point `SHARDS.CUBOIDS.REGIONS.spawn` back at the spawn menu's own cuboid (`spawn1` by default) and stamp a `LOCATION` and `RADIUS: 16` over it, so the zone the owner drew stopped paying shards and the ground around spawn started paying them instead.

## Why the existing guard missed it

`setupOwnsShardRegion` already decides whether setup still owns that region, but it reads only the region's `LOCATION`. A blank one means nobody has claimed the region yet, which is right for a fresh install and wrong here: `/cuboid bind` writes `CUBOID`, `WORLD`, `ENABLED` and `BOUND`, and never a `LOCATION`. So an owner-bound region kept reading as unclaimed, and every `/setspawn` took it back.

That guard came in with #150, which covered the half of this people hit by editing `LOCATION` in config.yml themselves. The cuboid half went uncovered, and the ownership test only ever exercised locations.

## The fix

`setupOwnsShardCuboid` asks the same ownership question about the bound cuboid, and `configureSetupShardRegion` now wants both answers before it writes anything. A region whose cuboid is blank, or whose cuboid is the one setup would have picked for the area being saved, still belongs to setup and still follows the spawn point around. Anything else belongs to whoever bound it.

The AFK branch runs `AFK-CUBOID` through the same check, since `/setafk` walks the identical path and had the identical hole.

## Notes

A brand new server bootstraps exactly as before; the only thing that changes is what happens to a region somebody had already bound. One case stays ambiguous on purpose: name your own cuboid `spawn1` and setup cannot tell it apart from its own, so it still claims the region. The binding survives that anyway, because the name written back is the name already there.

No config or language keys added. Four new tests cover the check and the reported scenario, next to the four already pinning the `LOCATION` half. Suite green at 524.
