### PR TITLE
fix(spawners): group stored loot by type and stop creative breaks giving spawners (#351)

### DIFF
--- a/docs/wiki/Crates-and-Spawners.md
+++ b/docs/wiki/Crates-and-Spawners.md
@@ -29,7 +29,8 @@ UltimateDonutSMP includes custom mob spawners engineered for high-performance mo
 ### Features:
 - **Spawner Stacking**: Place matching spawners onto an existing spawner to stack them (e.g., `x64 Pig Spawner`).
 - **Upgrade System**: Upgrade spawner rate, spawn count, and mob drop multipliers via GUI.
-- **Break Safeguards**: Requires Silk Touch or admin bypass permissions to break stacked spawners without losing count.
+- **Grouped Loot Storage**: Drops collect with each item type kept together in one run, so a skeleton spawner shows all of its arrows and then all of its bones instead of alternating the two down every page. Storage that filled up before this landed is tidied the next time the spawner produces anything.
+- **Break Safeguards**: Requires Silk Touch or admin bypass permissions to break stacked spawners without losing count. Creative mode is exempt from that requirement, and a spawner broken in Creative is removed instead of being handed back, matching the way placing one in Creative costs nothing.
 
 ### Player Spawner Commands (`/spawner`):
 - `/spawner info` – Inspect the spawner block you are looking at. Owner, stack size, stored loot and coordinates only show on spawners you are allowed to access: your own, a teammate's under `OWNER_AND_TEAM`, any of them under `PUBLIC` or while `ALLOW_SPAWNER_STEAL` is on. Anyone else sees the mob type and nothing further.

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -880,7 +880,8 @@ public class SpawnerManager {
             );
         }
 
-        if (player != null) {
+        boolean returnedItem = player != null && returnsSpawnerItemOnBreak(player.getGameMode());
+        if (returnedItem) {
             long remaining = breakAmount;
             List<ItemStack> itemsToGive = new ArrayList<>();
             while (remaining > 0) {
@@ -908,7 +909,8 @@ public class SpawnerManager {
                 plugin.getAntiEspManager().refreshNearby(block.getLocation());
             }
         });
-        return new ActionResult(true, "&apicked up &f" + NumberUtils.format(breakAmount) + "x "
+        String verb = returnedItem ? "&apicked up &f" : "&aremoved &f";
+        return new ActionResult(true, verb + NumberUtils.format(breakAmount) + "x "
                 + ColorUtils.strip(getTypeDisplayName(instance.getMobTypeKey())) + "&a.", (int) breakAmount, fullyDestroyed);
     }
 
@@ -1849,8 +1851,21 @@ public class SpawnerManager {
         }
     }
 
+    /**
+     * Placing a spawner in creative costs nothing, so breaking one must not hand a spawner back:
+     * paying out either way turned a creative break into a free spawner item. The two halves of
+     * that rule live here together so they cannot drift apart again.
+     */
+    static boolean consumesSpawnerItemOnPlace(GameMode gameMode) {
+        return gameMode != GameMode.CREATIVE;
+    }
+
+    static boolean returnsSpawnerItemOnBreak(GameMode gameMode) {
+        return gameMode != GameMode.CREATIVE;
+    }
+
     public void consumeHeldSpawnerItem(Player player, boolean all) {
-        if (player == null || player.getGameMode() == GameMode.CREATIVE) {
+        if (player == null || !consumesSpawnerItemOnPlace(player.getGameMode())) {
             return;
         }
 
@@ -1863,7 +1878,7 @@ public class SpawnerManager {
     }
 
     public void consumeHeldSpawnerItem(Player player, int amount) {
-        if (player == null || player.getGameMode() == GameMode.CREATIVE || amount <= 0) {
+        if (player == null || !consumesSpawnerItemOnPlace(player.getGameMode()) || amount <= 0) {
             return;
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
@@ -4,6 +4,7 @@ import org.bukkit.Material;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -289,6 +290,57 @@ public class SpawnerInstance {
             setSlotLoot(slotIndex, material, add);
             remaining -= add;
             slotIndex++;
+        }
+
+        groupStoredLootByMaterial();
+    }
+
+    /**
+     * A new stack goes to the lowest free slot, so a skeleton spawner ends up alternating arrows
+     * and bones the whole way down, and the storage menu draws slots in order. Re-pack the slots
+     * after each drop so every material sits in one run, materials keep the order they first
+     * appeared in, and nothing is left with a gap in front of it. Storage that is already grouped
+     * comes back out unchanged, so this does not shuffle items under a player who has the menu open.
+     */
+    private void groupStoredLootByMaterial() {
+        Map<String, SpawnerLootEntry> unslotted = new LinkedHashMap<>();
+        List<SpawnerLootEntry> slotted = new ArrayList<>();
+        for (Map.Entry<String, SpawnerLootEntry> stored : storedLoot.entrySet()) {
+            if (parseSlotIndex(stored.getKey()) < 0) {
+                unslotted.put(stored.getKey(), stored.getValue());
+            } else {
+                slotted.add(stored.getValue());
+            }
+        }
+
+        slotted.sort(Comparator.comparingInt(entry -> parseSlotIndex(entry.getKey())));
+
+        Map<Material, List<SpawnerLootEntry>> runs = new LinkedHashMap<>();
+        for (SpawnerLootEntry entry : slotted) {
+            runs.computeIfAbsent(entry.getMaterial(), ignored -> new ArrayList<>()).add(entry);
+        }
+
+        storedLoot.clear();
+        storedLoot.putAll(unslotted);
+
+        int nextSlot = 0;
+        for (List<SpawnerLootEntry> run : runs.values()) {
+            for (SpawnerLootEntry entry : run) {
+                String key = "SLOT_" + nextSlot;
+                storedLoot.put(key, new SpawnerLootEntry(key, entry.getMaterial(), entry.getAmount()));
+                nextSlot++;
+            }
+        }
+    }
+
+    private static int parseSlotIndex(String key) {
+        if (key == null || !key.startsWith("SLOT_")) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(key.substring(5));
+        } catch (NumberFormatException ignored) {
+            return -1;
         }
     }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/SpawnerCreativeBreakTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/SpawnerCreativeBreakTest.java
@@ -1,0 +1,34 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.GameMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpawnerCreativeBreakTest {
+
+    @Test
+    void everyGameModeThatPaysForASpawnerIsTheOneThatGetsItBack() {
+        for (GameMode gameMode : GameMode.values()) {
+            assertEquals(
+                    SpawnerManager.consumesSpawnerItemOnPlace(gameMode),
+                    SpawnerManager.returnsSpawnerItemOnBreak(gameMode),
+                    gameMode + " pays for a spawner and gets one back on different terms"
+            );
+        }
+    }
+
+    @Test
+    void creativeNeitherPaysForASpawnerNorGetsOneBack() {
+        assertFalse(SpawnerManager.consumesSpawnerItemOnPlace(GameMode.CREATIVE));
+        assertFalse(SpawnerManager.returnsSpawnerItemOnBreak(GameMode.CREATIVE));
+    }
+
+    @Test
+    void survivalStillPaysForASpawnerAndStillGetsItBack() {
+        assertTrue(SpawnerManager.consumesSpawnerItemOnPlace(GameMode.SURVIVAL));
+        assertTrue(SpawnerManager.returnsSpawnerItemOnBreak(GameMode.SURVIVAL));
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerAutoDropGroupingTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/models/SpawnerAutoDropGroupingTest.java
@@ -1,0 +1,174 @@
+package com.bx.ultimateDonutSmp.models;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpawnerAutoDropGroupingTest {
+
+    private static final int ITEMS_PER_PAGE = 45;
+
+    // Material.getMaxStackSize() walks the item registry, and org.bukkit.Registry never finishes
+    // initialising while Bukkit has no server. The registry proxy is built on first use because
+    // building it needs the server to already be in place.
+    @BeforeAll
+    static void installServer() throws Exception {
+        Field serverField = org.bukkit.Bukkit.class.getDeclaredField("server");
+        serverField.setAccessible(true);
+        if (serverField.get(null) != null) {
+            return;
+        }
+
+        Object[] registry = new Object[1];
+        org.bukkit.Server server = (org.bukkit.Server) Proxy.newProxyInstance(
+                org.bukkit.Server.class.getClassLoader(),
+                new Class<?>[]{org.bukkit.Server.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getRegistry" -> {
+                        if (registry[0] == null) {
+                            Class<?> registryClass = Class.forName("org.bukkit.Registry");
+                            registry[0] = Proxy.newProxyInstance(
+                                    registryClass.getClassLoader(),
+                                    new Class<?>[]{registryClass},
+                                    (registryProxy, registryMethod, registryArgs) -> defaultValue(registryMethod));
+                        }
+                        yield registry[0];
+                    }
+                    default -> defaultValue(method);
+                });
+
+        serverField.set(null, server);
+    }
+
+    private static Object defaultValue(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        return null;
+    }
+
+    @Test
+    void alternatingDropsKeepEachMaterialInOneRun() {
+        SpawnerInstance instance = spawner();
+
+        for (int round = 0; round < 4; round++) {
+            instance.addAutoMobDrop(Material.ARROW, 64L, 0L);
+            instance.addAutoMobDrop(Material.BONE, 64L, 0L);
+        }
+
+        assertEquals(
+                List.of(
+                        Material.ARROW, Material.ARROW, Material.ARROW, Material.ARROW,
+                        Material.BONE, Material.BONE, Material.BONE, Material.BONE
+                ),
+                materials(instance.getPageLootEntries(1, ITEMS_PER_PAGE))
+        );
+    }
+
+    @Test
+    void theNextDropTidiesStorageThatIsAlreadyInterleaved() {
+        SpawnerInstance instance = spawner();
+        instance.setStoredLootEntries(List.of(
+                slot(0, Material.ARROW, 64),
+                slot(1, Material.BONE, 64),
+                slot(2, Material.ARROW, 64),
+                slot(3, Material.BONE, 64)
+        ));
+
+        instance.addAutoMobDrop(Material.ARROW, 64L, 0L);
+
+        assertEquals(
+                List.of(Material.ARROW, Material.ARROW, Material.ARROW, Material.BONE, Material.BONE),
+                materials(instance.getPageLootEntries(1, ITEMS_PER_PAGE))
+        );
+    }
+
+    @Test
+    void groupingClosesTheGapsThatSpreadStorageOverExtraPages() {
+        SpawnerInstance instance = spawner();
+        instance.setStoredLootEntries(List.of(
+                slot(0, Material.ARROW, 64),
+                slot(90, Material.BONE, 32)
+        ));
+
+        instance.addAutoMobDrop(Material.ARROW, 10L, 0L);
+
+        assertEquals(
+                List.of(Material.ARROW, Material.ARROW, Material.BONE),
+                materials(instance.getPageLootEntries(1, ITEMS_PER_PAGE))
+        );
+        assertTrue(instance.getPageLootEntries(2, ITEMS_PER_PAGE).isEmpty());
+        assertTrue(instance.getPageLootEntries(3, ITEMS_PER_PAGE).isEmpty());
+        assertEquals(106L, instance.getTotalStoredItems());
+    }
+
+    @Test
+    void groupingLeavesTheStoredAmountsAlone() {
+        SpawnerInstance instance = spawner();
+
+        instance.addAutoMobDrop(Material.ARROW, 100L, 0L);
+        instance.addAutoMobDrop(Material.BONE, 30L, 0L);
+        instance.addAutoMobDrop(Material.ARROW, 30L, 0L);
+
+        assertEquals(160L, instance.getTotalStoredItems());
+        assertEquals(
+                List.of(Material.ARROW, Material.ARROW, Material.ARROW, Material.BONE),
+                materials(instance.getPageLootEntries(1, ITEMS_PER_PAGE))
+        );
+        // the second arrow stack was topped up to a full 64 before the leftover 2 opened a third
+        assertEquals(List.of(64L, 64L, 2L, 30L), amounts(instance.getPageLootEntries(1, ITEMS_PER_PAGE)));
+    }
+
+    @Test
+    void groupingDoesNotLetAMaterialPastItsStorageCap() {
+        SpawnerInstance instance = spawner();
+
+        instance.addAutoMobDrop(Material.ARROW, 100L, 64L);
+        instance.addAutoMobDrop(Material.ARROW, 100L, 64L);
+
+        assertEquals(64L, instance.getTotalStoredItems());
+    }
+
+    private static List<Material> materials(List<SpawnerLootEntry> entries) {
+        return entries.stream().map(SpawnerLootEntry::getMaterial).toList();
+    }
+
+    private static List<Long> amounts(List<SpawnerLootEntry> entries) {
+        return entries.stream().map(SpawnerLootEntry::getAmount).toList();
+    }
+
+    private static SpawnerLootEntry slot(int slotIndex, Material material, long amount) {
+        return new SpawnerLootEntry("SLOT_" + slotIndex, material, amount);
+    }
+
+    private static SpawnerInstance spawner() {
+        return new SpawnerInstance(
+                1L,
+                "world",
+                0,
+                64,
+                0,
+                UUID.randomUUID(),
+                "BeestoXd",
+                "SKELETON",
+                1L,
+                SpawnerInstance.AccessMode.OWNER_ONLY,
+                0L,
+                0L,
+                0L
+        );
+    }
+}


### PR DESCRIPTION
Closes #351

A skeleton spawner was storing arrows and bones in the order they arrived, so its storage read arrow, bone, arrow, bone all the way down and across every page. Breaking a spawner in creative also handed the spawner item over, even though placing one in creative never costs an item. This sorts out both.

## Grouped loot storage

`SpawnerInstance.addAutoMobDrop` tops up existing stacks of the material first, then drops any overflow into the lowest free `SLOT_n`. With two drop types alternating, the second type always lands one slot behind the first, so the two interleave forever. The storage menu draws slots in order, so that is exactly what the owner sees.

Once the new stacks are allocated, `addAutoMobDrop` re-packs the slots: one run per material, materials in the order they first appeared, gaps closed. Closing the gaps matters too, since `countStoredPages` measures pages off the highest slot index and a hole left by a collected stack was padding the page count.

Storage that is already grouped comes back out unchanged, so nothing shuffles under a player with the menu open, and a spawner that already filled up with interleaved loot gets tidied the next time it produces anything.

## Creative breaks

`consumeHeldSpawnerItem` returns early in creative, so placing a spawner there costs nothing. `breakSpawner` paid out regardless, which made a creative break mint a spawner item from nothing. Both halves of that rule now sit next to each other as `consumesSpawnerItemOnPlace` and `returnsSpawnerItemOnBreak`, and a creative break says "removed" rather than "picked up".

Creative is still exempt from `REQUIRE_SILK_TOUCH`, so this does not change who can break what.

## Notes

The other three things in the report are already configurable and need no code change: the shard zone size and rate live under `SHARDS.CUBOIDS.REGIONS.spawn` (`ENABLED`, `RADIUS`, `INTERVAL`, `AMOUNT`), the worth line has `WORTH-LORE.ENABLED` plus a per-player toggle in `/settings`, and the random spawn button appears once a second spawn area resolves, which is the `randomAreaCount > 1` check in `TeleportAreaMenu`.

No config or language keys added. Eight new tests across two files, one set covering the storage grouping and one pinning the place/break symmetry; suite is 542 green.

`docs/wiki/Crates-and-Spawners.md` picks up both behaviour changes.
