### PR TITLE
fix(maintenance): share one command body with the alias

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
@@ -23,27 +23,40 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        handle(plugin, sender, "/" + label, args);
+        return true;
+    }
+
+    /**
+     * The body of /maintenance. The /ultimatedonutsmp maintenance alias calls this with its own
+     * subcommand stripped off, so the two entry points cannot drift apart the way they did when
+     * setlobby learned to clear the stored server.
+     *
+     * @param usage what the calling entry point calls itself in a usage line
+     * @param args  the arguments from the maintenance subcommand onwards
+     */
+    static void handle(UltimateDonutSmp plugin, CommandSender sender, String usage, String[] args) {
         if (!sender.hasPermission("ultimatedonutsmp.admin.maintenance")) {
             sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to manage maintenance mode."));
-            return true;
+            return;
         }
 
         if (args.length < 1) {
-            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <on|off|status|setlobby [server]>"));
-            return true;
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " <on|off|status|setlobby [server]>"));
+            return;
         }
 
         var mm = plugin.getMaintenanceManager();
         if (mm == null) {
             sender.sendMessage(ColorUtils.toComponent("&cMaintenance manager is not available."));
-            return true;
+            return;
         }
 
         switch (args[0].toLowerCase(Locale.ROOT)) {
             case "on", "start", "enable" -> {
                 if (mm.isMaintenanceActive()) {
                     sender.sendMessage(ColorUtils.toComponent("&eMaintenance mode is already active."));
-                    return true;
+                    return;
                 }
                 mm.startMaintenance();
                 sender.sendMessage(ColorUtils.toComponent("&aMaintenance mode has been enabled. Players are being redirected."));
@@ -51,7 +64,7 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
             case "off", "stop", "disable" -> {
                 if (!mm.isMaintenanceActive()) {
                     sender.sendMessage(ColorUtils.toComponent("&eMaintenance mode is not active."));
-                    return true;
+                    return;
                 }
                 mm.stopMaintenance();
                 sender.sendMessage(ColorUtils.toComponent("&aMaintenance mode has been disabled. Reconnect signal sent."));
@@ -69,15 +82,14 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage(ColorUtils.toComponent(
                             "&aLobby server cleared. network.yml decides it now: "
                                     + describeLobbyServer(mm.getLobbyServer()) + "&a."));
-                    return true;
+                    return;
                 }
                 String lobby = args[1];
                 mm.setLobbyServer(lobby);
                 sender.sendMessage(ColorUtils.toComponent("&aLobby server set to &b" + lobby + "&a."));
             }
-            default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " <on|off|status|setlobby [server]>"));
+            default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " <on|off|status|setlobby [server]>"));
         }
-        return true;
     }
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -4,7 +4,6 @@ import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.FeatureManager;
-import com.bx.ultimateDonutSmp.managers.MaintenanceManager;
 import com.bx.ultimateDonutSmp.managers.OptimizationManager;
 import com.bx.ultimateDonutSmp.managers.SpawnManager;
 import com.bx.ultimateDonutSmp.managers.StatsWipeManager;
@@ -764,57 +763,8 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleMaintenance(CommandSender sender, String label, String[] args) {
-        if (!sender.hasPermission("ultimatedonutsmp.admin.maintenance")) {
-            sender.sendMessage(ColorUtils.toComponent("&cYou do not have permission to manage maintenance mode."));
-            return;
-        }
-
-        if (args.length < 2) {
-            sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " maintenance <on|off|status|setlobby [server]>"));
-            return;
-        }
-
-        MaintenanceManager mm = plugin.getMaintenanceManager();
-        if (mm == null) {
-            sender.sendMessage(ColorUtils.toComponent("&cMaintenance manager is not available."));
-            return;
-        }
-
-        switch (args[1].toLowerCase(Locale.ROOT)) {
-            case "on", "start", "enable" -> {
-                if (mm.isMaintenanceActive()) {
-                    sender.sendMessage(ColorUtils.toComponent("&eMaintenance mode is already active."));
-                    return;
-                }
-                mm.startMaintenance();
-                sender.sendMessage(ColorUtils.toComponent("&aMaintenance mode has been enabled. Players are being redirected."));
-            }
-            case "off", "stop", "disable" -> {
-                if (!mm.isMaintenanceActive()) {
-                    sender.sendMessage(ColorUtils.toComponent("&eMaintenance mode is not active."));
-                    return;
-                }
-                mm.stopMaintenance();
-                sender.sendMessage(ColorUtils.toComponent("&aMaintenance mode has been disabled. Reconnect signal sent."));
-            }
-            case "status" -> {
-                boolean active = mm.isMaintenanceActive();
-                String lobby = mm.getLobbyServer();
-                sender.sendMessage(ColorUtils.toComponent("&d&lMaintenance status:"));
-                sender.sendMessage(ColorUtils.toComponent("  &fActive: " + (active ? "&aYes" : "&cNo")));
-                sender.sendMessage(ColorUtils.toComponent("  &fLobby server: &b" + lobby));
-            }
-            case "setlobby" -> {
-                if (args.length < 3) {
-                    sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " maintenance setlobby <server>"));
-                    return;
-                }
-                String lobby = args[2];
-                mm.setLobbyServer(lobby);
-                sender.sendMessage(ColorUtils.toComponent("&aLobby server set to &b" + lobby + "&a."));
-            }
-            default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: /" + label + " maintenance <on|off|status|setlobby [server]>"));
-        }
+        MaintenanceCommand.handle(plugin, sender, "/" + label + " maintenance",
+                Arrays.copyOfRange(args, 1, args.length));
     }
 
     private record CommandEntry(String usage, String description) {

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/MaintenanceAliasTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/MaintenanceAliasTest.java
@@ -1,0 +1,144 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.MaintenanceManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * /ultimatedonutsmp maintenance is a second door onto /maintenance, and it used to keep its own copy
+ * of the body. The copy was not updated when setlobby learned to clear the stored server, so the two
+ * doors answered differently.
+ */
+class MaintenanceAliasTest {
+
+    @Test
+    void leavingTheServerNameOffClearsTheOverride() throws Exception {
+        Run run = alias("setlobby");
+
+        assertTrue(run.manager.cleared, "the alias has to clear the stored lobby, the same as /maintenance setlobby");
+        assertNull(run.manager.lobby);
+    }
+
+    @Test
+    void aNamedServerStillSetsIt() throws Exception {
+        Run run = alias("setlobby", "hub");
+
+        assertEquals("hub", run.manager.lobby, "the alias reads its server name one argument later than /maintenance");
+    }
+
+    @Test
+    void statusSaysWhatAnEmptyLobbyMeans() throws Exception {
+        Run run = alias("status");
+
+        assertTrue(run.sent.stream().anyMatch(line -> line.contains("cannot connect")),
+                "an empty lobby has to be spelled out rather than printed as nothing: " + run.sent);
+    }
+
+    private Run alias(String... maintenanceArgs) throws Exception {
+        UltimateDonutSmp plugin = allocate(UltimateDonutSmp.class);
+        RecordingMaintenanceManager manager = allocate(RecordingMaintenanceManager.class);
+        // allocating past the constructor leaves the fields at their defaults, so an empty lobby
+        // server, the documented single-server setup, has to be set explicitly.
+        manager.lobby = "";
+        set(UltimateDonutSmp.class, plugin, "maintenanceManager", manager);
+
+        List<String> sent = new ArrayList<>();
+        CommandSender sender = sender(sent);
+
+        String[] args = new String[maintenanceArgs.length + 1];
+        args[0] = "maintenance";
+        System.arraycopy(maintenanceArgs, 0, args, 1, maintenanceArgs.length);
+
+        new UltimateDonutSmpCommand(plugin)
+                .onCommand(sender, new StubCommand("ultimatedonutsmp"), "ultimatedonutsmp", args);
+        return new Run(manager, sent);
+    }
+
+    private record Run(RecordingMaintenanceManager manager, List<String> sent) {
+    }
+
+    public static class RecordingMaintenanceManager extends MaintenanceManager {
+        String lobby;
+        boolean cleared;
+
+        public RecordingMaintenanceManager(UltimateDonutSmp plugin) {
+            super(plugin);
+        }
+
+        @Override
+        public boolean isMaintenanceActive() {
+            return false;
+        }
+
+        @Override
+        public String getLobbyServer() {
+            return lobby;
+        }
+
+        @Override
+        public void setLobbyServer(String lobbyServer) {
+            lobby = lobbyServer;
+            cleared = lobbyServer == null;
+        }
+    }
+
+    private static final class StubCommand extends Command {
+        private StubCommand(String name) {
+            super(name);
+        }
+
+        @Override
+        public boolean execute(CommandSender sender, String label, String[] args) {
+            return true;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> type) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(type, objectConstructor);
+        return (T) constructor.newInstance();
+    }
+
+    private static void set(Class<?> owner, Object instance, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
+
+    private static CommandSender sender(List<String> sent) {
+        return (CommandSender) Proxy.newProxyInstance(
+                MaintenanceAliasTest.class.getClassLoader(),
+                new Class<?>[]{CommandSender.class},
+                (instance, method, args) -> switch (method.getName()) {
+                    case "hashCode" -> System.identityHashCode(instance);
+                    case "equals" -> instance == args[0];
+                    case "toString" -> "CommandSender-stub";
+                    case "hasPermission" -> true;
+                    case "getName" -> "CONSOLE";
+                    case "sendMessage" -> {
+                        if (args != null && args.length > 0) {
+                            sent.add(String.valueOf(args[0]));
+                        }
+                        yield null;
+                    }
+                    default -> null;
+                }
+        );
+    }
+}


### PR DESCRIPTION
`/ultimatedonutsmp maintenance` is a second door onto `/maintenance`, and it kept its own copy of the command body. #336 taught `setlobby` to clear the stored lobby server and rewrote what `status` prints, but only in `MaintenanceCommand`, so the two doors started answering differently.

`/maintenance setlobby` with no name clears the override and hands the decision back to `network.yml`. Through the alias it printed a usage line and could not clear at all, which is the hole #336 was written to close. `/maintenance status` says "none, so players without the bypass permission cannot connect" when there is no lobby, while the alias printed `Lobby server: ` and stopped, on exactly the empty-lobby setup `Config-network.yml.md` recommends for a single server.

The alias also advertised `setlobby [server]` in its own usage line, square brackets and all, then refused the form it had just advertised. Both copies did that before #336. Now neither does.

## One body

`MaintenanceCommand.handle` holds the permission check, the usage line, the manager lookup and the switch. Both entry points call it, the alias passing its arguments with its own subcommand sliced off. Fifty-three lines of duplicate went with it, so the next change to maintenance lands in one place instead of needing to be remembered in two.

Every message is the text `/maintenance` was already sending. Only the alias behaves differently, and only by catching up.

## Notes

`MaintenanceAliasTest` drives `/ultimatedonutsmp maintenance` three ways: `setlobby` on its own, `setlobby hub`, and `status` against an empty lobby server. The first and third fail on `main` before the change, the middle one passes throughout.

That middle case is the one worth keeping. The alias reads its server name one argument later than `/maintenance` does, so a delegation that forwards the array unsliced would quietly treat `setlobby hub` as a request to clear. It is the mistake this change was most likely to make.

The recording manager is allocated past its constructor, which leaves every field at its default, so the empty lobby server has to be assigned rather than written as an initialiser. There is a comment on it.

Suite runs 564, all green.
