### PR TITLE
refactor(commands): fold the last two label normalizers into the shared helper

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/GamemodeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/GamemodeCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
@@ -152,7 +153,7 @@ public class GamemodeCommand implements CommandExecutor, TabCompleter {
     }
 
     private GameMode modeFromLabel(String label) {
-        return switch (normalizeLabel(label)) {
+        return switch (CommandLabelUtils.normalizeLabel(label)) {
             case "gms" -> GameMode.SURVIVAL;
             case "gmc" -> GameMode.CREATIVE;
             case "gma" -> GameMode.ADVENTURE;
@@ -196,19 +197,6 @@ public class GamemodeCommand implements CommandExecutor, TabCompleter {
 
     private String senderName(CommandSender sender) {
         return sender instanceof Player player ? player.getName() : "console";
-    }
-
-    private String normalizeLabel(String label) {
-        if (label == null) {
-            return "";
-        }
-
-        String normalized = label.toLowerCase(Locale.ROOT);
-        int namespaceSeparator = normalized.indexOf(':');
-        if (namespaceSeparator >= 0 && namespaceSeparator + 1 < normalized.length()) {
-            normalized = normalized.substring(namespaceSeparator + 1);
-        }
-        return normalized;
     }
 
     private void send(CommandSender sender, String path, String fallback, String... placeholders) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
@@ -1,5 +1,6 @@
 package com.bx.ultimateDonutSmp.commands;
 
+import com.bx.ultimateDonutSmp.utils.CommandLabelUtils;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.utils.PunishmentExemptPolicy;
 
@@ -55,7 +56,7 @@ public class PunishmentCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        String action = normalizeLabel(label, command);
+        String action = CommandLabelUtils.normalizeLabel(label, command);
 
         return switch (action) {
             case "ban" -> handleCreate(sender, PunishmentType.BAN, args, false, false, action);
@@ -70,15 +71,6 @@ public class PunishmentCommand implements CommandExecutor {
             case "unblacklist" -> handleRemove(sender, PunishmentType.BLACKLIST, args, action);
             default -> false;
         };
-    }
-
-    private String normalizeLabel(String label, Command command) {
-        String normalized = label == null || label.isBlank() ? command.getName() : label;
-        int namespaceSeparator = normalized.indexOf(':');
-        if (namespaceSeparator >= 0 && namespaceSeparator + 1 < normalized.length()) {
-            normalized = normalized.substring(namespaceSeparator + 1);
-        }
-        return normalized.toLowerCase(Locale.ROOT);
     }
 
     static String permissionForAction(String action) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtils.java
@@ -30,4 +30,12 @@ public final class CommandLabelUtils {
         }
         return normalized.toLowerCase(Locale.ROOT);
     }
+
+    /**
+     * Same, for a caller with no {@link Command} to fall back on. An absent or blank label
+     * normalizes to an empty string rather than to the registered command name.
+     */
+    public static String normalizeLabel(String label) {
+        return normalizeLabel(label, null);
+    }
 }

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtilsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/CommandLabelUtilsTest.java
@@ -1,0 +1,55 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The two overloads differ only in what an absent label falls back to, which is the whole reason
+ * GamemodeCommand and PunishmentCommand used to carry their own copies of this.
+ */
+class CommandLabelUtilsTest {
+
+    private static final Command GMS = new StubCommand("gms");
+
+    @Test
+    void theNamespaceIsStrippedAndTheRestLowercased() {
+        assertEquals("gms", CommandLabelUtils.normalizeLabel("ultimatedonutsmp:GMS", GMS));
+        assertEquals("gms", CommandLabelUtils.normalizeLabel("ultimatedonutsmp:GMS"));
+        assertEquals("unban", CommandLabelUtils.normalizeLabel("Unban", GMS));
+    }
+
+    @Test
+    void withACommandAnAbsentLabelFallsBackToItsRegisteredName() {
+        assertEquals("gms", CommandLabelUtils.normalizeLabel(null, GMS));
+        assertEquals("gms", CommandLabelUtils.normalizeLabel("", GMS));
+        assertEquals("gms", CommandLabelUtils.normalizeLabel("   ", GMS));
+    }
+
+    @Test
+    void withoutACommandAnAbsentLabelNormalizesToAnEmptyString() {
+        assertEquals("", CommandLabelUtils.normalizeLabel(null));
+        assertEquals("", CommandLabelUtils.normalizeLabel(""));
+        assertEquals("", CommandLabelUtils.normalizeLabel("   "));
+        assertEquals("", CommandLabelUtils.normalizeLabel(null, null));
+    }
+
+    @Test
+    void aTrailingColonIsLeftAloneRatherThanEmptyingTheLabel() {
+        // The substring only runs when something follows the separator.
+        assertEquals("gms:", CommandLabelUtils.normalizeLabel("gms:", GMS));
+    }
+
+    private static final class StubCommand extends Command {
+        private StubCommand(String name) {
+            super(name);
+        }
+
+        @Override
+        public boolean execute(CommandSender sender, String label, String[] args) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
#343 moved eleven command classes onto `CommandLabelUtils.normalizeLabel` and left two alone that already had their own private copy, so the same five lines have been sitting in three places since. This folds the last two in without changing which label maps to which behaviour.

## The two copies

`PunishmentCommand`'s was a straight duplicate of the shared helper, one caller, same semantics. It goes away with nothing to think about, and it picks up a null check it did not have: it called `command.getName()` unguarded, where the helper returns an empty string for a null command.

`GamemodeCommand`'s differed, which is why it needed a decision rather than a swap. It returned an empty string for a null label instead of falling back to the registered command name, and it left a blank label blank instead of treating it as absent.

Neither difference is observable. The only thing that reads it is `modeFromLabel`, whose switch has cases for `gms`, `gmc`, `gma` and `gmsp`, so an empty string and a blank string both fall to `default` and both yield `null`. But "unobservable today" is not the same as "safe to quietly change", so rather than pointing it at the two-argument helper and altering what a null label resolves to, the helper gained a one-argument overload that carries exactly the old policy: with no command to fall back on, an absent label normalizes to an empty string.

That keeps both null contracts, puts them next to each other with a doc comment explaining the difference, and leaves one implementation instead of three.

## Notes

`CommandLabelUtilsTest` covers both overloads: namespace stripping and lowercasing, the fallback to the registered name for null, empty and blank labels with a command, the empty string for the same three without one, and a null command alongside a null label.

It also pins one edge the guard already handled and nobody had written down: a label of `gms:` stays `gms:` rather than normalizing to an empty string, because the substring only runs when something actually follows the separator.

Suite runs 573, all green.
