### PR TITLE
fix(notifications): show join and leave messages to everyone again

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -964,9 +964,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
-    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
-    #                     the death feed is server wide, so the button only mutes it.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES are on or off: both feeds are server
+    #                     wide, so those buttons only mute them.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted
@@ -1093,9 +1093,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
-    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
-    #                     the death feed is server wide, so the button only mutes it.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES are on or off: both feeds are server
+    #                     wide, so those buttons only mute them.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted
@@ -1141,10 +1141,10 @@ documented above.
 
 **Which values a setting accepts.** On/off buttons take `true` or `false` (`on`/`off`, `yes`/`no`
 and `enabled`/`disabled` are accepted too). The privacy buttons — `PRIVATE_MESSAGES`,
-`TPA_REQUESTS`, `TPA_HERE_REQUESTS`, `PAYMENTS`, `ADVANCEMENT_MESSAGES` and
-`JOIN_LEAVE_MESSAGES` — take `ANYONE`, `FRIENDS_FOLLOWED` or `OFF`. On those buttons `true` is
-shorthand for `ANYONE` and `false` is shorthand for `OFF`. `DEATH_MESSAGES` is a plain on/off
-button: the death feed goes to the whole server, so the setting only mutes it. `DISABLE_MOB_SPAWN`
+`TPA_REQUESTS`, `TPA_HERE_REQUESTS` and `PAYMENTS` — take `ANYONE`, `FRIENDS_FOLLOWED` or `OFF`,
+where `true` is shorthand for `ANYONE` and `false` for `OFF`. `ADVANCEMENT_MESSAGES`,
+`DEATH_MESSAGES` and `JOIN_LEAVE_MESSAGES` are plain on/off buttons: those feeds go to the whole
+server, so the settings only mute them. `DISABLE_MOB_SPAWN`
 and `DISABLE_PHANTOM_SPAWN` follow the button label, so `DEFAULT: true` means the prevention is
 on and the mobs stop spawning. An unusable value is ignored and logged as a console warning.
 

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -459,6 +459,12 @@ public class PlayerJoinQuitListener implements Listener {
         }
     }
 
+    /**
+     * A vanished joiner stays hidden from anyone without the permission to see them. Past that,
+     * everyone online reads the feed unless they muted it in /settings. Narrowing it to players who
+     * follow the joiner emptied it instead: the server's own join and leave message is cleared and
+     * resent through here, so on a server where nobody has followed anybody it reached no one.
+     */
     private boolean shouldReceiveJoinLeaveMessage(Player receiver, Player joiner) {
         if (plugin.getStaffModeManager() != null && plugin.getStaffModeManager().isVanished(joiner.getUniqueId())) {
             if (!PermissionUtils.has(receiver, plugin.getStaffModeManager().getSeeVanishedPermission())) {
@@ -466,14 +472,7 @@ public class PlayerJoinQuitListener implements Listener {
             }
         }
         PlayerData receiverData = plugin.getPlayerDataManager().get(receiver);
-        if (receiverData == null) {
-            return true;
-        }
-        com.bx.ultimateDonutSmp.models.TwoChoice choice = receiverData.getJoinLeaveMessagesChoice();
-        if (choice == com.bx.ultimateDonutSmp.models.TwoChoice.OFF) {
-            return false;
-        }
-        return plugin.getFriendsManager() != null && plugin.getFriendsManager().isFollowing(receiver.getUniqueId(), joiner.getUniqueId());
+        return receiverData == null || receiverData.isJoinLeaveMessagesEnabled();
     }
 
     private String kickMessage(PunishmentRecord record) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -287,7 +287,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
                     !data.isAdvancementMessagesEnabled(), data::setAdvancementMessagesEnabled);
             case "JOIN_LEAVE_MESSAGES" -> {
                 data.setJoinLeaveMessagesChoice(nextTwoChoice(data.getJoinLeaveMessagesChoice()));
-                sendChoiceMessage(player, "Join/Leave Messages", formatTwoChoice(data.getJoinLeaveMessagesChoice()));
+                sendToggleMessage(player, "Join/Leave Messages", data.isJoinLeaveMessagesEnabled());
             }
             case "TELEPORT_ALERTS" -> toggle(player, "Teleport Alerts",
                     !data.isTeleportAlertsEnabled(), data::setTeleportAlertsEnabled);
@@ -448,7 +448,7 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "RANDOMIZED_COORDS" -> state(data.isRandomizedCoords());
             case "DEATH_MESSAGES" -> state(data.isDeathMessagesEnabled());
             case "ADVANCEMENT_MESSAGES" -> state(data.isAdvancementMessagesEnabled());
-            case "JOIN_LEAVE_MESSAGES" -> new ButtonState(formatTwoChoice(data.getJoinLeaveMessagesChoice()), true);
+            case "JOIN_LEAVE_MESSAGES" -> state(data.isJoinLeaveMessagesEnabled());
             case "TELEPORT_ALERTS" -> state(data.isTeleportAlertsEnabled());
             case "FOLLOW_ALERT_SETTINGS" -> state(data.isFollowAlertsEnabled());
             case "EXPLOSION_SOUNDS" -> state(data.isExplosionSoundsEnabled());
@@ -615,13 +615,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
         return switch (choice) {
             case OFF -> "&cOff";
             case ANYONE -> "&aAnyone";
-            case FRIENDS_FOLLOWED -> "&dFriends/Followed";
-        };
-    }
-
-    private String formatTwoChoice(TwoChoice choice) {
-        return switch (choice) {
-            case OFF -> "&cOff";
             case FRIENDS_FOLLOWED -> "&dFriends/Followed";
         };
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerData.java
@@ -916,9 +916,8 @@ public class PlayerData {
     }
 
     /**
-     * Death lines go to the whole server, so this setting is only a mute switch. The value is
-     * stored as a {@link TwoChoice} because join and leave messages share the type, and there the
-     * second value narrows the feed to followed players.
+     * Death lines go to the whole server, so this setting is only a mute switch. The stored
+     * {@link TwoChoice} carries no more meaning than that: OFF, or anything else.
      */
     public boolean isDeathMessagesEnabled() {
         return deathMessagesChoice != TwoChoice.OFF;
@@ -940,6 +939,14 @@ public class PlayerData {
     public void setJoinLeaveMessagesChoice(TwoChoice joinLeaveMessagesChoice) {
         this.joinLeaveMessagesChoice = joinLeaveMessagesChoice;
         dirty = true;
+    }
+
+    /**
+     * Join and leave lines go to the whole server, so this setting is only a mute switch, the same
+     * way {@link #isDeathMessagesEnabled()} is.
+     */
+    public boolean isJoinLeaveMessagesEnabled() {
+        return joinLeaveMessagesChoice != TwoChoice.OFF;
     }
 
     public boolean isTeleportAlertsEnabled() {

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -636,9 +636,9 @@ SETTINGS-MENU:
     #   DEFAULT: <value>  Starting value for players who never touched the setting.
     #                     On/off buttons take true or false. The privacy buttons
     #                     (PRIVATE_MESSAGES, TPA_REQUESTS, TPA_HERE_REQUESTS, PAYMENTS)
-    #                     take ANYONE, FRIENDS_FOLLOWED or OFF, and JOIN_LEAVE_MESSAGES
-    #                     takes FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES is on or off:
-    #                     the death feed is server wide, so the button only mutes it.
+    #                     take ANYONE, FRIENDS_FOLLOWED or OFF. DEATH_MESSAGES and
+    #                     JOIN_LEAVE_MESSAGES are on or off: both feeds are server
+    #                     wide, so those buttons only mute them.
     #                     true/false also work as shortcuts.
     #   ENABLED: false    Removes the option from /settings and pins every player to the
     #                     DEFAULT above. Use this instead of deleting the block - deleted

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/JoinLeaveMessageAudienceTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/JoinLeaveMessageAudienceTest.java
@@ -1,0 +1,46 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.TwoChoice;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PlayerJoinQuitListener clears the server's own join and leave message and resends it per player,
+ * so whatever decides that audience decides whether anybody sees a join at all. These pin it to
+ * "everyone who did not mute it", the same rule the death feed follows.
+ */
+class JoinLeaveMessageAudienceTest {
+
+    @Test
+    void aPlayerWhoNeverTouchedTheSettingSeesJoinAndLeaveLines() {
+        assertTrue(newPlayer().isJoinLeaveMessagesEnabled());
+    }
+
+    @Test
+    void mutingTheSettingStopsThem() {
+        PlayerData data = newPlayer();
+        data.setJoinLeaveMessagesChoice(TwoChoice.OFF);
+        assertFalse(data.isJoinLeaveMessagesEnabled());
+    }
+
+    /**
+     * FRIENDS_FOLLOWED is the stored on value, not a request to be shown only the people you
+     * follow. Reading it the other way emptied the feed, because a server where nobody has
+     * followed anybody has no receiver that passes a follow check.
+     */
+    @Test
+    void theOnValueDoesNotNarrowTheFeedToFollowedPlayers() {
+        PlayerData data = newPlayer();
+        data.setJoinLeaveMessagesChoice(TwoChoice.FRIENDS_FOLLOWED);
+        assertTrue(data.isJoinLeaveMessagesEnabled());
+    }
+
+    private static PlayerData newPlayer() {
+        return new PlayerData(UUID.randomUUID(), "Tester");
+    }
+}


### PR DESCRIPTION
Join and leave lines were reaching nobody. The listener clears the server's own join message and resends it player by player, and the check in the middle only let it through when the receiver already followed whoever joined. Nobody follows anybody on a fresh server, so the feed was empty for everyone, and because the original message had already been cleared there was nothing left to fall back on.

Same defect as #337, same origin. 0231fba0 added `setJoinMessage(null)` and `setQuitMessage(null)` alongside the per-player send in July, and the follow check came with it. The configurable announcements from #195 arrived a month later and simply reused the route, so they inherited the problem rather than causing it.

## The change

The check now asks whether the player muted join and leave messages, and nothing else. Vanished players are still hidden from anyone without permission to see them; that part was never the problem and has not moved.

The stored value stays a `TwoChoice`, so there is no enum change, no column change and nothing to migrate. `OFF` still means off and everything else means on, which is how `PlayerSettingDefaults.parseTwoChoice` has always read `true`, `on` and `enabled` anyway.

## Settings menu

The button showed "Currently: Friends/Followed", which would now be wrong. It reads Enabled or Disabled, matching Death Messages after #339 and the rest of the notification toggles. That leaves `formatTwoChoice` with no callers, so it is gone; `nextTwoChoice` still drives both toggles.

## Docs

The comment block in `menus.yml`, its two copies quoted in `docs/wiki/Config-menus.yml.md`, and the prose paragraph below them all described `JOIN_LEAVE_MESSAGES` as taking `FRIENDS_FOLLOWED` or `OFF`. They now group it with `DEATH_MESSAGES` as a plain on/off button.

That paragraph also listed `ADVANCEMENT_MESSAGES` among the buttons taking `ANYONE` or `FRIENDS_FOLLOWED`, which was never true: it is bound with `bool(...)` and always has been, so an admin following the page would have written a value the parser rejects and logs as a warning. Since the sentence was being rewritten anyway, it moved to the on/off group where it belongs.

## Notes

`JoinLeaveMessageAudienceTest` covers the untouched default, an explicit mute, and the on value. Putting the follow-gated behaviour back fails two of the three. Suite is at 553 tests, all passing.
