### PR TITLE
fix(hide): lift the obfuscated alias to nametag height (#366)

### DIFF
--- a/docs/wiki/Config-hide.yml.md
+++ b/docs/wiki/Config-hide.yml.md
@@ -113,6 +113,10 @@ SCRAMBLE:
   CHARACTERS: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_
   # Determines whether Obfuscated is enabled or disabled. Available options: true, false
   OBFUSCATED: true
+  # How far above the player the obfuscated name is drawn, in blocks. The client draws it where a
+  # passenger sits, around the waist, so this is what carries it up to where a username belongs.
+  # Available options: Any decimal number
+  NAMETAG-OFFSET-Y: 1.0
 # Configuration section for Aliases.
 ```
 
@@ -123,6 +127,7 @@ SCRAMBLE:
 | `SCRAMBLE.LENGTH` | `int` | Any valid integer number | `'10'` | Configures the technical `LENGTH` parameter for `SCRAMBLE.LENGTH` in `hide.yml`. |
 | `SCRAMBLE.CHARACTERS` | `str` | Any string text | `'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi...'` | Configures the technical `CHARACTERS` parameter for `SCRAMBLE.CHARACTERS` in `hide.yml`. |
 | `SCRAMBLE.OBFUSCATED` | `bool` | `true`, `false` | `true` | Configures the technical `OBFUSCATED` parameter for `SCRAMBLE.OBFUSCATED` in `hide.yml`. |
+| `SCRAMBLE.NAMETAG-OFFSET-Y` | `double` | Any decimal number | `1.0` | How far above the player the obfuscated name floats, in blocks. The name is drawn as its own piece of text riding the player, and a rider sits around waist height, so this offset is what carries it up to where a username belongs. Raise it if the name still sits too low, lower it if it floats too far overhead. Only applies while `SCRAMBLE.OBFUSCATED` is `true`. |
 
 ### 3. Practical Setup Example
 
@@ -134,6 +139,10 @@ SCRAMBLE:
   CHARACTERS: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_
   # Determines whether Obfuscated is enabled or disabled. Available options: true, false
   OBFUSCATED: true
+  # How far above the player the obfuscated name is drawn, in blocks. The client draws it where a
+  # passenger sits, around the waist, so this is what carries it up to where a username belongs.
+  # Available options: Any decimal number
+  NAMETAG-OFFSET-Y: 1.0
 # Configuration section for Aliases.
 ```
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HideManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HideManager.java
@@ -195,6 +195,11 @@ public class HideManager {
                 && HideIdentityPolicy.usesObfuscatedText(state);
     }
 
+    /** How far above the point it rides the obfuscated alias is drawn, in blocks. */
+    public double nametagOffsetY() {
+        return config().getDouble("SCRAMBLE.NAMETAG-OFFSET-Y", 1.0D);
+    }
+
     public String plainPublicName(Player player) {
         return player == null ? "" : plainPublicName(player.getUniqueId(), player.getName());
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HideProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HideProtocolLibBridge.java
@@ -26,6 +26,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Transformation;
+import org.joml.Vector3f;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -460,6 +462,7 @@ final class HideProtocolLibBridge implements HidePacketBridge {
         }
 
         display.setText(ColorUtils.colorize(hideManager.publicName(state)));
+        liftClearOfPlayer(display);
         nametagDisplayIds.add(display.getEntityId());
         for (Player viewer : Bukkit.getOnlinePlayers()) {
             if (viewer.getUniqueId().equals(target.getUniqueId())
@@ -471,6 +474,29 @@ final class HideProtocolLibBridge implements HidePacketBridge {
             }
         }
         startNametagRideTask();
+    }
+
+    /**
+     * Raises the text off the player it rides. A ridden entity is drawn where its vehicle seats a
+     * passenger, which on a player is around the waist, so left alone the alias lands across their
+     * legs instead of where a username belongs. The lift goes in the display's own transformation
+     * rather than its location, because the location is not what the client draws it at.
+     */
+    private void liftClearOfPlayer(TextDisplay display) {
+        display.setTransformation(liftedBy(display.getTransformation(), hideManager.nametagOffsetY()));
+    }
+
+    /**
+     * Puts {@code offsetY} into a copy of {@code current}, leaving everything else it carries alone.
+     * Visible for tests, which have no server to spawn a display on.
+     */
+    static Transformation liftedBy(Transformation current, double offsetY) {
+        return new Transformation(
+                new Vector3f(0.0F, (float) offsetY, 0.0F),
+                current.getLeftRotation(),
+                current.getScale(),
+                current.getRightRotation()
+        );
     }
 
     /**

--- a/src/main/resources/hide.yml
+++ b/src/main/resources/hide.yml
@@ -14,6 +14,10 @@ SCRAMBLE:
   CHARACTERS: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_
   # Determines whether Obfuscated is enabled or disabled. Available options: true, false
   OBFUSCATED: true
+  # How far above the player the obfuscated name is drawn, in blocks. The client draws it where a
+  # passenger sits, around the waist, so this is what carries it up to where a username belongs.
+  # Available options: Any decimal number
+  NAMETAG-OFFSET-Y: 1.0
 # Configuration section for Aliases.
 ALIASES:
   # Configuration section for Mrbeast.

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/HideNametagOffsetTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/HideNametagOffsetTest.java
@@ -1,0 +1,61 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HideNametagOffsetTest {
+
+    private static final double BUNDLED_DEFAULT = 1.0D;
+
+    @Test
+    void liftedByRaisesTheTextAndKeepsTheRestOfTheTransformation() {
+        Quaternionf left = new Quaternionf(0.0F, 0.5F, 0.0F, 0.5F);
+        Quaternionf right = new Quaternionf(0.0F, 0.0F, 0.25F, 1.0F);
+        Vector3f scale = new Vector3f(0.6F, 0.6F, 0.6F);
+        Transformation current = new Transformation(new Vector3f(0.0F, 0.0F, 0.0F), left, scale, right);
+
+        Transformation lifted = HideProtocolLibBridge.liftedBy(current, 1.25D);
+
+        assertEquals(1.25F, lifted.getTranslation().y());
+        assertEquals(0.0F, lifted.getTranslation().x());
+        assertEquals(0.0F, lifted.getTranslation().z());
+        assertEquals(scale, lifted.getScale());
+        assertEquals(left, lifted.getLeftRotation());
+        assertEquals(right, lifted.getRightRotation());
+    }
+
+    @Test
+    void liftedByReplacesAnOffsetItHasAlreadyApplied() {
+        Transformation once = HideProtocolLibBridge.liftedBy(identity(), BUNDLED_DEFAULT);
+        Transformation twice = HideProtocolLibBridge.liftedBy(once, BUNDLED_DEFAULT);
+
+        assertEquals((float) BUNDLED_DEFAULT, twice.getTranslation().y());
+    }
+
+    @Test
+    void bundledHideConfigCarriesTheOffsetTheCodeFallsBackTo() throws Exception {
+        YamlConfiguration hide = new YamlConfiguration();
+        hide.load(new File("src/main/resources/hide.yml"));
+
+        assertTrue(hide.contains("SCRAMBLE.NAMETAG-OFFSET-Y"));
+        assertEquals(BUNDLED_DEFAULT, hide.getDouble("SCRAMBLE.NAMETAG-OFFSET-Y"));
+        assertTrue(hide.getBoolean("SCRAMBLE.OBFUSCATED"));
+    }
+
+    private static Transformation identity() {
+        return new Transformation(
+                new Vector3f(0.0F, 0.0F, 0.0F),
+                new Quaternionf(),
+                new Vector3f(1.0F, 1.0F, 1.0F),
+                new Quaternionf()
+        );
+    }
+}


### PR DESCRIPTION
Closes #366

`/hide` on the default `SCRAMBLE.OBFUSCATED: true` was drawing the scrambled name across the player's legs instead of over their head, so anyone hidden looked like they were wearing a label on their belt. The name is a `TextDisplay` that rides its player by packet, and a rider gets drawn where its vehicle seats a passenger, which on a player is somewhere around the waist. Nothing ever moved it off that point.

## The lift

`syncNametagDisplay` set eleven things on the display when it spawned it and never touched the transformation, so the translation sat at zero. It now runs through `liftClearOfPlayer`, which writes the configured offset into the display's own transformation and carries the rotations and the scale across untouched.

That offset goes in the transformation rather than in the entity's location on purpose. The location is only there so the entity tracker knows who to send the display to; `suppressNametagMovement` throws away its movement packets precisely so the client keeps drawing it on the player it rides, which means shifting the entity itself would have changed nothing on screen.

The lift goes in next to `setText` rather than inside the spawn consumer, so a reload reaches a display that already exists and not just new ones.

## The new key

`SCRAMBLE.NAMETAG-OFFSET-Y` in `hide.yml`, default `1.0`. A hardcoded number would have been shorter, but where a passenger sits has moved between Minecraft releases, and crates and portals already hand out their hologram height the same way through `SETTINGS.HOLOGRAM.OFFSET-Y` and `PORTAL-SYSTEM.HOLOGRAM.OFFSET-Y`. A server owner on a build where `1.0` lands badly can nudge it rather than wait for a release.

## Notes

Admin config in a self-contained file, so there's no language file work here.

`liftedBy` is package-visible for the same reason `MoneyNametagManager.render` is: there's no server in the test JVM to spawn a display on, and `Transformation` is plain data. Three tests cover it. One checks the offset landing on Y with X and Z zeroed and the rotations and scale surviving, one calls it twice to prove a second lift replaces the first instead of stacking on it, and the last reads the bundled `hide.yml` to catch the key or its default drifting away from the code. Suite is at 556, all green.

One thing from the issue I left alone because I couldn't confirm it: `createObfuscatedNametagTeam` sends `nametagVisibility` `never` for both the alias and the real name, but a client honours only one team per entry, so a rank plugin's own team may win and leave the real nametag drawn next to the display. It would explain the readable nametag sitting above the obfuscated one in the screenshot on the issue, and it needs a server running a rank plugin to pin down.
