### PR TITLE
feat(spawn): confirm before a menu click deletes a teleport area

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -2742,8 +2742,11 @@ locations by hand. The random button only appears once **two or more** areas res
 single-area menu never shows it however the button is configured.
 
 Players holding `ultimatedonutsmp.admin.teleportareas.delete` or `ultimatedonutsmp.admin` get an
-extra `&cRight-click to delete` line and can remove an area straight from the menu. Turn the whole
-menu off with `SETTINGS.AFK-MENU` in `config.yml`.
+extra `&cRight-click to delete` line on each area. That click opens a confirmation screen instead of
+removing the area on the spot, because deleting one also blanks the point `/setafk` saved in
+`LOCATIONS.AFK-LOCATION`; on the spawn menu the same click would take the server spawn with it.
+Whoever confirms is named in the server log, along with the config key that was cleared. Turn the
+whole menu off with `SETTINGS.AFK-MENU` in `config.yml`.
 
 ### 3. Practical Setup Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnManager.java
@@ -721,6 +721,15 @@ public class SpawnManager {
     }
 
     public AreaDeleteResult deleteMenuArea(TeleportArea area) {
+        return deleteMenuArea(area, null);
+    }
+
+    /**
+     * Deleting an area can also blank the location /setspawn or /setafk saved, which leaves a server
+     * with no spawn at all and nothing in the log to say why. Pass the player who asked for it so the
+     * deletion is recorded.
+     */
+    public AreaDeleteResult deleteMenuArea(TeleportArea area, String actorName) {
         if (area == null) {
             return AreaDeleteResult.failure("area is not available.");
         }
@@ -745,7 +754,8 @@ public class SpawnManager {
             menus.set(areaPath, null);
         }
 
-        boolean configChanged = clearMatchingSetupLocation(config, area.type(), deletedLocation);
+        boolean clearedSetupLocation = clearMatchingSetupLocation(config, area.type(), deletedLocation);
+        boolean configChanged = clearedSetupLocation;
         configChanged = clearMatchingCuboidBind(config, area.type(), area.cuboidName()) || configChanged;
         if (area.type() == AreaType.AFK) {
             configChanged = clearMatchingSetupShardRegion(config, deletedLocation) || configChanged;
@@ -770,8 +780,30 @@ public class SpawnManager {
         if (configChanged && plugin.getShardManager() != null) {
             plugin.getShardManager().reloadSettings();
         }
+        plugin.getLogger().info(describeAreaDeletion(
+                actorName,
+                getLocationLabel(area.type()),
+                area.id(),
+                area.slot(),
+                clearedSetupLocation ? setupLocationPath(area.type()) : null
+        ));
         return AreaDeleteResult.success("Removed " + getLocationLabel(area.type()) + " area "
                 + area.id() + " from slot " + area.slot() + ".");
+    }
+
+    /**
+     * The line written to the server log when an area is deleted. Named so a server owner reading
+     * latest.log can tell who removed which area, and whether the saved spawn or AFK point went with
+     * it; {@code clearedSetupPath} is null when the deletion left that key alone.
+     */
+    static String describeAreaDeletion(String actorName, String label, String areaId, int slot, String clearedSetupPath) {
+        String actor = actorName == null || actorName.isBlank() ? "An unnamed sender" : actorName;
+        return "[SpawnManager] " + actor + " deleted " + label + " area " + areaId + " from slot " + slot
+                + (clearedSetupPath == null ? "" : ", which also cleared " + clearedSetupPath) + ".";
+    }
+
+    private String setupLocationPath(AreaType type) {
+        return type == AreaType.SPAWN ? "LOCATIONS.SPAWN-LOCATION" : "LOCATIONS.AFK-LOCATION";
     }
 
     public boolean isStoredMenuArea(TeleportArea area) {
@@ -793,7 +825,7 @@ public class SpawnManager {
             return false;
         }
 
-        String path = type == AreaType.SPAWN ? "LOCATIONS.SPAWN-LOCATION" : "LOCATIONS.AFK-LOCATION";
+        String path = setupLocationPath(type);
         Location configuredLocation = LocationUtils.parse(config.getString(path, ""));
         if (!sameStoredLocation(configuredLocation, deletedLocation)) {
             return false;

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaDeleteConfirmMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaDeleteConfirmMenu.java
@@ -1,0 +1,89 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.SpawnManager;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.ItemUtils;
+import com.bx.ultimateDonutSmp.utils.SoundUtils;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Asked before an area is removed from the spawn or AFK menu. Right-clicking an area icon used to
+ * delete it outright, which is a heavy thing to do by accident: the same click also blanks the point
+ * /setspawn or /setafk saved, so a stray right-click could leave the whole server with no spawn.
+ */
+public class TeleportAreaDeleteConfirmMenu extends BaseMenu {
+
+    private static final int CONFIRM_SLOT = 11;
+    private static final int CANCEL_SLOT = 15;
+
+    private final SpawnManager.TeleportArea area;
+    private final Map<Integer, Runnable> slotActions = new HashMap<>();
+
+    public TeleportAreaDeleteConfirmMenu(UltimateDonutSmp plugin, SpawnManager.TeleportArea area) {
+        super(plugin, "&8Delete " + label(area) + " area: &c" + (area == null ? "" : area.id()) + "?", 27);
+        this.area = area;
+    }
+
+    @Override
+    public void build(Player player) {
+        clear();
+        slotActions.clear();
+        fill(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
+
+        if (area == null) {
+            return;
+        }
+
+        String label = label(area);
+
+        set(CONFIRM_SLOT, ItemUtils.createItem(
+                Material.LIME_TERRACOTTA,
+                "&aConfirm Delete",
+                List.of(
+                        "&7Permanently delete " + label + " area &f" + area.id(),
+                        "&7from slot &f" + area.slot() + "&7.",
+                        "&cIf this is the point /set" + label + " saved, that is cleared too."
+                )
+        ));
+        slotActions.put(CONFIRM_SLOT, () -> {
+            SpawnManager.AreaDeleteResult result = plugin.getSpawnManager().deleteMenuArea(area, player.getName());
+            player.sendMessage(ColorUtils.toComponent(result.success()
+                    ? "&a" + result.message()
+                    : "&cCould not delete this " + label + " Area: &f" + result.message()));
+            parentMenu().open(player);
+        });
+
+        set(CANCEL_SLOT, ItemUtils.createItem(
+                Material.RED_TERRACOTTA,
+                "&cCancel",
+                List.of("&7Keep this " + label + " area")
+        ));
+        slotActions.put(CANCEL_SLOT, () -> parentMenu().open(player));
+    }
+
+    @Override
+    public void handleClick(int slot, Player player, ClickType clickType) {
+        Runnable action = slotActions.get(slot);
+        if (action != null) {
+            SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
+            action.run();
+        }
+    }
+
+    private TeleportAreaMenu parentMenu() {
+        return area != null && area.type() == SpawnManager.AreaType.AFK
+                ? new AfkMenu(plugin)
+                : new SpawnMenu(plugin);
+    }
+
+    private static String label(SpawnManager.TeleportArea area) {
+        return area != null && area.type() == SpawnManager.AreaType.AFK ? "afk" : "spawn";
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/TeleportAreaMenu.java
@@ -127,23 +127,11 @@ public abstract class TeleportAreaMenu extends BaseMenu {
 
         SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
         if (canDeleteArea(player, area) && clickType.isRightClick()) {
-            deleteArea(player, area);
+            new TeleportAreaDeleteConfirmMenu(plugin, area).open(player);
             return;
         }
 
         queueTeleport(player, area);
-    }
-
-    private void deleteArea(Player player, SpawnManager.TeleportArea area) {
-        SpawnManager.AreaDeleteResult result = plugin.getSpawnManager().deleteMenuArea(area);
-        if (!result.success()) {
-            player.sendMessage(ColorUtils.toComponent("&cCould not delete this " + getLocationLabel()
-                    + " Area: &f" + result.message()));
-            return;
-        }
-
-        player.sendMessage(ColorUtils.toComponent("&a" + result.message()));
-        build(player);
     }
 
     private void buildRandomButton(int areaCount) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AreaDeletionLogLineTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AreaDeletionLogLineTest.java
@@ -1,0 +1,48 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AreaDeletionLogLineTest {
+
+    private static final String SPAWN_PATH = "LOCATIONS.SPAWN-LOCATION";
+    private static final String AFK_PATH = "LOCATIONS.AFK-LOCATION";
+
+    @Test
+    void aDeletionThatTookTheSavedSpawnWithItSaysSo() {
+        assertEquals(
+                "[SpawnManager] Notch deleted spawn area 1 from slot 22, which also cleared "
+                        + SPAWN_PATH + ".",
+                SpawnManager.describeAreaDeletion("Notch", "spawn", "1", 22, SPAWN_PATH)
+        );
+    }
+
+    @Test
+    void aDeletionThatLeftTheSavedSpawnAloneDoesNotMentionIt() {
+        String line = SpawnManager.describeAreaDeletion("Notch", "spawn", "2", 24, null);
+
+        assertEquals("[SpawnManager] Notch deleted spawn area 2 from slot 24.", line);
+        assertFalse(line.contains(SPAWN_PATH));
+    }
+
+    @Test
+    void theAfkMenuIsReportedAgainstItsOwnKey() {
+        assertEquals(
+                "[SpawnManager] Notch deleted afk area 1 from slot 13, which also cleared "
+                        + AFK_PATH + ".",
+                SpawnManager.describeAreaDeletion("Notch", "afk", "1", 13, AFK_PATH)
+        );
+    }
+
+    @Test
+    void aDeletionWithNoNameBehindItStillGetsLogged() {
+        for (String missing : new String[]{null, "", "   "}) {
+            String line = SpawnManager.describeAreaDeletion(missing, "spawn", "1", 22, SPAWN_PATH);
+            assertTrue(line.startsWith("[SpawnManager] An unnamed sender deleted spawn area 1"), line);
+            assertTrue(line.endsWith("cleared " + SPAWN_PATH + "."), line);
+        }
+    }
+}


### PR DESCRIPTION
Right-clicking an area in the `/spawn` or `/afk` menu used to delete it on the spot. That same click also blanks whatever `/setspawn` or `/setafk` saved, so one stray right-click could leave a server with no spawn at all, and nothing went to the log to explain it afterwards. This puts a confirmation screen in front of the delete and writes a line when it goes through.

## Confirmation screen

`TeleportAreaDeleteConfirmMenu` follows the shape `HomeDeleteConfirmMenu` already uses: 27 slots, confirm on 11, cancel on 15, and both routes reopen the menu the admin came from. The confirm lore names the area and its slot, and warns that the saved point goes with it if this area happens to be it.

Nothing else about the click changed. The `&cRight-click to delete` lore line still appears for the same two permissions, and left-click still teleports. Since the confirm menu now owns the delete and the message that follows it, `TeleportAreaMenu.deleteArea` is gone.

## Log line

`deleteMenuArea` now takes the name of whoever asked for the deletion and writes an INFO line naming the area, its slot, and the config key that was cleared when one was. The old single-argument overload stays for callers with no player to name. Building the message lives in a static `describeAreaDeletion`, which is the part the new test covers.

## Notes

`CONFIRM-MENU` in `menus.yml` looked like a fit for this, but nothing reads that block today and it isn't clear what it was meant for, so this menu hardcodes its strings the way the other confirm menus do. No new config or language keys, so the eight language files are untouched.

`docs/wiki/Config-menus.yml.md` described the click as removing an area straight from the menu; that paragraph now covers the confirmation and the log line instead.

Related to #348, where a server owner reports their spawn disappearing on its own. This is the only code path in the plugin that clears `LOCATIONS.SPAWN-LOCATION`, but that issue is still waiting on the reporter and this does not close it.

Suite is green at 550 tests, four of them new.
