### PR TITLE
feat(motd): let servers write their own multiplayer list message (#396)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1821,6 +1821,56 @@ TABLIST:
 
 ---
 
+## Section: `SERVER-LIST`
+
+### 1. Commented Setup Code Example
+
+```yaml
+# Configuration section for Server List.
+SERVER-LIST:
+  # Determines whether Enabled is enabled or disabled. When true, the text under this server's name
+  # in the multiplayer list is taken from MOTD below instead of the motd line in server.properties.
+  # Set it to false to leave that entry alone. Available options: true, false
+  ENABLED: false
+  # Configuration section for Motd. The lines shown under the server name, written in the same
+  # colour codes as the rest of the plugin. The client only draws the first two. %online% becomes
+  # the number of players on the server and %max_players% the slot count, the same two tokens the
+  # tablist header takes. Maintenance mode keeps its own text while it is on, set in network.yml
+  MOTD:
+  - '&d&lUltimateDonutSMP'
+  - '&7%online%&8/&7%max_players% &7online'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SERVER-LIST.ENABLED` | `bool` | `true`, `false` | `false` | Global toggle for `SERVER-LIST` system. Set to `true` to enable, `false` to disable. It ships off, so updating the jar leaves the entry reading exactly as it did before. |
+| `SERVER-LIST.MOTD` | `list` | Any lines of text | `['&d&lUltimateDonutSMP', '&7%online%&8/&7%max_players% &7online']` | The lines drawn under the server name. The client shows the first two and ignores anything after them, so a longer list costs nothing and gains nothing. `%online%` becomes the number of players on the server and `%max_players%` the slot count. Colour codes, hex codes and PlaceholderAPI server placeholders all work in these lines. An empty list leaves the `motd` line from `server.properties` where it is. |
+
+Nothing here rewrites `server.properties`, and that file still answers for the server whenever this
+block is off. What the block adds is two lines instead of one, the `&` colours used everywhere else
+in the plugin, counts that move as players come and go, and `/uds reload` picking up an edit without
+a restart.
+
+Maintenance mode dresses the same entry. While `/maintenance on` is running and
+`MAINTENANCE.SERVER_LIST.ENABLED` in `network.yml` is `true`, the maintenance text is what people
+see and this block waits its turn. Switch that maintenance block off and the server keeps this MOTD
+even while it is closed, so a maintenance window is not announced to everyone browsing the list.
+
+### 3. Practical Setup Example
+
+```yaml
+SERVER-LIST:
+  ENABLED: true
+  MOTD:
+  # the first line carries the name, the second tells people how busy it is
+  - '&d&lDonut &f&lSMP &7[1.21]'
+  - '&a%online%&7 of &a%max_players%&7 playing right now'
+```
+
+---
+
 ## Section: `CLEAR-LAG`
 
 ### 1. Commented Setup Code Example

--- a/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/UltimateDonutSmp.java
@@ -268,6 +268,7 @@ public final class UltimateDonutSmp extends JavaPlugin {
         maintenanceManager.initializeRedisListener();
         maintenanceManager.startExpiryTask();
         new MaintenanceProtocolLibBridge(this).initialize();
+        new ServerListProtocolLibBridge(this).initialize();
         duelManager.initializeCrossServer();
         discordWebhookManager = new DiscordWebhookManager(this);
         pingManager = new PingManager(this);

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ServerListProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ServerListProtocolLibBridge.java
@@ -1,0 +1,151 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedServerPing;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * Puts the configured MOTD on the status ping, so what a server writes in config.yml is what the
+ * multiplayer list shows. server.properties holds one line, takes no colour codes in the form the
+ * rest of the plugin uses, and only changes on a restart.
+ *
+ * <p>Maintenance dresses the same entry from {@link MaintenanceProtocolLibBridge}, at a higher
+ * listener priority. That alone would settle who wins, but the check here says so outright rather
+ * than leaving it to the order the two happen to be registered in.
+ */
+public final class ServerListProtocolLibBridge {
+
+    /** Token replaced in any configured line with the number of players on the server. */
+    static final String ONLINE_PLACEHOLDER = "%online%";
+
+    /** Token replaced with the slot count. Named as the tablist header names it. */
+    static final String MAX_PLAYERS_PLACEHOLDER = "%max_players%";
+
+    private final UltimateDonutSmp plugin;
+    private boolean loggedFailure;
+
+    public ServerListProtocolLibBridge(UltimateDonutSmp plugin) {
+        this.plugin = plugin;
+    }
+
+    public void initialize() {
+        if (!plugin.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+            return;
+        }
+
+        try {
+            ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
+            protocolManager.addPacketListener(new PacketAdapter(
+                    plugin,
+                    ListenerPriority.NORMAL,
+                    PacketType.Status.Server.SERVER_INFO
+            ) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    onServerInfo(event);
+                }
+            });
+        } catch (Throwable throwable) {
+            plugin.getLogger().log(Level.WARNING, "Failed to register the server list MOTD listener", throwable);
+        }
+    }
+
+    private void onServerInfo(PacketEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
+        FileConfiguration config = plugin.getConfigManager().getConfig();
+        if (!config.getBoolean("SERVER-LIST.ENABLED", false)) {
+            return;
+        }
+
+        if (maintenanceOwnsTheEntry()) {
+            return;
+        }
+
+        List<String> lines = config.getStringList("SERVER-LIST.MOTD");
+        if (lines.isEmpty()) {
+            // Nothing written to show, so the server.properties line stays rather than the entry
+            // going blank on a server that only emptied the list.
+            return;
+        }
+
+        try {
+            WrappedServerPing ping = event.getPacket().getServerPings().read(0);
+            if (ping == null) {
+                return;
+            }
+            String motd = renderMotd(lines, Bukkit.getOnlinePlayers().size(), Bukkit.getMaxPlayers());
+            ping.setMotD(ColorUtils.colorize(motd));
+            // Recent server versions hand out an immutable status object, so the wrapper collects
+            // the edits and only the write-back puts them on the packet.
+            event.getPacket().getServerPings().write(0, ping);
+        } catch (Throwable throwable) {
+            logOnce("Could not put the configured MOTD on the server list ping", throwable);
+        }
+    }
+
+    /**
+     * True only while maintenance is both active and rewriting the entry itself. With its
+     * SERVER_LIST block switched off the server was asked to look untouched from the outside, and
+     * on a server that wrote an MOTD, untouched is that MOTD.
+     */
+    private boolean maintenanceOwnsTheEntry() {
+        MaintenanceManager maintenanceManager = plugin.getMaintenanceManager();
+        if (maintenanceManager == null || !maintenanceManager.isMaintenanceActive()) {
+            return false;
+        }
+        return plugin.getConfigManager().getNetwork().getBoolean("MAINTENANCE.SERVER_LIST.ENABLED", true);
+    }
+
+    /**
+     * A ping is answered for every client that opens its server list, so a fault that repeats would
+     * fill the console with the same stack trace. One copy is enough to act on.
+     */
+    private void logOnce(String message, Throwable throwable) {
+        if (loggedFailure) {
+            return;
+        }
+        loggedFailure = true;
+        plugin.getLogger().log(Level.WARNING, message, throwable);
+    }
+
+    /**
+     * Joins the configured lines into the MOTD. The client draws the first two of them, so a
+     * longer list costs nothing but is not shown either.
+     */
+    static String renderMotd(List<String> lines, int online, int maxPlayers) {
+        if (lines == null || lines.isEmpty()) {
+            return "";
+        }
+        StringBuilder motd = new StringBuilder();
+        for (String line : lines) {
+            if (motd.length() > 0) {
+                motd.append('\n');
+            }
+            motd.append(applyCounts(line, online, maxPlayers));
+        }
+        return motd.toString();
+    }
+
+    static String applyCounts(String line, int online, int maxPlayers) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+        return line
+                .replace(ONLINE_PLACEHOLDER, Integer.toString(online))
+                .replace(MAX_PLAYERS_PLACEHOLDER, Integer.toString(maxPlayers));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -691,6 +691,19 @@ TABLIST:
   - ''
   - '   &#37BFF9/discord  /guide  /store   '
   - ''
+# Configuration section for Server List.
+SERVER-LIST:
+  # Determines whether Enabled is enabled or disabled. When true, the text under this server's name
+  # in the multiplayer list is taken from MOTD below instead of the motd line in server.properties.
+  # Set it to false to leave that entry alone. Available options: true, false
+  ENABLED: false
+  # Configuration section for Motd. The lines shown under the server name, written in the same
+  # colour codes as the rest of the plugin. The client only draws the first two. %online% becomes
+  # the number of players on the server and %max_players% the slot count, the same two tokens the
+  # tablist header takes. Maintenance mode keeps its own text while it is on, set in network.yml
+  MOTD:
+  - '&d&lUltimateDonutSMP'
+  - '&7%online%&8/&7%max_players% &7online'
 # Configuration section for Optimization.
 OPTIMIZATION:
   # Determines whether Enabled is enabled or disabled. Available options: true, false

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ServerListMotdTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ServerListMotdTest.java
@@ -1,0 +1,70 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The MOTD a server writes for itself, and what reaches the multiplayer list entry from it.
+ */
+class ServerListMotdTest {
+
+    private static final List<String> LINES =
+            List.of("&d&lUltimateDonutSMP", "&7%online%&8/&7%max_players% &7online");
+
+    @Test
+    void bothCountsLandOnTheLineThatAsksForThem() {
+        assertEquals(
+                "&d&lUltimateDonutSMP\n&712&8/&760 &7online",
+                ServerListProtocolLibBridge.renderMotd(LINES, 12, 60)
+        );
+    }
+
+    @Test
+    void everyConfiguredLineIsKeptSoTheEntryLooksAsItWasWritten() {
+        assertEquals("one\ntwo\nthree", ServerListProtocolLibBridge.renderMotd(List.of("one", "two", "three"), 0, 20));
+        assertEquals("alone", ServerListProtocolLibBridge.renderMotd(List.of("alone"), 0, 20));
+        assertEquals("", ServerListProtocolLibBridge.renderMotd(List.of(), 0, 20));
+        assertEquals("", ServerListProtocolLibBridge.renderMotd(null, 0, 20));
+    }
+
+    @Test
+    void aLineWithoutThePlaceholdersIsLeftAlone() {
+        assertEquals("untouched", ServerListProtocolLibBridge.applyCounts("untouched", 12, 60));
+        assertEquals("", ServerListProtocolLibBridge.applyCounts(null, 12, 60));
+        assertEquals("", ServerListProtocolLibBridge.applyCounts("", 12, 60));
+    }
+
+    @Test
+    void anEmptyServerStillReadsAsAnEmptyServerRatherThanAsAToken() {
+        String motd = ServerListProtocolLibBridge.renderMotd(LINES, 0, 60);
+
+        assertFalse(motd.contains("%online%"), "an unresolved placeholder would be printed on the server list as it is");
+        assertEquals("&d&lUltimateDonutSMP\n&70&8/&760 &7online", motd);
+    }
+
+    @Test
+    void theBundledBlockShipsSwitchedOffSoUpdatingTheJarLeavesTheEntryAlone() {
+        YamlConfiguration config = bundledConfig();
+
+        assertFalse(config.getBoolean("SERVER-LIST.ENABLED"));
+        assertEquals(LINES, config.getStringList("SERVER-LIST.MOTD"));
+    }
+
+    @Test
+    void theBundledLinesAreReadyToTurnOnWithoutBeingRewritten() {
+        assertEquals(
+                "&d&lUltimateDonutSMP\n&73&8/&720 &7online",
+                ServerListProtocolLibBridge.renderMotd(bundledConfig().getStringList("SERVER-LIST.MOTD"), 3, 20)
+        );
+    }
+
+    private static YamlConfiguration bundledConfig() {
+        return YamlConfiguration.loadConfiguration(new File("src/main/resources/config.yml"));
+    }
+}


### PR DESCRIPTION
Closes #396

Outside maintenance mode the plugin never touched the status ping, so the multiplayer list showed whatever sat in the `motd` line of `server.properties`: a single line that takes no `&` colours and needs a restart before anyone sees an edit. A `SERVER-LIST` block in `config.yml` now writes those lines instead, coloured the same way as everything else the plugin prints.

## The config block

`SERVER-LIST.ENABLED` ships as `false`, so a server that pulls this jar keeps the entry it already has until somebody asks for the change. `SERVER-LIST.MOTD` is a list, and the client draws the first two entries and drops the rest; that is a client limit rather than a choice made here. Two tokens resolve before the line is coloured, `%online%` and `%max_players%`, named the way the tablist header already names them so nobody has to learn a second spelling. Legacy codes, hex and PlaceholderAPI server placeholders all survive the trip, since these lines go through `ColorUtils.colorize` like any other configured text.

An empty list leaves the ping alone, so `server.properties` answers for the server exactly as it does today.

## Who wins during maintenance

`MAINTENANCE.SERVER_LIST` already dresses this same entry, and none of that code moved. The new listener sits at `NORMAL` priority against the maintenance one at `HIGH`, so ordering on its own would settle it, but `ServerListProtocolLibBridge` asks `MaintenanceManager` outright instead of trusting the order two listeners happen to register in. That check has a consequence worth spelling out: turning `MAINTENANCE.SERVER_LIST.ENABLED` off is a server asking for its entry to look ordinary while the doors are shut, and on a server that wrote an MOTD, ordinary means that MOTD.

## Notes

The new keys are `SERVER-LIST.ENABLED` and `SERVER-LIST.MOTD` in `config.yml`. They merge into an existing file in bundled order, so an updated server finds them sitting between `TABLIST` and `OPTIMIZATION` rather than tacked on the end. Nothing here is a `MESSAGES.*` key, so the language files stayed shut.

`ServerListMotdTest` covers the rendering: both counts landing on the line that asks for them, an empty server reading as `0` instead of leaving a raw token on the entry, lines with nothing to replace coming back byte for byte, and the bundled block shipping switched off with text that works as written. Suite is at 629 tests, all green.

`docs/wiki/Config-config.yml.md` gains a `SERVER-LIST` section between `TABLIST` and `CLEAR-LAG`.
