### PR TITLE
fix(commands): strip the namespace from labels before dispatching (#343)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/HideCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/HideCommand.java
@@ -7,6 +7,7 @@ import com.bx.ultimateDonutSmp.menus.DisguiseSkinMenu;
 import com.bx.ultimateDonutSmp.menus.HideListMenu;
 import com.bx.ultimateDonutSmp.menus.HideMenu;
 import com.bx.ultimateDonutSmp.models.HideState;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import org.bukkit.command.Command;
@@ -31,7 +32,7 @@ public class HideCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         HideManager manager = plugin.getHideManager();
-        if (label.equalsIgnoreCase("disguise")) {
+        if (CommandLabelUtils.normalizeLabel(label, command).equals("disguise")) {
             return handleDisguise(sender, args, manager);
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/HomeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/HomeCommand.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.commands;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.HomeMenu;
 import com.bx.ultimateDonutSmp.models.Home;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -27,7 +28,7 @@ public class HomeCommand implements CommandExecutor {
             return true;
         }
 
-        String sub = label.toLowerCase();
+        String sub = CommandLabelUtils.normalizeLabel(label, command);
 
         if (sub.equals("homes")) {
             if (plugin.getHomeBedrockManager() != null && plugin.getHomeBedrockManager().isBedrockPlayer(player)) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/IgnoreCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/IgnoreCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
@@ -41,7 +42,7 @@ public class IgnoreCommand implements CommandExecutor {
             return true;
         }
 
-        boolean removeOnly = label.equalsIgnoreCase("unignore");
+        boolean removeOnly = CommandLabelUtils.normalizeLabel(label, command).equals("unignore");
         if (args.length == 0) {
             send(player, removeOnly
                     ? message("UNIGNORE-USAGE", "&cUsage: /unignore <player>")

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/LeaderboardCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/LeaderboardCommand.java
@@ -4,6 +4,7 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.LeaderboardManager;
 import com.bx.ultimateDonutSmp.menus.LeaderboardMenu;
 import com.bx.ultimateDonutSmp.menus.LeaderboardTypeMenu;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -28,7 +29,7 @@ public class LeaderboardCommand implements CommandExecutor {
             return true;
         }
 
-        if (args.length == 0 && label.equalsIgnoreCase("baltop")) {
+        if (args.length == 0 && CommandLabelUtils.normalizeLabel(label, cmd).equals("baltop")) {
             new LeaderboardTypeMenu(plugin, LeaderboardManager.LeaderboardType.MONEY).open(player);
             return true;
         }

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/MessageCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/MessageCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
@@ -35,7 +36,8 @@ public class MessageCommand implements CommandExecutor {
             return true;
         }
 
-        if (label.equalsIgnoreCase("reply") || label.equalsIgnoreCase("r")) {
+        String sub = CommandLabelUtils.normalizeLabel(label, command);
+        if (sub.equals("reply") || sub.equals("r")) {
             return handleReply(sender, args, label);
         }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/SellCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/SellCommand.java
@@ -7,6 +7,7 @@ import com.bx.ultimateDonutSmp.menus.SellMenu;
 import com.bx.ultimateDonutSmp.menus.SellProgressMenu;
 import com.bx.ultimateDonutSmp.menus.SellStatsAdminMenu;
 import com.bx.ultimateDonutSmp.models.SellCategory;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -30,7 +31,9 @@ public class SellCommand implements CommandExecutor, TabCompleter {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) { sender.sendMessage("Player only."); return true; }
 
-        if (label.equalsIgnoreCase("topsell") || label.equalsIgnoreCase("sellstats")) {
+        String sub = CommandLabelUtils.normalizeLabel(label, command);
+
+        if (sub.equals("topsell") || sub.equals("sellstats")) {
             return new SellStatsCommand(plugin).onCommand(sender, command, label, args);
         }
 
@@ -38,7 +41,7 @@ public class SellCommand implements CommandExecutor, TabCompleter {
             return new SellStatsCommand(plugin).onCommand(sender, command, label, args);
         }
 
-        switch (label.toLowerCase()) {
+        switch (sub) {
             case "sell" -> new SellMenu(plugin).open(player);
             case "sellmulti", "sellmultiplier", "sellprogress" -> {
                 SellCategory category = SellCategory.CROPS;

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/SocialCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/SocialCommand.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.menus.MediaMenu;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -26,7 +27,7 @@ public class SocialCommand implements CommandExecutor {
             return true;
         }
 
-        String normalizedLabel = label.toLowerCase();
+        String normalizedLabel = CommandLabelUtils.normalizeLabel(label, cmd);
         if (normalizedLabel.equals("media")) {
             new MediaMenu(plugin).open(player);
             return true;

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/TPACommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/TPACommand.java
@@ -5,6 +5,7 @@ import com.bx.ultimateDonutSmp.managers.TPAManager;
 import com.bx.ultimateDonutSmp.menus.TpaConfirmMenu;
 import com.bx.ultimateDonutSmp.menus.TpaQueueMenu;
 import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
@@ -33,7 +34,7 @@ public class TPACommand implements CommandExecutor {
             return true;
         }
 
-        String sub = label.toLowerCase();
+        String sub = CommandLabelUtils.normalizeLabel(label, command);
         switch (sub) {
             case "tpa" -> handleTpa(player, args);
             case "tpahere" -> handleTpaHere(player, args);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UniversalCommandTabCompleter.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
@@ -63,7 +64,7 @@ public class UniversalCommandTabCompleter implements TabCompleter {
         }
 
         String commandName = normalize(command.getName());
-        String label = normalize(alias);
+        String label = CommandLabelUtils.normalizeLabel(alias, command);
         return switch (commandName) {
             case "team" -> completeTeam(sender, args);
             case "home", "homes", "sethome", "delhome", "renamehome" -> completeHome(sender, commandName, args);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/WarpManagerCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/WarpManagerCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
@@ -26,7 +27,7 @@ public class WarpManagerCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        String loweredLabel = label.toLowerCase(Locale.ROOT);
+        String loweredLabel = CommandLabelUtils.normalizeLabel(label, command);
 
         if (loweredLabel.equals("setwarp")) {
             handleCreateAlias(sender, args);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/WorthCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/WorthCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
 
@@ -28,7 +29,7 @@ public class WorthCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        boolean pricesAlias = label.equalsIgnoreCase("prices");
+        boolean pricesAlias = CommandLabelUtils.normalizeLabel(label, command).equals("prices");
 
         if (pricesAlias || args.length == 0) {
             openBrowser(sender);

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtils.java
@@ -1,0 +1,33 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.command.Command;
+
+import java.util.Locale;
+
+public final class CommandLabelUtils {
+
+    private CommandLabelUtils() {
+    }
+
+    /**
+     * Returns the label a command was invoked under, without the plugin namespace.
+     *
+     * <p>Bukkit registers every command under {@code plugin:name} as well as its plain name and hands
+     * whichever form was typed to {@code onCommand}, so a class that decides which command it is by
+     * comparing the raw label matches nothing when the namespaced form is used.</p>
+     */
+    public static String normalizeLabel(String label, Command command) {
+        String normalized = label == null || label.isBlank()
+                ? (command == null ? "" : command.getName())
+                : label;
+        if (normalized == null) {
+            return "";
+        }
+
+        int namespaceSeparator = normalized.indexOf(':');
+        if (namespaceSeparator >= 0 && namespaceSeparator + 1 < normalized.length()) {
+            normalized = normalized.substring(namespaceSeparator + 1);
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/NamespacedCommandLabelTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/NamespacedCommandLabelTest.java
@@ -1,0 +1,165 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.CombatManager;
+import com.bx.ultimateDonutSmp.managers.ConfigManager;
+import com.bx.ultimateDonutSmp.managers.HomeManager;
+import com.bx.ultimateDonutSmp.managers.ShopManager;
+import com.bx.ultimateDonutSmp.models.Home;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bukkit registers every command under "plugin:name" as well as its plain name, and hands whichever
+ * form was typed to onCommand as the label. A class that decides which command it is by comparing that
+ * raw label matches no branch when the namespaced form is used.
+ */
+class NamespacedCommandLabelTest {
+
+    @Test
+    void plainLabelSellsTheHeldStack() throws Exception {
+        RecordingShopManager shop = runSell("sellhand");
+        assertTrue(shop.sold, "control: /sellhand has to reach ShopManager.sellInventory");
+    }
+
+    @Test
+    void namespacedLabelSellsTheHeldStackToo() throws Exception {
+        RecordingShopManager shop = runSell("ultimatedonutsmp:sellhand");
+        assertTrue(shop.sold, "/ultimatedonutsmp:sellhand has to reach ShopManager.sellInventory");
+    }
+
+    @Test
+    void plainLabelSavesAHome() throws Exception {
+        RecordingHomeManager homes = runHome("sethome");
+        assertTrue(homes.saved, "control: /sethome has to reach HomeManager.setHome");
+    }
+
+    @Test
+    void namespacedLabelSavesAHomeToo() throws Exception {
+        RecordingHomeManager homes = runHome("ultimatedonutsmp:sethome");
+        assertTrue(homes.saved, "/ultimatedonutsmp:sethome has to save a home rather than teleport");
+    }
+
+    private RecordingShopManager runSell(String label) throws Exception {
+        UltimateDonutSmp plugin = allocate(UltimateDonutSmp.class);
+        RecordingShopManager shop = allocate(RecordingShopManager.class);
+        set(UltimateDonutSmp.class, plugin, "shopManager", shop);
+
+        Player player = proxy(Player.class);
+        Command command = new StubCommand("sellhand");
+
+        new SellCommand(plugin).onCommand(player, command, label, new String[0]);
+        return shop;
+    }
+
+    private RecordingHomeManager runHome(String label) throws Exception {
+        UltimateDonutSmp plugin = allocate(UltimateDonutSmp.class);
+        RecordingHomeManager homes = new RecordingHomeManager(plugin);
+        ConfigManager configManager = new ConfigManager(plugin);
+        set(ConfigManager.class, configManager, "messages", new YamlConfiguration());
+        set(UltimateDonutSmp.class, plugin, "configManager", configManager);
+        set(UltimateDonutSmp.class, plugin, "combatManager", new CombatManager(plugin));
+        set(UltimateDonutSmp.class, plugin, "homeManager", homes);
+
+        Player player = proxy(Player.class);
+        Command command = new StubCommand("sethome");
+
+        // The assertion is about which branch ran. When the label reaches the wrong one, the /home
+        // block asks for managers this test has no reason to stand up, so let that throw and read the
+        // recorder instead.
+        try {
+            new HomeCommand(plugin).onCommand(player, command, label, new String[]{"base"});
+        } catch (Throwable ignored) {
+            // wrong branch, and the recorder below says so
+        }
+        return homes;
+    }
+
+    public static class RecordingShopManager extends ShopManager {
+        boolean sold;
+
+        public RecordingShopManager(UltimateDonutSmp plugin) {
+            super(plugin);
+        }
+
+        @Override
+        public double sellInventory(Player player, boolean handOnly) {
+            sold = true;
+            return 1.0D;
+        }
+    }
+
+    public static class RecordingHomeManager extends HomeManager {
+        boolean saved;
+
+        public RecordingHomeManager(UltimateDonutSmp plugin) {
+            super(plugin);
+        }
+
+        @Override
+        public boolean setHome(Player player, String name) {
+            saved = true;
+            return true;
+        }
+
+        @Override
+        public List<Home> getHomes(UUID uuid) {
+            return List.of();
+        }
+    }
+
+    private static final class StubCommand extends Command {
+        private StubCommand(String name) {
+            super(name);
+        }
+
+        @Override
+        public boolean execute(CommandSender sender, String label, String[] args) {
+            return true;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> type) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(type, objectConstructor);
+        return (T) constructor.newInstance();
+    }
+
+    private static void set(Class<?> owner, Object instance, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type) {
+        UUID uuid = UUID.randomUUID();
+        return (T) Proxy.newProxyInstance(
+                NamespacedCommandLabelTest.class.getClassLoader(),
+                new Class<?>[]{type},
+                (instance, method, args) -> switch (method.getName()) {
+                    case "hashCode" -> System.identityHashCode(instance);
+                    case "equals" -> instance == args[0];
+                    case "toString" -> type.getSimpleName() + "-stub";
+                    case "getUniqueId" -> uuid;
+                    case "getName" -> "Tester";
+                    default -> null;
+                }
+        );
+    }
+}


### PR DESCRIPTION
Closes #343

Bukkit registers every command twice, under its plain name and under `ultimatedonutsmp:<name>`, and hands `onCommand` whichever spelling was typed. Eleven places in `commands/` worked out which command they were by comparing that raw label, so the namespaced form matched no branch and fell through to a default. `/ultimatedonutsmp:sethome` teleported the player instead of saving a home, `/ultimatedonutsmp:unignore` added rather than removed, and `/ultimatedonutsmp:setwarp` answered with the `/warpmanager` usage line.

The spelling is not exotic. The plugin produces it itself: `PunishmentCommandAliasListener` rewrites `/ban` into `ultimatedonutsmp:ban` at `EventPriority.LOWEST`, which is why `PunishmentCommand` already had a `normalizeLabel`. Players reach it the ordinary way too, since it is how you pick one plugin's command when EssentialsX or CMI registers `/home` or `/sell` as well.

## The helper

`CommandLabelUtils.normalizeLabel(label, command)` drops everything up to the first colon, falls back to the registered command name when the label is null or blank, and lowercases what is left. Same semantics as the private version in `PunishmentCommand`.

## Where it went

`HomeCommand`, `IgnoreCommand`, `SellCommand`, `MessageCommand`, `HideCommand`, `LeaderboardCommand`, `SocialCommand`, `TPACommand`, `WorthCommand` and `WarpManagerCommand`, plus `UniversalCommandTabCompleter`, whose own `normalize` only lowercased, so the teleport completer never recognised `tphere` or `tpall` in namespaced form.

Only the reads that decide behaviour changed. Where the label gets shown back to the player, such as the "only players can use /reply" line, the raw text still goes through, so those messages keep repeating what was actually typed.

`GamemodeCommand` and `PunishmentCommand` keep their own private copies. Both already work, and Gamemode's null handling is not quite the shared helper's, so folding them in would mean changing correct code inside a bug fix. There is a task open for that call separately.

## Notes

`NamespacedCommandLabelTest` runs `SellCommand` and `HomeCommand` twice each, once per spelling. On `main` the two plain-label controls pass and both namespaced cases fail, which is what makes it a regression test rather than four assertions that would pass either way.

The `HomeCommand` case wraps the call in a catch. When the label reaches the wrong branch the `/home` path asks for managers the test has no reason to stand up, so the recorder is what the assertion reads rather than whatever that branch throws on its way down.

Suite runs 561, all green.
