### PR TITLE
feat(rtp): let servers cut the wait before an rtp teleport (#386)

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -47,6 +47,13 @@ SETTINGS:
   ATTEMPT-INTERVAL-TICKS: 1
   # Number of location attempts evaluated in parallel per sample interval
   SEARCH-ATTEMPTS-PER-TICK: 4
+  # Ticks the searching display is held for before the teleport starts. Lower it to teleport
+  # sooner once a spot is found, 0 teleports the moment the search succeeds
+  SEARCH-DISPLAY-MIN-TICKS: 30
+  # Ticks the found location display is held for before the teleport is queued. This one is paid
+  # on every RTP, including one served from LOCATION-CACHE below, so it is the whole wait when
+  # nothing had to be searched for. 0 queues the teleport as soon as the chunks are ready
+  FOUND-DISPLAY-TICKS: 20
   # Generate new chunks while searching. Keep false for pregenerated RTP worlds to protect TPS
   GENERATE-CHUNKS: false
   # Generate a limited number of chunks only after pregenerated/loaded RTP search cannot find a safe spot
@@ -83,6 +90,8 @@ SETTINGS:
 | `SETTINGS.MAX-CHUNK-SAMPLES` | `int` | Any valid integer number | `'128'` | Configures the technical `MAX-CHUNK-SAMPLES` parameter for `SETTINGS.MAX-CHUNK-SAMPLES` in `rtp.yml`. |
 | `SETTINGS.ATTEMPT-INTERVAL-TICKS` | `int` | Any valid integer number | `'1'` | Configures the technical `ATTEMPT-INTERVAL-TICKS` parameter for `SETTINGS.ATTEMPT-INTERVAL-TICKS` in `rtp.yml`. |
 | `SETTINGS.SEARCH-ATTEMPTS-PER-TICK` | `int` | Any valid integer number | `'4'` | How many candidate locations are checked side by side instead of one after another. Higher values find a spot sooner at the cost of more chunk work per search. |
+| `SETTINGS.SEARCH-DISPLAY-MIN-TICKS` | `int` | `0` or higher | `'30'` | How long the searching display is held before the teleport may start, in ticks, where 20 ticks is a second. A search that lands on its first sample would otherwise flash the action bar and teleport in the same breath, so the floor is there to keep the message readable. `0` teleports the moment a spot is found. |
+| `SETTINGS.FOUND-DISPLAY-TICKS` | `int` | `0` or higher | `'20'` | How long the found location display is held before the teleport is queued, in ticks. Unlike the setting above this one is paid on every RTP, a teleport served straight from `LOCATION-CACHE` included, so it is the whole wait a player sees when nothing had to be searched for. `0` queues the teleport as soon as the surrounding chunks are ready. |
 | `SETTINGS.GENERATE-CHUNKS` | `bool` | `true`, `false` | `false` | Configures the technical `GENERATE-CHUNKS` parameter for `SETTINGS.GENERATE-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.GENERATE-FALLBACK-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `GENERATE-FALLBACK-CHUNKS` parameter for `SETTINGS.GENERATE-FALLBACK-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'8'` | Configures the technical `GENERATE-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.GENERATE-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
@@ -106,6 +115,13 @@ SETTINGS:
   ATTEMPT-INTERVAL-TICKS: 1
   # Number of location attempts evaluated in parallel per sample interval
   SEARCH-ATTEMPTS-PER-TICK: 4
+  # Ticks the searching display is held for before the teleport starts. Lower it to teleport
+  # sooner once a spot is found, 0 teleports the moment the search succeeds
+  SEARCH-DISPLAY-MIN-TICKS: 30
+  # Ticks the found location display is held for before the teleport is queued. This one is paid
+  # on every RTP, including one served from LOCATION-CACHE below, so it is the whole wait when
+  # nothing had to be searched for. 0 queues the teleport as soon as the chunks are ready
+  FOUND-DISPLAY-TICKS: 20
   # Generate new chunks while searching. Keep false for pregenerated RTP worlds to protect TPS
   GENERATE-CHUNKS: false
   # Generate a limited number of chunks only after pregenerated/loaded RTP search cannot find a safe spot

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -63,9 +63,9 @@ public class RTPManager {
     }
 
     private static final long SEARCH_ACTIONBAR_REFRESH_TICKS = 1L;
-    private static final long MIN_SEARCH_DISPLAY_TICKS = 30L;
+    private static final long DEFAULT_MIN_SEARCH_DISPLAY_TICKS = 30L;
     private static final int DEFAULT_SEARCH_ATTEMPTS_PER_TICK = 1;
-    private static final long FOUND_ACTIONBAR_DELAY_TICKS = 20L;
+    private static final long DEFAULT_FOUND_DISPLAY_TICKS = 20L;
     private static final int DEFAULT_MAX_CONCURRENT_RTP = 1;
     private static final int MIN_MAX_ATTEMPTS = 32;
     private static final int MIN_MAX_CHUNK_SAMPLES = 64;
@@ -82,6 +82,8 @@ public class RTPManager {
     private static final String LOAD_GENERATED_CHUNKS_SETTING = "SETTINGS.LOAD-GENERATED-CHUNKS";
     private static final String LOADED_CHUNK_FALLBACK_SETTING = "SETTINGS.FALLBACK-TO-LOADED-CHUNKS";
     private static final String LOADED_CHUNK_FALLBACK_AFTER_SETTING = "SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES";
+    private static final String MIN_SEARCH_DISPLAY_TICKS_SETTING = "SETTINGS.SEARCH-DISPLAY-MIN-TICKS";
+    private static final String FOUND_DISPLAY_TICKS_SETTING = "SETTINGS.FOUND-DISPLAY-TICKS";
     private static final String PRELOAD_TELEPORT_CHUNKS_SETTING = "SETTINGS.PRELOAD-TELEPORT-CHUNKS";
     private static final String PRELOAD_RADIUS_SETTING = "SETTINGS.PRELOAD-RADIUS";
     private static final String PRELOAD_CHUNKS_PER_TICK_SETTING = "SETTINGS.PRELOAD-CHUNKS-PER-TICK";
@@ -350,6 +352,36 @@ public class RTPManager {
             return DEFAULT_SEARCH_ATTEMPTS_PER_TICK;
         }
         return Math.max(1, plugin.getConfigManager().getRtp().getInt("SETTINGS.SEARCH-ATTEMPTS-PER-TICK", DEFAULT_SEARCH_ATTEMPTS_PER_TICK));
+    }
+
+    /**
+     * How long the searching display is held before the teleport is allowed to start, in ticks.
+     *
+     * <p>A search that succeeds on its first sample would otherwise flash the action bar and
+     * teleport in the same breath, so this floor exists to keep the message readable rather than
+     * to pace the search itself. 0 teleports as soon as a spot is known.</p>
+     */
+    public long getMinSearchDisplayTicks() {
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return DEFAULT_MIN_SEARCH_DISPLAY_TICKS;
+        }
+        return Math.max(0L, plugin.getConfigManager().getRtp()
+                .getLong(MIN_SEARCH_DISPLAY_TICKS_SETTING, DEFAULT_MIN_SEARCH_DISPLAY_TICKS));
+    }
+
+    /**
+     * How long the found location display is held before the teleport is queued, in ticks.
+     *
+     * <p>This one is paid on every teleport, including one served straight from the location
+     * cache, so it is the whole wait a player sees when nothing had to be searched for at all.
+     * 0 queues the teleport as soon as the surrounding chunks are ready.</p>
+     */
+    public long getFoundDisplayTicks() {
+        if (plugin == null || plugin.getConfigManager() == null || plugin.getConfigManager().getRtp() == null) {
+            return DEFAULT_FOUND_DISPLAY_TICKS;
+        }
+        return Math.max(0L, plugin.getConfigManager().getRtp()
+                .getLong(FOUND_DISPLAY_TICKS_SETTING, DEFAULT_FOUND_DISPLAY_TICKS));
     }
 
     public void refillPreCacheAllWorlds() {
@@ -1354,7 +1386,7 @@ public class RTPManager {
         sendSearchActionBar(player, progress);
 
         if (progress.pendingFoundLocation != null) {
-            if (progress.elapsedTicks >= MIN_SEARCH_DISPLAY_TICKS) {
+            if (progress.elapsedTicks >= getMinSearchDisplayTicks()) {
                 stopSearch(playerId, false);
                 finishSearch(player, progress.worldName, progress.pendingFoundLocation);
             }
@@ -1465,7 +1497,7 @@ public class RTPManager {
         if (found != null) {
             progress.pendingFoundLocation = found;
             Player player = Bukkit.getPlayer(playerId);
-            if (player != null && player.isOnline() && progress.elapsedTicks >= MIN_SEARCH_DISPLAY_TICKS) {
+            if (player != null && player.isOnline() && progress.elapsedTicks >= getMinSearchDisplayTicks()) {
                 stopSearch(playerId, false);
                 finishSearch(player, progress.worldName, found);
             }
@@ -1567,6 +1599,7 @@ public class RTPManager {
         UUID playerId = player.getUniqueId();
         CompletableFuture<Void> preloadFuture = preloadTeleportChunks(found);
 
+        final long foundDisplayTicks = getFoundDisplayTicks();
         final long[] shownTicks = {0L};
         final boolean[] queuedTeleport = {false};
         final BukkitTask[] resultTaskRef = new BukkitTask[1];
@@ -1583,7 +1616,7 @@ public class RTPManager {
             sendFoundActionBar(player, worldName, found, shownTicks[0]);
             shownTicks[0]++;
 
-            if (shownTicks[0] >= FOUND_ACTIONBAR_DELAY_TICKS && preloadFuture.isDone()) {
+            if (shownTicks[0] >= foundDisplayTicks && preloadFuture.isDone()) {
                 queuePreparedRtpTeleport(player, found, playerId, resultTaskRef, queuedTeleport);
             }
         }, 1L, SEARCH_ACTIONBAR_REFRESH_TICKS);

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -17,6 +17,13 @@ SETTINGS:
   ATTEMPT-INTERVAL-TICKS: 1
   # Number of location attempts evaluated in parallel per sample interval
   SEARCH-ATTEMPTS-PER-TICK: 4
+  # Ticks the searching display is held for before the teleport starts. Lower it to teleport
+  # sooner once a spot is found, 0 teleports the moment the search succeeds
+  SEARCH-DISPLAY-MIN-TICKS: 30
+  # Ticks the found location display is held for before the teleport is queued. This one is paid
+  # on every RTP, including one served from LOCATION-CACHE below, so it is the whole wait when
+  # nothing had to be searched for. 0 queues the teleport as soon as the chunks are ready
+  FOUND-DISPLAY-TICKS: 20
   # Generate new chunks while searching. Keep false for pregenerated RTP worlds to protect TPS
   GENERATE-CHUNKS: false
   # Generate a limited number of chunks only after pregenerated/loaded RTP search cannot find a safe spot

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -256,6 +256,40 @@ class RTPManagerTest {
     }
 
     @Test
+    void testSearchDisplayTicksReadConfiguredValue() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+        assertEquals(30L, rtpManager.getMinSearchDisplayTicks());
+
+        rtpConfig.set("SETTINGS.SEARCH-DISPLAY-MIN-TICKS", 60);
+        assertEquals(60L, rtpManager.getMinSearchDisplayTicks());
+
+        // 0 is the point of the setting rather than an edge case: it is what a server sets to
+        // have the teleport happen the moment a spot is found.
+        rtpConfig.set("SETTINGS.SEARCH-DISPLAY-MIN-TICKS", 0);
+        assertEquals(0L, rtpManager.getMinSearchDisplayTicks());
+
+        rtpConfig.set("SETTINGS.SEARCH-DISPLAY-MIN-TICKS", -20);
+        assertEquals(0L, rtpManager.getMinSearchDisplayTicks());
+    }
+
+    @Test
+    void testFoundDisplayTicksReadConfiguredValue() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+        assertEquals(20L, rtpManager.getFoundDisplayTicks());
+
+        rtpConfig.set("SETTINGS.FOUND-DISPLAY-TICKS", 45);
+        assertEquals(45L, rtpManager.getFoundDisplayTicks());
+
+        rtpConfig.set("SETTINGS.FOUND-DISPLAY-TICKS", 0);
+        assertEquals(0L, rtpManager.getFoundDisplayTicks());
+
+        rtpConfig.set("SETTINGS.FOUND-DISPLAY-TICKS", -20);
+        assertEquals(0L, rtpManager.getFoundDisplayTicks());
+    }
+
+    @Test
     void testPreCacheSizeIsClampedAndRespectsToggle() throws Exception {
         YamlConfiguration rtpConfig = new YamlConfiguration();
         RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));


### PR DESCRIPTION
Closes #386

Ten seconds to run `/rtp`, with a request to pick a random block and teleport there if it's safe instead of checking 120 chunks. It already works that way. `nextRandomSample` picks a random block inside the world's radius, the search checks the chunk around it, and the first safe hit wins; `MAX-CHUNK-SAMPLES: 128` is where it gives up, not a scan it pays every time. The ten seconds come from elsewhere, and two of the three pieces sat in `RTPManager` as magic numbers with no config key attached, so no setting could shorten them. Those two are settings now.

## Where the wait came from

Three separate delays stack onto one `/rtp`. `TELEPORT-COOLDOWN.RTP` in `config.yml` is the five second "do not move" countdown, and that one could always be turned down. The other two couldn't: a 30 tick floor on the "Searching..." action bar that ran even when the very first sample succeeded, and a 20 tick hold on "Safe location found" before the teleport reached the queue. That adds another two and a half seconds, and the second of the two got paid even when the location came straight out of the cache and nothing had been searched for at all.

## The two new settings

`SETTINGS.SEARCH-DISPLAY-MIN-TICKS` (default 30) and `SETTINGS.FOUND-DISPLAY-TICKS` (default 20) replace the constants. Both accept 0, which is the value worth having: with the location cache on, as it is by default, and `TELEPORT-COOLDOWN.RTP` at 0, a `/rtp` collapses into a cache lookup and a teleport queued on the next tick.

Defaults match the old hard-coded numbers exactly, so nothing changes for a server that doesn't touch them. Negative values clamp to 0.

Neither hold was a mistake. Both keep the action bar from flashing and vanishing inside a single tick, which looks like a glitch when a search lands on its first try. They just shouldn't have been unreachable.

## What I left alone

The search, and the sampling ceiling. Rebuilding it around the shape in the request would mean rewriting it into what it already is. `SETTINGS.LOCATION-CACHE` stays as it is too, since it's the existing answer to "don't search at all", it's on by default at size 3, and it does the real work once the display holds are out of the way.

## Notes

Both keys are ints under `SETTINGS` in `rtp.yml`, so the language catalogue skips them and there's no eight file translation chore. `docs/wiki/Config-rtp.yml.md` picks up both keys in its example blocks and its options table.

Two tests in `RTPManagerTest` cover the default, a raised value, 0 and a negative clamp for each getter. Suite is 620 green, up from 618.
