### PR TITLE
refactor(hide): fix the removal message check and drop the unused key normalizer

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/HideCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/HideCommand.java
@@ -198,7 +198,7 @@ public class HideCommand implements CommandExecutor, TabCompleter {
                 }
                 send(sender, manager.message(
                         key,
-                        key.equals("removed")
+                        key.equals("REMOVED")
                                 ? "&aYour hide state has been removed."
                                 : "&aYour identity is now &f{alias}&a.",
                         "{alias}", manager.publicName(result.state())
@@ -275,9 +275,5 @@ public class HideCommand implements CommandExecutor, TabCompleter {
                 .distinct()
                 .sorted(String.CASE_INSENSITIVE_ORDER)
                 .toList();
-    }
-
-    private String normalizeKey(String value) {
-        return HideManager.normalize(value).replace('-', '_').replace(' ', '_');
     }
 }


### PR DESCRIPTION
Two tidies in `HideCommand`. Neither changes what a player sees on a server whose config is intact.

## The removal message

`sendResult` builds a config key of `SCRAMBLED`, `DISGUISED` or `REMOVED`, then chooses the Java fallback string with `key.equals("removed")`. The comparison is lowercase, so it never matches, and the removal case was picking the "your identity is now ..." fallback rather than the removal wording.

Nobody has seen that happen. The fallback only gets used when `MESSAGES.REMOVED` is missing from `hide.yml`, and `syncBundledConfigurations()` writes missing bundled paths back into that file on every startup and reload, so a key an admin deletes comes straight back on the next restart. What the change buys is the next person reading those eight lines: right now the variable is assigned three uppercase literals and then compared against a lowercase one, and you have to go read `HideManager.message` and the config sync to work out whether that is a bug or a deliberate disable.

## The unused normalizer

`HideCommand.normalizeKey` had no callers anywhere in the file. `HideManager` carries its own private copy, and that one is used in a dozen places, so nothing here loses a helper.

## Notes

No test for either. The corrected branch still cannot be reached on a server whose `hide.yml` is intact, so a test would have to delete the key from the config first, and pinning a branch production cannot enter is scaffolding rather than coverage. Suite runs 553, all green.
