### PR TITLE
test(worth): cover the guard that keeps worth lines off menu buttons

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplay.java
@@ -81,17 +81,30 @@ public class WorthPacketDisplay implements Listener {
         if (player != null && inPluginMenu.contains(player.getUniqueId())) {
             return true;
         }
-        if (topInv == null) {
+        return topInv != null && isMenuHolder(topInv.getHolder());
+    }
+
+    // a chest belongs to the player, so its contents are worth something and get the line. anything
+    // held by a plugin is a screen made of items, and pricing its buttons is nonsense: the sell menu
+    // confirms with a lime pane, which worth.yml prices at 3, so the button read "Worth: $3"
+    static boolean isMenuHolder(org.bukkit.inventory.InventoryHolder holder) {
+        if (holder == null) {
             return false;
         }
-        org.bukkit.inventory.InventoryHolder holder = topInv.getHolder();
         if (holder instanceof BaseMenu) {
             return true;
         }
-        if (holder != null && !(holder instanceof org.bukkit.block.Container) && !(holder instanceof org.bukkit.entity.Player)) {
-            return true;
+        return !(holder instanceof org.bukkit.block.Container) && !(holder instanceof org.bukkit.entity.Player);
+    }
+
+    // window 0 is the player's own inventory and always keeps the line. above that, only the menu's
+    // own rows are skipped; the player rows underneath still show what their items are worth. a
+    // topSize the server would not give us means skip the window rather than guess at the boundary
+    static boolean shouldSkipSlot(boolean isMenu, int windowId, int slot, int topSize) {
+        if (!isMenu || windowId <= 0) {
+            return false;
         }
-        return false;
+        return topSize == 0 || slot == -1 || slot < topSize;
     }
 
     private void registerPacketListener() {
@@ -136,7 +149,7 @@ public class WorthPacketDisplay implements Listener {
 
                 if (event.getPacketType() == PacketType.Play.Server.SET_SLOT) {
                     int slot = readSlotIndex(packet);
-                    if (windowId > 0 && isMenu && (slot < topSize || slot == -1 || topSize == 0)) {
+                    if (shouldSkipSlot(isMenu, windowId, slot, topSize)) {
                         return;
                     }
                     ItemStack item = packet.getItemModifier().read(0);
@@ -158,7 +171,7 @@ public class WorthPacketDisplay implements Listener {
                 boolean changed = false;
                 for (int i = 0; i < items.size(); i++) {
                     ItemStack item = items.get(i);
-                    if (windowId > 0 && isMenu && (topSize == 0 || i < topSize)) {
+                    if (shouldSkipSlot(isMenu, windowId, i, topSize)) {
                         updated.add(item);
                         continue;
                     }

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplayTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/WorthPacketDisplayTest.java
@@ -1,0 +1,158 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.menus.BaseMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryHolder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorthPacketDisplayTest {
+
+    @Test
+    void theSellMenuConfirmButtonIsLeftAlone() throws Exception {
+        Object previousServer = installServerThatCreatesInventories();
+        try {
+            assertTrue(
+                    WorthPacketDisplay.isMenuHolder(new TestMenu()),
+                    "a plugin menu is a screen built out of items, so none of it is for sale"
+            );
+        } finally {
+            restoreServer(previousServer);
+        }
+
+        assertTrue(
+                WorthPacketDisplay.shouldSkipSlot(true, 1, 53, 54),
+                "slot 53 of the 54 slot sell menu holds Confirm Sell, a lime pane worth.yml prices at 3"
+        );
+    }
+
+    @Test
+    void thePlayerRowsBelowAMenuStillShowWhatTheirItemsAreWorth() {
+        assertFalse(
+                WorthPacketDisplay.shouldSkipSlot(true, 1, 54, 54),
+                "slot 54 is the first of the player's own rows, drawn underneath the menu"
+        );
+        assertFalse(WorthPacketDisplay.shouldSkipSlot(true, 1, 89, 54));
+    }
+
+    @Test
+    void aChestIsNotAMenuSoItsContentsKeepTheirPrices() {
+        assertFalse(WorthPacketDisplay.isMenuHolder(holderProxy(org.bukkit.block.Container.class)));
+    }
+
+    @Test
+    void aPlayerHoldingTheirOwnInventoryIsNotAMenu() {
+        assertFalse(WorthPacketDisplay.isMenuHolder(holderProxy(Player.class)));
+    }
+
+    @Test
+    void anInventoryWithNoHolderIsTreatedAsStorage() {
+        assertFalse(
+                WorthPacketDisplay.isMenuHolder(null),
+                "guessing menu here would strip prices off anything the server hands over without an owner"
+        );
+    }
+
+    @Test
+    void aMenuBelongingToAnotherPluginIsLeftAloneToo() {
+        assertTrue(WorthPacketDisplay.isMenuHolder(holderProxy(InventoryHolder.class)));
+    }
+
+    @Test
+    void thePlayersOwnWindowAndPlainChestsAreNeverSkipped() {
+        assertFalse(
+                WorthPacketDisplay.shouldSkipSlot(true, 0, 5, 54),
+                "window 0 is the player's own inventory, which is where the worth line belongs"
+        );
+        assertFalse(WorthPacketDisplay.shouldSkipSlot(false, 1, 5, 54));
+    }
+
+    @Test
+    void aWindowWeCannotMeasureIsSkippedRatherThanGuessedAt() {
+        assertTrue(
+                WorthPacketDisplay.shouldSkipSlot(true, 1, 0, 0),
+                "topSize 0 means the menu's last slot is unknown, so pricing any of it risks the button again"
+        );
+        assertTrue(
+                WorthPacketDisplay.shouldSkipSlot(true, 1, -1, 54),
+                "-1 is the packet's marker for no particular slot"
+        );
+    }
+
+    private static InventoryHolder holderProxy(Class<? extends InventoryHolder> type) {
+        return (InventoryHolder) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxy, method, args) -> defaultValue(method)
+        );
+    }
+
+    private static final class TestMenu extends BaseMenu {
+
+        private TestMenu() {
+            super(null, "&8Test menu", 54);
+        }
+
+        @Override
+        public void build(Player player) {
+        }
+    }
+
+    // BaseMenu builds its inventory in the constructor, so it needs a server to exist. the previous
+    // one is handed back so the next test class gets whatever it was expecting
+    private static Object installServerThatCreatesInventories() throws Exception {
+        Field serverField = org.bukkit.Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        Object previous = serverField.get(null);
+
+        org.bukkit.Server mockServer = (org.bukkit.Server) Proxy.newProxyInstance(
+                org.bukkit.Server.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.Server.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("createInventory")) {
+                        return Proxy.newProxyInstance(
+                                org.bukkit.inventory.Inventory.class.getClassLoader(),
+                                new Class<?>[]{org.bukkit.inventory.Inventory.class},
+                                (iProxy, iMethod, iArgs) -> defaultValue(iMethod)
+                        );
+                    }
+                    return defaultValue(method);
+                }
+        );
+
+        serverField.set(null, mockServer);
+        return previous;
+    }
+
+    private static void restoreServer(Object previous) throws Exception {
+        Field serverField = org.bukkit.Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        serverField.set(null, previous);
+    }
+
+    private static Object defaultValue(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == double.class) {
+            return 0.0;
+        }
+        if (returnType == float.class) {
+            return 0.0f;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Issue #330 was a player reading `Worth: $3` on the sell menu's Confirm Sell button and taking it for the value of the 36 stacks they were about to sell. It wasn't that. The button is a lime stained glass pane, `worth.yml` prices those at 3, so the number under the button was the button's own price. `6ce7dd7e` fixed it back in August by teaching the packet listener to leave plugin GUIs alone, and nothing has covered that guard since.

## The extraction

`isMenuInventory` and the packet handler are both private, and the decision worth testing sat in three places: one `instanceof` chain, plus two copies of a `windowId > 0 && isMenu && ...` expression that had drifted into different orderings. Those are now two package-private statics, `isMenuHolder` and `shouldSkipSlot`, called from the same spots as before. No behaviour changes.

`shouldSkipSlot` folds both call sites into one expression. The SET_SLOT copy tested for `slot == -1` and the WINDOW_ITEMS copy didn't, since a list index is never negative; keeping the check costs nothing there and the two now agree.

Driving the real handler would have meant mocking ProtocolLib for very little, so the tests go straight at the helpers.

## Notes

Eight tests. The one carrying the issue is `theSellMenuConfirmButtonIsLeftAlone`, which pins slot 53 of a 54 slot menu. The others cover the boundary just below it, where the player's own rows do still get prices, along with chests and player inventories not counting as menus, a null holder, window 0, and a window whose size the server didn't give us.

`BaseMenu` builds its inventory in its constructor, so that one test installs a stand-in server and puts the previous one back afterwards. Leaving a stubbed server behind is how you break `Material.isAir()` for whatever runs next.

I checked the tests bite by stubbing each guard back to its pre-fix answer: with both stubbed, 3 fail; with only `shouldSkipSlot` stubbed, 2 fail, including the slot 53 assertion. Suite is 533 green.
