### PR TITLE
feat(maintenance): show maintenance and a countdown in the server list (#326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Commands can be disabled through their related feature toggle. Arguments in `<an
 | `/leaderboard` | `/lb`, `/top`, `/leaderboards`, `/baltop` | `/leaderboard [type]` | `ultimatedonutsmp.command.leaderboard` |
 | `/leave` | - | `/leave` | `ultimatedonutsmp.command.leave` |
 | `/logs` | - | `/logs` | `ultimatedonutsmp.command.logs` |
-| `/maintenance` | - | `/maintenance <on\|off\|status\|setlobby [server]>` | `ultimatedonutsmp.command.maintenance` |
+| `/maintenance` | - | `/maintenance <on [duration]\|off\|status\|setlobby [server]>` | `ultimatedonutsmp.command.maintenance` |
 | `/meta` | `/farmingmeta` | `/meta` | `ultimatedonutsmp.command.meta` |
 | `/msg` | `/message`, `/tell`, `/whisper`, `/w` | `/msg <player> <message>` | `ultimatedonutsmp.command.msg` |
 | `/mute` | - | `/mute <player> [reason]` | `ultimatedonutsmp.command.mute` |

--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -260,7 +260,7 @@ NETWORK-STATUS:
 ### 1. Commented Setup Code Example
 
 ```yaml
-# Maintenance mode behaviour (/maintenance on|off|status|setlobby)
+# Maintenance mode behaviour (/maintenance on [duration]|off|status|setlobby)
 MAINTENANCE:
   # Permission node that lets a player join while maintenance mode is active
   BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
@@ -280,6 +280,34 @@ MAINTENANCE:
 
   # Countdown in seconds shown before players are sent back once the server returns
   RECONNECT_DELAY_SECONDS: 5
+
+  # How this server looks in the multiplayer list while maintenance mode is active
+  SERVER_LIST:
+    # Set to false to leave the server list entry alone and only gate the login
+    ENABLED: true
+
+    # The lines shown under the server name. The client draws the first two. %time% is the
+    # time left before maintenance lifts itself, written as 03:29, or 1:03:29 once more than an
+    # hour is left
+    LINES:
+    - '&cCurrently under maintenance'
+    - '&bCome back in: &d%time%'
+
+    # Used instead of LINES when maintenance was started with no duration, as in a plain
+    # /maintenance on, so the entry never shows a countdown with nothing to count down to
+    LINES_NO_TIMER:
+    - '&cCurrently under maintenance'
+    - '&7come back later'
+
+    # Text shown where the player count normally sits. The client draws it in red next to a
+    # broken connection icon, which is what makes the entry stand out in a long server list.
+    # Leave it empty to keep the real player count on show
+    VERSION_LABEL: '&cMaintenance'
+
+    # Lines shown when the player count is hovered. Leaving the list empty keeps the usual
+    # sample of online player names
+    HOVER:
+    - '&cCurrently under maintenance'
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -291,6 +319,11 @@ MAINTENANCE:
 | `MAINTENANCE.LOBBY_SERVER` | `str` | Any proxy server name, or empty | `'lobby'` | Destination used when `USE_PROXY` is `true`. `/maintenance setlobby <server>` overrides it at runtime, and `/maintenance setlobby` with no name clears that override and hands the decision back to this key. Leave it empty on a server with no lobby: the connection is then refused during login, so players never enter the world. |
 | `MAINTENANCE.LOBBY_WORLD` | `str` | Any loaded world name | `'WORLD'` | Destination used when `USE_PROXY` is `false`. When that world is not loaded the spawn location is used, and when neither resolves the connection is refused during login. |
 | `MAINTENANCE.RECONNECT_DELAY_SECONDS` | `int` | Any valid integer number | `'5'` | Countdown shown to players waiting to be sent back once the server reports itself online again over Redis. `0` sends them back straight away. |
+| `MAINTENANCE.SERVER_LIST.ENABLED` | `bool` | `true`, `false` | `true` | `true` rewrites this server's entry in the multiplayer list while maintenance is active. `false` leaves the entry alone, and maintenance only shows itself when someone tries to join. |
+| `MAINTENANCE.SERVER_LIST.LINES` | `list` | Any lines of text | `['&cCurrently under maintenance', '&bCome back in: &d%time%']` | The MOTD shown while a duration is running. The client draws the first two entries. `%time%` becomes the time left, written as `03:29` and widening to `1:03:29` past an hour. |
+| `MAINTENANCE.SERVER_LIST.LINES_NO_TIMER` | `list` | Any lines of text | `['&cCurrently under maintenance', '&7come back later']` | Used instead of `LINES` when maintenance was started without a duration, so the entry never shows a countdown that has nothing to count down to. |
+| `MAINTENANCE.SERVER_LIST.VERSION_LABEL` | `str` | Any string text, or empty | `'&cMaintenance'` | Replaces the player count on the entry. The client draws it in red beside a broken connection icon, which is what makes a closed server stand out in a long list. Empty leaves the real player count on show. |
+| `MAINTENANCE.SERVER_LIST.HOVER` | `list` | Any lines of text | `['&cCurrently under maintenance']` | Shown when the player count is hovered, in place of the usual sample of online names. An empty list keeps that sample, staff working through the maintenance included. |
 
 ### 3. Practical Setup Example
 
@@ -301,6 +334,20 @@ MAINTENANCE:
   BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
   USE_PROXY: true
   LOBBY_SERVER: ''
+```
+
+An hour of scheduled downtime, announced in the multiplayer list. `/maintenance on 1h` starts the
+countdown, players watch it run down on the server entry, and maintenance lifts itself when it
+reaches zero:
+
+```yaml
+MAINTENANCE:
+  SERVER_LIST:
+    ENABLED: true
+    LINES:
+    - '&cUpgrading the server'
+    - '&bBack in: &d%time%'
+    VERSION_LABEL: '&cMaintenance'
 ```
 
 ---

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -264,6 +264,8 @@ public final class UltimateDonutSmp extends JavaPlugin {
         ordersManager.initializeNetworkSync();
         maintenanceManager = new MaintenanceManager(this);
         maintenanceManager.initializeRedisListener();
+        maintenanceManager.startExpiryTask();
+        new MaintenanceProtocolLibBridge(this).initialize();
         duelManager.initializeCrossServer();
         discordWebhookManager = new DiscordWebhookManager(this);
         pingManager = new PingManager(this);

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/MaintenanceCommand.java
@@ -1,6 +1,8 @@
 package com.bx.ultimateDonutSmp.commands;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.MaintenanceManager;
+import com.bx.ultimateDonutSmp.managers.OffenseManager;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -14,6 +16,11 @@ import java.util.List;
 import java.util.Locale;
 
 public class MaintenanceCommand implements CommandExecutor, TabCompleter {
+
+    static final String ARGUMENTS = "<on [duration]|off|status|setlobby [server]>";
+
+    /** Offered after /maintenance on. Any duration the punishment commands accept works too. */
+    static final List<String> DURATION_SUGGESTIONS = List.of("15m", "30m", "1h", "2h", "6h");
 
     private final UltimateDonutSmp plugin;
 
@@ -42,7 +49,7 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length < 1) {
-            sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " <on|off|status|setlobby [server]>"));
+            sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " " + ARGUMENTS));
             return;
         }
 
@@ -58,7 +65,24 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage(ColorUtils.toComponent("&eMaintenance mode is already active."));
                     return;
                 }
-                mm.startMaintenance();
+                long durationMillis = 0L;
+                if (args.length >= 2 && !args[1].isBlank()) {
+                    Long parsed = OffenseManager.parseDurationToMillis(args[1]);
+                    if (parsed == null || parsed <= 0L) {
+                        sender.sendMessage(ColorUtils.toComponent(
+                                "&cCould not read &b" + args[1] + "&c as a duration. Try something like 30m, 2h or 1d."));
+                        return;
+                    }
+                    durationMillis = parsed;
+                }
+                mm.startMaintenance(durationMillis);
+                if (durationMillis > 0L) {
+                    sender.sendMessage(ColorUtils.toComponent(
+                            "&aMaintenance mode has been enabled for &b"
+                                    + plugin.getLanguageManager().formatDuration(durationMillis / 1000L, true)
+                                    + "&a. Players are being redirected."));
+                    return;
+                }
                 sender.sendMessage(ColorUtils.toComponent("&aMaintenance mode has been enabled. Players are being redirected."));
             }
             case "off", "stop", "disable" -> {
@@ -75,6 +99,7 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
                 sender.sendMessage(ColorUtils.toComponent("&d&lMaintenance status:"));
                 sender.sendMessage(ColorUtils.toComponent("  &fActive: " + (active ? "&aYes" : "&cNo")));
                 sender.sendMessage(ColorUtils.toComponent("  &fLobby server: " + describeLobbyServer(lobby)));
+                sender.sendMessage(ColorUtils.toComponent("  &fEnds in: " + describeRemaining(mm.getRemainingSeconds())));
             }
             case "setlobby" -> {
                 if (clearsLobbyServer(args)) {
@@ -88,7 +113,7 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
                 mm.setLobbyServer(lobby);
                 sender.sendMessage(ColorUtils.toComponent("&aLobby server set to &b" + lobby + "&a."));
             }
-            default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " <on|off|status|setlobby [server]>"));
+            default -> sender.sendMessage(ColorUtils.toComponent("&cUsage: " + usage + " " + ARGUMENTS));
         }
     }
 
@@ -98,6 +123,24 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
      */
     static boolean clearsLobbyServer(String[] args) {
         return args.length < 2 || args[1].isBlank();
+    }
+
+    /** The three spellings of /maintenance on, all of which may be followed by a duration. */
+    static boolean isEnableArgument(String argument) {
+        return argument.equalsIgnoreCase("on")
+                || argument.equalsIgnoreCase("start")
+                || argument.equalsIgnoreCase("enable");
+    }
+
+    /**
+     * Maintenance started without a duration has nothing to count down to, and saying so beats
+     * printing a zero that reads like the server is about to reopen.
+     */
+    static String describeRemaining(long remainingSeconds) {
+        if (remainingSeconds == MaintenanceManager.NO_DEADLINE) {
+            return "&7nothing scheduled, it stays on until &f/maintenance off";
+        }
+        return "&b" + MaintenanceManager.formatCountdown(remainingSeconds);
     }
 
     static String describeLobbyServer(String lobby) {
@@ -115,6 +158,10 @@ public class MaintenanceCommand implements CommandExecutor, TabCompleter {
 
         if (args.length == 1) {
             return StringUtil.copyPartialMatches(args[0], List.of("on", "off", "status", "setlobby"), new ArrayList<>());
+        }
+
+        if (args.length == 2 && isEnableArgument(args[0])) {
+            return StringUtil.copyPartialMatches(args[1], DURATION_SUGGESTIONS, new ArrayList<>());
         }
 
         if (args.length == 2 && args[0].equalsIgnoreCase("setlobby")) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/UltimateDonutSmpCommand.java
@@ -689,6 +689,9 @@ public class UltimateDonutSmpCommand implements CommandExecutor, TabCompleter {
             if (args.length == 2) {
                 return partialMatches(args[1], List.of("on", "off", "status", "setlobby"));
             }
+            if (args.length == 3 && MaintenanceCommand.isEnableArgument(args[1])) {
+                return partialMatches(args[2], MaintenanceCommand.DURATION_SUGGESTIONS);
+            }
             if (args.length == 3 && args[1].equalsIgnoreCase("setlobby")) {
                 List<String> servers = new ArrayList<>();
                 ConfigurationSection sec = plugin.getConfigManager().getNetwork().getConfigurationSection("NETWORK-STATUS.SERVERS");

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
@@ -9,6 +9,7 @@ import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -21,10 +22,15 @@ public class MaintenanceManager {
 
     private static final String REDIS_MAINTENANCE_CHANNEL = "ultimatedonutsmp:maintenance";
 
+    /** Returned by {@link #getRemainingSeconds()} when maintenance has no scheduled end. */
+    public static final long NO_DEADLINE = -1L;
+
     private final UltimateDonutSmp plugin;
     private final File stateFile;
     private boolean maintenanceActive;
     private String customLobbyServer;
+    private long maintenanceEndsAt;
+    private BukkitTask expiryTask;
 
     public MaintenanceManager(UltimateDonutSmp plugin) {
         this.plugin = plugin;
@@ -36,12 +42,14 @@ public class MaintenanceManager {
         if (!stateFile.exists()) {
             this.maintenanceActive = false;
             this.customLobbyServer = null;
+            this.maintenanceEndsAt = 0L;
             return;
         }
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(stateFile);
         this.maintenanceActive = config.getBoolean("active", false);
         this.customLobbyServer = config.getString("lobby", null);
+        this.maintenanceEndsAt = config.getLong("until", 0L);
     }
 
     public void save() {
@@ -49,6 +57,9 @@ public class MaintenanceManager {
         config.set("active", maintenanceActive);
         if (customLobbyServer != null) {
             config.set("lobby", customLobbyServer);
+        }
+        if (maintenanceEndsAt > 0L) {
+            config.set("until", maintenanceEndsAt);
         }
 
         try {
@@ -65,6 +76,63 @@ public class MaintenanceManager {
     public void setMaintenanceActive(boolean active) {
         this.maintenanceActive = active;
         save();
+    }
+
+    /**
+     * Seconds left before maintenance lifts itself, or {@link #NO_DEADLINE} when there is no end
+     * time to count down to.
+     */
+    public long getRemainingSeconds() {
+        return remainingSeconds(maintenanceEndsAt, System.currentTimeMillis());
+    }
+
+    static long remainingSeconds(long endsAt, long now) {
+        if (endsAt <= 0L) {
+            return NO_DEADLINE;
+        }
+        long remainingMillis = endsAt - now;
+        if (remainingMillis <= 0L) {
+            return 0L;
+        }
+        // Rounded up, so a deadline 3.4 seconds out reads as 4. Rounding down would park the
+        // countdown on 00:00 for a whole second while the server is still shut.
+        return (remainingMillis + 999L) / 1000L;
+    }
+
+    /**
+     * Renders a countdown the way the multiplayer list shows it: mm:ss, widening to h:mm:ss once
+     * more than an hour is left.
+     */
+    public static String formatCountdown(long totalSeconds) {
+        long seconds = Math.max(0L, totalSeconds);
+        long hours = seconds / 3600L;
+        long minutes = (seconds % 3600L) / 60L;
+        long remaining = seconds % 60L;
+        if (hours > 0L) {
+            return String.format(Locale.ROOT, "%d:%02d:%02d", hours, minutes, remaining);
+        }
+        return String.format(Locale.ROOT, "%02d:%02d", minutes, remaining);
+    }
+
+    static boolean hasExpired(boolean active, long endsAt, long now) {
+        return active && endsAt > 0L && now >= endsAt;
+    }
+
+    /**
+     * Watches the deadline set by /maintenance on with a duration. Without it the countdown in the
+     * server list would run down to 00:00 and the server would stay shut, which is the one thing a
+     * countdown promises will not happen.
+     */
+    public void startExpiryTask() {
+        if (expiryTask != null) {
+            return;
+        }
+        expiryTask = plugin.getSpigotScheduler().runGlobalTimer(() -> {
+            if (hasExpired(maintenanceActive, maintenanceEndsAt, System.currentTimeMillis())) {
+                plugin.getLogger().info("Maintenance mode ended: the scheduled duration ran out.");
+                stopMaintenance();
+            }
+        }, 20L, 20L);
     }
 
     public String getLobbyServer() {
@@ -132,6 +200,15 @@ public class MaintenanceManager {
     }
 
     public void startMaintenance() {
+        startMaintenance(0L);
+    }
+
+    /**
+     * @param durationMillis how long maintenance should last, or 0 to stay shut until someone runs
+     *                       /maintenance off
+     */
+    public void startMaintenance(long durationMillis) {
+        this.maintenanceEndsAt = durationMillis > 0L ? System.currentTimeMillis() + durationMillis : 0L;
         setMaintenanceActive(true);
         save();
 
@@ -189,6 +266,7 @@ public class MaintenanceManager {
     }
 
     public void stopMaintenance() {
+        this.maintenanceEndsAt = 0L;
         setMaintenanceActive(false);
         save();
         broadcastOnline();

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceProtocolLibBridge.java
@@ -1,0 +1,185 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedServerPing;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * Dresses the status ping while maintenance mode is active, so a closed server says so in the
+ * multiplayer list instead of looking open right up until someone tries to join.
+ *
+ * <p>The MOTD is the part Bukkit could do on its own. The label that replaces the player count
+ * cannot: it is the version string, and the client only draws it once the protocol number fails to
+ * match its own, so both are set together here.
+ */
+public final class MaintenanceProtocolLibBridge {
+
+    /** Token replaced in any configured line with the time left before maintenance lifts. */
+    static final String TIME_PLACEHOLDER = "%time%";
+
+    /**
+     * No client speaks this protocol, which is what makes the version string surface in place of
+     * the player count instead of being hidden behind a version match.
+     */
+    private static final int UNMATCHABLE_PROTOCOL = -1;
+
+    private static final List<String> DEFAULT_LINES =
+            List.of("&cCurrently under maintenance", "&bCome back in: &d%time%");
+    private static final List<String> DEFAULT_LINES_WITHOUT_TIMER =
+            List.of("&cCurrently under maintenance", "&7come back later");
+
+    private final UltimateDonutSmp plugin;
+    private boolean loggedFailure;
+
+    public MaintenanceProtocolLibBridge(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void initialize() {
+        if (!plugin.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+            return;
+        }
+
+        try {
+            ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
+            protocolManager.addPacketListener(new PacketAdapter(
+                    plugin,
+                    ListenerPriority.HIGH,
+                    PacketType.Status.Server.SERVER_INFO
+            ) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    onServerInfo(event);
+                }
+            });
+        } catch (Throwable throwable) {
+            plugin.getLogger().log(Level.WARNING, "Failed to register the maintenance server list listener", throwable);
+        }
+    }
+
+    private void onServerInfo(PacketEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
+        MaintenanceManager maintenanceManager = plugin.getMaintenanceManager();
+        if (maintenanceManager == null || !maintenanceManager.isMaintenanceActive()) {
+            return;
+        }
+
+        FileConfiguration network = plugin.getConfigManager().getNetwork();
+        if (!network.getBoolean("MAINTENANCE.SERVER_LIST.ENABLED", true)) {
+            return;
+        }
+
+        try {
+            WrappedServerPing ping = event.getPacket().getServerPings().read(0);
+            if (ping == null) {
+                return;
+            }
+            apply(ping, network, maintenanceManager.getRemainingSeconds());
+            // Recent server versions hand out an immutable status object, so the wrapper collects
+            // the edits and only the write-back puts them on the packet.
+            event.getPacket().getServerPings().write(0, ping);
+        } catch (Throwable throwable) {
+            logOnce("Could not rewrite the server list ping for maintenance mode", throwable);
+        }
+    }
+
+    /**
+     * A ping is answered for every client that opens its server list, so a fault that repeats
+     * would fill the console with the same stack trace. One copy is enough to act on.
+     */
+    private void logOnce(String message, Throwable throwable) {
+        if (loggedFailure) {
+            return;
+        }
+        loggedFailure = true;
+        plugin.getLogger().log(Level.WARNING, message, throwable);
+    }
+
+    private void apply(WrappedServerPing ping, FileConfiguration network, long remainingSeconds) {
+        boolean counting = remainingSeconds != MaintenanceManager.NO_DEADLINE;
+        List<String> lines = network.getStringList(
+                counting ? "MAINTENANCE.SERVER_LIST.LINES" : "MAINTENANCE.SERVER_LIST.LINES_NO_TIMER");
+        if (lines.isEmpty()) {
+            // A network.yml written before this block existed still gets the entry rather than an
+            // empty MOTD.
+            lines = counting ? DEFAULT_LINES : DEFAULT_LINES_WITHOUT_TIMER;
+        }
+        ping.setMotD(ColorUtils.colorize(renderMotd(lines, remainingSeconds)));
+
+        String versionLabel = network.getString("MAINTENANCE.SERVER_LIST.VERSION_LABEL", "&cMaintenance");
+        if (versionLabel != null && !versionLabel.isBlank()) {
+            ping.setVersionName(ColorUtils.colorize(applyCountdown(versionLabel, remainingSeconds)));
+            ping.setVersionProtocol(UNMATCHABLE_PROTOCOL);
+        }
+
+        List<String> hoverLines = network.getStringList("MAINTENANCE.SERVER_LIST.HOVER");
+        if (hoverLines.isEmpty()) {
+            return;
+        }
+
+        // The hover box is carried by fake player entries, and how much a server accepts in one of
+        // those names varies with its authlib. Losing the hover is a fair price; losing the MOTD
+        // and the label with it would not be, so this part fails on its own.
+        try {
+            List<WrappedGameProfile> sample = new ArrayList<>(hoverLines.size());
+            for (String line : hoverLines) {
+                sample.add(new WrappedGameProfile(
+                        UUID.randomUUID(),
+                        ColorUtils.colorize(applyCountdown(line, remainingSeconds))
+                ));
+            }
+            // Replacing the sample also keeps whoever is still on the server, staff working
+            // through the maintenance included, out of the hover box.
+            ping.setPlayers(sample);
+        } catch (Throwable throwable) {
+            logOnce("Could not put the maintenance text on the server list hover", throwable);
+        }
+    }
+
+    /**
+     * Joins the configured lines into the MOTD. The client draws the first two of them, so a
+     * longer list costs nothing but is not shown either.
+     */
+    static String renderMotd(List<String> lines, long remainingSeconds) {
+        if (lines == null || lines.isEmpty()) {
+            return "";
+        }
+        StringBuilder motd = new StringBuilder();
+        for (String line : lines) {
+            if (motd.length() > 0) {
+                motd.append('\n');
+            }
+            motd.append(applyCountdown(line, remainingSeconds));
+        }
+        return motd.toString();
+    }
+
+    static String applyCountdown(String line, long remainingSeconds) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+        if (!line.contains(TIME_PLACEHOLDER)) {
+            return line;
+        }
+        String rendered = remainingSeconds == MaintenanceManager.NO_DEADLINE
+                ? ""
+                : MaintenanceManager.formatCountdown(remainingSeconds);
+        return line.replace(TIME_PLACEHOLDER, rendered);
+    }
+}

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2124,6 +2124,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cZurzeit in Wartung'
+        - '&bZurück in: &d%time%'
+        LINES_NO_TIMER:
+        - '&cZurzeit in Wartung'
+        - '&7schau später wieder vorbei'
+        VERSION_LABEL: '&cWartung'
+        HOVER:
+        - '&cZurzeit in Wartung'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2329,6 +2329,16 @@ CONFIG:
         KICK_FALLBACK: '&cThis server is in maintenance and no lobby is available.'
         RECONNECTING_TITLE: '&a&lServer online'
         RECONNECTING_SUBTITLE: '&7Sending you back in %seconds% seconds...'
+      SERVER_LIST:
+        LINES:
+        - '&cCurrently under maintenance'
+        - '&bCome back in: &d%time%'
+        LINES_NO_TIMER:
+        - '&cCurrently under maintenance'
+        - '&7come back later'
+        VERSION_LABEL: '&cMaintenance'
+        HOVER:
+        - '&cCurrently under maintenance'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -1989,6 +1989,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cActualmente en mantenimiento'
+        - '&bVuelve en: &d%time%'
+        LINES_NO_TIMER:
+        - '&cActualmente en mantenimiento'
+        - '&7vuelve más tarde'
+        VERSION_LABEL: '&cMantenimiento'
+        HOVER:
+        - '&cActualmente en mantenimiento'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -1989,6 +1989,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cActuellement en maintenance'
+        - '&bDe retour dans: &d%time%'
+        LINES_NO_TIMER:
+        - '&cActuellement en maintenance'
+        - '&7revenez plus tard'
+        VERSION_LABEL: '&cMaintenance'
+        HOVER:
+        - '&cActuellement en maintenance'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2126,6 +2126,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cSedang dalam pemeliharaan'
+        - '&bKembali dalam: &d%time%'
+        LINES_NO_TIMER:
+        - '&cSedang dalam pemeliharaan'
+        - '&7kembali lagi nanti'
+        VERSION_LABEL: '&cPemeliharaan'
+        HOVER:
+        - '&cSedang dalam pemeliharaan'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -1989,6 +1989,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cAtualmente em manutenção'
+        - '&bVolte em: &d%time%'
+        LINES_NO_TIMER:
+        - '&cAtualmente em manutenção'
+        - '&7volte mais tarde'
+        VERSION_LABEL: '&cManutenção'
+        HOVER:
+        - '&cAtualmente em manutenção'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -1988,6 +1988,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&cСейчас на техобслуживании'
+        - '&bВозвращение через: &d%time%'
+        LINES_NO_TIMER:
+        - '&cСейчас на техобслуживании'
+        - '&7загляните позже'
+        VERSION_LABEL: '&cТехработы'
+        HOVER:
+        - '&cСейчас на техобслуживании'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -1983,6 +1983,16 @@ CONFIG:
         KICK_FALLBACK: "&cThis server is in maintenance and no lobby is available."
         RECONNECTING_TITLE: "&a&lServer online"
         RECONNECTING_SUBTITLE: "&7Sending you back in %seconds% seconds..."
+      SERVER_LIST:
+        LINES:
+        - '&c服务器维护中'
+        - '&b请在 &d%time% 后回来'
+        LINES_NO_TIMER:
+        - '&c服务器维护中'
+        - '&7请稍后再来'
+        VERSION_LABEL: '&c维护中'
+        HOVER:
+        - '&c服务器维护中'
   STAFF_MODE:
     STAFF-MODE:
       VANISH-ACTIONBAR:

--- a/src/main/resources/network.yml
+++ b/src/main/resources/network.yml
@@ -132,3 +132,31 @@ MAINTENANCE:
 
   # Countdown in seconds shown before players are sent back once the server returns
   RECONNECT_DELAY_SECONDS: 5
+
+  # How this server looks in the multiplayer list while maintenance mode is active
+  SERVER_LIST:
+    # Set to false to leave the server list entry alone and only gate the login
+    ENABLED: true
+
+    # The lines shown under the server name. The client draws the first two. %time% is the
+    # time left before maintenance lifts itself, written as 03:29, or 1:03:29 once more than an
+    # hour is left
+    LINES:
+    - '&cCurrently under maintenance'
+    - '&bCome back in: &d%time%'
+
+    # Used instead of LINES when maintenance was started with no duration, as in a plain
+    # /maintenance on, so the entry never shows a countdown with nothing to count down to
+    LINES_NO_TIMER:
+    - '&cCurrently under maintenance'
+    - '&7come back later'
+
+    # Text shown where the player count normally sits. The client draws it in red next to a
+    # broken connection icon, which is what makes the entry stand out in a long server list.
+    # Leave it empty to keep the real player count on show
+    VERSION_LABEL: '&cMaintenance'
+
+    # Lines shown when the player count is hovered. Leaving the list empty keeps the usual
+    # sample of online player names
+    HOVER:
+    - '&cCurrently under maintenance'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceCountdownTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceCountdownTest.java
@@ -1,0 +1,61 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The clock behind /maintenance on with a duration. The server list promises players a time, so
+ * the arithmetic behind that promise is worth pinning down.
+ */
+class MaintenanceCountdownTest {
+
+    @Test
+    void maintenanceStartedWithoutADurationHasNothingToCountDown() {
+        assertEquals(MaintenanceManager.NO_DEADLINE, MaintenanceManager.remainingSeconds(0L, 1_000L));
+        assertEquals(MaintenanceManager.NO_DEADLINE, MaintenanceManager.remainingSeconds(-1L, 1_000L));
+    }
+
+    @Test
+    void aDeadlineAlreadyGoneReadsAsZeroRatherThanACountUp() {
+        assertEquals(0L, MaintenanceManager.remainingSeconds(1_000L, 1_000L));
+        assertEquals(0L, MaintenanceManager.remainingSeconds(1_000L, 5_000L));
+    }
+
+    @Test
+    void partSecondsRoundUpSoTheCountdownNeverRestsOnZeroWhileTheServerIsShut() {
+        assertEquals(4L, MaintenanceManager.remainingSeconds(3_400L, 0L));
+        assertEquals(1L, MaintenanceManager.remainingSeconds(1L, 0L));
+        assertEquals(30L, MaintenanceManager.remainingSeconds(30_000L, 0L));
+    }
+
+    @Test
+    void theCountdownIsWrittenTheWayTheMultiplayerListShowsIt() {
+        assertEquals("03:29", MaintenanceManager.formatCountdown(209L));
+        assertEquals("00:00", MaintenanceManager.formatCountdown(0L));
+        assertEquals("00:09", MaintenanceManager.formatCountdown(9L));
+        assertEquals("59:59", MaintenanceManager.formatCountdown(3_599L));
+    }
+
+    @Test
+    void anHourOrMoreGrowsTheClockRatherThanRunningTheMinutesPastSixty() {
+        assertEquals("1:00:00", MaintenanceManager.formatCountdown(3_600L));
+        assertEquals("2:03:04", MaintenanceManager.formatCountdown(7_384L));
+    }
+
+    @Test
+    void aNegativeCountIsClampedInsteadOfPrintingAMinusSign() {
+        assertEquals("00:00", MaintenanceManager.formatCountdown(MaintenanceManager.NO_DEADLINE));
+    }
+
+    @Test
+    void onlyAnActiveMaintenanceWithItsDeadlinePassedLiftsItself() {
+        assertTrue(MaintenanceManager.hasExpired(true, 1_000L, 1_000L));
+        assertTrue(MaintenanceManager.hasExpired(true, 1_000L, 2_000L));
+        assertFalse(MaintenanceManager.hasExpired(true, 1_000L, 999L));
+        assertFalse(MaintenanceManager.hasExpired(true, 0L, 5_000L), "no duration means it waits for /maintenance off");
+        assertFalse(MaintenanceManager.hasExpired(false, 1_000L, 5_000L));
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceServerListTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceServerListTest.java
@@ -1,0 +1,75 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The text that lands on the multiplayer list entry while maintenance mode is on.
+ */
+class MaintenanceServerListTest {
+
+    private static final List<String> LINES =
+            List.of("&cCurrently under maintenance", "&bCome back in: &d%time%");
+
+    @Test
+    void theCountdownLandsOnTheSecondLineOfTheMotd() {
+        assertEquals(
+                "&cCurrently under maintenance\n&bCome back in: &d03:29",
+                MaintenanceProtocolLibBridge.renderMotd(LINES, 209L)
+        );
+    }
+
+    @Test
+    void everyConfiguredLineIsKeptSoTheEntryLooksAsItWasWritten() {
+        assertEquals("one\ntwo\nthree", MaintenanceProtocolLibBridge.renderMotd(List.of("one", "two", "three"), 30L));
+        assertEquals("alone", MaintenanceProtocolLibBridge.renderMotd(List.of("alone"), 30L));
+        assertEquals("", MaintenanceProtocolLibBridge.renderMotd(List.of(), 30L));
+        assertEquals("", MaintenanceProtocolLibBridge.renderMotd(null, 30L));
+    }
+
+    @Test
+    void withNoDeadlineThePlaceholderIsEmptiedRatherThanShownToPlayers() {
+        String motd = MaintenanceProtocolLibBridge.renderMotd(LINES, MaintenanceManager.NO_DEADLINE);
+
+        assertFalse(motd.contains("%time%"), "an unresolved placeholder would be printed on the server list as it is");
+        assertEquals("&cCurrently under maintenance\n&bCome back in: &d", motd);
+    }
+
+    @Test
+    void aLineWithoutThePlaceholderIsLeftAlone() {
+        assertEquals("untouched", MaintenanceProtocolLibBridge.applyCountdown("untouched", 30L));
+        assertEquals("back soon: 00:30", MaintenanceProtocolLibBridge.applyCountdown("back soon: %time%", 30L));
+        assertEquals("", MaintenanceProtocolLibBridge.applyCountdown(null, 30L));
+    }
+
+    @Test
+    void bundledConfigShipsTheServerListBlock() {
+        YamlConfiguration network = YamlConfiguration.loadConfiguration(new File("src/main/resources/network.yml"));
+
+        assertTrue(network.getBoolean("MAINTENANCE.SERVER_LIST.ENABLED"));
+        assertEquals(LINES, network.getStringList("MAINTENANCE.SERVER_LIST.LINES"));
+        assertEquals(
+                List.of("&cCurrently under maintenance", "&7come back later"),
+                network.getStringList("MAINTENANCE.SERVER_LIST.LINES_NO_TIMER")
+        );
+        assertEquals("&cMaintenance", network.getString("MAINTENANCE.SERVER_LIST.VERSION_LABEL"));
+        assertEquals(List.of("&cCurrently under maintenance"), network.getStringList("MAINTENANCE.SERVER_LIST.HOVER"));
+    }
+
+    @Test
+    void theBundledDefaultsProduceTheEntryTheRequestAskedFor() {
+        YamlConfiguration network = YamlConfiguration.loadConfiguration(new File("src/main/resources/network.yml"));
+
+        assertEquals(
+                "&cCurrently under maintenance\n&bCome back in: &d03:29",
+                MaintenanceProtocolLibBridge.renderMotd(network.getStringList("MAINTENANCE.SERVER_LIST.LINES"), 209L)
+        );
+    }
+}


### PR DESCRIPTION
Closes #326

Maintenance mode already shut the door. `/maintenance on` moved players to the lobby, refused new
logins and held the server until someone turned it off again, but it never said so anywhere a player
could see. Ping the server from the multiplayer list and the entry looked completely ordinary, usual
MOTD, usual player count, right up until the join attempt bounced. The screenshot on the issue shows
what was wanted instead, and that's what the entry looks like now.

## The server list entry

While maintenance is on, a status ping answers with the configured MOTD, a label where the
player count normally sits, and a hover box that no longer names whoever is still working on the
server. The MOTD is the easy half. The red label with the broken-connection icon next to it is not,
because Bukkit has no call for it: that text is the version string, and a client only draws it once
the protocol number fails to match its own, so this sets both together through ProtocolLib.
ProtocolLib is already a hard `depend`, so `plugin.yml` and `pom.xml` are untouched.

The hover box rides on fake player-sample entries, and how much text a server accepts inside one of
those names depends on its authlib. That part catches its own failures instead of letting
them escape, because losing the hover is a fair price and losing the MOTD with it is not.

## A duration, and the countdown

A plain `/maintenance on` still means "until I say otherwise". `/maintenance on 30m` now sets a
deadline, `%time%` in any configured line renders it the way the screenshot shows it (`03:29`,
widening to `1:03:29` past an hour), and maintenance lifts itself when the clock runs out. That it lifts itself
is the point: a countdown running out on a server that stays shut is worse than no countdown at
all. Durations go through the same parser the punishment
commands use, so `2h`, `1d` and `90m` all work, and `/maintenance status` prints the time left.

The lines are configured as a list rather than as `LINE_1` and `LINE_2`. That's partly the better
shape, and partly the only version the language layer picks up: it mirrors a key named `LINES` for
translation and skips one named `LINE_1`.

## Notes

`network.yml` gains `MAINTENANCE.SERVER_LIST`, holding `ENABLED`, `LINES`, `LINES_NO_TIMER`,
`VERSION_LABEL` and `HOVER`. A server still running an older `network.yml` gets the same defaults
from code, so the entry works before anyone regenerates the file. Empty `VERSION_LABEL` keeps the
real player count; `ENABLED: false` leaves the entry alone and gates only the login.

All eight language files carry the five new text keys, translated. The `MAINTENANCE.MESSAGES` block
beside them is still untranslated English in the other seven; that predates this and I've left it
alone.

13 new tests cover the countdown arithmetic, the clock format, expiry, and the MOTD rendered from the
bundled defaults. The suite is 605 and green. `docs/wiki/Config-network.yml.md` and the README
command table are updated.
