### PR TITLE
fix(staffchat): fill in placeholders in the staff chat format (#393)

### DIFF
--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -115,7 +115,29 @@ NETWORK:
 | `NETWORK.STAFF_JOIN` | `str` | Any string text | `'&8[&a+&8] &a%player% &7joined &b%se...'` | Configures the technical `STAFF_JOIN` parameter for `NETWORK.STAFF_JOIN` in `network.yml`. |
 | `NETWORK.STAFF_LEAVE` | `str` | Any string text | `'&8[&c-&8] &a%player% &7left &b%serv...'` | Configures the technical `STAFF_LEAVE` parameter for `NETWORK.STAFF_LEAVE` in `network.yml`. |
 
-### 3. Practical Setup Example
+### 3. Placeholders In The Message Formats
+
+`NETWORK.STAFF_CHAT`, `NETWORK.STAFF_JOIN`, `NETWORK.STAFF_LEAVE` and `NETWORK.SERVER_STATUS` take
+four built-in tokens: `%server%` is the display name of the server the message came from, `%player%`
+the staff member, `%message%` what they said, and `%status%` the online or offline word on a status
+broadcast. Those same tokens work in `STAFFCHAT.FORMAT` in `messages.yml`, which is what the plugin
+falls back to when `NETWORK.STAFF_CHAT` has been removed.
+
+PlaceholderAPI placeholders work in these formats as well, and they resolve against the staff member
+who sent the message rather than the person reading it, so a rank or prefix placeholder shows the
+sender's rank on every screen the line lands on. That holds across servers: a message arriving over
+Redis was sent by somebody who is usually not online locally, so their placeholders are read from
+offline data instead. An expansion with no answer for an offline player leaves its placeholder
+unfilled.
+
+A placeholder typed into the message itself is not expanded; it prints as the text that was typed.
+
+```yaml
+NETWORK:
+  STAFF_CHAT: '&8[&dNetwork&8] &7[%server%] %luckperms_prefix%&e%player%&8: &f%message%'
+```
+
+### 4. Practical Setup Example
 
 ```yaml
 NETWORK:

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/NetworkStaffChatManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/NetworkStaffChatManager.java
@@ -5,6 +5,8 @@ import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.StaffChatPayload;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.StaffChatFormatPolicy;
+import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -316,11 +318,55 @@ public class NetworkStaffChatManager {
     }
 
     private String applyPlaceholders(String format, StaffChatPayload payload) {
-        return safe(format)
-                .replace("%server%", payload.sourceServerName())
-                .replace("%player%", payload.senderName())
-                .replace("%message%", payload.message())
-                .replace("%status%", payload.message());
+        return StaffChatFormatPolicy.render(
+                format,
+                text -> resolveSenderPlaceholders(text, payload),
+                payload.sourceServerName(),
+                payload.senderName(),
+                payload.message()
+        );
+    }
+
+    /**
+     * Expands PlaceholderAPI placeholders written into a staff chat format against the staff
+     * member who sent the message. The sender is often not online on the server printing the line,
+     * because the payload may have arrived over Redis from somewhere else or been sent from the
+     * console, so an offline lookup backs up the online one; that covers the rank and prefix
+     * expansions these formats are usually built from.
+     */
+    private String resolveSenderPlaceholders(String format, StaffChatPayload payload) {
+        String text = safe(format);
+        if (text.indexOf('%') < 0 || !ColorUtils.hasPAPI()) {
+            return text;
+        }
+
+        UUID senderUuid = parseUuid(payload.senderUuid());
+        if (senderUuid == null) {
+            return text;
+        }
+
+        try {
+            Player online = Bukkit.getPlayer(senderUuid);
+            if (online != null) {
+                return me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(online, text);
+            }
+            return me.clip.placeholderapi.PlaceholderAPI
+                    .setPlaceholders(Bukkit.getOfflinePlayer(senderUuid), text);
+        } catch (Exception ignored) {
+            return text;
+        }
+    }
+
+    private UUID parseUuid(String value) {
+        String trimmed = safe(value).trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(trimmed);
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
     }
 
     private boolean markSeen(String messageId) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/StaffChatFormatPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/StaffChatFormatPolicy.java
@@ -1,0 +1,52 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Builds the line a staff chat message is printed as.
+ *
+ * <p>Two things decide the order of the work here. Placeholders written into the format belong to
+ * the staff member who sent the message rather than to whoever is reading it, so they are resolved
+ * once against the sender instead of per recipient; resolving them per recipient would give every
+ * reader their own rank in front of somebody else's name. The message goes in after that, because
+ * it is typed by a player: a placeholder somebody types into staff chat stays the text they typed.
+ */
+public final class StaffChatFormatPolicy {
+
+    private StaffChatFormatPolicy() {
+    }
+
+    /**
+     * Fills in one staff chat or staff notice format.
+     *
+     * @param format             the configured format, before any substitution
+     * @param senderPlaceholders resolves placeholders against the sender, or null to skip that pass
+     * @param serverName         display name of the server the message came from
+     * @param senderName         name of the staff member who sent it
+     * @param message            the message text, or the status word on a server status notice
+     */
+    public static String render(
+            String format,
+            UnaryOperator<String> senderPlaceholders,
+            String serverName,
+            String senderName,
+            String message
+    ) {
+        String resolved = safe(format);
+        if (senderPlaceholders != null) {
+            resolved = safe(senderPlaceholders.apply(resolved));
+        }
+
+        // %message% goes last so that neither it nor the sender's name can be substituted into a
+        // second time by whatever the player happened to type.
+        return resolved
+                .replace("%server%", safe(serverName))
+                .replace("%player%", safe(senderName))
+                .replace("%status%", safe(message))
+                .replace("%message%", safe(message));
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/StaffChatFormatPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/StaffChatFormatPolicyTest.java
@@ -1,0 +1,75 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A placeholder written into the staff chat format used to survive into the printed line as its own
+ * name, because the only substitution the format ever got was the four literal tokens below and a
+ * PlaceholderAPI pass that ran with no player attached. These pin down who the format is resolved
+ * against, and that the sender's own text is not resolved at all.
+ */
+class StaffChatFormatPolicyTest {
+
+    private static final String FORMAT = "&8[&6StaffChat&8] %luckperms_prefix%&e%player%&7: %message%";
+
+    /** Stands in for PlaceholderAPI resolving against the staff member who sent the message. */
+    private static UnaryOperator<String> sender(String prefix) {
+        return text -> text.replace("%luckperms_prefix%", prefix);
+    }
+
+    @Test
+    void aPlaceholderInTheFormatIsFilledInFromTheSender() {
+        String line = StaffChatFormatPolicy.render(
+                FORMAT, sender("&c[Admin] "), "Crystal", "Notch", "anyone on?");
+
+        assertEquals("&8[&6StaffChat&8] &c[Admin] &eNotch&7: anyone on?", line);
+    }
+
+    @Test
+    void theFormatReachesTheResolverBeforeAnyTokenIsSubstituted() {
+        AtomicReference<String> seen = new AtomicReference<>();
+
+        StaffChatFormatPolicy.render(FORMAT, text -> {
+            seen.set(text);
+            return text;
+        }, "Crystal", "Notch", "anyone on?");
+
+        assertEquals(FORMAT, seen.get());
+    }
+
+    @Test
+    void aPlaceholderSomebodyTypesIntoStaffChatStaysTheTextTheyTyped() {
+        String line = StaffChatFormatPolicy.render(
+                FORMAT, sender(""), "Crystal", "Notch", "why is %luckperms_prefix% empty?");
+
+        assertTrue(line.endsWith("why is %luckperms_prefix% empty?"), line);
+    }
+
+    @Test
+    void theSendersNameIsNotSubstitutedIntoASecondTime() {
+        String line = StaffChatFormatPolicy.render(
+                "%player%: %message%", null, "Crystal", "Notch", "%player% is me");
+
+        assertEquals("Notch: %player% is me", line);
+    }
+
+    @Test
+    void aServerStatusNoticeStillFillsInItsStatusWord() {
+        String line = StaffChatFormatPolicy.render(
+                "&6%server% &eis now %status%&e.", null, "Crystal", "server", "online");
+
+        assertEquals("&6Crystal &eis now online&e.", line);
+    }
+
+    @Test
+    void aMissingFormatAndMissingValuesRenderAsEmptyText() {
+        assertEquals("", StaffChatFormatPolicy.render(null, null, null, null, null));
+        assertEquals(": ", StaffChatFormatPolicy.render("%player%: %message%", null, null, null, null));
+    }
+}


### PR DESCRIPTION
Closes #393

A PlaceholderAPI placeholder written into the staff chat format never showed up. `NetworkStaffChatManager` substituted four literal tokens into the format (`%server%`, `%player%`, `%message%`, `%status%`) and left everything else to the colour pass. That pass is `ColorUtils.colorize(String)`, which picks its player out of `PlayerContext`, and `PlayerContextListener` clears that thread local at `MONITOR` on `PlayerCommandPreprocessEvent`, which fires before Bukkit hands the command to its executor. So the format reached PlaceholderAPI with a null player, and every player-bound expansion came back blank.

## Who the placeholders resolve against

They now resolve against the staff member who sent the message, once per message rather than once per recipient. Resolving per recipient would have been the smaller change and the wrong one: everyone reading staff chat would see their own rank printed in front of somebody else's name.

The sender usually isn't online on the server printing the line, because the payload may have crossed Redis from another server, so an online lookup falls back to an offline one. LuckPerms and Vault both answer for an offline player, which covers the prefix and rank placeholders these formats get built from. A message sent from the console carries no UUID and skips the pass.

## Ordering, and the sender's own text

`StaffChatFormatPolicy` holds the ordering so it can be tested without a server. The format resolves first, then the four tokens go in, `%message%` last. So a placeholder somebody types into staff chat prints as the text they typed; it never expands. That ordering also kills an old double substitution, where a message containing `%status%` got replaced a second time.

The notice formats `NETWORK.STAFF_JOIN`, `STAFF_LEAVE` and `SERVER_STATUS` share the same helper, so they pick this up as well.

## Notes

This adds no config or language keys. `docs/wiki/Config-network.yml.md` gains a section on what the four tokens mean and how PlaceholderAPI behaves in these formats.

Six tests cover the ordering: the format arrives at the resolver with nothing substituted yet, a placeholder in the format gets filled in, one typed into the message is left alone, the sender's name is not substituted into twice, a status notice still renders, and empty input gives empty text. Suite is 629, all green.
