### PR TITLE
fix(team): add the missing self-invite message (#340)

### DIFF
--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -35,6 +35,8 @@ TEAM:
   NO-PENDING-INVITES: '&cYou have no pending invites for &6{team}&c.'
   # The text or value for Join Success. Available options: Any valid string text
   JOIN-SUCCESS: '&aYou have joined to &e{team}&a.'
+  # The text or value for Cannot Invite Yourself. Available options: Any valid string text
+  CANNOT-INVITE-YOURSELF: '&cYou cannot invite yourself!'
   # The text or value for Cant Kick Self. Available options: Any valid string text
   CANT-KICK-SELF: '&cYou cannot kick yourself!'
   # The text or value for Kick Success. Available options: Any valid string text
@@ -98,6 +100,7 @@ TEAM:
 | `TEAM.INVITE-SENT` | `str` | Any string text | `'&eYou have invited &a{player} &eto ...'` | Configures the technical `INVITE-SENT` parameter for `TEAM.INVITE-SENT` in `messages.yml`. |
 | `TEAM.NO-PENDING-INVITES` | `str` | Any string text | `'&cYou have no pending invites for &...'` | Configures the technical `NO-PENDING-INVITES` parameter for `TEAM.NO-PENDING-INVITES` in `messages.yml`. |
 | `TEAM.JOIN-SUCCESS` | `str` | Any string text | `'&aYou have joined to &e{team}&a.'` | Configures the technical `JOIN-SUCCESS` parameter for `TEAM.JOIN-SUCCESS` in `messages.yml`. |
+| `TEAM.CANNOT-INVITE-YOURSELF` | `str` | Any string text | `'&cYou cannot invite yourself!'` | Configures the technical `CANNOT-INVITE-YOURSELF` parameter for `TEAM.CANNOT-INVITE-YOURSELF` in `messages.yml`. |
 | `TEAM.CANT-KICK-SELF` | `str` | Any string text | `'&cYou cannot kick yourself!'` | Configures the technical `CANT-KICK-SELF` parameter for `TEAM.CANT-KICK-SELF` in `messages.yml`. |
 | `TEAM.KICK-SUCCESS` | `str` | Any string text | `'&aSuccessfully kicked &7({player}).'` | Configures the technical `KICK-SUCCESS` parameter for `TEAM.KICK-SUCCESS` in `messages.yml`. |
 | `TEAM.KICKED-FROM-TEAM` | `str` | Any string text | `'&aYou have been kicked from the tea...'` | Configures the technical `KICKED-FROM-TEAM` parameter for `TEAM.KICKED-FROM-TEAM` in `messages.yml`. |

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2375,6 +2375,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself!"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2637,6 +2637,7 @@ MESSAGES:
     HOVER-JOIN: '&eClick to join the {team} team.'
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: '&a{player} &eHas joined the team.'
+    CANNOT-INVITE-YOURSELF: '&cYou cannot invite yourself!'
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2240,6 +2240,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself!"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2240,6 +2240,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself !"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2375,6 +2375,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself!"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2240,6 +2240,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself!"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2237,6 +2237,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team."
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team."
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself!"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2232,6 +2232,7 @@ MESSAGES:
     HOVER-JOIN: "&eClick to join the {team} team。"
     OR-TYPE-COMMAND: '&7Or type &f{command}&7 to join.'
     JOINED-BROADCAST: "&a{player} &eHas joined the team。"
+    CANNOT-INVITE-YOURSELF: "&cYou cannot invite yourself！"
   CHAT-MANAGER:
     HELP:
     - ''

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -24,6 +24,8 @@ TEAM:
   NO-PENDING-INVITES: '&cYou have no pending invites for &6{team}&c.'
   # The text or value for Join Success. Available options: Any valid string text
   JOIN-SUCCESS: '&aYou have joined to &e{team}&a.'
+  # The text or value for Cannot Invite Yourself. Available options: Any valid string text
+  CANNOT-INVITE-YOURSELF: '&cYou cannot invite yourself!'
   # The text or value for Cant Kick Self. Available options: Any valid string text
   CANT-KICK-SELF: '&cYou cannot kick yourself!'
   # The text or value for Kick Success. Available options: Any valid string text

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/TeamMessageKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/TeamMessageKeyTest.java
@@ -1,0 +1,51 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TeamMessageKeyTest {
+
+    private static final Pattern KEY = Pattern.compile("getMessage\\(\\s*\"(TEAM\\.[A-Z0-9_-]+)\"");
+
+    private static final Path COMMAND =
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/commands/TeamCommand.java");
+
+    /**
+     * ConfigManager.getMessage(path) reads messages.yml for the legacy value and then asks
+     * LanguageManager for "MESSAGES." + path, so a key shipped in either file resolves. One that is in
+     * neither reaches the player as "&cmissing language key: MESSAGES.&lt;path&gt;".
+     */
+    @Test
+    void everyTeamMessageKeyTheCommandReadsIsShipped() throws IOException {
+        ConfigurationSection legacy = YamlConfiguration
+                .loadConfiguration(new File("src/main/resources/messages.yml"));
+        ConfigurationSection language = YamlConfiguration
+                .loadConfiguration(new File("src/main/resources/languages/en_US.yml"))
+                .getConfigurationSection("MESSAGES");
+
+        Set<String> missing = new TreeSet<>();
+        Matcher matcher = KEY.matcher(Files.readString(COMMAND));
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            boolean shipped = legacy.isString(key) || (language != null && language.isString(key));
+            if (!shipped) {
+                missing.add(key);
+            }
+        }
+
+        assertTrue(missing.isEmpty(),
+                "neither messages.yml nor languages/en_US.yml ships keys TeamCommand reads: " + missing);
+    }
+}


### PR DESCRIPTION
Closes #340

`/team invite` has two guards against inviting yourself. Only the first one has a message that ships.

The second guard exists because the first compares what you typed against your real name, so it misses anyone playing under a `/hide` alias. `HideManager` resolves an alias back to its owner before it ever looks at names, which drops you into the second guard with your own UUID on both sides. That guard asked for `TEAM.CANNOT-INVITE-YOURSELF`, and neither `messages.yml` nor any of the eight language files carried that key. `LanguageManager` falls through to its diagnostic string instead, so the player gets `missing language key: MESSAGES.TEAM.CANNOT-INVITE-YOURSELF` in red and the console logs a warning.

## The key

Added to `messages.yml` next to `CANT-KICK-SELF`, with the wording the first guard already hardcodes: `&cYou cannot invite yourself!`. The eight language files got it too. Each one copies its own `TPA.CANNOT-INVITE-YOURSELF` line so the colour code and the locale punctuation match what is already there, which is why `fr_FR` keeps its narrow no-break space before the exclamation mark and `zh_CN` its fullwidth one.

## Docs

`Config-messages.yml.md` lists every `TEAM.*` key twice, once in the sample block and once in the reference table, so both got the new row.

## Notes

If you go looking at this yourself, grepping `messages.yml` for `CANNOT-INVITE-YOURSELF` does turn up a hit. It belongs to the `TPA:` section further down. The `TEAM` one really was absent.

`TeamMessageKeyTest` pulls every `getMessage("TEAM.…")` literal out of `TeamCommand` and checks each one resolves in `messages.yml` or in `languages/en_US.yml`. Checking both matters. `ConfigManager.getMessage` reads `messages.yml` only for the legacy value and then asks `LanguageManager` for `MESSAGES.<path>`, so plenty of working keys live in the language files alone, and a `messages.yml`-only check would flag every one of them. Suite is at 534, all green.
