### PR TITLE
fix(spawnstash): read the blocked break message under its shipped key (#345)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/SpawnStashListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/SpawnStashListener.java
@@ -71,7 +71,7 @@ public class SpawnStashListener implements Listener {
 
         event.setCancelled(true);
         event.getPlayer().sendMessage(ColorUtils.toComponent(plugin.getSpawnStashManager()
-                .publicMessage("Blocked-break", "&cThis stash is protected.")));
+                .publicMessage("BLOCKED-BREAK", "&cThis stash is protected.")));
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/SpawnStashMessageKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/SpawnStashMessageKeyTest.java
@@ -1,0 +1,63 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpawnStashMessageKeyTest {
+
+    private static final Pattern MESSAGE_KEY =
+            Pattern.compile("(?:publicMessage|message)\\(\\s*\"([A-Za-z0-9-]+)\"");
+
+    private static final List<Path> SOURCES = List.of(
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/listeners/SpawnStashListener.java"),
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/commands/SpawnStashCommand.java"),
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/managers/SpawnStashManager.java")
+    );
+
+    @Test
+    void everySpawnStashMessageKeyTheCodeReadsIsShipped() throws IOException {
+        ConfigurationSection messages = YamlConfiguration
+                .loadConfiguration(new File("src/main/resources/spawn-stash.yml"))
+                .getConfigurationSection("MESSAGES");
+        assertNotNull(messages, "MESSAGES");
+
+        Set<String> missing = new TreeSet<>();
+        for (Path source : SOURCES) {
+            Matcher matcher = MESSAGE_KEY.matcher(read(source));
+            while (matcher.find()) {
+                String key = matcher.group(1);
+                if (!messages.isString(key)) {
+                    missing.add(key);
+                }
+            }
+        }
+
+        // SpawnStashManager.message does config().getString("MESSAGES." + path, fallback), and Bukkit
+        // paths are case sensitive, so a key spelled differently from the shipped one silently falls
+        // back to the hardcoded English string and the configured (and translated) value is dead.
+        assertTrue(missing.isEmpty(), "spawn-stash.yml MESSAGES is missing keys the code reads: " + missing);
+    }
+
+    private String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #345

Breaking a protected spawn stash told the staff member "This stash is protected." and stopped there. The text the plugin actually ships goes on to say how to clear it, "use /spawnstash remove nearest to rollback it", and nobody had seen that line on a stock server.

The listener asked for the message under `Blocked-break`. It ships as `BLOCKED-BREAK`. `SpawnStashManager.message` resolves it with `config().getString("MESSAGES." + path, fallback)`, and Bukkit paths are case sensitive, so the lookup found nothing and the hardcoded English fallback won every time. Editing the value in `spawn-stash.yml` did nothing either, and the key could never be translated, because the code was never reading it.

Changing the literal in the listener is the whole fix. Nothing in `spawn-stash.yml` moves, so no bundled default changes and no live server inherits anything on update.

## Why only this one

Nine message keys are read across the listener, the command and the manager. `Blocked-break` was the only one not spelled in upper case; `DISABLED`, `INVALID-CONFIG`, `NO-ACTIVE`, `NO-PERMISSION`, `PLAYER-ONLY`, `RELOADED`, `REMOVED` and `REMOVED-ALL` all resolved correctly.

## Notes

`SpawnStashMessageKeyTest` pulls every key those three files read and checks each one against the `MESSAGES` section of `spawn-stash.yml`. It fails on `main` with `[Blocked-break]`, which I confirmed against the current tip rather than the commit quoted in the issue.

Checking the bundled yml alone is right for this feature, and it is the opposite of what a `messages.yml` key needs. These go through `getSpawnStash()`, whose localized copy is built from the bundled file, so a key living only in a language file would not reach the code. That is the same check `AmethystMessageKeyTest` has been making since #317, and this is the same class of bug it was written for.

The wiki already documented `MESSAGES.BLOCKED-BREAK`, so nothing there needed correcting. Suite runs 565, all green.
