### PR TITLE
feat(sounds): limit how far the wither and dragon sounds carry (#384)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1228,7 +1228,7 @@ RESPAWN-ANCHOR:
   ENABLED: false
   # The decimal value for Damage. Available options: Any decimal number
   DAMAGE: 2.0
-# Configuration section for Ender Chest.
+# Configuration section for Boss Sounds.
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -1246,11 +1246,60 @@ RESPAWN-ANCHOR:
   ENABLED: false
   # The decimal value for Damage. Available options: Any decimal number
   DAMAGE: 2.0
-# Configuration section for Ender Chest.
+# Configuration section for Boss Sounds.
 ```
 
 ---
 
+## Section: `BOSS-SOUNDS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BOSS-SOUNDS:
+  # Determines whether Enabled is enabled or disabled. When true, the two boss sounds Minecraft
+  # plays to everyone online are kept to players within RADIUS blocks of the boss. Set it to false
+  # to leave the vanilla behaviour alone. Available options: true, false
+  ENABLED: true
+  # The numerical value for Radius. How far the sound carries, in blocks, measured from the boss to
+  # the player. 1600 is 100 chunks. Players in another world never hear it. A value of 0 or less
+  # turns the limit off. Available options: Any valid integer
+  RADIUS: 1600
+  # Determines whether Wither Spawn is enabled or disabled. Covers the roar a wither makes once it
+  # finishes charging up. Available options: true, false
+  WITHER-SPAWN: true
+  # Determines whether Ender Dragon Death is enabled or disabled. Covers the growl an ender dragon
+  # makes as it starts dying. Available options: true, false
+  ENDER-DRAGON-DEATH: true
+# Configuration section for Ender Chest.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BOSS-SOUNDS.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `BOSS-SOUNDS` system. Set to `true` to enable, `false` to disable. With it off, Minecraft plays both sounds to every player online, wherever they are. |
+| `BOSS-SOUNDS.RADIUS` | `int` | Any valid integer | `'1600'` | How far the sound carries, in blocks, measured from the boss to the player. `1600` is 100 chunks. Height counts towards the distance, and a player in another world never hears it. `0` or less turns the limit off and leaves both sounds server-wide. |
+| `BOSS-SOUNDS.WITHER-SPAWN` | `bool` | `true`, `false` | `true` | Whether the radius applies to the roar a wither makes once it finishes charging up. |
+| `BOSS-SOUNDS.ENDER-DRAGON-DEATH` | `bool` | `true`, `false` | `true` | Whether the radius applies to the growl an ender dragon makes as it starts dying. |
+
+These are the only two sounds Minecraft plays to the whole server. A wither dying and a dragon
+spawning already fade out over distance the way any other mob sound does, so there is nothing to
+limit there. Trimming the range needs ProtocolLib, which the plugin already requires.
+
+### 3. Practical Setup Example
+
+```yaml
+BOSS-SOUNDS:
+  ENABLED: true
+  # 320 blocks, so the roar stays inside the fight it belongs to
+  RADIUS: 320
+  WITHER-SPAWN: true
+  # leave the dragon growl reaching the whole server, the way vanilla plays it
+  ENDER-DRAGON-DEATH: false
+```
+
+---
 ## Section: `ENDER-CHEST`
 
 ### 1. Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -48,6 +48,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
     private PlayerDataManager playerDataManager;
     private PlayerVisibilityManager playerVisibilityManager;
     private ExplosionParticleFilter explosionParticleFilter;
+    private BossSoundRangeFilter bossSoundRangeFilter;
     private EconomyManager economyManager;
     private ChatManager chatManager;
     private IgnoreManager ignoreManager;
@@ -171,6 +172,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         playerVisibilityManager = new PlayerVisibilityManager(this);
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
             explosionParticleFilter = new ExplosionParticleFilter(this);
+            bossSoundRangeFilter = new BossSoundRangeFilter(this);
         } else {
             getLogger().info("ProtocolLib is not installed; packet-based explosion particle filtering is disabled.");
         }
@@ -390,6 +392,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         if (explosionParticleFilter != null) {
             explosionParticleFilter.shutdown();
         }
+        if (bossSoundRangeFilter != null) {
+            bossSoundRangeFilter.shutdown();
+        }
         if (playerVisibilityManager != null) {
             playerVisibilityManager.clear();
         }
@@ -552,6 +557,9 @@ public final class UltimateDonutSmp extends JavaPlugin {
         pm.registerEvents(new PhantomListener(this), this);
         pm.registerEvents(new MobSpawnListener(this), this);
         pm.registerEvents(new PlayerSettingEffectsListener(this), this);
+        if (bossSoundRangeFilter != null) {
+            pm.registerEvents(bossSoundRangeFilter, this);
+        }
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
             worthManager.setPacketDisplayActive(true);
             pm.registerEvents(new WorthPacketDisplay(this), this);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/BossSoundRangeFilter.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/BossSoundRangeFilter.java
@@ -1,0 +1,161 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.BossSoundRangePolicy;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.PacketListener;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import org.bukkit.Location;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Wither;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Keeps the wither spawn and ender dragon death sounds from reaching the whole server.
+ *
+ * <p>Both are sent as global level events, which carry a position but not a world, so the world is
+ * taken from the boss itself as it spawns or dies and held for a short while. A wither only makes
+ * its noise once its charge-up finishes, which is why the window has to outlive that; the dragon
+ * fires on the tick after it dies. When there is no world to match against, the distance alone
+ * decides, which is still the part the reporter cares about.
+ */
+public final class BossSoundRangeFilter implements Listener {
+
+    private static final long ORIGIN_LIFETIME_MS = 60_000L;
+
+    private final UltimateDonutSmp plugin;
+    private final Map<Integer, TrackedOrigin> origins = new ConcurrentHashMap<>();
+    private ProtocolManager protocolManager;
+    private PacketListener listener;
+    private boolean available;
+
+    public BossSoundRangeFilter(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+        initialize();
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public void shutdown() {
+        if (protocolManager != null && listener != null) {
+            protocolManager.removePacketListener(listener);
+        }
+        listener = null;
+        protocolManager = null;
+        available = false;
+        origins.clear();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntitySpawn(EntitySpawnEvent event) {
+        if (event.getEntity() instanceof Wither) {
+            remember(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID, event.getLocation());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEntityDeath(EntityDeathEvent event) {
+        if (event.getEntity() instanceof EnderDragon) {
+            remember(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID, event.getEntity().getLocation());
+        }
+    }
+
+    private void remember(int effectId, Location location) {
+        if (location == null || location.getWorld() == null) {
+            return;
+        }
+        origins.put(effectId, new TrackedOrigin(
+                location.getWorld().getName(),
+                System.currentTimeMillis() + ORIGIN_LIFETIME_MS
+        ));
+    }
+
+    private String originWorld(int effectId) {
+        TrackedOrigin tracked = origins.get(effectId);
+        if (tracked == null) {
+            return null;
+        }
+        if (System.currentTimeMillis() > tracked.expiresAt()) {
+            origins.remove(effectId, tracked);
+            return null;
+        }
+        return tracked.world();
+    }
+
+    private void initialize() {
+        if (!plugin.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+            return;
+        }
+        try {
+            protocolManager = ProtocolLibrary.getProtocolManager();
+            listener = new PacketAdapter(
+                    plugin,
+                    ListenerPriority.NORMAL,
+                    PacketType.Play.Server.WORLD_EVENT
+            ) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    BossSoundRangeFilter.this.handle(event);
+                }
+            };
+            protocolManager.addPacketListener(listener);
+            available = true;
+        } catch (Throwable error) {
+            plugin.getLogger().warning("Boss sound range limiting is unavailable: " + error.getMessage());
+            shutdown();
+        }
+    }
+
+    private void handle(PacketEvent event) {
+        Player viewer = event.getPlayer();
+        if (viewer == null) {
+            return;
+        }
+        Integer effectId = event.getPacket().getIntegers().readSafely(0);
+        if (effectId == null) {
+            return;
+        }
+        BossSoundRangePolicy policy = BossSoundRangePolicy.fromConfig(plugin.getConfig());
+        if (!policy.filters(effectId)) {
+            return;
+        }
+        BlockPosition source = event.getPacket().getBlockPositionModifier().readSafely(0);
+        if (source == null) {
+            return;
+        }
+        Location at = viewer.getLocation();
+        BossSoundRangePolicy.Position origin = new BossSoundRangePolicy.Position(
+                originWorld(effectId),
+                source.getX() + 0.5D,
+                source.getY() + 0.5D,
+                source.getZ() + 0.5D
+        );
+        BossSoundRangePolicy.Position listenerAt = new BossSoundRangePolicy.Position(
+                at.getWorld() == null ? null : at.getWorld().getName(),
+                at.getX(),
+                at.getY(),
+                at.getZ()
+        );
+        if (!policy.canHear(origin, listenerAt)) {
+            event.setCancelled(true);
+        }
+    }
+
+    private record TrackedOrigin(String world, long expiresAt) {
+    }
+}

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/BossSoundRangePolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/BossSoundRangePolicy.java
@@ -1,0 +1,93 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * Decides who is close enough to hear the two boss sounds Minecraft plays to the whole server.
+ *
+ * <p>A wither finishing its charge-up and an ender dragon starting to die are sent as global level
+ * events, so every player online hears them wherever they happen to be standing. The only vanilla
+ * lever is the {@code globalSoundEvents} game rule, which drops both all the way down to the
+ * ordinary 64 block level event radius. This sits in between: the sound still carries a long way,
+ * but it stops at the configured radius.
+ */
+public final class BossSoundRangePolicy {
+
+    /** Level event Minecraft fires once a wither finishes charging up. */
+    public static final int WITHER_SPAWN_EFFECT_ID = 1023;
+
+    /** Level event Minecraft fires as an ender dragon starts its death animation. */
+    public static final int ENDER_DRAGON_DEATH_EFFECT_ID = 1028;
+
+    private static final int DEFAULT_RADIUS = 1600;
+
+    /**
+     * A point the sound is measured between. {@code world} is null when the world could not be
+     * worked out, which leaves the distance as the only thing checked.
+     */
+    public record Position(String world, double x, double y, double z) {
+    }
+
+    private final boolean enabled;
+    private final int radius;
+    private final boolean witherSpawn;
+    private final boolean enderDragonDeath;
+
+    public BossSoundRangePolicy(boolean enabled, int radius, boolean witherSpawn, boolean enderDragonDeath) {
+        this.enabled = enabled;
+        this.radius = radius;
+        this.witherSpawn = witherSpawn;
+        this.enderDragonDeath = enderDragonDeath;
+    }
+
+    public static BossSoundRangePolicy fromConfig(ConfigurationSection config) {
+        if (config == null) {
+            return new BossSoundRangePolicy(true, DEFAULT_RADIUS, true, true);
+        }
+        return new BossSoundRangePolicy(
+                config.getBoolean("BOSS-SOUNDS.ENABLED", true),
+                config.getInt("BOSS-SOUNDS.RADIUS", DEFAULT_RADIUS),
+                config.getBoolean("BOSS-SOUNDS.WITHER-SPAWN", true),
+                config.getBoolean("BOSS-SOUNDS.ENDER-DRAGON-DEATH", true)
+        );
+    }
+
+    public int getRadius() {
+        return radius;
+    }
+
+    /** Whether anything is being limited at all, so callers can skip the packet listener entirely. */
+    public boolean isActive() {
+        return enabled && radius > 0 && (witherSpawn || enderDragonDeath);
+    }
+
+    /** Whether this level event is one of the two the radius applies to. */
+    public boolean filters(int effectId) {
+        if (!enabled || radius <= 0) {
+            return false;
+        }
+        return switch (effectId) {
+            case WITHER_SPAWN_EFFECT_ID -> witherSpawn;
+            case ENDER_DRAGON_DEATH_EFFECT_ID -> enderDragonDeath;
+            default -> false;
+        };
+    }
+
+    /**
+     * Whether {@code listener} is near enough to the boss to be left hearing it. A world missing on
+     * either side means the worlds cannot be compared, so only the distance decides.
+     */
+    public boolean canHear(Position origin, Position listener) {
+        if (origin == null || listener == null) {
+            return true;
+        }
+        if (origin.world() != null && listener.world() != null && !origin.world().equals(listener.world())) {
+            return false;
+        }
+        double dx = origin.x() - listener.x();
+        double dy = origin.y() - listener.y();
+        double dz = origin.z() - listener.z();
+        double radiusSquared = (double) radius * radius;
+        return dx * dx + dy * dy + dz * dz <= radiusSquared;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -450,6 +450,22 @@ RESPAWN-ANCHOR:
   ENABLED: false
   # The decimal value for Damage. Available options: Any decimal number
   DAMAGE: 2.0
+# Configuration section for Boss Sounds.
+BOSS-SOUNDS:
+  # Determines whether Enabled is enabled or disabled. When true, the two boss sounds Minecraft
+  # plays to everyone online are kept to players within RADIUS blocks of the boss. Set it to false
+  # to leave the vanilla behaviour alone. Available options: true, false
+  ENABLED: true
+  # The numerical value for Radius. How far the sound carries, in blocks, measured from the boss to
+  # the player. 1600 is 100 chunks. Players in another world never hear it. A value of 0 or less
+  # turns the limit off. Available options: Any valid integer
+  RADIUS: 1600
+  # Determines whether Wither Spawn is enabled or disabled. Covers the roar a wither makes once it
+  # finishes charging up. Available options: true, false
+  WITHER-SPAWN: true
+  # Determines whether Ender Dragon Death is enabled or disabled. Covers the growl an ender dragon
+  # makes as it starts dying. Available options: true, false
+  ENDER-DRAGON-DEATH: true
 # Configuration section for Ender Chest.
 ENDER-CHEST:
   # Determines whether Six Row is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/BossSoundRangePolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/BossSoundRangePolicyTest.java
@@ -1,0 +1,169 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BossSoundRangePolicyTest {
+
+    private static final String OVERWORLD = "world";
+    private static final String NETHER = "world_nether";
+
+    private static BossSoundRangePolicy policy(int radius) {
+        return new BossSoundRangePolicy(true, radius, true, true);
+    }
+
+    private static BossSoundRangePolicy.Position at(String world, double x, double z) {
+        return new BossSoundRangePolicy.Position(world, x, 64.0D, z);
+    }
+
+    @Test
+    void onlyTheTwoGlobalBossEventsAreFiltered() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        assertTrue(policy.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertTrue(policy.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+
+        // Other level events ride the same packet and must be left alone: 1024 is a wither shooting,
+        // 1038 is the end portal spawning, 2001 is a block breaking.
+        assertFalse(policy.filters(1024));
+        assertFalse(policy.filters(1038));
+        assertFalse(policy.filters(2001));
+    }
+
+    @Test
+    void eachSoundCanBeLeftGlobalOnItsOwn() {
+        BossSoundRangePolicy witherOnly = new BossSoundRangePolicy(true, 1600, true, false);
+        assertTrue(witherOnly.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertFalse(witherOnly.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+
+        BossSoundRangePolicy dragonOnly = new BossSoundRangePolicy(true, 1600, false, true);
+        assertFalse(dragonOnly.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertTrue(dragonOnly.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+    }
+
+    @Test
+    void turningItOffLeavesEveryEventAlone() {
+        BossSoundRangePolicy disabled = new BossSoundRangePolicy(false, 1600, true, true);
+        assertFalse(disabled.isActive());
+        assertFalse(disabled.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertFalse(disabled.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+    }
+
+    @Test
+    void aRadiusOfZeroOrLessTurnsTheLimitOffRatherThanSilencingEveryone() {
+        // Reading it the other way round would let one mistyped number mute both sounds server-wide.
+        for (int radius : new int[]{0, -1, -1600}) {
+            BossSoundRangePolicy policy = policy(radius);
+            assertFalse(policy.isActive(), "radius " + radius);
+            assertFalse(policy.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID), "radius " + radius);
+        }
+    }
+
+    @Test
+    void playersInsideTheRadiusStillHearIt() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 0, 0)));
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 1500, 0)));
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 1600, 0)));
+        assertTrue(policy.canHear(at(OVERWORLD, 2000, -3000), at(OVERWORLD, 2900, -3200)));
+    }
+
+    @Test
+    void playersOutsideTheRadiusDoNot() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 1601, 0)));
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 1200, 1200)));
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 30000, 30000)));
+    }
+
+    @Test
+    void heightCountsTowardsTheDistance() {
+        BossSoundRangePolicy policy = policy(100);
+
+        assertTrue(policy.canHear(
+                new BossSoundRangePolicy.Position(OVERWORLD, 0, 0, 0),
+                new BossSoundRangePolicy.Position(OVERWORLD, 0, 100, 0)));
+        assertFalse(policy.canHear(
+                new BossSoundRangePolicy.Position(OVERWORLD, 0, -64, 0),
+                new BossSoundRangePolicy.Position(OVERWORLD, 0, 320, 0)));
+    }
+
+    @Test
+    void anotherWorldNeverHearsIt() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        // Nether coordinates sit right on top of overworld ones, so distance alone would let a
+        // player standing next to a nether portal hear a wither charging up in the overworld.
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(NETHER, 0, 0)));
+        assertFalse(policy.canHear(at(OVERWORLD, 100, 100), at(NETHER, 100, 100)));
+    }
+
+    @Test
+    void distanceAloneDecidesWhenTheWorldIsUnknown() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        assertTrue(policy.canHear(at(null, 0, 0), at(OVERWORLD, 800, 0)));
+        assertFalse(policy.canHear(at(null, 0, 0), at(OVERWORLD, 4000, 0)));
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), at(null, 800, 0)));
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(null, 4000, 0)));
+    }
+
+    @Test
+    void aMissingPositionLeavesTheSoundAlone() {
+        BossSoundRangePolicy policy = policy(1600);
+
+        assertTrue(policy.canHear(null, at(OVERWORLD, 30000, 30000)));
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), null));
+    }
+
+    @Test
+    void theShippedConfigLimitsBothSoundsToAHundredChunks() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.loadFromString(Files.readString(
+                new File("src/main/resources/config.yml").toPath(), StandardCharsets.UTF_8));
+
+        BossSoundRangePolicy policy = BossSoundRangePolicy.fromConfig(config);
+
+        assertTrue(policy.isActive());
+        assertEquals(1600, policy.getRadius());
+        assertTrue(policy.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertTrue(policy.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+    }
+
+    @Test
+    void configValuesAreReadBackOffTheKeysServerOwnersEdit() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.loadFromString(String.join("\n",
+                "BOSS-SOUNDS:",
+                "  ENABLED: true",
+                "  RADIUS: 320",
+                "  WITHER-SPAWN: false",
+                "  ENDER-DRAGON-DEATH: true"));
+
+        BossSoundRangePolicy policy = BossSoundRangePolicy.fromConfig(config);
+
+        assertEquals(320, policy.getRadius());
+        assertFalse(policy.filters(BossSoundRangePolicy.WITHER_SPAWN_EFFECT_ID));
+        assertTrue(policy.filters(BossSoundRangePolicy.ENDER_DRAGON_DEATH_EFFECT_ID));
+        assertTrue(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 300, 0)));
+        assertFalse(policy.canHear(at(OVERWORLD, 0, 0), at(OVERWORLD, 400, 0)));
+    }
+
+    @Test
+    void aMissingSectionFallsBackToTheShippedDefaults() {
+        BossSoundRangePolicy policy = BossSoundRangePolicy.fromConfig(new YamlConfiguration());
+
+        assertTrue(policy.isActive());
+        assertEquals(1600, policy.getRadius());
+    }
+}


### PR DESCRIPTION
Closes #384

Minecraft sends the wither's spawn roar and the ender dragon's death growl as global level events, so every player online hears them at full volume wherever they happen to be standing. The one vanilla lever is the globalSoundEvents game rule, and it's all or nothing: on means the whole server hears it, off drops both down to the ordinary 64 block level event radius. This puts something in between, so the sound still carries a long way but stops at a radius you pick.

## How it works

A ProtocolLib listener on WORLD_EVENT watches for two effect ids: 1023, the wither finishing its charge-up, and 1028, the dragon starting to die. It cancels the packet for anyone further from the source than BOSS-SOUNDS.RADIUS, and leaves every other level event riding that packet alone, since those two are the only ones vanilla broadcasts to everybody.

That packet carries a position but no world, so a player standing at matching coordinates in the nether would otherwise sail straight through the distance check. BossSoundRangeFilter takes the world off the boss instead, noting it when a wither spawns or a dragon dies and keeping it for a minute. A wither only makes its noise once the 220 tick charge-up finishes, which is why the window has to outlive that; the dragon fires on the tick after it dies and needs nowhere near as long. With no world to compare against, the distance decides on its own.

## What this doesn't cover

The report names spawn and death for both mobs, but only two of those four are global in vanilla. A wither dying and a dragon spawning already fade out with distance like any other mob sound, so there's nothing there to trim.

## Notes

New BOSS-SOUNDS block in config.yml with ENABLED, RADIUS, WITHER-SPAWN and ENDER-DRAGON-DEATH. RADIUS ships at 1600 blocks, which is the 100 chunks the report asked for, and the section ships on, since matching DonutSMP is the whole point of the plugin. Setting RADIUS to 0 or less turns the limit off rather than muting everyone, so one mistyped number can't silence the server.

Nothing here is player facing, so no language keys. Config-config.yml.md documents the new section. BossSoundRangePolicyTest adds 13 tests covering the effect ids, both per-sound toggles, the radius boundary at exactly 1600, height counting towards the distance, the cross-world case and the shipped defaults. Suite is at 618, green.
