### PR TITLE
feat(wipe): add playerunwipe to restore a wiped player (#322)

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -105,6 +105,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/billford` | `/billford <gui\|reload>` | Manage Billford rotating trades NPC | `ultimatedonutsmp.admin.billford` |
 | `/serverwipe` | `/serverwipe <confirm\|cancel>` | Guarded admin server wipe execution | `ultimatedonutsmp.admin.serverwipe` |
 | `/playerwipe` | `/playerwipe <player> [confirm]` | Wipe everything stored about one player | `ultimatedonutsmp.admin.playerwipe` |
+| `/playerunwipe` | `/playerunwipe <player> [confirm]` | Restore a wiped player from the backup their wipe left behind | `ultimatedonutsmp.admin.playerunwipe` |
 | `/uds` | `/uds <reload|version|status>` | Main plugin administration & hot-reload | `ultimatedonutsmp.admin.uds` |
 
 ---

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -184,8 +184,33 @@ It works on offline players as well as online ones, and it clears:
 
 Punishments, IP history, and freeze or staff-mode state survive a wipe, so a ban history stays intact
 and alt tracking still works. Spawners they placed are left standing as well, since those are blocks
-in the world rather than stored progress. There is no undo, so take a database backup first if the
-account matters.
+in the world rather than stored progress.
+
+### Undoing A Wipe (`/playerunwipe`)
+
+Every wipe writes what it removed to a file in `plugins/UltimateDonutSmp/player-wipe-backups/` before
+deleting anything, and `/playerunwipe` reads that file back. `/punwipe` and `/unwipe` are the same
+command. It is the answer to a ban that turns out to have been wrong: clear the punishment, then hand
+the account back what it had.
+
+`/playerunwipe <player>` on its own reports who ran the wipe, when, and what the backup holds.
+`confirm` puts it all back:
+
+```
+/playerunwipe Notch
+/playerunwipe Notch confirm
+```
+
+The restore is exact rather than additive, so anything the account picked up between the wipe and the
+restore is dropped in favour of what the backup holds. On a wrongly banned player that difference is
+usually nothing, since they could not log in to earn any of it.
+
+Backups are never deleted or overwritten, so a player wiped more than once keeps a file per wipe and
+the restore uses the most recent. The one thing a restore cannot bring back is a team the player led,
+because wiping a leader disbands the team outright and the team itself is not part of any single
+player's data; their membership row is dropped rather than restored, leaving them free to join
+another team. Filenames carry the player's name, their uuid and the time of the wipe, so an older
+backup can be restored by hand: delete the newer files, or move the one you want into place.
 
 ### Wiping On A Ban (`offenses.yml`)
 
@@ -211,7 +236,7 @@ It only fires on a real ban. A `MUTE`, `WARN` or `KICK` preset ignores it, and s
 `0s`, since that tier is issued as a warning rather than a ban. Staff running the command see the
 number of records removed underneath the usual punishment confirmation.
 
-The wipe itself is the same one `/playerwipe` performs, down to what survives it, and it cannot be
-undone either. Turning it on for an offense your team hands out often is a good way to delete a lot
-of accounts you meant to keep, so it suits things like duping or botting rather than a first-strike
-chat rule.
+The wipe itself is the same one `/playerwipe` performs, down to what survives it and the backup it
+leaves behind, so `/playerunwipe` undoes it the same way. Turning it on for an offense your team hands
+out often still fills the backup folder with accounts you meant to keep, so it suits things like
+duping or botting rather than a first-strike chat rule.

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -107,6 +107,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private OffenseManager offenseManager;
     private StatsWipeManager statsWipeManager;
     private PlayerWipeManager playerWipeManager;
+    private PlayerUnwipeManager playerUnwipeManager;
     private ServerWipeManager serverWipeManager;
     private SpawnerManager spawnerManager;
     private AntiEspManager antiEspManager;
@@ -250,6 +251,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         anvilModerationManager.load();
         statsWipeManager = new StatsWipeManager(this);
         playerWipeManager = new PlayerWipeManager(this);
+        playerUnwipeManager = new PlayerUnwipeManager(this);
         spawnerManager = new SpawnerManager(this);
         antiEspManager = new AntiEspManager(this);
         spawnStashManager = new SpawnStashManager(this);
@@ -811,6 +813,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         PlayerWipeCommand playerWipeCommand = new PlayerWipeCommand(this);
         setExecutor("playerwipe", playerWipeCommand);
         setTabCompleter("playerwipe", playerWipeCommand);
+        PlayerUnwipeCommand playerUnwipeCommand = new PlayerUnwipeCommand(this);
+        setExecutor("playerunwipe", playerUnwipeCommand);
+        setTabCompleter("playerunwipe", playerUnwipeCommand);
 
         AnvilModerationCommand anvilModCommand = new AnvilModerationCommand(this);
         setExecutor("amod", anvilModCommand);
@@ -1475,6 +1480,10 @@ public final class UltimateDonutSmp extends JavaPlugin {
 
     public PlayerWipeManager getPlayerWipeManager() {
         return playerWipeManager;
+    }
+
+    public PlayerUnwipeManager getPlayerUnwipeManager() {
+        return playerUnwipeManager;
     }
 
     public ServerWipeManager getServerWipeManager() {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerUnwipeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerUnwipeCommand.java
@@ -1,0 +1,177 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.DatabaseManager;
+import com.bx.ultimateDonutSmp.managers.PlayerUnwipeManager;
+import com.bx.ultimateDonutSmp.managers.PlayerWipeManager;
+import com.bx.ultimateDonutSmp.models.PlayerWipeArchive;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Puts back the data a {@code /playerwipe} removed, from the backup that wipe left behind. */
+public class PlayerUnwipeCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PERMISSION = "ultimatedonutsmp.admin.playerunwipe";
+    private static final long BACKED_UP_NAMES_TTL_MS = 60_000L;
+
+    private final UltimateDonutSmp plugin;
+    private final AtomicBoolean backedUpNamesLoading = new AtomicBoolean();
+
+    private volatile List<String> backedUpNames = List.of();
+    private volatile long backedUpNamesLoadedAt;
+
+    public PlayerUnwipeCommand(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!PermissionUtils.has(sender, PERMISSION)) {
+            send(sender, "&cYou do not have permission to restore player data.");
+            return true;
+        }
+        if (args.length == 0) {
+            send(sender, "&cUsage: /" + label + " <player> [confirm]");
+            return true;
+        }
+
+        PlayerUnwipeManager unwipeManager = plugin.getPlayerUnwipeManager();
+        UUID playerUuid = unwipeManager.resolveBackedUpPlayer(args[0]);
+        PlayerWipeArchive archive = playerUuid == null ? null : unwipeManager.findLatest(playerUuid);
+        if (archive == null) {
+            send(sender, "&cThere is no wipe backup for &f" + args[0] + "&c.");
+            send(sender, "&7Backups land in the &f" + unwipeManager.backupDirectory().getName()
+                    + " &7folder the moment a wipe runs.");
+            return true;
+        }
+
+        if (args.length < 2 || !args[1].equalsIgnoreCase("confirm")) {
+            sendPreview(sender, label, archive);
+            return true;
+        }
+
+        PlayerUnwipeManager.RestoreResult result = unwipeManager.restore(archive, sender.getName());
+        if (result.busy()) {
+            send(sender, "&cA player wipe or restore is already running.");
+            return true;
+        }
+        if (!result.success()) {
+            String error = result.errorMessage() == null || result.errorMessage().isBlank()
+                    ? "unknown error"
+                    : result.errorMessage();
+            send(sender, "&cRestore failed: &f" + error);
+            return true;
+        }
+
+        send(sender, "&aRestored &f" + archive.playerName() + "&a. Records put back: &f"
+                + result.counts().total() + "&a.");
+        for (String key : PlayerWipeManager.COUNT_KEYS) {
+            int affected = result.counts().affected(key);
+            if (affected > 0) {
+                send(sender, "&8- &7" + PlayerWipeManager.label(key) + ": &f" + affected);
+            }
+        }
+        return true;
+    }
+
+    private void sendPreview(CommandSender sender, String label, PlayerWipeArchive archive) {
+        send(sender, "&6Restore preview &8- &f" + archive.playerName());
+        send(sender, "&7Wiped by &f" + archive.wipedBy() + " &7on &f"
+                + PlayerUnwipeManager.formatWipeTime(archive.wipedAt()) + "&7.");
+
+        Map<String, Integer> counts = countsByGroup(archive);
+        if (counts.isEmpty()) {
+            send(sender, "&7That wipe found nothing to remove, so there is nothing to put back.");
+            return;
+        }
+
+        for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+            send(sender, "&8- &7" + PlayerWipeManager.label(entry.getKey()) + ": &f" + entry.getValue());
+        }
+        send(sender, "&cAnything they have earned since that wipe is replaced. Run &f/" + label + " "
+                + archive.playerName() + " confirm &cto restore them.");
+    }
+
+    /** Groups the backup's rows the way the wipe command counts them, so the two previews line up. */
+    private Map<String, Integer> countsByGroup(PlayerWipeArchive archive) {
+        Map<String, Integer> byGroup = new LinkedHashMap<>();
+        if (archive.hasStats()) {
+            byGroup.put("stats", 1);
+        }
+        for (Map.Entry<String, PlayerWipeArchive.TableRows> entry : archive.tables().entrySet()) {
+            String group = DatabaseManager.playerWipeGroup(entry.getKey());
+            if (group != null) {
+                byGroup.merge(group, entry.getValue().rows().size(), Integer::sum);
+            }
+        }
+
+        Map<String, Integer> ordered = new LinkedHashMap<>();
+        for (String key : PlayerWipeManager.COUNT_KEYS) {
+            Integer count = byGroup.get(key);
+            if (count != null && count > 0) {
+                ordered.put(key, count);
+            }
+        }
+        return ordered;
+    }
+
+    private void send(CommandSender sender, String message) {
+        sender.sendMessage(ColorUtils.toComponent(message));
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!PermissionUtils.has(sender, PERMISSION)) {
+            return List.of();
+        }
+        if (args.length == 1) {
+            return matches(backedUpNames(), args[0]);
+        }
+        if (args.length == 2) {
+            return matches(List.of("confirm"), args[1]);
+        }
+        return List.of();
+    }
+
+    /**
+     * Tab completion fires on every keystroke, so the backup folder is listed off-thread and the
+     * result reused for a minute rather than read from disk on the main thread each time.
+     */
+    private List<String> backedUpNames() {
+        long now = System.currentTimeMillis();
+        if (now - backedUpNamesLoadedAt >= BACKED_UP_NAMES_TTL_MS && backedUpNamesLoading.compareAndSet(false, true)) {
+            plugin.getSpigotScheduler().runAsync(() -> {
+                try {
+                    backedUpNames = List.copyOf(plugin.getPlayerUnwipeManager().backedUpPlayerNames());
+                    backedUpNamesLoadedAt = System.currentTimeMillis();
+                } finally {
+                    backedUpNamesLoading.set(false);
+                }
+            });
+        }
+        return backedUpNames;
+    }
+
+    private List<String> matches(List<String> candidates, String input) {
+        String normalized = input.toLowerCase(Locale.ROOT);
+        List<String> matches = new ArrayList<>();
+        for (String candidate : candidates) {
+            if (candidate.toLowerCase(Locale.ROOT).startsWith(normalized)) {
+                matches.add(candidate);
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PlayerWipeCommand.java
@@ -77,6 +77,9 @@ public class PlayerWipeCommand implements CommandExecutor, TabCompleter {
                 send(sender, "&8- &7" + PlayerWipeManager.label(key) + ": &f" + affected);
             }
         }
+        if (result.backupFile() != null) {
+            send(sender, "&7Backup saved as &f" + result.backupFile().getName() + "&7.");
+        }
         return true;
     }
 
@@ -96,7 +99,9 @@ public class PlayerWipeCommand implements CommandExecutor, TabCompleter {
             }
         }
         send(sender, "&7Punishments, IP history and their placed spawners are kept.");
-        send(sender, "&cThis cannot be undone. Run &f/" + label + " " + target.name() + " confirm &cto wipe them.");
+        send(sender, "&7A backup is written first, so &f/playerunwipe " + target.name()
+                + " &7can put this back.");
+        send(sender, "&cRun &f/" + label + " " + target.name() + " confirm &cto wipe them.");
     }
 
     private void send(CommandSender sender, String message) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DatabaseManager.java
@@ -5,6 +5,7 @@ import com.bx.ultimateDonutSmp.utils.ItemSerializationUtils;
 import com.bx.ultimateDonutSmp.utils.LazyLocation;
 import com.bx.ultimateDonutSmp.models.Bounty;
 import com.bx.ultimateDonutSmp.models.PlayerLogEntry;
+import com.bx.ultimateDonutSmp.models.PlayerWipeArchive;
 import com.bx.ultimateDonutSmp.models.FreezeState;
 import com.bx.ultimateDonutSmp.models.Home;
 import com.bx.ultimateDonutSmp.models.HideMode;
@@ -4700,6 +4701,35 @@ public class DatabaseManager {
 
     private static final Map<String, String> PLAYER_WIPE_GROUPS = playerWipeGroups();
 
+    private static final Map<String, Object> PLAYER_WIPE_STAT_RESETS = playerWipeStatResets();
+
+    /**
+     * The player columns a wipe resets, each beside the value it goes back to. The wipe, the backup
+     * and the restore all read this one map, so a column added here cannot quietly drop out of a
+     * backup and leave a restored player short. {@code money} is the exception: it is overwritten
+     * with the configured starting balance rather than the placeholder below.
+     */
+    private static Map<String, Object> playerWipeStatResets() {
+        Map<String, Object> resets = new LinkedHashMap<>();
+        resets.put("money", 0D);
+        resets.put("shards", 0);
+        resets.put("kills", 0);
+        resets.put("deaths", 0);
+        resets.put("playtime_seconds", 0);
+        resets.put("blocks_placed", 0);
+        resets.put("blocks_broken", 0);
+        resets.put("mobs_killed", 0);
+        resets.put("kill_streak", 0);
+        resets.put("highest_kill_streak", 0);
+        resets.put("money_spent", 0);
+        resets.put("money_made", 0);
+        resets.put("keyall_remaining_seconds", -1);
+        resets.put("shard_booster_expiry", 0);
+        resets.put("mob_spawn_disabled_until", 0);
+        resets.put("phantom_disabled_until", 0);
+        return Collections.unmodifiableMap(resets);
+    }
+
     private static Map<String, String> playerWipeGroups() {
         Map<String, String> groups = new LinkedHashMap<>();
         groups.put("homes", "homes");
@@ -4769,28 +4799,20 @@ public class DatabaseManager {
             autoCommitDisabled = true;
 
             if (serverWipeTableExists("players")) {
-                try (PreparedStatement statement = connection.prepareStatement("""
-                        UPDATE players SET
-                            money = ?,
-                            shards = 0,
-                            kills = 0,
-                            deaths = 0,
-                            playtime_seconds = 0,
-                            blocks_placed = 0,
-                            blocks_broken = 0,
-                            mobs_killed = 0,
-                            kill_streak = 0,
-                            highest_kill_streak = 0,
-                            money_spent = 0,
-                            money_made = 0,
-                            keyall_remaining_seconds = -1,
-                            shard_booster_expiry = 0,
-                            mob_spawn_disabled_until = 0,
-                            phantom_disabled_until = 0
-                        WHERE uuid = ?
-                        """)) {
-                    statement.setDouble(1, Math.max(0D, startingMoney));
-                    statement.setString(2, uuid);
+                StringJoiner assignments = new StringJoiner(", ");
+                for (String column : PLAYER_WIPE_STAT_RESETS.keySet()) {
+                    assignments.add(quoteIdentifier(column) + " = ?");
+                }
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE players SET " + assignments + " WHERE uuid = ?")) {
+                    int index = 1;
+                    for (Map.Entry<String, Object> reset : PLAYER_WIPE_STAT_RESETS.entrySet()) {
+                        Object value = "money".equals(reset.getKey())
+                                ? Math.max(0D, startingMoney)
+                                : reset.getValue();
+                        statement.setObject(index++, value);
+                    }
+                    statement.setString(index, uuid);
                     affected.put("stats", statement.executeUpdate());
                 }
             }
@@ -4818,6 +4840,233 @@ public class DatabaseManager {
                 }
             }
         }
+    }
+
+    /** The count group a player wipe prints one table's rows under, so callers can label a restore. */
+    public static String playerWipeGroup(String table) {
+        return PLAYER_WIPE_GROUPS.get(table);
+    }
+
+    /**
+     * Reads back every row a player wipe is about to delete, along with the player stats it is about
+     * to reset. Nothing is modified here: the caller writes the result to disk first, so a wipe that
+     * fails halfway leaves an unused backup rather than an unrecoverable player.
+     */
+    public PlayerWipeArchive capturePlayerWipeArchive(UUID playerUuid, String playerName, String actorName)
+            throws SQLException {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        if (connection == null || connection.isClosed()) {
+            throw new SQLException("Database connection is not available.");
+        }
+
+        String uuid = playerUuid.toString();
+        List<String> statColumns = List.copyOf(PLAYER_WIPE_STAT_RESETS.keySet());
+        List<Object> statValues = readPlayerStats(uuid, statColumns);
+
+        Map<String, PlayerWipeArchive.TableRows> tables = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : PLAYER_WIPE_TABLES.entrySet()) {
+            PlayerWipeArchive.TableRows rows = readPlayerRows(entry.getKey(), entry.getValue(), uuid);
+            if (rows != null && !rows.rows().isEmpty()) {
+                tables.put(entry.getKey(), rows);
+            }
+        }
+
+        return new PlayerWipeArchive(
+                playerUuid,
+                playerName,
+                System.currentTimeMillis(),
+                actorName,
+                statValues.isEmpty() ? List.of() : statColumns,
+                statValues,
+                tables
+        );
+    }
+
+    /**
+     * Puts an archived player back in a single transaction. Every table a wipe touches is cleared for
+     * them first, so they land on the state the backup holds instead of a merge of that and whatever
+     * they picked up since. Rows belonging to anybody else are never read or written.
+     */
+    public PlayerWipeResult restorePlayerWipeArchive(PlayerWipeArchive archive) throws SQLException {
+        Objects.requireNonNull(archive, "archive");
+        if (connection == null || connection.isClosed()) {
+            throw new SQLException("Database connection is not available.");
+        }
+
+        String uuid = archive.playerUuid().toString();
+        Map<String, Integer> affected = new LinkedHashMap<>();
+        boolean autoCommitDisabled = false;
+        boolean originalAutoCommit = connection.getAutoCommit();
+        try {
+            connection.setAutoCommit(false);
+            autoCommitDisabled = true;
+
+            if (archive.hasStats() && serverWipeTableExists("players")) {
+                affected.put("stats", restorePlayerStats(uuid, archive));
+            }
+
+            for (Map.Entry<String, List<String>> entry : PLAYER_WIPE_TABLES.entrySet()) {
+                String table = entry.getKey();
+                if (!serverWipeTableExists(table)) {
+                    continue;
+                }
+                deletePlayerRows(table, entry.getValue(), uuid);
+
+                PlayerWipeArchive.TableRows archived = archive.tables().get(table);
+                if (archived == null) {
+                    continue;
+                }
+                if ("team_members".equals(table)) {
+                    archived = withoutDisbandedTeams(archived);
+                }
+                affected.merge(PLAYER_WIPE_GROUPS.get(table), insertArchivedRows(table, archived), Integer::sum);
+            }
+
+            connection.commit();
+            return new PlayerWipeResult(Map.copyOf(affected));
+        } catch (SQLException exception) {
+            if (autoCommitDisabled) {
+                try {
+                    connection.rollback();
+                } catch (SQLException ignored) {
+                }
+            }
+            throw exception;
+        } finally {
+            if (autoCommitDisabled) {
+                try {
+                    connection.setAutoCommit(originalAutoCommit);
+                } catch (SQLException ignored) {
+                }
+            }
+        }
+    }
+
+    private List<Object> readPlayerStats(String uuid, List<String> columns) throws SQLException {
+        if (!serverWipeTableExists("players")) {
+            return List.of();
+        }
+
+        StringJoiner selected = new StringJoiner(", ");
+        for (String column : columns) {
+            selected.add(quoteIdentifier(column));
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT " + selected + " FROM players WHERE uuid = ?")) {
+            statement.setString(1, uuid);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    return List.of();
+                }
+                List<Object> values = new ArrayList<>(columns.size());
+                for (int index = 1; index <= columns.size(); index++) {
+                    values.add(rs.getObject(index));
+                }
+                return values;
+            }
+        }
+    }
+
+    private PlayerWipeArchive.TableRows readPlayerRows(String table, List<String> owners, String uuid)
+            throws SQLException {
+        if (owners.isEmpty() || !serverWipeTableExists(table)) {
+            return null;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT * FROM " + quoteIdentifier(table) + " WHERE " + ownerPredicate(owners))) {
+            bindOwnerUuid(statement, owners, uuid);
+            try (ResultSet rs = statement.executeQuery()) {
+                ResultSetMetaData metadata = rs.getMetaData();
+                int columnCount = metadata.getColumnCount();
+
+                List<String> columns = new ArrayList<>(columnCount);
+                for (int index = 1; index <= columnCount; index++) {
+                    columns.add(metadata.getColumnName(index));
+                }
+
+                List<List<Object>> rows = new ArrayList<>();
+                while (rs.next()) {
+                    List<Object> row = new ArrayList<>(columnCount);
+                    for (int index = 1; index <= columnCount; index++) {
+                        row.add(rs.getObject(index));
+                    }
+                    rows.add(row);
+                }
+                return new PlayerWipeArchive.TableRows(columns, rows);
+            }
+        }
+    }
+
+    private int restorePlayerStats(String uuid, PlayerWipeArchive archive) throws SQLException {
+        StringJoiner assignments = new StringJoiner(", ");
+        for (String column : archive.statColumns()) {
+            assignments.add(quoteIdentifier(column) + " = ?");
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "UPDATE players SET " + assignments + " WHERE uuid = ?")) {
+            List<Object> values = archive.statValues();
+            for (int index = 0; index < values.size(); index++) {
+                statement.setObject(index + 1, values.get(index));
+            }
+            statement.setString(values.size() + 1, uuid);
+            return statement.executeUpdate();
+        }
+    }
+
+    /**
+     * Drops archived team memberships whose team is gone. Wiping a team leader disbands the team, so
+     * restoring the row unchanged would leave the player holding the only membership of a team that
+     * no longer exists — and because that row owns their primary key, it would block them from ever
+     * joining another one.
+     */
+    private PlayerWipeArchive.TableRows withoutDisbandedTeams(PlayerWipeArchive.TableRows archived)
+            throws SQLException {
+        int nameIndex = archived.columns().indexOf("team_name");
+        if (nameIndex < 0 || !serverWipeTableExists("teams")) {
+            return archived;
+        }
+
+        List<List<Object>> kept = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement("SELECT 1 FROM teams WHERE name = ?")) {
+            for (List<Object> row : archived.rows()) {
+                Object teamName = row.get(nameIndex);
+                if (teamName == null) {
+                    continue;
+                }
+                statement.setString(1, String.valueOf(teamName));
+                try (ResultSet rs = statement.executeQuery()) {
+                    if (rs.next()) {
+                        kept.add(row);
+                    }
+                }
+            }
+        }
+        return new PlayerWipeArchive.TableRows(archived.columns(), kept);
+    }
+
+    private int insertArchivedRows(String table, PlayerWipeArchive.TableRows archived) throws SQLException {
+        if (archived.columns().isEmpty() || archived.rows().isEmpty()) {
+            return 0;
+        }
+
+        StringJoiner columns = new StringJoiner(", ");
+        StringJoiner placeholders = new StringJoiner(", ");
+        for (String column : archived.columns()) {
+            columns.add(quoteIdentifier(column));
+            placeholders.add("?");
+        }
+
+        int inserted = 0;
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO " + quoteIdentifier(table) + " (" + columns + ") VALUES (" + placeholders + ")")) {
+            for (List<Object> row : archived.rows()) {
+                for (int index = 0; index < row.size(); index++) {
+                    statement.setObject(index + 1, row.get(index));
+                }
+                inserted += statement.executeUpdate();
+            }
+        }
+        return inserted;
     }
 
     private int deletePlayerRows(String table, List<String> columns, String uuid) throws SQLException {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerDataManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerDataManager.java
@@ -73,6 +73,14 @@ public class PlayerDataManager {
         return cache.values();
     }
 
+    /**
+     * Drops one player's cached copy without saving it. A restore has just rewritten their row, so
+     * writing the in-memory totals back would undo it before they have even noticed.
+     */
+    public void discardWithoutSaving(UUID uuid) {
+        cache.remove(uuid);
+    }
+
     public void discardAllForServerWipe() {
         cache.clear();
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerUnwipeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerUnwipeManager.java
@@ -1,0 +1,287 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.models.PlayerWipeArchive;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The other half of {@link PlayerWipeManager}: every wipe leaves a backup of the rows it removed in
+ * a folder beside the plugin's configuration, and this puts one of them back. Backups are kept
+ * indefinitely and never overwritten, so a player wiped twice can be taken back to either point.
+ */
+public class PlayerUnwipeManager {
+
+    private static final String BACKUP_FOLDER = "player-wipe-backups";
+    private static final DateTimeFormatter STAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter READABLE =
+            DateTimeFormatter.ofPattern("d MMM yyyy 'at' HH:mm").withZone(ZoneId.systemDefault());
+
+    /**
+     * A backup filename, read without opening the file. Tab completion runs on every keystroke, so
+     * the name and uuid live in the filename rather than behind a parse of every backup on disk.
+     */
+    private static final Pattern FILE_NAME = Pattern.compile(
+            "^(.*)_([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_(.+)\\.yml$");
+
+    private static final Pattern UNSAFE_NAME_CHARACTER = Pattern.compile("[^A-Za-z0-9_.-]");
+
+    public record RestoreResult(
+            boolean success,
+            boolean busy,
+            DatabaseManager.PlayerWipeResult counts,
+            String errorMessage
+    ) {
+        public static RestoreResult alreadyRunning() {
+            return new RestoreResult(false, true, null, null);
+        }
+
+        public static RestoreResult failure(String errorMessage) {
+            return new RestoreResult(false, false, null, errorMessage);
+        }
+    }
+
+    /** One backup on disk, described by its filename alone. */
+    public record ArchiveFile(File file, UUID playerUuid, String playerName, String stamp) {
+    }
+
+    private final UltimateDonutSmp plugin;
+    private final AtomicBoolean restoreInProgress = new AtomicBoolean(false);
+
+    public PlayerUnwipeManager(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public static String formatWipeTime(long epochMillis) {
+        return READABLE.format(Instant.ofEpochMilli(epochMillis));
+    }
+
+    public boolean isRestoreInProgress() {
+        return restoreInProgress.get();
+    }
+
+    public File backupDirectory() {
+        return new File(plugin.getDataFolder(), BACKUP_FOLDER);
+    }
+
+    /**
+     * Writes the backup a wipe just captured. The wipe has not run yet when this is called, so a
+     * failure here stops the wipe rather than losing the only copy of the player's data.
+     */
+    public File write(PlayerWipeArchive archive) throws IOException {
+        File directory = backupDirectory();
+        String base = sanitize(archive.playerName()) + "_" + archive.playerUuid() + "_"
+                + STAMP.format(Instant.ofEpochMilli(archive.wipedAt()));
+
+        File file = new File(directory, base + ".yml");
+        for (int attempt = 2; file.exists(); attempt++) {
+            file = new File(directory, base + "-" + attempt + ".yml");
+        }
+
+        archive.save(file);
+        return file;
+    }
+
+    /** The most recent backup for one player, or null when they have never been wiped. */
+    public PlayerWipeArchive findLatest(UUID playerUuid) {
+        ArchiveFile latest = null;
+        for (ArchiveFile candidate : listArchiveFiles()) {
+            if (!candidate.playerUuid().equals(playerUuid)) {
+                continue;
+            }
+            if (latest == null || candidate.stamp().compareTo(latest.stamp()) > 0) {
+                latest = candidate;
+            }
+        }
+        if (latest == null) {
+            return null;
+        }
+
+        try {
+            return PlayerWipeArchive.load(latest.file());
+        } catch (IOException exception) {
+            plugin.getLogger().log(Level.WARNING, "Could not read wipe backup " + latest.file().getName(), exception);
+            return null;
+        }
+    }
+
+    /** Every player with a backup on disk, newest name first, for tab completion. */
+    public List<String> backedUpPlayerNames() {
+        Set<String> names = new LinkedHashSet<>();
+        for (ArchiveFile archive : listArchiveFiles()) {
+            names.add(archive.playerName());
+        }
+        return names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList();
+    }
+
+    public List<ArchiveFile> listArchiveFiles() {
+        File[] files = backupDirectory().listFiles();
+        if (files == null) {
+            return List.of();
+        }
+
+        List<ArchiveFile> archives = new ArrayList<>();
+        for (File file : files) {
+            if (!file.isFile()) {
+                continue;
+            }
+            Matcher matcher = FILE_NAME.matcher(file.getName());
+            if (!matcher.matches()) {
+                continue;
+            }
+            try {
+                archives.add(new ArchiveFile(
+                        file,
+                        UUID.fromString(matcher.group(2)),
+                        matcher.group(1),
+                        matcher.group(3)
+                ));
+            } catch (IllegalArgumentException ignored) {
+                // A file that only looks like a backup. Leave it where it is.
+            }
+        }
+        return archives;
+    }
+
+    /**
+     * Resolves a name to a player who has a backup. Unlike a wipe this cannot fall back to the
+     * server's player list: the whole point is that the target may be long gone.
+     */
+    public UUID resolveBackedUpPlayer(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+
+        String trimmed = input.trim();
+        ArchiveFile latest = null;
+        for (ArchiveFile candidate : listArchiveFiles()) {
+            if (!candidate.playerName().equalsIgnoreCase(trimmed)) {
+                continue;
+            }
+            if (latest == null || candidate.stamp().compareTo(latest.stamp()) > 0) {
+                latest = candidate;
+            }
+        }
+        if (latest != null) {
+            return latest.playerUuid();
+        }
+
+        Player online = Bukkit.getPlayerExact(trimmed);
+        if (online != null) {
+            return online.getUniqueId();
+        }
+        return plugin.getDatabaseManager().findPlayerUuidByUsername(trimmed);
+    }
+
+    public RestoreResult restore(PlayerWipeArchive archive, String actorName) {
+        if (archive == null) {
+            return RestoreResult.failure("no backup selected.");
+        }
+        if (plugin.getPlayerWipeManager().isWipeInProgress()) {
+            return RestoreResult.alreadyRunning();
+        }
+        if (!restoreInProgress.compareAndSet(false, true)) {
+            return RestoreResult.alreadyRunning();
+        }
+
+        UUID playerUuid = archive.playerUuid();
+        try {
+            discardOpenState(playerUuid);
+            DatabaseManager.PlayerWipeResult counts = plugin.getDatabaseManager()
+                    .restorePlayerWipeArchive(archive);
+            reloadCaches(playerUuid);
+            refreshDisplays(playerUuid);
+
+            plugin.getLogger().info("Player wipe restored by " + actorName + " for "
+                    + archive.playerName() + " (" + playerUuid + ").");
+            return new RestoreResult(true, false, counts, null);
+        } catch (SQLException | RuntimeException exception) {
+            plugin.getLogger().log(Level.SEVERE, "player unwipe failed for " + playerUuid, exception);
+            return RestoreResult.failure(exception.getMessage());
+        } finally {
+            restoreInProgress.set(false);
+        }
+    }
+
+    /** Closes anything showing the player's current contents before those rows are replaced. */
+    private void discardOpenState(UUID playerUuid) {
+        if (plugin.getEnderChestManager() != null) {
+            plugin.getEnderChestManager().discardForPlayerWipe(playerUuid);
+        }
+        plugin.getCrateManager().clearSession(playerUuid);
+        plugin.getCrateManager().clearPendingBind(playerUuid);
+    }
+
+    /**
+     * Reads the restored rows back into memory. This mirrors the cache clearing a wipe does, with
+     * the player's own data loaded again afterwards so nothing writes the wiped state back over it.
+     */
+    private void reloadCaches(UUID playerUuid) {
+        plugin.getPlayerDataManager().discardWithoutSaving(playerUuid);
+        plugin.getCrateManager().unloadKeyBalanceCache(playerUuid);
+        plugin.getShopManager().cleanupPlayer(playerUuid);
+        plugin.getHomeManager().unloadHomes(playerUuid);
+        plugin.getIgnoreManager().unloadPlayer(playerUuid);
+        plugin.getDuelManager().forgetStats(playerUuid);
+        plugin.getFfaManager().forgetStats(playerUuid);
+        plugin.getTeamManager().loadAll();
+        plugin.getBountyManager().loadAll();
+        if (plugin.getFriendsManager() != null) {
+            plugin.getFriendsManager().unloadPlayer(playerUuid);
+        }
+        if (plugin.getAuctionHouseManager() != null) {
+            plugin.getAuctionHouseManager().cleanupPlayer(playerUuid);
+        }
+        if (plugin.getOrdersManager() != null) {
+            plugin.getOrdersManager().forgetUiState(playerUuid);
+        }
+        if (plugin.getLeaderboardManager() != null) {
+            plugin.getLeaderboardManager().invalidateAll();
+        }
+
+        Player online = Bukkit.getPlayer(playerUuid);
+        if (online != null) {
+            plugin.getPlayerDataManager().loadOrCreate(online);
+            plugin.getHomeManager().loadHomes(online);
+            plugin.getIgnoreManager().loadPlayer(playerUuid);
+            if (plugin.getFriendsManager() != null) {
+                plugin.getFriendsManager().loadPlayer(playerUuid);
+            }
+        }
+    }
+
+    private void refreshDisplays(UUID playerUuid) {
+        plugin.getScoreboardManager().updateAll();
+        plugin.getTablistManager().updateAll();
+
+        Player online = Bukkit.getPlayer(playerUuid);
+        if (online != null) {
+            plugin.getTablistManager().updateTablistName(online);
+        }
+    }
+
+    private static String sanitize(String playerName) {
+        if (playerName == null || playerName.isBlank()) {
+            return "unknown";
+        }
+        String cleaned = UNSAFE_NAME_CHARACTER.matcher(playerName.trim()).replaceAll("");
+        return cleaned.isBlank() ? "unknown" : cleaned;
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerWipeManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PlayerWipeManager.java
@@ -1,12 +1,15 @@
 package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.models.PlayerData;
+import com.bx.ultimateDonutSmp.models.PlayerWipeArchive;
 import com.bx.ultimateDonutSmp.models.Team;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
+import java.io.File;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +22,10 @@ import java.util.logging.Level;
  * which clears a single category across everybody. Moderation records — punishments, IP history,
  * freeze and staff-mode state — survive a player wipe, and so do world objects such as the
  * spawners they placed.
+ *
+ * <p>Every wipe writes what it removed to a backup file first, so
+ * {@link PlayerUnwipeManager} can put the player back if the wipe turns out to have been a
+ * mistake.
  */
 public class PlayerWipeManager {
 
@@ -69,14 +76,15 @@ public class PlayerWipeManager {
             boolean success,
             boolean busy,
             DatabaseManager.PlayerWipeResult counts,
-            String errorMessage
+            String errorMessage,
+            File backupFile
     ) {
         public static WipeResult alreadyRunning() {
-            return new WipeResult(false, true, null, null);
+            return new WipeResult(false, true, null, null, null);
         }
 
         public static WipeResult failure(String errorMessage) {
-            return new WipeResult(false, false, null, errorMessage);
+            return new WipeResult(false, false, null, errorMessage, null);
         }
     }
 
@@ -140,9 +148,12 @@ public class PlayerWipeManager {
             return WipeResult.alreadyRunning();
         }
 
+        File backupFile = null;
         try {
             Team team = plugin.getTeamManager().getTeam(target.uuid());
             boolean wasLeader = team != null && team.isLeader(target.uuid());
+
+            backupFile = writeBackup(target, actorName);
 
             discardOpenState(target.uuid());
             DatabaseManager.PlayerWipeResult counts = plugin.getDatabaseManager()
@@ -153,13 +164,31 @@ public class PlayerWipeManager {
             refreshDisplays(target.uuid());
 
             plugin.getLogger().info("Player wipe completed by " + actorName + " for "
-                    + target.name() + " (" + target.uuid() + ").");
-            return new WipeResult(true, false, counts, null);
-        } catch (SQLException | RuntimeException exception) {
+                    + target.name() + " (" + target.uuid() + "). Backup: " + backupFile.getName());
+            return new WipeResult(true, false, counts, null, backupFile);
+        } catch (SQLException | IOException | RuntimeException exception) {
+            discardBackup(backupFile);
             plugin.getLogger().log(Level.SEVERE, "player wipe failed for " + target.uuid(), exception);
             return WipeResult.failure(exception.getMessage());
         } finally {
             wipeInProgress.set(false);
+        }
+    }
+
+    /**
+     * Captures the player as they are now and writes it to disk before anything is deleted, so a
+     * wipe that fails partway through still leaves a complete copy to restore from.
+     */
+    private File writeBackup(Target target, String actorName) throws SQLException, IOException {
+        PlayerWipeArchive archive = plugin.getDatabaseManager()
+                .capturePlayerWipeArchive(target.uuid(), target.name(), actorName);
+        return plugin.getPlayerUnwipeManager().write(archive);
+    }
+
+    /** Removes the backup of a wipe that never happened, so it cannot be restored by mistake. */
+    private void discardBackup(File backupFile) {
+        if (backupFile != null && backupFile.exists() && !backupFile.delete()) {
+            plugin.getLogger().warning("Could not remove the backup of a failed wipe: " + backupFile);
         }
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/models/PlayerWipeArchive.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/models/PlayerWipeArchive.java
@@ -1,0 +1,194 @@
+package com.bx.ultimateDonutSmp.models;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Everything a player wipe removed, kept on disk so {@code /playerunwipe} can put it back. The rows
+ * are stored exactly as the database handed them over — column names beside the values, one entry
+ * per row — so restoring is an insert rather than a guess at what the old state looked like.
+ */
+public final class PlayerWipeArchive {
+
+    /** The archive layout, so an older file is rejected rather than half-read. */
+    public static final int FORMAT = 1;
+
+    public record TableRows(List<String> columns, List<List<Object>> rows) {
+
+        public TableRows {
+            columns = List.copyOf(columns);
+            List<List<Object>> copied = new ArrayList<>(rows.size());
+            for (List<Object> row : rows) {
+                copied.add(Collections.unmodifiableList(new ArrayList<>(row)));
+            }
+            rows = Collections.unmodifiableList(copied);
+        }
+    }
+
+    private final UUID playerUuid;
+    private final String playerName;
+    private final long wipedAt;
+    private final String wipedBy;
+    private final List<String> statColumns;
+    private final List<Object> statValues;
+    private final Map<String, TableRows> tables;
+
+    public PlayerWipeArchive(
+            UUID playerUuid,
+            String playerName,
+            long wipedAt,
+            String wipedBy,
+            List<String> statColumns,
+            List<Object> statValues,
+            Map<String, TableRows> tables
+    ) {
+        this.playerUuid = playerUuid;
+        this.playerName = playerName;
+        this.wipedAt = wipedAt;
+        this.wipedBy = wipedBy;
+        this.statColumns = List.copyOf(statColumns);
+        this.statValues = Collections.unmodifiableList(new ArrayList<>(statValues));
+        this.tables = Collections.unmodifiableMap(new LinkedHashMap<>(tables));
+    }
+
+    public UUID playerUuid() {
+        return playerUuid;
+    }
+
+    public String playerName() {
+        return playerName;
+    }
+
+    public long wipedAt() {
+        return wipedAt;
+    }
+
+    public String wipedBy() {
+        return wipedBy;
+    }
+
+    public List<String> statColumns() {
+        return statColumns;
+    }
+
+    public List<Object> statValues() {
+        return statValues;
+    }
+
+    public Map<String, TableRows> tables() {
+        return tables;
+    }
+
+    /** True when the wipe found a {@code players} row to reset, so there is one to restore. */
+    public boolean hasStats() {
+        return !statColumns.isEmpty() && statColumns.size() == statValues.size();
+    }
+
+    public int rowCount() {
+        int total = hasStats() ? 1 : 0;
+        for (TableRows table : tables.values()) {
+            total += table.rows().size();
+        }
+        return total;
+    }
+
+    public void save(File file) throws IOException {
+        YamlConfiguration yaml = new YamlConfiguration();
+        yaml.set("format", FORMAT);
+        yaml.set("player-uuid", playerUuid.toString());
+        yaml.set("player-name", playerName);
+        yaml.set("wiped-at", wipedAt);
+        yaml.set("wiped-by", wipedBy);
+        if (hasStats()) {
+            yaml.set("stats.columns", new ArrayList<>(statColumns));
+            yaml.set("stats.values", new ArrayList<>(statValues));
+        }
+        for (Map.Entry<String, TableRows> entry : tables.entrySet()) {
+            List<List<Object>> rows = new ArrayList<>();
+            for (List<Object> row : entry.getValue().rows()) {
+                rows.add(new ArrayList<>(row));
+            }
+            yaml.set("tables." + entry.getKey() + ".columns", new ArrayList<>(entry.getValue().columns()));
+            yaml.set("tables." + entry.getKey() + ".rows", rows);
+        }
+
+        File parent = file.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        yaml.save(file);
+    }
+
+    /**
+     * Reads an archive back. Anything malformed throws rather than restoring part of a player, so a
+     * hand-edited or truncated file cannot leave them half-way between two states.
+     */
+    public static PlayerWipeArchive load(File file) throws IOException {
+        YamlConfiguration yaml = new YamlConfiguration();
+        try {
+            yaml.load(file);
+        } catch (org.bukkit.configuration.InvalidConfigurationException exception) {
+            throw new IOException("Wipe backup " + file.getName() + " is not readable.", exception);
+        }
+
+        int format = yaml.getInt("format", 0);
+        if (format != FORMAT) {
+            throw new IOException("Wipe backup " + file.getName() + " uses unsupported format " + format + ".");
+        }
+
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(String.valueOf(yaml.getString("player-uuid")));
+        } catch (IllegalArgumentException exception) {
+            throw new IOException("Wipe backup " + file.getName() + " has no valid player uuid.", exception);
+        }
+
+        List<String> statColumns = yaml.getStringList("stats.columns");
+        List<Object> statValues = new ArrayList<>(yaml.getList("stats.values", List.of()));
+        if (statColumns.size() != statValues.size()) {
+            throw new IOException("Wipe backup " + file.getName() + " has mismatched stat columns.");
+        }
+
+        Map<String, TableRows> tables = new LinkedHashMap<>();
+        ConfigurationSection tablesSection = yaml.getConfigurationSection("tables");
+        if (tablesSection != null) {
+            for (String table : tablesSection.getKeys(false)) {
+                ConfigurationSection tableSection = tablesSection.getConfigurationSection(table);
+                if (tableSection == null) {
+                    continue;
+                }
+                List<String> columns = tableSection.getStringList("columns");
+                List<List<Object>> rows = new ArrayList<>();
+                for (Object row : tableSection.getList("rows", List.of())) {
+                    if (!(row instanceof List<?> values)) {
+                        throw new IOException("Wipe backup " + file.getName() + " has a malformed row in " + table + ".");
+                    }
+                    if (values.size() != columns.size()) {
+                        throw new IOException("Wipe backup " + file.getName() + " has a short row in " + table + ".");
+                    }
+                    rows.add(new ArrayList<>(values));
+                }
+                tables.put(table, new TableRows(columns, rows));
+            }
+        }
+
+        return new PlayerWipeArchive(
+                uuid,
+                yaml.getString("player-name", uuid.toString()),
+                yaml.getLong("wiped-at"),
+                yaml.getString("wiped-by", "unknown"),
+                statColumns,
+                statValues,
+                tables
+        );
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -778,6 +778,14 @@ commands:
     - wipe
     permission: ultimatedonutsmp.command.playerwipe
     permission-message: "&cYou do not have permission to use /playerwipe."
+  playerunwipe:
+    description: Restore a wiped player from the backup their wipe left behind
+    usage: /playerunwipe <player> [confirm]
+    aliases:
+    - punwipe
+    - unwipe
+    permission: ultimatedonutsmp.command.playerunwipe
+    permission-message: "&cYou do not have permission to use /playerunwipe."
   amod:
     description: Command amod
     permission: ultimatedonutsmp.command.amod
@@ -825,6 +833,7 @@ permissions:
       ultimatedonutsmp.admin.reload: true
       ultimatedonutsmp.admin.statswipe: true
       ultimatedonutsmp.admin.playerwipe: true
+      ultimatedonutsmp.admin.playerunwipe: true
       ultimatedonutsmp.admin.optimize: true
       ultimatedonutsmp.admin.sellstats: true
       ultimatedonutsmp.admin.shards: true
@@ -968,6 +977,9 @@ permissions:
     default: op
   ultimatedonutsmp.admin.playerwipe:
     description: Preview and wipe a single player's stored data
+    default: op
+  ultimatedonutsmp.admin.playerunwipe:
+    description: Preview and restore a wiped player's stored data
     default: op
   ultimatedonutsmp.admin.optimize:
     description: View and reload runtime optimization controls
@@ -1380,6 +1392,7 @@ permissions:
       ultimatedonutsmp.command.maintenance: true
       ultimatedonutsmp.command.serverwipe: true
       ultimatedonutsmp.command.playerwipe: true
+      ultimatedonutsmp.command.playerunwipe: true
       ultimatedonutsmp.command.amod: true
   ultimatedonutsmp.command.team:
     description: Access to /team command
@@ -1819,6 +1832,9 @@ permissions:
     default: op
   ultimatedonutsmp.command.playerwipe:
     description: Access to /playerwipe command
+    default: op
+  ultimatedonutsmp.command.playerunwipe:
+    description: Access to /playerunwipe command
     default: op
   ultimatedonutsmp.command.amod:
     description: Access to /amod command

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerUnwipeTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DatabaseManagerPlayerUnwipeTest.java
@@ -1,0 +1,254 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.models.PlayerWipeArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseManagerPlayerUnwipeTest {
+
+    private static final UUID TARGET = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID BYSTANDER = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @Test
+    void restoringABackupPutsTheWipedPlayerBackExactlyAsTheyWere() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection);
+            seedData(connection);
+
+            PlayerWipeArchive archive = manager.capturePlayerWipeArchive(TARGET, "Target", "Moderator");
+            manager.resetForPlayerWipe(TARGET, 1000D);
+
+            assertEquals(1000D, money(connection, TARGET), 0.001D);
+            assertEquals(0, countWhere(connection, "homes", "player_uuid = '" + TARGET + "'"));
+
+            DatabaseManager.PlayerWipeResult restored = manager.restorePlayerWipeArchive(archive);
+
+            assertEquals(250D, money(connection, TARGET), 0.001D);
+            assertEquals(7, queryInt(connection, "SELECT kills FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(40, queryInt(connection, "SELECT shards FROM players WHERE uuid = '" + TARGET + "'"));
+            assertEquals(60, queryInt(connection,
+                    "SELECT keyall_remaining_seconds FROM players WHERE uuid = '" + TARGET + "'"));
+
+            assertEquals("base", queryString(connection,
+                    "SELECT home_name FROM homes WHERE player_uuid = '" + TARGET + "'"));
+            assertEquals(1, countWhere(connection, "shop_favorites", "player_uuid = '" + TARGET + "'"));
+            assertEquals(2, countWhere(connection, "ender_chest_items", "player_uuid = '" + TARGET + "'"));
+            assertEquals("mending-book", queryString(connection,
+                    "SELECT item_data FROM ender_chest_items WHERE player_uuid = '" + TARGET + "' AND slot = 0"));
+
+            // Rows the player owns through either of two columns come back on both sides.
+            assertEquals(2, count(connection, "bounties"));
+            assertEquals(2, count(connection, "player_friends"));
+
+            assertTrue(restored.total() > 0);
+            assertEquals(1, restored.affected("stats"));
+            assertEquals(1, restored.affected("homes"));
+            assertEquals(2, restored.affected("ender_chest"));
+
+            // The bystander is untouched by both halves of the round trip.
+            assertEquals(500D, money(connection, BYSTANDER), 0.001D);
+            assertEquals(1, countWhere(connection, "homes", "player_uuid = '" + BYSTANDER + "'"));
+        }
+    }
+
+    @Test
+    void restoringDropsAnythingEarnedAfterTheWipe() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection);
+            seedData(connection);
+
+            PlayerWipeArchive archive = manager.capturePlayerWipeArchive(TARGET, "Target", "Moderator");
+            manager.resetForPlayerWipe(TARGET, 1000D);
+
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate("INSERT INTO homes VALUES ('" + TARGET + "', 'after-the-wipe')");
+            }
+
+            manager.restorePlayerWipeArchive(archive);
+
+            assertEquals(1, countWhere(connection, "homes", "player_uuid = '" + TARGET + "'"));
+            assertEquals("base", queryString(connection,
+                    "SELECT home_name FROM homes WHERE player_uuid = '" + TARGET + "'"));
+        }
+    }
+
+    @Test
+    void aMembershipOfADisbandedTeamIsNotRestored() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection);
+            seedData(connection);
+
+            PlayerWipeArchive archive = manager.capturePlayerWipeArchive(TARGET, "Target", "Moderator");
+            manager.resetForPlayerWipe(TARGET, 1000D);
+
+            // Wiping the leader disbands the team, so the team row is gone by restore time.
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate("DELETE FROM teams WHERE name = 'donuts'");
+            }
+
+            manager.restorePlayerWipeArchive(archive);
+
+            assertEquals(0, count(connection, "team_members"));
+        }
+    }
+
+    @Test
+    void aBackupSurvivesBeingWrittenToDiskAndReadBack(@TempDir Path directory) throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+            DatabaseManager manager = managerWithConnection(connection);
+            createSchema(connection);
+            seedData(connection);
+
+            PlayerWipeArchive archive = manager.capturePlayerWipeArchive(TARGET, "Target_1", "Moderator");
+            File file = directory.resolve("Target_1_" + TARGET + "_2026-09-02_10-00-00.yml").toFile();
+            archive.save(file);
+
+            PlayerWipeArchive reloaded = PlayerWipeArchive.load(file);
+            assertEquals(TARGET, reloaded.playerUuid());
+            assertEquals("Target_1", reloaded.playerName());
+            assertEquals("Moderator", reloaded.wipedBy());
+            assertEquals(archive.wipedAt(), reloaded.wipedAt());
+            assertEquals(archive.rowCount(), reloaded.rowCount());
+
+            // A null column has to survive the trip, or the restore would silently invent a value.
+            List<Object> firstLog = reloaded.tables().get("player_logs").rows().get(0);
+            assertNull(firstLog.get(reloaded.tables().get("player_logs").columns().indexOf("details")));
+
+            manager.resetForPlayerWipe(TARGET, 1000D);
+            manager.restorePlayerWipeArchive(reloaded);
+
+            assertEquals(250D, money(connection, TARGET), 0.001D);
+            assertEquals("mending-book", queryString(connection,
+                    "SELECT item_data FROM ender_chest_items WHERE player_uuid = '" + TARGET + "' AND slot = 0"));
+            assertNull(queryString(connection, "SELECT details FROM player_logs WHERE player_uuid = '" + TARGET + "'"));
+        }
+    }
+
+    private DatabaseManager managerWithConnection(Connection connection) throws Exception {
+        DatabaseManager manager = new DatabaseManager(null);
+        Field connectionField = DatabaseManager.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(manager, connection);
+        return manager;
+    }
+
+    private void createSchema(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    CREATE TABLE players (
+                        uuid TEXT PRIMARY KEY,
+                        username TEXT,
+                        money REAL,
+                        shards INTEGER,
+                        kills INTEGER,
+                        deaths INTEGER,
+                        playtime_seconds INTEGER,
+                        blocks_placed INTEGER,
+                        blocks_broken INTEGER,
+                        mobs_killed INTEGER,
+                        kill_streak INTEGER,
+                        highest_kill_streak INTEGER,
+                        money_spent REAL,
+                        money_made REAL,
+                        scoreboard_visible INTEGER,
+                        keyall_remaining_seconds INTEGER,
+                        shard_booster_expiry INTEGER,
+                        mob_spawn_disabled_until BIGINT,
+                        phantom_disabled_until BIGINT
+                    )
+                    """);
+            statement.execute("CREATE TABLE homes (player_uuid TEXT, home_name TEXT)");
+            statement.execute("CREATE TABLE teams (name TEXT PRIMARY KEY, leader_uuid TEXT)");
+            statement.execute("CREATE TABLE team_members (player_uuid TEXT PRIMARY KEY, team_name TEXT)");
+            statement.execute("CREATE TABLE ender_chest_profiles (player_uuid TEXT)");
+            statement.execute("CREATE TABLE ender_chest_items (player_uuid TEXT, slot INTEGER, item_data TEXT)");
+            statement.execute("CREATE TABLE player_crate_keys (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_history (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_progress (player_uuid TEXT)");
+            statement.execute("CREATE TABLE sell_summary_players (player_uuid TEXT)");
+            statement.execute("CREATE TABLE shop_favorites (player_uuid TEXT, favorite_id TEXT)");
+            statement.execute("CREATE TABLE player_logs (player_uuid TEXT, details TEXT)");
+            statement.execute("CREATE TABLE bounties (target_uuid TEXT, placer_uuid TEXT)");
+            statement.execute("CREATE TABLE player_friends (follower_uuid TEXT, followed_uuid TEXT)");
+            statement.execute("CREATE TABLE player_ignores (owner_uuid TEXT, ignored_uuid TEXT)");
+            statement.execute("CREATE TABLE duel_stats (player_uuid TEXT)");
+            statement.execute("CREATE TABLE duel_matches (player_one_uuid TEXT, player_two_uuid TEXT)");
+            statement.execute("CREATE TABLE ffa_matches (player_one_uuid TEXT, player_two_uuid TEXT)");
+        }
+    }
+
+    private void seedData(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(playerRow(TARGET, "Target", 250, 40, 7));
+            statement.executeUpdate(playerRow(BYSTANDER, "Bystander", 500, 25, 9));
+
+            statement.executeUpdate("INSERT INTO homes VALUES ('" + TARGET + "', 'base')");
+            statement.executeUpdate("INSERT INTO homes VALUES ('" + BYSTANDER + "', 'base')");
+            statement.executeUpdate("INSERT INTO teams VALUES ('donuts', '" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO team_members VALUES ('" + TARGET + "', 'donuts')");
+            statement.executeUpdate("INSERT INTO ender_chest_items VALUES ('" + TARGET + "', 0, 'mending-book')");
+            statement.executeUpdate("INSERT INTO ender_chest_items VALUES ('" + TARGET + "', 1, 'netherite-pick')");
+            statement.executeUpdate("INSERT INTO shop_favorites VALUES ('" + TARGET + "', 'diamond')");
+            statement.executeUpdate("INSERT INTO player_logs VALUES ('" + TARGET + "', NULL)");
+            statement.executeUpdate("INSERT INTO bounties VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+            statement.executeUpdate("INSERT INTO bounties VALUES ('" + BYSTANDER + "', '" + TARGET + "')");
+            statement.executeUpdate("INSERT INTO player_friends VALUES ('" + TARGET + "', '" + BYSTANDER + "')");
+            statement.executeUpdate("INSERT INTO player_friends VALUES ('" + BYSTANDER + "', '" + TARGET + "')");
+        }
+    }
+
+    private String playerRow(UUID uuid, String username, int money, int shards, int kills) {
+        return "INSERT INTO players VALUES ('" + uuid + "', '" + username + "', " + money + ", " + shards + ", "
+                + kills + ", 3, 900, 12, 13, 14, 4, 8, 200, 300, 1, 60, 12345, 0, 0)";
+    }
+
+    private double money(Connection connection, UUID uuid) throws Exception {
+        return queryDouble(connection, "SELECT money FROM players WHERE uuid = '" + uuid + "'");
+    }
+
+    private int count(Connection connection, String table) throws Exception {
+        return queryInt(connection, "SELECT COUNT(*) FROM " + table);
+    }
+
+    private int countWhere(Connection connection, String table, String predicate) throws Exception {
+        return queryInt(connection, "SELECT COUNT(*) FROM " + table + " WHERE " + predicate);
+    }
+
+    private int queryInt(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getInt(1) : 0;
+        }
+    }
+
+    private double queryDouble(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getDouble(1) : 0D;
+        }
+    }
+
+    private String queryString(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getString(1) : null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #322

`/playerwipe` deleted a player's rows across 25 tables and reset their `players` row in one
transaction, keeping nothing anywhere; the preview said as much. That is fine until the ban behind the
wipe turns out to have been wrong, and then there is nothing to hand back. Now every wipe writes what
it is about to remove into `plugins/UltimateDonutSmp/player-wipe-backups/` first, and
`/playerunwipe <player>` reads that file back.

## The backup

`DatabaseManager.capturePlayerWipeArchive` selects the rows the wipe is about to delete, walking the
same `PLAYER_WIPE_TABLES` map the delete walks, and reads the player stats the wipe resets. Nothing is
hardcoded per table: the column names come from `ResultSetMetaData`, so a column added to a table
later lands in the backup without anybody remembering to update this.

The stat columns were the one place that could drift, since the wipe listed them in a hand-written
`UPDATE` and the backup would have needed its own copy of the same list. They now come from one
`PLAYER_WIPE_STAT_RESETS` map that the wipe, the backup and the restore all read, and the `UPDATE` is
built from it.

The backup gets written before the delete runs rather than after it commits, so a wipe that blows up
halfway still leaves a complete copy behind. If the wipe does fail, the file is deleted again, because
restoring from a wipe that never happened would be its own mess.

## The restore

`/playerunwipe <player>` reports who ran the wipe, when, and what the backup holds; `confirm` puts it
back. `/punwipe` and `/unwipe` are aliases, matching `/pwipe` and `/wipe` on the other side. The
restore clears every wipe-owned table for that player before it inserts, so they land exactly on the
backup instead of on a merge of it and whatever they picked up since. On a wrongly banned account that
difference is usually nothing, since they could not log in to earn any of it. All of it runs in one
transaction.

Afterwards the caches a wipe drops get dropped again, and this time the player's own data is read back
in. The in-memory `PlayerData` is discarded without saving first; otherwise the next autosave would
write the wiped totals straight back over the row that was just restored.

## Teams

Wiping a team leader disbands the team, and the team row is not part of any one player's data, so a
restore cannot bring it back. Putting the membership row back unchanged would be worse than dropping
it: `team_members` is keyed on `player_uuid`, and `TeamManager` inserts rather than replaces, so an
orphan row pointing at a disbanded team would stop that player from ever joining another one. The
restore drops membership rows whose team is gone.

## Notes

Backups are kept forever and never overwritten; a player wiped twice gets a file per wipe, and the
restore takes the newest. Filenames carry the name, the uuid and the wipe time, so restoring an older
one by hand means moving files around inside that folder.

The wipe that `offenses.yml` can attach to a ban goes through the same `PlayerWipeManager.wipe`, so it
gets a backup too with no extra config.

New permissions are `ultimatedonutsmp.command.playerunwipe` and `ultimatedonutsmp.admin.playerunwipe`,
both `op` by default and both bundled into the same admin groups the wipe nodes already sit in. No new
language keys and no schema change: the backup is a YAML file on disk.

`DatabaseManagerPlayerUnwipeTest` covers the round trip against in-memory SQLite: a capture, a wipe, a
restore, and the player back where they started with the bystander untouched. It also covers a row
earned after the wipe being dropped, a disbanded team's membership not coming back, and a backup that
goes to disk and returns with a null column still null. Suite is 577 tests, all green.

The two wiki pages that told admins a wipe could not be undone are updated, and so is the in-game
preview line that said the same.
