### PR TITLE
refactor(listeners): drop the unreachable duel message and the no-op ffa check

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/DuelListener.java
@@ -370,10 +370,6 @@ public class DuelListener implements Listener {
 
         event.setCancelled(true);
         event.getPlayer().sendMessage(ColorUtils.toComponent(plugin.getDuelManager().getCommandBlockedMessage()));
-        if (plugin.getDuelManager() != null) {
-            return;
-        }
-        event.getPlayer().sendMessage(ColorUtils.toComponent("&cyou cannot use that command during a duel."));
     }
 
     @EventHandler

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/FfaListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/FfaListener.java
@@ -97,10 +97,6 @@ public class FfaListener implements Listener {
             event.setCancelled(true);
             return;
         }
-
-        if (event instanceof EntityDamageByEntityEvent) {
-            return;
-        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)


### PR DESCRIPTION
Two blocks that cannot run, in two listeners.

## The duel one

`DuelListener.onCommand` blocked the command, sent the configured message, and then asked whether the duel manager was null before sending a second hardcoded message. By that point the method had already called through `plugin.getDuelManager()` four times, so the guard was always true and the line under it never ran.

It is not reachable in principle either. `duelManager` is assigned unconditionally during startup and never set back to null, and the listener is only registered afterwards, so a null manager would have thrown at `isInDuel` long before anything reached that guard. The null checks in `onServerLoad` and `onWorldLoad` further down the same file are the same kind of belt and braces.

Worth removing rather than leaving: the file carried two different "you cannot use that command during a duel" messages with a path to only one of them, and the guard reads like an inverted condition, `!= null` where `== null` looks intended, which invites someone to correct it into a guard that quietly swallows a real failure.

## The ffa one

`FfaListener.onDamage` ended with `if (event instanceof EntityDamageByEntityEvent) { return; }` and nothing after it, so returning early and falling off the end did the same thing. `git log -S` puts it in the first import of the source, and no commit since has argued for it.

## Notes

No test. Both are deletions of code that cannot execute, so there is no behaviour to pin, and nothing in the suite touches either listener today. Suite runs 564, unchanged and green.
