### PR TITLE
feat(auction): tell players in the browser how to list an item

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/AuctionHouseBrowseMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/AuctionHouseBrowseMenu.java
@@ -144,7 +144,10 @@ public final class AuctionHouseBrowseMenu extends BaseMenu {
                 "PLAYER_ITEMS",
                 Material.CHEST,
                 "&fYour items",
-                List.of("&7View active, sold, expired, and cancelled listings")
+                List.of(
+                        "&7View active, sold, expired, and cancelled listings",
+                        "&eTo list an item, hold it and run /ah sell <price>"
+                )
         ));
         set(controlSlot("NEXT", 53), renderedPage.hasNext()
                 ? control("NEXT", Material.ARROW, "&fNext page",

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -1548,6 +1548,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -1731,6 +1731,7 @@ CONFIG:
             NAME: '&fYour items'
             LORE:
             - '&7View active, sold, expired, and cancelled listings'
+            - '&eTo list an item, hold it and run /ah sell <price>'
           NEXT:
             NAME: '&fNext page'
             LORE:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1413,6 +1413,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1412,6 +1412,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -1549,6 +1549,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1413,6 +1413,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1412,6 +1412,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1411,6 +1411,7 @@ CONFIG:
             NAME: "&fYour items"
             LORE:
             - "&7View active, sold, expired, and cancelled listings"
+            - "&eTo list an item, hold it and run /ah sell <price>"
           NEXT:
             NAME: "&fNext page"
             LORE:


### PR DESCRIPTION
Two people in Discord went hunting for a create-listing button inside `/ah` and gave up. There isn't one: listing only happens by holding an item and running `/ah sell <price>`, and nothing in the browser says so.

The "Your items" button now carries a second lore line naming the command. That is where people already look, being the only personal-looking entry in the browser.

Both the Java fallback and the eight language files needed the line. On a default English server `applyLanguageSection` skips language values that match the bundled copy, so the menu's own fallback is what renders; on a server running any other locale the language file wins instead. Changing only one of them would have fixed this for roughly half the servers.

550 tests pass locally.
