### PR TITLE
chore(death-messages): drop the radius settings the plugin never reads

### DIFF
--- a/docs/wiki/Config-death-messages.yml.md
+++ b/docs/wiki/Config-death-messages.yml.md
@@ -5,37 +5,6 @@ Each section details the exact commented setup code block, allowed option values
 
 ---
 
-## Section: `SETTINGS`
-
-### 1. Commented Setup Code Example
-
-```yaml
-SETTINGS:
-  # Determines whether Radius is enabled or disabled. Available options: true, false
-  RADIUS: true
-  # The numerical value for Chunks. Available options: Any valid integer
-  CHUNKS: 5
-```
-
-### 2. Key Options & Technical Breakdown
-
-| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
-| :--- | :--- | :--- | :--- | :--- |
-| `SETTINGS.RADIUS` | `bool` | `true`, `false` | `true` | If `true`, death messages are restricted to nearby chunk radii. Set to `false` to broadcast death messages GLOBALLY server-wide. |
-| `SETTINGS.CHUNKS` | `int` | Any valid integer number | `'5'` | Configures the technical `CHUNKS` parameter for `SETTINGS.CHUNKS` in `death-messages.yml`. |
-
-### 3. Practical Setup Example
-
-```yaml
-SETTINGS:
-  # Determines whether Radius is enabled or disabled. Available options: true, false
-  RADIUS: true
-  # The numerical value for Chunks. Available options: Any valid integer
-  CHUNKS: 5
-```
-
----
-
 ## Section: `MESSAGES`
 
 ### 1. Commented Setup Code Example

--- a/src/main/resources/death-messages.yml
+++ b/src/main/resources/death-messages.yml
@@ -1,9 +1,3 @@
-# Configuration section for Settings.
-SETTINGS:
-  # Determines whether Radius is enabled or disabled. Available options: true, false
-  RADIUS: true
-  # The numerical value for Chunks. Available options: Any valid integer
-  CHUNKS: 5
 MESSAGES:
   # Determines whether Enabled is enabled or disabled. Available options: true, false
   ENABLED: true

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2992,7 +2992,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: '&7(Versuche: &f'
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -3302,7 +3302,6 @@ DEATH_MESSAGES:
       NORMAL: '{player} Was blown up'
       PVP: '{player} Was blown up by {killer}'
     DEFAULT: '{player} Died'
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: ' &7(Attempts: &f'
   39f0408258ee4724d5ba: ' &7-> &e'

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2860,7 +2860,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: '&7(Intentos: &f'
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2860,7 +2860,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: "&7(Tentatives : &f"
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2993,7 +2993,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Dan {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: '&7(Upaya: &f'
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2861,7 +2861,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: '&7(Tentativas: &f'
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2858,7 +2858,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: '{player}'
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: "&7(Попытки: &f"
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2846,7 +2846,6 @@ DEATH_MESSAGES:
       NORMAL: "{player} Was blown up"
       PVP: "{player} Was blown up by {killer}"
     DEFAULT: "{player} Died"
-  SETTINGS: {}
 BUILTIN:
   f644b07bb7d7194c2190: "&7（尝试：&f"
   39f0408258ee4724d5ba: '&7-> &e'

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/DeathMessageAudienceTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/DeathMessageAudienceTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,15 +53,29 @@ class DeathMessageAudienceTest {
 
     @Test
     void bundledDeathMessagesShipEnabled() {
+        YamlConfiguration config = bundledDeathMessages();
+        assertTrue(config.isBoolean("MESSAGES.ENABLED"));
+        assertTrue(config.getBoolean("MESSAGES.ENABLED"));
+    }
+
+    /**
+     * The file used to ship a SETTINGS block promising a radius the plugin never read, so an owner
+     * could set it either way and watch nothing happen. Only MESSAGES is wired up; a key here that
+     * nothing reads is a setting admins waste an evening on.
+     */
+    @Test
+    void bundledDeathMessagesShipNothingTheCodeIgnores() {
+        assertEquals(Set.of("MESSAGES"), bundledDeathMessages().getKeys(false));
+    }
+
+    private static YamlConfiguration bundledDeathMessages() {
         var stream = DeathMessageAudienceTest.class.getClassLoader()
                 .getResourceAsStream("death-messages.yml");
         assertNotNull(stream);
 
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(
+        return YamlConfiguration.loadConfiguration(
                 new InputStreamReader(stream, StandardCharsets.UTF_8)
         );
-        assertTrue(config.isBoolean("MESSAGES.ENABLED"));
-        assertTrue(config.getBoolean("MESSAGES.ENABLED"));
     }
 
     private static PlayerData newPlayer() {


### PR DESCRIPTION
`death-messages.yml` shipped a `SETTINGS` block with `RADIUS` and `CHUNKS` in it, and nothing in the plugin has ever read either one. The only code that opens that file is the death listener, and it only ever touches the `MESSAGES` subtree. So an owner could set `RADIUS: false` expecting a server-wide feed, or `CHUNKS: 20` expecting a local one, and get the same behaviour either way.

The wiki made it worse by describing the setting as though it worked, down to which value broadcast globally. Anyone reading that page had every reason to think they were configuring something.

Both keys are gone now, along with the `SETTINGS` section of the wiki page. Nothing changes about how death messages behave: they go to everyone online who has not muted them, which is what they already did.

## Why remove rather than implement

Implementing it was the other option, and the default is what killed it. The bundled file shipped `RADIUS: true`, so building the filter to match the documentation would have narrowed every default server's death feed to five chunks the moment they updated. That's the same complaint as #337 wearing a different hat, and #337 only just shipped. Adding the filter behind a `false` default would avoid that, but it's a new feature rather than a fix, and nobody has asked for it.

## Language files

The merge that copies `death-messages.yml` into the eight language files had left a `DEATH_MESSAGES.SETTINGS: {}` behind in every one of them. It's an empty map, because neither a boolean nor an integer is translatable text, so it never had anything in it and never did anything. Removing the source keys wouldn't have cleaned those up on its own, so all eight lost the line here. `en_US.yml` came back from the test suite unchanged apart from that.

## Notes

Existing servers keep whatever is already in their own `death-messages.yml`; the two keys simply stop being written into new ones, and they were inert where they sat anyway.

`DeathMessageAudienceTest` gains a check that the bundled file has no top-level key other than `MESSAGES`, so a setting nothing reads cannot quietly reappear. Suite is at 525 tests, all passing.
