### PR TITLE
fix(cuboid): write the rtp queue binding to the file that gets saved (#350)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java
@@ -255,7 +255,7 @@ public class CuboidCommand implements CommandExecutor {
             case "rtp-zone" -> config.set("RTP-ZONE.CUBOID", enabled ? cuboidName : "");
             // The matchmaking cuboid is a queue setting rather than a world setting, so it lives
             // in rtp.yml next to the rest of QUEUE and is saved from there.
-            case "rtp-queue" -> plugin.getConfigManager().getRtp().set("QUEUE.CUBOID", enabled ? cuboidName : "");
+            case "rtp-queue" -> plugin.getConfigManager().getOriginalRtp().set("QUEUE.CUBOID", enabled ? cuboidName : "");
             default -> {
                 player.sendMessage(ColorUtils.toComponent("&cUnknown role."));
                 return;

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1351,6 +1351,7 @@ public class ConfigManager {
     public FileConfiguration getOriginalPvp() { return pvp; }
     public FileConfiguration getOriginalMenus() { return menus; }
     public FileConfiguration getOriginalShop() { return shop; }
+    public FileConfiguration getOriginalRtp() { return rtp; }
     public FileConfiguration getSpawners()      { return localized("CONFIG.SPAWNERS", spawners); }
     public FileConfiguration getSpawnStash()    { return localized("CONFIG.SPAWN_STASH", spawnStash); }
     public FileConfiguration getNetwork()       { return localized("CONFIG.NETWORK", network); }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LocalizedConfigWriteTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LocalizedConfigWriteTest.java
@@ -1,0 +1,109 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.ReflectionFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * ConfigManager.getRtp() hands back LanguageManager.localize("CONFIG.RTP", rtp), which is a freshly
+ * built copy whenever the active or fallback language file carries a CONFIG.RTP section - and every
+ * bundled language file does. saveRtp() writes the raw field, so a set() through getRtp() is dropped
+ * and the command that made it still reports success.
+ */
+class LocalizedConfigWriteTest {
+
+    private static final Path CUBOID_COMMAND =
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java");
+
+    @Test
+    void aWriteThroughGetRtpNeverReachesTheConfigurationSaveRtpPersists() throws Exception {
+        UltimateDonutSmp plugin = newPlugin();
+        YamlConfiguration rtp = (YamlConfiguration) rawRtp(plugin);
+
+        plugin.getConfigManager().getRtp().set("QUEUE.CUBOID", "arena");
+
+        assertEquals("", rtp.getString("QUEUE.CUBOID"),
+                "getRtp() is a localized copy on every install, which is why writers must not use it");
+    }
+
+    @Test
+    void getOriginalRtpIsTheConfigurationSaveRtpPersists() throws Exception {
+        UltimateDonutSmp plugin = newPlugin();
+
+        plugin.getConfigManager().getOriginalRtp().set("QUEUE.CUBOID", "arena");
+
+        assertEquals("arena", rawRtp(plugin).getString("QUEUE.CUBOID"),
+                "the accessor the bind uses has to be the field saveRtp() writes");
+    }
+
+    @Test
+    void cuboidCommandDoesNotBindTheRtpQueueThroughTheLocalizedGetter() throws IOException {
+        String source = Files.readString(CUBOID_COMMAND);
+
+        assertFalse(source.contains("getRtp().set("),
+                "CuboidCommand has to write QUEUE.CUBOID through the raw accessor saveRtp() persists,"
+                        + " otherwise the bind is silently dropped and the command still reports success");
+    }
+
+    private static FileConfiguration rawRtp(UltimateDonutSmp plugin) throws Exception {
+        Field field = ConfigManager.class.getDeclaredField("rtp");
+        field.setAccessible(true);
+        return (FileConfiguration) field.get(plugin.getConfigManager());
+    }
+
+    private static UltimateDonutSmp newPlugin() throws Exception {
+        UltimateDonutSmp plugin = allocate(UltimateDonutSmp.class);
+
+        YamlConfiguration language = new YamlConfiguration();
+        // Any string under CONFIG.RTP makes it a section, which is all localize() checks for.
+        language.set("CONFIG.RTP.MESSAGES.DISABLED", "&cRTP is disabled.");
+
+        LanguageManager languageManager = allocate(LanguageManager.class);
+        Map<String, YamlConfiguration> languages = new LinkedHashMap<>();
+        languages.put("en_US", language);
+        set(LanguageManager.class, languageManager, "languages", languages);
+        set(LanguageManager.class, languageManager, "bundledLanguages", new LinkedHashMap<String, YamlConfiguration>());
+        set(LanguageManager.class, languageManager, "localizedConfigurations",
+                new IdentityHashMap<FileConfiguration, Map<String, FileConfiguration>>());
+        set(LanguageManager.class, languageManager, "activeLocale", "en_US");
+        set(LanguageManager.class, languageManager, "fallbackLocale", "en_US");
+        set(UltimateDonutSmp.class, plugin, "languageManager", languageManager);
+
+        YamlConfiguration rtp = new YamlConfiguration();
+        rtp.set("QUEUE.CUBOID", "");
+
+        ConfigManager configManager = new ConfigManager(plugin);
+        set(ConfigManager.class, configManager, "rtp", rtp);
+        set(UltimateDonutSmp.class, plugin, "configManager", configManager);
+        return plugin;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> type) throws Exception {
+        Constructor<Object> objectConstructor = Object.class.getConstructor();
+        Constructor<?> constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(type, objectConstructor);
+        return (T) constructor.newInstance();
+    }
+
+    private static void set(Class<?> owner, Object instance, String name, Object value) throws Exception {
+        Field field = owner.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
+}


### PR DESCRIPTION
Closes #350

`/cuboid bind <name> rtp-queue true` said it worked and wrote nothing. The bind for the `rtp-queue` role went through `getConfigManager().getRtp()`, which is `localized("CONFIG.RTP", rtp)`, and every bundled language file ships a `CONFIG.RTP` section, so that hands back a freshly built copy rather than the configuration `saveRtp()` writes. The set landed on the copy, `saveRtp()` saved the untouched original, and the `reloadAllPluginConfigurations()` on the next line threw the copy away. `saveRtp()` returned true throughout, because saving an unchanged file genuinely succeeds, which is why the admin got a success message for a binding that never existed.

`ConfigManager` had no raw accessor for `rtp`, so this adds `getOriginalRtp()` next to `getOriginalCrates()`, `getOriginalShop()` and the rest of that family, and the bind uses it. The localized read path is untouched, so no message or translation behaviour moves. The other three roles the command handles were always correct: `spawn`, `shard` and `rtp-zone` write into `getConfig()`, which is raw.

## About the test

The test in the issue could not be used as written. It asserts that a write through `getRtp()` lands in the raw field, which is red on `main` but stays red after the fix, because `getRtp()` has to keep returning the localized copy. Making that assertion pass would mean breaking localization for every reader of `rtp.yml`.

`LocalizedConfigWriteTest` keeps the issue's harness and splits it into three:

- a write through `getRtp()` does not reach the saved configuration, which documents the trap and proves the harness really exercises `localize`
- `getOriginalRtp()` is the configuration `saveRtp()` persists
- `CuboidCommand` contains no `getRtp().set(`

The third is the regression test. It fails on `main` and passes here, while the first passes on both sides.

## One thing the issue got wrong

It says this is the only site in the plugin that writes through a localized getter. It is not. `UltimateDonutSmpCommand` takes `getNetwork()`, also localized and also shipped in all eight language files, writes seven keys into it and calls `saveNetwork()`, so `/ultimatedonutsmp setup apply` loses its network settings the same silent way. That is filed separately rather than widened into this PR. `CrateManager` and `SpawnManager` looked like candidates while I was checking and are fine; both already use `getOriginalCrates()` and `getOriginalMenus()`.

Suite runs 569, all green.
