### PR TITLE
fix(setup): write the network preset to the file that gets saved (#376)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -275,7 +275,7 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
         try {
             FileConfiguration config = plugin.getConfigManager().getConfig();
             FileConfiguration database = plugin.getConfigManager().getDatabase();
-            FileConfiguration network = plugin.getConfigManager().getNetwork();
+            FileConfiguration network = plugin.getConfigManager().getOriginalNetwork();
             FileConfiguration discord = plugin.getConfigManager().getDiscord();
 
             config.set("SETTINGS.SPAWN-MENU", true);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -1031,6 +1031,7 @@ public class ConfigManager {
     public FileConfiguration getOriginalMenus() { return menus; }
     public FileConfiguration getOriginalShop() { return shop; }
     public FileConfiguration getOriginalRtp() { return rtp; }
+    public FileConfiguration getOriginalNetwork() { return network; }
     public FileConfiguration getSpawners()      { return localized("CONFIG.SPAWNERS", spawners); }
     public FileConfiguration getSpawnStash()    { return localized("CONFIG.SPAWN_STASH", spawnStash); }
     public FileConfiguration getNetwork()       { return localized("CONFIG.NETWORK", network); }

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/LocalizedConfigWriteTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/LocalizedConfigWriteTest.java
@@ -14,10 +14,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * ConfigManager.getRtp() hands back LanguageManager.localize("CONFIG.RTP", rtp), which is a freshly
@@ -27,8 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class LocalizedConfigWriteTest {
 
-    private static final Path CUBOID_COMMAND =
-            Path.of("src/main/java/com/bx/ultimateDonutSmp/commands/CuboidCommand.java");
+    private static final Path CONFIG_MANAGER =
+            Path.of("src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java");
 
     @Test
     void aWriteThroughGetRtpNeverReachesTheConfigurationSaveRtpPersists() throws Exception {
@@ -51,13 +58,80 @@ class LocalizedConfigWriteTest {
                 "the accessor the bind uses has to be the field saveRtp() writes");
     }
 
+    /**
+     * Both known instances of this bug wrote through a different getter in a different file, so the
+     * guard covers every localized getter rather than the two that were caught: #350 for
+     * CuboidCommand and getRtp(), #376 for UltimateDonutSmpCommand and getNetwork().
+     */
     @Test
-    void cuboidCommandDoesNotBindTheRtpQueueThroughTheLocalizedGetter() throws IOException {
-        String source = Files.readString(CUBOID_COMMAND);
+    void noSourceWritesThroughALocalizedConfigurationGetter() throws IOException {
+        Set<String> getters = localizedGetterNames();
+        assertFalse(getters.isEmpty(), "the localized getters have to be discoverable from ConfigManager");
 
-        assertFalse(source.contains("getRtp().set("),
-                "CuboidCommand has to write QUEUE.CUBOID through the raw accessor saveRtp() persists,"
-                        + " otherwise the bind is silently dropped and the command still reports success");
+        Set<String> offenders = new TreeSet<>();
+        for (Path source : javaSources()) {
+            String text = Files.readString(source);
+            String file = source.getFileName().toString();
+            for (String getter : getters) {
+                if (text.contains(getter + "().set(")) {
+                    offenders.add(file + ": " + getter + "().set(");
+                }
+
+                // The #376 shape: the copy is parked in a local first, then written several lines down.
+                Matcher assigned = Pattern
+                        .compile("(?:FileConfiguration|var)\\s+(\\w+)\\s*=[^;]*\\b" + getter + "\\(\\)")
+                        .matcher(text);
+                while (assigned.find()) {
+                    String local = assigned.group(1);
+                    // Only within the method holding the assignment. These names are reused across
+                    // methods in the same file, where the write is usually the getOriginal* one.
+                    String scope = restOfEnclosingMethod(text, assigned.end());
+                    if (Pattern.compile("\\b" + local + "\\s*\\.set\\(").matcher(scope).find()) {
+                        offenders.add(file + ": " + local + " = " + getter + "() then " + local + ".set(");
+                    }
+                }
+            }
+        }
+
+        assertTrue(offenders.isEmpty(),
+                "a localized getter returns a copy that no save() persists, so a write through one is"
+                        + " dropped while the command still reports success: " + offenders);
+    }
+
+    /**
+     * Everything from {@code from} up to the brace that closes the method containing it.
+     */
+    private static String restOfEnclosingMethod(String text, int from) {
+        int depth = 0;
+        for (int index = from; index < text.length(); index++) {
+            char character = text.charAt(index);
+            if (character == '{') {
+                depth++;
+            } else if (character == '}') {
+                if (depth == 0) {
+                    return text.substring(from, index);
+                }
+                depth--;
+            }
+        }
+        return text.substring(from);
+    }
+
+    private static Set<String> localizedGetterNames() throws IOException {
+        Matcher matcher = Pattern
+                .compile("public FileConfiguration (\\w+)\\(\\)\\s*\\{\\s*return localized\\(")
+                .matcher(Files.readString(CONFIG_MANAGER));
+        Set<String> names = new TreeSet<>();
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private static List<Path> javaSources() throws IOException {
+        try (Stream<Path> paths = Files.walk(Path.of("src/main/java"))) {
+            return paths.filter(path -> path.toString().endsWith(".java")).toList();
+        }
     }
 
     private static FileConfiguration rawRtp(UltimateDonutSmp plugin) throws Exception {


### PR DESCRIPTION
Closes #376

`/ultimatedonutsmp setup apply` reported "Single paper setup preset applied" and wrote none of its network settings. The command took `getConfigManager().getNetwork()`, which is `localized("CONFIG.NETWORK", network)`, and every bundled language file ships a `CONFIG.NETWORK` section, so that is always a freshly built copy. Seven keys went into the copy, `saveNetwork()` saved the untouched original, and the `reloadAllPluginConfigurations()` a few lines later threw the copy away. It returned true throughout, because saving an unchanged file genuinely succeeds. The other three files the same command touches were always fine: `config.yml`, `database.yml` and `discord.yml` all come from raw accessors.

`getOriginalNetwork()` joins the rest of that family and the preset writes through it. The read at line 694 still uses `getNetwork()`, which is correct, and no localized read path moves.

This is the second instance of the defect #350 fixed for `/cuboid bind ... rtp-queue`.

## A guard that covers the shape rather than the instance

Both instances were the same mistake in different files with different getters, and neither was visible from the outside: the command reports success either way. So the source guard from #350, which only checked `CuboidCommand` for `getRtp().set(`, is replaced by one that derives every localized getter from `ConfigManager` and scans all of `src/main/java`.

It has to catch two shapes. `#350` wrote directly, `getRtp().set(...)`. `#376` parked the copy in a local and wrote eleven lines further down, which the old guard would have missed entirely.

I checked it fails for the right reason in both cases before trusting it. Reverting this fix produces `UltimateDonutSmpCommand.java: network = getNetwork() then network.set(`, and reverting #350 produces `CuboidCommand.java: getRtp().set(`.

Deriving the getter list from `ConfigManager` rather than hardcoding it means a new localized getter is covered the day it is added.

## The scoping that took a second pass

The first version of the local-variable check searched the whole file for a write to that name, and flagged `CrateManager`, `SpawnManager` and `MaintenanceManager`. All three were wrong. Those files reuse the same variable names across methods, and every one of them already writes through the correct accessor: `getOriginalCrates()` and `getOriginalMenus()` where they save, the localized getter only where they read. `MaintenanceManager`'s `config.set(` is a fresh `YamlConfiguration` for the state file in an unrelated method.

The check now only looks between the assignment and the brace that closes the method holding it, which leaves the three alone and still catches both real cases.

## Notes

Suite runs 573, all green.
