### PR TITLE
fix(maintenance): shut the server to everyone when no lobby is set (#392)

### DIFF
--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -274,12 +274,34 @@ MAINTENANCE:
   LOBBY_SERVER: lobby
 
   # World players are teleported to while maintenance is active, used when USE_PROXY is false.
-  # Falls back to the spawn location when that world is not loaded, and refuses the connection
-  # at login when neither one resolves
+  # Falls back to the spawn location when that world is not loaded. Leave it empty when this
+  # server has nowhere to put players: maintenance then kicks everyone who is online and refuses
+  # the connection at login, so nobody is left standing in the world while the server is shut
   LOBBY_WORLD: WORLD
 
   # Countdown in seconds shown before players are sent back once the server returns
   RECONNECT_DELAY_SECONDS: 5
+
+  # Everything maintenance says to players. Colour codes work in all of them
+  MESSAGES:
+    # Sent to everyone still online when /maintenance on runs
+    ENTERING: '&d[Maintenance] &7server is entering maintenance. Moving you to the lobby...'
+
+    # Sent to a player who joins during maintenance without the bypass permission
+    NOT_ALLOWED: '&d[Maintenance] &cthis server is currently in maintenance. Redirecting to lobby...'
+
+    # Sent instead to a player who joins holding the bypass permission
+    BYPASS_JOIN: '&d[Maintenance] &7you joined while maintenance mode is active.'
+
+    # Disconnect screen text, used when a proxy handoff fails and on every login refused
+    # because no lobby is set
+    KICK_FALLBACK: '&cThis server is in maintenance and no lobby is available.'
+
+    # Title shown while players wait to be sent back once the server returns
+    RECONNECTING_TITLE: '&a&lServer online'
+
+    # Subtitle under it. %seconds% is the time left on RECONNECT_DELAY_SECONDS
+    RECONNECTING_SUBTITLE: '&7Sending you back in %seconds% seconds...'
 
   # How this server looks in the multiplayer list while maintenance mode is active
   SERVER_LIST:
@@ -317,13 +339,19 @@ MAINTENANCE:
 | `MAINTENANCE.BYPASS_PERMISSION` | `str` | Any permission node | `'ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS'` | Players holding this node join normally while maintenance is active and are never moved or kicked by it. |
 | `MAINTENANCE.USE_PROXY` | `bool` | `true`, `false` | `true` | `true` hands players to another server over the BungeeCord/Velocity plugin channel. `false` keeps them on this server and teleports them instead. |
 | `MAINTENANCE.LOBBY_SERVER` | `str` | Any proxy server name, or empty | `'lobby'` | Destination used when `USE_PROXY` is `true`. `/maintenance setlobby <server>` overrides it at runtime, and `/maintenance setlobby` with no name clears that override and hands the decision back to this key. Leave it empty on a server with no lobby: the connection is then refused during login, so players never enter the world. |
-| `MAINTENANCE.LOBBY_WORLD` | `str` | Any loaded world name | `'WORLD'` | Destination used when `USE_PROXY` is `false`. When that world is not loaded the spawn location is used, and when neither resolves the connection is refused during login. |
+| `MAINTENANCE.LOBBY_WORLD` | `str` | Any loaded world name, or empty | `'WORLD'` | Destination used when `USE_PROXY` is `false`. When that world is not loaded the spawn location is used in its place. Leave it empty on a server with nowhere to put players: maintenance kicks everyone who is online and refuses every connection after that, which is how an empty `LOBBY_SERVER` already behaves in proxy mode. |
 | `MAINTENANCE.RECONNECT_DELAY_SECONDS` | `int` | Any valid integer number | `'5'` | Countdown shown to players waiting to be sent back once the server reports itself online again over Redis. `0` sends them back straight away. |
 | `MAINTENANCE.SERVER_LIST.ENABLED` | `bool` | `true`, `false` | `true` | `true` rewrites this server's entry in the multiplayer list while maintenance is active. `false` leaves the entry alone, and maintenance only shows itself when someone tries to join. |
 | `MAINTENANCE.SERVER_LIST.LINES` | `list` | Any lines of text | `['&cCurrently under maintenance', '&bCome back in: &d%time%']` | The MOTD shown while a duration is running. The client draws the first two entries. `%time%` becomes the time left, written as `03:29` and widening to `1:03:29` past an hour. |
 | `MAINTENANCE.SERVER_LIST.LINES_NO_TIMER` | `list` | Any lines of text | `['&cCurrently under maintenance', '&7come back later']` | Used instead of `LINES` when maintenance was started without a duration, so the entry never shows a countdown that has nothing to count down to. |
 | `MAINTENANCE.SERVER_LIST.VERSION_LABEL` | `str` | Any string text, or empty | `'&cMaintenance'` | Replaces the player count on the entry. The client draws it in red beside a broken connection icon, which is what makes a closed server stand out in a long list. Empty leaves the real player count on show. |
 | `MAINTENANCE.SERVER_LIST.HOVER` | `list` | Any lines of text | `['&cCurrently under maintenance']` | Shown when the player count is hovered, in place of the usual sample of online names. An empty list keeps that sample, staff working through the maintenance included. |
+| `MAINTENANCE.MESSAGES.ENTERING` | `str` | Any string text | `'&d[Maintenance] &7server is entering maintenance. Moving you to the lobby...'` | Sent to everyone online the moment `/maintenance on` runs, just before they are moved. |
+| `MAINTENANCE.MESSAGES.NOT_ALLOWED` | `str` | Any string text | `'&d[Maintenance] &cthis server is currently in maintenance. Redirecting to lobby...'` | Sent to a player who joins during maintenance without the bypass node, on a server that still has a lobby to move them to. |
+| `MAINTENANCE.MESSAGES.BYPASS_JOIN` | `str` | Any string text | `'&d[Maintenance] &7you joined while maintenance mode is active.'` | Sent instead to staff holding the bypass node, so nobody forgets the server is shut while they work. |
+| `MAINTENANCE.MESSAGES.KICK_FALLBACK` | `str` | Any string text | `'&cThis server is in maintenance and no lobby is available.'` | The disconnect screen text: shown when a proxy handoff fails, and on every login refused because no lobby is set. |
+| `MAINTENANCE.MESSAGES.RECONNECTING_TITLE` | `str` | Any string text | `'&a&lServer online'` | Title shown while players wait to be sent back once the server reports itself online again over Redis. |
+| `MAINTENANCE.MESSAGES.RECONNECTING_SUBTITLE` | `str` | Any string text | `'&7Sending you back in %seconds% seconds...'` | Subtitle under that title. `%seconds%` becomes the time left on `RECONNECT_DELAY_SECONDS`. |
 
 ### 3. Practical Setup Example
 
@@ -334,6 +362,18 @@ MAINTENANCE:
   BYPASS_PERMISSION: ULTIMATEDONUTSMP.ADMIN.MAINTENANCE.BYPASS
   USE_PROXY: true
   LOBBY_SERVER: ''
+```
+
+A single server with no proxy behind it and no world to park anyone in. `/maintenance on` kicks
+whoever is online and turns away every connection after that, with the disconnect text written to
+suit the server:
+
+```yaml
+MAINTENANCE:
+  USE_PROXY: false
+  LOBBY_WORLD: ''
+  MESSAGES:
+    KICK_FALLBACK: '&cWe are down for maintenance, back shortly.'
 ```
 
 An hour of scheduled downtime, announced in the multiplayer list. `/maintenance on 1h` starts the

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/MaintenanceManager.java
@@ -162,7 +162,24 @@ public class MaintenanceManager {
     }
 
     static boolean isLobbyServerSet(String lobbyServer) {
-        return lobbyServer != null && !lobbyServer.isBlank();
+        return isLobbyDestinationSet(lobbyServer);
+    }
+
+    /**
+     * Blank means the same thing in either lobby key: nothing is set, so maintenance has nowhere
+     * to put anyone and falls back to refusing them instead of leaving them in the world.
+     */
+    static boolean isLobbyDestinationSet(String lobby) {
+        return lobby != null && !lobby.isBlank();
+    }
+
+    /**
+     * Whether players still on the server once the handoff window closes get kicked. Proxy mode
+     * always kicks, since the connect packet can go unanswered; a local server only kicks when it
+     * has no lobby world to move them to, because otherwise they are already where they belong.
+     */
+    static boolean kicksLeftoverPlayers(boolean useProxy, boolean hasLocalDestination) {
+        return useProxy || !hasLocalDestination;
     }
 
     /**
@@ -174,7 +191,13 @@ public class MaintenanceManager {
     }
 
     public Location resolveLocalDestination() {
-        World world = Bukkit.getWorld(getLobbyWorld());
+        String lobbyWorld = getLobbyWorld();
+        // An empty LOBBY_WORLD is the local answer to an empty LOBBY_SERVER: the server has nowhere
+        // to put players, so it must not quietly drop them at spawn and let them carry on playing.
+        if (!isLobbyDestinationSet(lobbyWorld)) {
+            return null;
+        }
+        World world = Bukkit.getWorld(lobbyWorld);
         if (world != null) {
             return world.getSpawnLocation();
         }
@@ -218,6 +241,7 @@ public class MaintenanceManager {
         String lobby = getLobbyServer();
         String localServerId = config.getString("NETWORK.LOCAL_SERVER_ID", "local");
         boolean useProxy = isUseProxy();
+        Location localDestination = useProxy ? null : resolveLocalDestination();
 
         for (Player player : Bukkit.getOnlinePlayers()) {
             if (player.hasPermission(bypassPerm)) {
@@ -244,16 +268,14 @@ public class MaintenanceManager {
             player.sendMessage(ColorUtils.toComponent(enteringMessage));
             if (useProxy) {
                 sendToLobby(player, lobby);
-            } else {
-                Location destination = resolveLocalDestination();
-                if (destination != null) {
-                    plugin.getSpigotScheduler().teleport(player, destination);
-                }
+            } else if (localDestination != null) {
+                plugin.getSpigotScheduler().teleport(player, localDestination);
             }
         }
 
-        // Kick players who failed to transfer after 2 seconds (only in proxy mode)
-        if (useProxy) {
+        // Kick whoever is still here 2 seconds later: a proxy handoff can fail, and a local server
+        // with no lobby world set never had anywhere to move them to in the first place
+        if (kicksLeftoverPlayers(useProxy, localDestination != null)) {
             plugin.getSpigotScheduler().runGlobalLater(() -> {
                 String kickMessage = config.getString("MAINTENANCE.MESSAGES.KICK_FALLBACK", "&cThis server is in maintenance and no lobby is available.");
                 for (Player player : Bukkit.getOnlinePlayers()) {

--- a/src/main/resources/network.yml
+++ b/src/main/resources/network.yml
@@ -126,12 +126,34 @@ MAINTENANCE:
   LOBBY_SERVER: lobby
 
   # World players are teleported to while maintenance is active, used when USE_PROXY is false.
-  # Falls back to the spawn location when that world is not loaded, and refuses the connection
-  # at login when neither one resolves
+  # Falls back to the spawn location when that world is not loaded. Leave it empty when this
+  # server has nowhere to put players: maintenance then kicks everyone who is online and refuses
+  # the connection at login, so nobody is left standing in the world while the server is shut
   LOBBY_WORLD: WORLD
 
   # Countdown in seconds shown before players are sent back once the server returns
   RECONNECT_DELAY_SECONDS: 5
+
+  # Everything maintenance says to players. Colour codes work in all of them
+  MESSAGES:
+    # Sent to everyone still online when /maintenance on runs
+    ENTERING: '&d[Maintenance] &7server is entering maintenance. Moving you to the lobby...'
+
+    # Sent to a player who joins during maintenance without the bypass permission
+    NOT_ALLOWED: '&d[Maintenance] &cthis server is currently in maintenance. Redirecting to lobby...'
+
+    # Sent instead to a player who joins holding the bypass permission
+    BYPASS_JOIN: '&d[Maintenance] &7you joined while maintenance mode is active.'
+
+    # Disconnect screen text, used when a proxy handoff fails and on every login refused
+    # because no lobby is set
+    KICK_FALLBACK: '&cThis server is in maintenance and no lobby is available.'
+
+    # Title shown while players wait to be sent back once the server returns
+    RECONNECTING_TITLE: '&a&lServer online'
+
+    # Subtitle under it. %seconds% is the time left on RECONNECT_DELAY_SECONDS
+    RECONNECTING_SUBTITLE: '&7Sending you back in %seconds% seconds...'
 
   # How this server looks in the multiplayer list while maintenance mode is active
   SERVER_LIST:

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/MaintenanceLobbyDestinationTest.java
@@ -27,11 +27,45 @@ class MaintenanceLobbyDestinationTest {
     }
 
     @Test
+    void bundledConfigShipsTheMaintenanceMessages() {
+        YamlConfiguration network = YamlConfiguration.loadConfiguration(new File("src/main/resources/network.yml"));
+
+        assertEquals(
+                "&cThis server is in maintenance and no lobby is available.",
+                network.getString("MAINTENANCE.MESSAGES.KICK_FALLBACK")
+        );
+        assertEquals(
+                "&d[Maintenance] &7you joined while maintenance mode is active.",
+                network.getString("MAINTENANCE.MESSAGES.BYPASS_JOIN")
+        );
+        assertEquals("&a&lServer online", network.getString("MAINTENANCE.MESSAGES.RECONNECTING_TITLE"));
+        assertTrue(network.getString("MAINTENANCE.MESSAGES.RECONNECTING_SUBTITLE", "").contains("%seconds%"));
+        assertTrue(network.contains("MAINTENANCE.MESSAGES.ENTERING"));
+        assertTrue(network.contains("MAINTENANCE.MESSAGES.NOT_ALLOWED"));
+    }
+
+    @Test
     void anEmptyLobbyServerCountsAsNoDestination() {
         assertTrue(MaintenanceManager.isLobbyServerSet("lobby"));
         assertFalse(MaintenanceManager.isLobbyServerSet(""));
         assertFalse(MaintenanceManager.isLobbyServerSet("   "));
         assertFalse(MaintenanceManager.isLobbyServerSet(null));
+    }
+
+    @Test
+    void anEmptyLobbyWorldCountsAsNoDestinationEither() {
+        assertTrue(MaintenanceManager.isLobbyDestinationSet("WORLD"));
+        assertFalse(MaintenanceManager.isLobbyDestinationSet(""));
+        assertFalse(MaintenanceManager.isLobbyDestinationSet("   "));
+        assertFalse(MaintenanceManager.isLobbyDestinationSet(null));
+    }
+
+    @Test
+    void withNowhereToPutThemEveryoneOnlineIsKickedInsteadOfLeftPlaying() {
+        assertTrue(MaintenanceManager.kicksLeftoverPlayers(false, false));
+        assertFalse(MaintenanceManager.kicksLeftoverPlayers(false, true));
+        assertTrue(MaintenanceManager.kicksLeftoverPlayers(true, false));
+        assertTrue(MaintenanceManager.kicksLeftoverPlayers(true, true));
     }
 
     @Test


### PR DESCRIPTION
Closes #392

Maintenance mode had a hole on servers that run without a proxy. An empty `LOBBY_SERVER` already means there is nowhere to send players, and an empty `LOBBY_WORLD` should mean the same thing locally, but the code read a blank world name exactly like a world that failed to load and fell back to the server spawn. Any server with a spawn set still had a destination, so the login gate never fired. Players connected, got told they were being redirected, then stood at spawn and carried on playing.

## A blank LOBBY_WORLD now means no destination

`resolveLocalDestination` returns null when the key is empty instead of quietly resolving spawn. The spawn fallback stays for the case it was written for, a world name that is set but not loaded, and servers that never touched the key see no change since the default is still `WORLD`.

With no destination `hasLobbyDestination` is false, so the login gate added in #328 refuses the connection during login and the player never reaches the world.

## Players already online are kicked as well

`startMaintenance` only swept up leftovers in proxy mode. A local server with nowhere to send anyone sent the "entering maintenance" line and then did nothing, so whoever was already in kept playing. The two-second sweep now runs locally too when there is no lobby world, which is the other half of what the reporter asked for.

## MAINTENANCE.MESSAGES ships in network.yml

The code reads `MAINTENANCE.MESSAGES.*` already, but the block appeared in neither the bundled config nor the wiki, so nobody could edit the disconnect text without knowing the key existed. All six keys now ship with the defaults the code was falling back to. `KICK_FALLBACK` is the one that matters here: it is the line a refused player reads.

## Notes

- Config-only addition, so an existing `network.yml` picks the block up through the usual bundled defaults merge.
- `docs/wiki/Config-network.yml.md` gains the six message keys, a rewritten `LOBBY_WORLD` row, and a worked example for a single server with no proxy and no lobby world.
- Three new tests in `MaintenanceLobbyDestinationTest` cover the blank world rule, the kick decision and the shipped message defaults. Full suite green at 623 tests.
