### PR TITLE
refactor(spawners): remove the unused addStoredLoot method

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/SpawnerInstance.java
@@ -344,20 +344,6 @@ public class SpawnerInstance {
         }
     }
 
-    public void addStoredLoot(String key, Material material, long amount, long capPerKey) {
-        if (key == null || material == null || amount <= 0L) {
-            return;
-        }
-
-        String normalizedKey = key.toUpperCase(Locale.US);
-        SpawnerLootEntry entry = storedLoot.computeIfAbsent(normalizedKey, ignored -> new SpawnerLootEntry(normalizedKey, material, 0L));
-        long targetAmount = entry.getAmount() + amount;
-        if (capPerKey > 0L) {
-            targetAmount = Math.min(capPerKey, targetAmount);
-        }
-        entry.setAmount(targetAmount);
-    }
-
     public long removeStoredLoot(String key, long amount) {
         SpawnerLootEntry entry = getStoredLoot(key);
         if (entry == null) {


### PR DESCRIPTION
Removes SpawnerInstance.addStoredLoot. Nothing calls it: grepping the repository for the name turns up a single hit, which is its own declaration.

## Why remove it rather than leave it alone

Every live write path stores loot under a SLOT_<n> key, whether that's setSlotLoot, addAutoMobDrop, or the database load through setStoredLootEntries. addStoredLoot took whatever key the caller handed it, so the first code to start using it would have put a non-slot key into storedLoot, and the storage GUI, getPageLootEntries and countStoredPages all address entries by slot index. Such an entry would sit in the map with no way for a player to see it or collect it.

## Notes

Nothing under com.bx.ultimateDonutSmp.api touches SpawnerInstance; that package holds the PlaceholderAPI expansions and nothing else, and no wiki page names the class, so dropping a public method here breaks no documented surface. The rest of the file is unchanged, and both Locale and Material are still used by the methods that remain. Suite stays at 542 passing.
