### PR TITLE
docs(auction): explain the dynamic listing limit permission nodes

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -224,6 +224,31 @@ and give everyone `DEFAULT-ROWS`.
 
 ---
 
+## Auction Listing Limit Permissions
+
+These nodes are not registered in `plugin.yml` and are read straight off the player, so they work with
+LuckPerms or any other permission plugin. Assign them per rank.
+
+| Permission Node | Default | Description |
+| :--- | :--- | :--- |
+| `ultimatedonutsmp.auctionhouse.limit.<1-100>` | `false` | How many auctions the player may have active at once. `ultimatedonutsmp.auctionhouse.limit.15` allows fifteen listings. |
+| `donutauction.limit.<1-100>` | `false` | The same limit under the short alias prefix, for servers carrying an older node layout. |
+
+The number is a total, not a bonus added to the default. When a player holds more than one node the
+**highest** value wins, so a player with both `.limit.10` and `.limit.25` gets 25. A player with no
+limit node falls back to `SETTINGS.MAX_ACTIVE_LISTINGS_DEFAULT` in `auction-house.yml`, which ships as
+5, and `/ah limit` prints a player's active count against whatever they are entitled to.
+
+Wildcards do not grant a limit. `ultimatedonutsmp.*` leaves the player on `MAX_ACTIVE_LISTINGS_DEFAULT`,
+the same way it does for `ultimatedonutsmp.homes.<1-100>`, so a staff wildcard cannot quietly hand every
+player 100 listings.
+
+Named rank nodes can be mapped to a listing count instead of using numeric nodes. See
+`SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION` in [Config-auction-house.yml](Config-auction-house.yml) — map a
+node there to a negative number to give it unlimited listings.
+
+---
+
 ## Media Rank & Badge Permissions
 
 Media permissions are registered with `default: false` and require explicit assignment via LuckPerms (or explicit permission attachment). Being an OP player does not automatically grant media badge status.

--- a/docs/wiki/Config-auction-house.yml.md
+++ b/docs/wiki/Config-auction-house.yml.md
@@ -17,7 +17,12 @@ SETTINGS:
   LISTING_DURATION_HOURS: 48
   # Default maximum active listings a player can post simultaneously
   MAX_ACTIVE_LISTINGS_DEFAULT: 5
-  # Maximum active listing limits granted by permission node
+  # Explicit mapping from permission node to a maximum active listing count
+  # Players can also be given ultimatedonutsmp.auctionhouse.limit.<1-100> directly, for example
+  # ultimatedonutsmp.auctionhouse.limit.25 for 25 active listings, without adding it below
+  # Each value is a total, not a bonus added on top of MAX_ACTIVE_LISTINGS_DEFAULT
+  # The highest value the player has wins, and a negative value here means unlimited
+  # Wildcards do not grant a limit, the node has to be set on the player or their group
   MAX_ACTIVE_LISTINGS_BY_PERMISSION:
     ultimatedonutsmp.auctionhouse.limit.10: 10
     ultimatedonutsmp.auctionhouse.limit.15: 15
@@ -36,8 +41,7 @@ SETTINGS:
 | `SETTINGS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `SETTINGS` system. Set to `true` to enable, `false` to disable. |
 | `SETTINGS.LISTING_DURATION_HOURS` | `int` | Any valid integer number | `'48'` | Configures the technical `LISTING_DURATION_HOURS` parameter for `SETTINGS.LISTING_DURATION_HOURS` in `auction-house.yml`. |
 | `SETTINGS.MAX_ACTIVE_LISTINGS_DEFAULT` | `int` | Any valid integer number | `'5'` | Configures the technical `MAX_ACTIVE_LISTINGS_DEFAULT` parameter for `SETTINGS.MAX_ACTIVE_LISTINGS_DEFAULT` in `auction-house.yml`. |
-| `SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION.ultimatedonutsmp.auctionhouse.limit.10` | `int` | Any valid integer number | `'10'` | Configures the technical `10` parameter for `SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION.ultimatedonutsmp.auctionhouse.limit.10` in `auction-house.yml`. |
-| `SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION.ultimatedonutsmp.auctionhouse.limit.15` | `int` | Any valid integer number | `'15'` | Configures the technical `15` parameter for `SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION.ultimatedonutsmp.auctionhouse.limit.15` in `auction-house.yml`. |
+| `SETTINGS.MAX_ACTIVE_LISTINGS_BY_PERMISSION` | `section` | Permission node to listing count | `{'ultimatedonutsmp.auctionhouse.limit.10': 10, 'ultimatedonutsmp.auctionhouse.limit.15': 15}` | Named nodes mapped to a maximum active listing count, for servers that prefer their own rank nodes over the numbered ones. Each value is a total rather than a bonus on top of `MAX_ACTIVE_LISTINGS_DEFAULT`, the highest value a player holds wins, and a negative value means unlimited. The two shipped entries are only examples: `ultimatedonutsmp.auctionhouse.limit.<1-100>` resolves without being listed here. See [Commands-and-Permissions](Commands-and-Permissions). |
 | `SETTINGS.CLICK_COOLDOWN_MS` | `int` | Any valid integer number | `'750'` | Configures the technical `CLICK_COOLDOWN_MS` parameter for `SETTINGS.CLICK_COOLDOWN_MS` in `auction-house.yml`. |
 | `SETTINGS.EXPIRE_CHECK_SECONDS` | `int` | Any valid integer number | `'30'` | Configures the technical `EXPIRE_CHECK_SECONDS` parameter for `SETTINGS.EXPIRE_CHECK_SECONDS` in `auction-house.yml`. |
 
@@ -51,7 +55,12 @@ SETTINGS:
   LISTING_DURATION_HOURS: 48
   # Default maximum active listings a player can post simultaneously
   MAX_ACTIVE_LISTINGS_DEFAULT: 5
-  # Maximum active listing limits granted by permission node
+  # Explicit mapping from permission node to a maximum active listing count
+  # Players can also be given ultimatedonutsmp.auctionhouse.limit.<1-100> directly, for example
+  # ultimatedonutsmp.auctionhouse.limit.25 for 25 active listings, without adding it below
+  # Each value is a total, not a bonus added on top of MAX_ACTIVE_LISTINGS_DEFAULT
+  # The highest value the player has wins, and a negative value here means unlimited
+  # Wildcards do not grant a limit, the node has to be set on the player or their group
   MAX_ACTIVE_LISTINGS_BY_PERMISSION:
     ultimatedonutsmp.auctionhouse.limit.10: 10
     ultimatedonutsmp.auctionhouse.limit.15: 15

--- a/src/main/resources/auction-house.yml
+++ b/src/main/resources/auction-house.yml
@@ -10,7 +10,12 @@ SETTINGS:
   LISTING_DURATION_HOURS: 48
   # Default maximum active listings a player can post simultaneously
   MAX_ACTIVE_LISTINGS_DEFAULT: 5
-  # Maximum active listing limits granted by permission node
+  # Explicit mapping from permission node to a maximum active listing count
+  # Players can also be given ultimatedonutsmp.auctionhouse.limit.<1-100> directly, for example
+  # ultimatedonutsmp.auctionhouse.limit.25 for 25 active listings, without adding it below
+  # Each value is a total, not a bonus added on top of MAX_ACTIVE_LISTINGS_DEFAULT
+  # The highest value the player has wins, and a negative value here means unlimited
+  # Wildcards do not grant a limit, the node has to be set on the player or their group
   MAX_ACTIVE_LISTINGS_BY_PERMISSION:
     ultimatedonutsmp.auctionhouse.limit.10: 10
     ultimatedonutsmp.auctionhouse.limit.15: 15


### PR DESCRIPTION
Someone in Discord asked how to give moderators a higher auction limit, and neither the config nor the wiki could answer it. `MAX_ACTIVE_LISTINGS_BY_PERMISSION` ships with `limit.10` and `limit.15` under a one-line comment, which reads as the complete list of nodes the plugin understands.

It isn't. `ultimatedonutsmp.auctionhouse.limit.<1-100>` resolves on its own without appearing in that map, the number is a total rather than a bonus on top of `MAX_ACTIVE_LISTINGS_DEFAULT`, the highest value a player holds wins, a negative value in the map means unlimited, and matching is exact so a wildcard grants nothing. None of that was written down anywhere.

The config comment now follows the same shape `ROW-PERMISSIONS` already uses in `ender-chest.yml`. On the wiki, the two generated boilerplate rows became one row that explains the map, matching how `SETTINGS.HOME-PERMISSIONS.PERMISSIONS` is documented.

One thing beyond the obvious two files: `Commands-and-Permissions.md` already has a section for the homes limit and another for ender chest rows, both covering exactly this ground, and had nothing for auctions. It has one now. That page is where a server owner goes looking for a permission node, so leaving it out would have left the original question unanswered in the place people actually search.

Docs only, no behaviour change. `ultimatedonutsmp.auctionhouse.<1-100>` also resolves as a limit and is deliberately left undocumented; it looks like a leftover and is easy to confuse with `.use` or `.buy`, so it is probably better removed from the code than enshrined in the wiki.
