### PR TITLE
feat(chat): let a gradient span the whole chat format (#324)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -696,6 +696,28 @@ CHAT:
  
 ```
 
+### 4. Colours In The Chat Format
+
+`FORMAT` reads the same colour syntax as the rest of the plugin: `&a` codes, `&#RRGGBB` for a single
+hex colour, and MiniMessage tags such as `<red>`, `<bold>`, `<gradient:#FF0000:#0000FF>` or
+`<rainbow>`. A gradient may run across `%prefix%` and `%player%`, so
+
+```yaml
+CHAT:
+  FORMAT: '<gradient:#FF0000:#0000FF>%prefix%%player%</gradient>&7: &f%message%'
+```
+
+fades the rank prefix and the name together from red to blue, and the hover stats stay attached to
+the name. Drop the `</gradient>` and the fade carries on to the end of the line instead.
+
+Whatever colour is active when the format reaches `%player%` carries onto the name, so a LuckPerms
+prefix ending in `&c` gives you a red name unless the format sets a colour of its own after it.
+
+`%message%` sits outside all of this on purpose. What a player types goes out as written, tinted by
+`MESSAGE-COLORS` and nothing else, so colour codes someone types into chat stay visible as the
+characters they are. Staff chat is assembled in one piece rather than around a clickable name, and
+`STAFFCHAT.FORMAT` in `messages.yml` has always taken gradients the same way.
+
 ---
 
 ## Section: `SERVER-NOTIFICATIONS`

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HoverStatsManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HoverStatsManager.java
@@ -60,8 +60,14 @@ public class HoverStatsManager {
             applyEvents(senderComponent, hover, click);
             root.addExtra(senderComponent);
         } else {
-            append(root, ColorUtils.toBaseComponents(beforePlayer, speaker));
-            TextComponent nameComponent = ColorUtils.toBaseComponent(displayName, speaker);
+            // Everything up to and including the name is coloured in one pass, so a gradient opened
+            // before %player% still runs across the name instead of being cut in half and printed as
+            // plain text. The result is split apart again afterwards to keep the hover on the name.
+            String colorizedHead = ColorUtils.colorize(beforePlayer + displayName, speaker);
+            int nameLength = ColorUtils.visibleLength(ColorUtils.colorize(displayName, speaker));
+            String[] head = ColorUtils.splitTrailingVisible(colorizedHead, nameLength);
+            append(root, TextComponent.fromLegacyText(head[0]));
+            TextComponent nameComponent = legacyComponent(head[1]);
             if (isEnabled()) {
                 applyEvents(nameComponent, hover, click);
             }
@@ -252,6 +258,14 @@ public class HoverStatsManager {
             }
         }
         return "";
+    }
+
+    private TextComponent legacyComponent(String legacy) {
+        TextComponent component = new TextComponent();
+        for (BaseComponent part : TextComponent.fromLegacyText(legacy)) {
+            component.addExtra(part);
+        }
+        return component;
     }
 
     private void append(TextComponent root, BaseComponent[] components) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/ColorUtils.java
@@ -287,6 +287,88 @@ public class ColorUtils {
         return count;
     }
 
+    public static int visibleLength(String text) {
+        return text == null ? 0 : countVisibleCharacters(text);
+    }
+
+    /**
+     * Splits already-coloured text so that its last {@code trailingVisible} visible characters come
+     * back as the second half, with whatever colour and formatting was active at the cut repeated at
+     * the start of it. Chat colours a whole line at once and then hangs a hover event on the player's
+     * name alone, and the name has to keep the colour the line gave it once it is on its own.
+     */
+    public static String[] splitTrailingVisible(String text, int trailingVisible) {
+        if (text == null || text.isEmpty()) {
+            return new String[]{"", ""};
+        }
+        if (trailingVisible <= 0) {
+            return new String[]{text, ""};
+        }
+        int total = countVisibleCharacters(text);
+        if (trailingVisible >= total) {
+            return new String[]{"", text};
+        }
+
+        int cutAt = total - trailingVisible;
+        String activeColor = "";
+        StringBuilder activeFormats = new StringBuilder();
+        int visible = 0;
+        int index = 0;
+        while (index < text.length() && visible < cutAt) {
+            char current = text.charAt(index);
+            if ((current == '&' || current == SECTION_CHAR) && index + 1 < text.length()) {
+                int hexLength = legacyHexLength(text, index);
+                if (hexLength > 0) {
+                    activeColor = text.substring(index, index + hexLength);
+                    activeFormats.setLength(0);
+                    index += hexLength;
+                    continue;
+                }
+                char code = Character.toLowerCase(text.charAt(index + 1));
+                if (code == 'r') {
+                    activeColor = "";
+                    activeFormats.setLength(0);
+                } else if ("0123456789abcdef".indexOf(code) >= 0) {
+                    activeColor = text.substring(index, index + 2);
+                    activeFormats.setLength(0);
+                } else if (isFormatCode(code)) {
+                    String marker = text.substring(index, index + 2);
+                    if (activeFormats.indexOf(marker) < 0) {
+                        activeFormats.append(marker);
+                    }
+                }
+                index += 2;
+                continue;
+            }
+            visible++;
+            index++;
+        }
+
+        return new String[]{
+                text.substring(0, index),
+                activeColor + activeFormats + text.substring(index)
+        };
+    }
+
+    // A hex colour is one §x§R§R§G§G§B§B run rather than seven separate codes, so the cut has to
+    // read it whole or it carries half a colour into the second half.
+    private static int legacyHexLength(String text, int start) {
+        if (start + 14 > text.length()) {
+            return 0;
+        }
+        char marker = text.charAt(start);
+        if (Character.toLowerCase(text.charAt(start + 1)) != 'x') {
+            return 0;
+        }
+        for (int i = 0; i < 6; i++) {
+            if (text.charAt(start + 2 + i * 2) != marker
+                    || Character.digit(text.charAt(start + 3 + i * 2), 16) < 0) {
+                return 0;
+            }
+        }
+        return 14;
+    }
+
     private static boolean isFormatCode(char code) {
         return code == 'k' || code == 'l' || code == 'm' || code == 'n' || code == 'o';
     }
@@ -821,15 +903,15 @@ public class ColorUtils {
             if (gradientTag && !closing) {
                 int contentStart = close + 1;
                 int contentEnd = findMiniClosingTag(text, contentStart, name);
-                if (contentEnd < 0) {
-                    out.append(text, i, close + 1);
-                    i = close + 1;
-                    continue;
-                }
+                // A tag left open runs to the end of the text, the way MiniMessage itself reads it.
+                // Emitting it verbatim instead put the raw "<gradient:...>" on screen whenever a
+                // caller coloured one line in pieces, which is how chat formats are assembled.
+                boolean closed = contentEnd >= 0;
+                int contentLimit = closed ? contentEnd : length;
 
                 StringBuilder content = new StringBuilder();
                 appendActiveStyle(content, null, decorations);
-                content.append(renderMiniMessage(text.substring(contentStart, contentEnd), null, decorations));
+                content.append(renderMiniMessage(text.substring(contentStart, contentLimit), null, decorations));
                 String inner = content.toString();
 
                 out.append(name.equals("gradient")
@@ -837,7 +919,7 @@ public class ColorUtils {
                         : expandRainbow(inner, argument));
                 out.append("&r");
                 appendActiveStyle(out, color, decorations);
-                i = text.indexOf('>', contentEnd) + 1;
+                i = closed ? text.indexOf('>', contentEnd) + 1 : length;
                 continue;
             }
 

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/ChatFormatGradientTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/ChatFormatGradientTest.java
@@ -1,0 +1,129 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The chat line is coloured in pieces so the player's name can carry a hover event of its own, and a
+ * gradient opened before the name used to be cut in half by that split and printed as plain text.
+ * These cover the pieces the line is built from.
+ */
+class ChatFormatGradientTest {
+
+    private static final char SECTION = '§';
+
+    @Test
+    void anUnclosedGradientColoursTheRestOfTheTextInsteadOfPrintingItsTag() {
+        String colorized = ColorUtils.colorize("<gradient:#FF0000:#0000FF>Notch");
+
+        assertFalse(colorized.contains("gradient"), colorized);
+        assertFalse(colorized.contains("<"), colorized);
+        assertTrue(colorized.startsWith(hex("FF0000")), colorized);
+        assertTrue(colorized.contains(hex("0000FF")), colorized);
+        assertEquals("Notch", ColorUtils.strip(colorized));
+    }
+
+    @Test
+    void anUnclosedRainbowColoursTheRestOfTheTextToo() {
+        String colorized = ColorUtils.colorize("<rainbow>Notch");
+
+        assertFalse(colorized.contains("rainbow"), colorized);
+        assertFalse(colorized.contains("<"), colorized);
+        assertEquals("Notch", ColorUtils.strip(colorized));
+    }
+
+    @Test
+    void aClosingTagLeftOnItsOwnPrintsNothing() {
+        String colorized = ColorUtils.colorize("</gradient>");
+
+        assertFalse(colorized.contains("gradient"), colorized);
+        assertEquals("", ColorUtils.strip(colorized));
+    }
+
+    @Test
+    void aGradientOpenedBeforeThePlayerNameStillReachesIt() {
+        String beforePlayer = "<gradient:#FF0000:#0000FF>[VIP] ";
+        String displayName = "Notch";
+
+        String head = ColorUtils.colorize(beforePlayer + displayName);
+        String[] split = ColorUtils.splitTrailingVisible(
+                head, ColorUtils.visibleLength(ColorUtils.colorize(displayName)));
+
+        assertEquals("[VIP] ", ColorUtils.strip(split[0]));
+        assertEquals("Notch", ColorUtils.strip(split[1]));
+        assertTrue(split[0].startsWith(hex("FF0000")), split[0]);
+        assertTrue(split[1].startsWith(String.valueOf(SECTION) + 'x'), split[1]);
+        assertTrue(split[1].contains(hex("0000FF")), split[1]);
+    }
+
+    @Test
+    void noPieceOfTheChatLineShowsARawTag() {
+        String resolved = "<gradient:#FF0000:#0000FF>%prefix%%player%</gradient>&7: &f%message%"
+                .replace("%prefix%", "");
+        int playerIndex = resolved.indexOf("%player%");
+        int messageIndex = resolved.indexOf("%message%");
+        String beforePlayer = resolved.substring(0, playerIndex);
+        String between = resolved.substring(playerIndex + "%player%".length(), messageIndex);
+        String after = resolved.substring(messageIndex + "%message%".length());
+
+        String rendered = ColorUtils.colorize(beforePlayer + "Notch")
+                + ColorUtils.colorize(between)
+                + ColorUtils.colorize(after);
+
+        assertFalse(rendered.contains("<"), rendered);
+        assertFalse(rendered.contains("gradient"), rendered);
+        assertEquals("Notch: ", ColorUtils.strip(rendered));
+    }
+
+    @Test
+    void theSplitCarriesTheColourActiveAtTheCut() {
+        String[] split = ColorUtils.splitTrailingVisible(ColorUtils.colorize("&a[VIP] Notch"), 5);
+
+        assertEquals(SECTION + "a[VIP] ", split[0]);
+        assertEquals(SECTION + "aNotch", split[1]);
+    }
+
+    @Test
+    void theSplitCarriesAFormatCodeThatIsStillOpen() {
+        String[] split = ColorUtils.splitTrailingVisible(ColorUtils.colorize("&c&lAlex Steve"), 5);
+
+        assertEquals(SECTION + "c" + SECTION + "lAlex ", split[0]);
+        assertEquals(SECTION + "c" + SECTION + "lSteve", split[1]);
+    }
+
+    @Test
+    void theSplitReadsAHexColourRunWhole() {
+        String[] split = ColorUtils.splitTrailingVisible(ColorUtils.colorize("&#FF0000ab"), 1);
+
+        assertEquals(hex("FF0000") + "a", split[0]);
+        assertEquals(hex("FF0000") + "b", split[1]);
+    }
+
+    @Test
+    void askingForMoreThanIsThereLeavesTheWholeLineAsTheName() {
+        String[] split = ColorUtils.splitTrailingVisible(ColorUtils.colorize("&aNotch"), 20);
+
+        assertEquals("", split[0]);
+        assertEquals(SECTION + "aNotch", split[1]);
+    }
+
+    @Test
+    void aStaffChatLineIsUnaffectedBecauseItIsColouredInOnePass() {
+        String colorized = ColorUtils.colorize(
+                "<gradient:#FF0000:#0000FF>[SC] Notch: hello</gradient>");
+
+        assertFalse(colorized.contains("gradient"), colorized);
+        assertEquals("[SC] Notch: hello", ColorUtils.strip(colorized));
+    }
+
+    private static String hex(String value) {
+        StringBuilder out = new StringBuilder().append(SECTION).append('x');
+        for (int i = 0; i < value.length(); i++) {
+            out.append(SECTION).append(value.charAt(i));
+        }
+        return out.toString();
+    }
+}


### PR DESCRIPTION
Closes #324

A gradient written into the chat format never made it to the screen. Chat colours its line in pieces so the player's name can carry its own hover box, and a `<gradient:...>` opened before `%player%` has no closing tag inside its piece, so the renderer printed the tag as literal text and the name came out with no fade on it at all. Staff chat was never affected, since it colours the whole line in one pass.

## Where the tag was leaking

`ColorUtils` gave up on a gradient whose closing tag it could not find, and wrote the tag out verbatim. Anyone colouring a line in fragments hit that, chat being the obvious one. It now does what MiniMessage itself does and runs the fade to the end of the text. A `</gradient>` left on its own still just resets, as before.

## Keeping the hover on the name

`HoverStatsManager` used to colour the text before `%player%` and the name separately. It now colours them together and splits the result apart afterwards, counting visible characters so the cut lands in front of the name instead of inside a hex colour run. Whatever colour, bold or italic is still open at that point gets repeated at the start of the name piece, which keeps the hover and the click on the name alone.

That has one visible consequence. The colour in force when the format reaches `%player%` now carries onto the name, so a prefix ending in `&c` gives a red name where it used to force white. The carry is what lets a gradient cross the name in the first place, so it isn't really separable from the fix.

## Notes

`%message%` is untouched. What a player types still goes out as written, tinted only by `CHAT.MESSAGE-COLORS`, so nobody can colour chat by typing codes into it. Team chat runs through the same builder and picks up the same behaviour.

Ten new tests in `ChatFormatGradientTest` cover the unclosed gradient and rainbow, the stray closing tag, the split carrying a colour, a format code and a whole hex run, and a full format line with nothing raw left in it. Suite is at 592 and green.

`docs/wiki/Config-config.yml.md` gets a section on colours in the chat format.
