### PR TITLE
test(menus): pin the two-area rule for the random teleport button

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaMenu.java
@@ -90,9 +90,15 @@ public abstract class TeleportAreaMenu extends BaseMenu {
             return;
         }
 
-        if (randomAreaCount > 1) {
+        if (shouldDrawRandomButton(randomAreaCount)) {
             buildRandomButton(randomAreaCount);
         }
+    }
+
+    // A random pick between fewer than two areas is just the area itself, so the button only
+    // earns its slot once a second area resolves. Configuring it with one area draws nothing.
+    static boolean shouldDrawRandomButton(int resolvedAreaCount) {
+        return resolvedAreaCount > 1;
     }
 
     @Override

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/TeleportAreaRandomButtonTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/TeleportAreaRandomButtonTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TeleportAreaRandomButtonTest {
+
+    @Test
+    void aMenuWithNothingResolvedDrawsNoRandomButton() {
+        assertFalse(TeleportAreaMenu.shouldDrawRandomButton(0));
+    }
+
+    @Test
+    void aSingleResolvedAreaDrawsNoRandomButton() {
+        assertFalse(
+                TeleportAreaMenu.shouldDrawRandomButton(1),
+                "one area makes the random button a duplicate of that area's own icon, so it stays"
+                        + " hidden however SPAWN-MENU.RANDOM-BUTTON or AFK-MENU.RANDOM-BUTTON is set"
+        );
+    }
+
+    @Test
+    void twoOrMoreResolvedAreasDrawTheRandomButton() {
+        assertTrue(TeleportAreaMenu.shouldDrawRandomButton(2));
+        assertTrue(TeleportAreaMenu.shouldDrawRandomButton(3));
+        assertTrue(TeleportAreaMenu.shouldDrawRandomButton(12));
+    }
+
+    @Test
+    void aNegativeCountIsTreatedAsNothingToPickFrom() {
+        assertFalse(TeleportAreaMenu.shouldDrawRandomButton(-1));
+    }
+}


### PR DESCRIPTION
Adds coverage for the rule that keeps the random teleport button out of the spawn and AFK menus until a second area resolves. Nothing tested it before, and issue #351 showed what that costs: the reporter had SPAWN-MENU.RANDOM-BUTTON configured with one spawn area set, saw no button, and read it as a bug.

## What changed

The condition itself is untouched. It moves out of build() into a named predicate, shouldDrawRandomButton, so the rule has somewhere to carry its reasoning and somewhere for a test to reach it. TeleportAreaMenu.build() needs a live inventory and plugin, and no test in this repo boots a Bukkit server, so a package-private static is the same route SpawnerStorageMenu.countStoredPages already takes.

## Notes

Four cases: nothing resolved, one area, two or more, and a negative count. The single-area case carries the explanation in its assertion message, so flipping > 1 to >= 1 fails with the reason rather than a bare expected/actual. I checked that by making the flip and watching it go red before putting it back.

The behaviour stays as it is, since a random pick between one area and itself is just that area. Both menu sections in docs/wiki/Config-menus.yml.md already spell the rule out, so no documentation changed here. Suite goes from 542 to 546.
