### PR TITLE
fix(afk): use concurrent collections for the state async chat touches (#346)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/AFKManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/AFKManager.java
@@ -5,18 +5,17 @@ import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AFKManager {
 
     private final UltimateDonutSmp plugin;
-    private final Map<UUID, Long> lastMovement = new HashMap<>();
-    private final Set<UUID> afkPlayers = new HashSet<>();
+    private final Map<UUID, Long> lastMovement = new ConcurrentHashMap<>();
+    private final Set<UUID> afkPlayers = ConcurrentHashMap.newKeySet();
 
     public AFKManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HomeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HomeManager.java
@@ -13,6 +13,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class HomeManager {
 
@@ -24,7 +25,7 @@ public class HomeManager {
     private final UltimateDonutSmp plugin;
     /** UUID → list of homes */
     private final Map<UUID, List<Home>> cache = new HashMap<>();
-    private final Map<UUID, PendingHomeInput> pendingInputs = new HashMap<>();
+    private final Map<UUID, PendingHomeInput> pendingInputs = new ConcurrentHashMap<>();
 
     public HomeManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/OrdersManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/OrdersManager.java
@@ -273,8 +273,8 @@ public class OrdersManager {
     private final Set<UUID> activeTransactions = new HashSet<>();
     private final Map<UUID, Long> lastClickTimes = new HashMap<>();
     private final Map<UUID, NewOrderSession> pendingCreations = new HashMap<>();
-    private final Map<UUID, PendingSearchInput> pendingSearchInputs = new HashMap<>();
-    private final Map<UUID, PendingOrderEdit> pendingEdits = new HashMap<>();
+    private final Map<UUID, PendingSearchInput> pendingSearchInputs = new ConcurrentHashMap<>();
+    private final Map<UUID, PendingOrderEdit> pendingEdits = new ConcurrentHashMap<>();
     private final Map<String, List<OrderCatalogEntry>> catalogByCategory = new LinkedHashMap<>();
     private final List<String> categoryOrder = new ArrayList<>();
     private final Map<UUID, OrderUiState> uiStates = new ConcurrentHashMap<>();

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/TeamManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/TeamManager.java
@@ -8,15 +8,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class TeamManager {
 
     private final UltimateDonutSmp plugin;
-    private final Map<String, Team> teams = new HashMap<>();
-    private final Map<UUID, String> playerTeamMap = new HashMap<>();
+    private final Map<String, Team> teams = new ConcurrentHashMap<>();
+    private final Map<UUID, String> playerTeamMap = new ConcurrentHashMap<>();
     private final Map<UUID, List<String>> pendingInvites = new HashMap<>();
-    private final Set<UUID> teamChatEnabled = new HashSet<>();
-    private final Map<UUID, PendingTeamSearch> pendingSearchInputs = new HashMap<>();
+    private final Set<UUID> teamChatEnabled = ConcurrentHashMap.newKeySet();
+    private final Map<UUID, PendingTeamSearch> pendingSearchInputs = new ConcurrentHashMap<>();
     private final Map<UUID, String> activeSearchQueries = new HashMap<>();
 
     public TeamManager(UltimateDonutSmp plugin) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/AFKManagerConcurrencyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/AFKManagerConcurrencyTest.java
@@ -1,0 +1,66 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * AFKManager.recordMovement is called from PlayerActivityListener.onChat, which handles
+ * AsyncPlayerChatEvent off the main thread, and from PlayerMoveListener.onMove on the main thread.
+ * The map behind it is a plain HashMap.
+ */
+class AFKManagerConcurrencyTest {
+
+    private static final int THREADS = 8;
+    private static final int PER_THREAD = 4000;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void recordMovementFromSeveralThreadsKeepsEveryEntry() throws Exception {
+        AFKManager manager = new AFKManager(newPlugin());
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        for (int thread = 0; thread < THREADS; thread++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    for (int index = 0; index < PER_THREAD; index++) {
+                        manager.recordMovement(UUID.randomUUID());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+
+        start.countDown();
+        done.await(30, TimeUnit.SECONDS);
+
+        Field field = AFKManager.class.getDeclaredField("lastMovement");
+        field.setAccessible(true);
+        Map<UUID, Long> lastMovement = (Map<UUID, Long>) field.get(manager);
+
+        assertEquals(THREADS * PER_THREAD, lastMovement.size(),
+                "every recorded movement has to survive; a plain HashMap drops entries under concurrent puts");
+    }
+
+    private static UltimateDonutSmp newPlugin() throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> pluginConstructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(UltimateDonutSmp.class, objectConstructor);
+        return (UltimateDonutSmp) pluginConstructor.newInstance();
+    }
+}


### PR DESCRIPTION
Closes #346

Chat is handled on its own thread. `AsyncPlayerChatEvent` reaches `PlayerActivityListener.onChat`, which calls `AFKManager.recordMovement`, which put into a plain `HashMap` and removed from a plain `HashSet` that seven main-thread handlers and `PlayerMoveListener` were writing at the same time. Concurrent puts into a `HashMap` drop entries, and a lost `lastMovement` entry means `shouldGoAfk` returns false, so the AFK timer quietly stops applying to that player, and `hasRecentMovement`, which gates shards-everywhere eligibility, reads false when it should read true.

The collections are now `ConcurrentHashMap` and `ConcurrentHashMap.newKeySet()`. No call site changed, and nothing about which player is AFK when changed either.

## The rest of what the chat thread touches

`ChatListener.onChat` runs on the same thread and reaches further than `AFKManager`, so the same treatment went to what it touches.

`TeamManager.teamChatEnabled` was the other one written from both threads: `ChatListener` calls `setTeamChat(uuid, false)` off the main thread when a player with team chat on has no team, while `disbandTeam`, `leaveTeam`, `kickMember`, the quit listener and `/team chat` all write it on the main thread.

The others are read from the chat thread and written on the main one, which is not a lost write but is still an unsynchronised read against a resize: `HomeManager.pendingInputs` behind `hasPendingInput`, `TeamManager.pendingSearchInputs` behind `hasPendingSearchInput`, and `TeamManager.playerTeamMap` and `teams` behind `getTeam`.

One correction to the issue: `OrdersManager` has no field called `pendingInputs`. Its `hasPendingInput` reads two, `pendingSearchInputs` and `pendingEdits`, and both are converted.

`TeamManager.pendingInvites` and `activeSearchQueries` are left alone. Nothing on the chat thread reaches them, and widening the change to every map in the class would be guessing rather than following the callers.

## Notes

Every converted collection was checked for null keys and values first, since `ConcurrentHashMap` rejects both where `HashMap` accepts them. Every insertion is a freshly constructed object or a non-null string, and none of them use `compute`, so this is a drop-in.

`AFKManagerConcurrencyTest` drives 8 threads through 4000 `recordMovement` calls each and counts what survives. On `main` it failed three runs in a row at 31986, 31980 and 31971 of 32000, which is the shape of the bug: small, silent, and different every time. It passes three for three after.

`ChatManager` was already doing this correctly with two `ConcurrentHashMap` fields, and `StaffModeListener` and `WorthDisplayListener` use the same pair for the same shape, so this follows what the codebase already settled on.

Suite runs 566, all green.
