### PR TITLE
fix(punishments): lift the voice mute when its record is deleted

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PunishmentManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PunishmentManager.java
@@ -316,8 +316,24 @@ public class PunishmentManager {
         );
     }
 
+    /**
+     * Deleting the row is not enough for a voice mute on its own: the microphone gate answers from
+     * a cache rather than the database, so it has to be told the record is gone. The record is read
+     * before the delete because afterwards there is nothing left to read its type from.
+     */
     public boolean deleteRecord(long punishmentId) {
-        return plugin.getDatabaseManager().deletePunishmentRecord(punishmentId);
+        PunishmentRecord existing = plugin.getDatabaseManager().loadPunishmentRecord(punishmentId);
+        if (!plugin.getDatabaseManager().deletePunishmentRecord(punishmentId)) {
+            return false;
+        }
+
+        if (existing != null && existing.getType() == PunishmentType.VOICE_MUTE) {
+            VoiceChatConsentManager voiceChat = plugin.getVoiceChatConsentManager();
+            if (voiceChat != null) {
+                voiceChat.refreshVoiceMute(existing.getTargetUuid(), existing.getTargetNameSnapshot());
+            }
+        }
+        return true;
     }
 
     public PunishmentState getState(PunishmentRecord record) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/VoiceMutePunishmentTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/VoiceMutePunishmentTest.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -91,6 +93,19 @@ class VoiceMutePunishmentTest {
 
         assertTrue(dbManager.markPunishmentRemoved(id, null, "console", System.currentTimeMillis(), "vcunmute"));
         assertTrue(active(PunishmentType.VOICE_MUTE).isEmpty());
+    }
+
+    @Test
+    void deletingTheRecordFromTheGuiAlsoEndsTheMute() {
+        long id = record(PunishmentType.VOICE_MUTE, null);
+        assertNotNull(dbManager.loadPunishmentRecord(id));
+
+        assertTrue(dbManager.deletePunishmentRecord(id));
+        assertTrue(active(PunishmentType.VOICE_MUTE).isEmpty());
+
+        // The row is unreadable once it is gone, so anything that reacts to the delete has to
+        // capture the record first. PunishmentManager.deleteRecord loads it before deleting.
+        assertNull(dbManager.loadPunishmentRecord(id));
     }
 
     private long record(PunishmentType type, Long expiresAt) {


### PR DESCRIPTION
Follow-up to #383, which added `/vcmute`.

Shift-right-click in `/punishments` hard-deletes a record. For a ban or a chat mute that does no harm, because both get read straight out of the database every time the player talks or logs in. A voice mute is different: `mayTalk` runs on the Simple Voice Chat packet thread, so it answers from a cache, and deleting the row left that cache alone. The player kept their microphone switched off until they relogged or somebody ran `/vcunmute`.

## Where the fix went

`PunishmentManager.deleteRecord`, rather than the two menus that call it. `PunishmentHistoryMenu` and `PunishmentsListMenu` both delete records, and patching each one separately would leave the same trap set for whatever calls `deleteRecord` next. The manager now loads the record, deletes it, then refreshes the voice mute cache if what it just removed was a `VOICE_MUTE`.

Order matters: the record has to be read before the delete, because afterwards there's nothing left to read its type from.

## Notes

One test added to `VoiceMutePunishmentTest`. It covers the delete path and pins that ordering down, since `loadPunishmentRecord` returns null once the row is gone. Suite is at 582, green.

`/vcunmute` was never caught by this. It goes through `markActiveRecordsRemoved`, and `PunishmentCommand` already refreshed the cache on that path.
