### PR TITLE
refactor(punishments): share the punishment message helpers between both commands

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/OffendCommand.java
@@ -4,7 +4,6 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.OffenseManager;
 import com.bx.ultimateDonutSmp.managers.PlayerWipeManager;
 import com.bx.ultimateDonutSmp.managers.PunishmentManager;
-import com.bx.ultimateDonutSmp.managers.VoiceChatConsentManager;
 import com.bx.ultimateDonutSmp.models.PunishmentQuery;
 import com.bx.ultimateDonutSmp.models.PunishmentRecord;
 import com.bx.ultimateDonutSmp.models.PunishmentScope;
@@ -29,9 +28,11 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
     private static final String CREATE_PERMISSION = "ultimatedonutsmp.staff.punishments.create";
 
     private final UltimateDonutSmp plugin;
+    private final PunishmentMessages messages;
 
     public OffendCommand(UltimateDonutSmp plugin) {
         this.plugin = plugin;
+        this.messages = new PunishmentMessages(plugin, false);
     }
 
     @Override
@@ -124,7 +125,7 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
-        applyRuntimeEffect(type, onlineTarget, record);
+        messages.applyRuntimeEffect(type, onlineTarget, record);
 
         if (plugin.getDiscordWebhookManager() != null) {
             plugin.getDiscordWebhookManager().sendPunishment(record);
@@ -201,126 +202,6 @@ public class OffendCommand implements CommandExecutor, TabCompleter {
         }
 
         sendMessage(sender, "&aWiped &f" + target.name() + "&a. Records removed: &f" + result.counts().total() + "&a.");
-    }
-
-    private void applyRuntimeEffect(PunishmentType type, Player onlineTarget, PunishmentRecord record) {
-        if (onlineTarget == null) {
-            return;
-        }
-
-        switch (type) {
-            case BAN, BLACKLIST, KICK -> onlineTarget.kickPlayer(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            case WARN -> onlineTarget.sendMessage(ColorUtils.toComponent(
-                    plugin.getConfigManager().getMessageOrDefault(
-                            "PUNISHMENTS.WARN-RECEIVED",
-                            "&cWarning: &f{reason}",
-                            "{reason}", record.getReason()
-                    )
-            ));
-            case MUTE -> onlineTarget.sendMessage(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            case VOICE_MUTE -> {
-                VoiceChatConsentManager voiceChat = plugin.getVoiceChatConsentManager();
-                if (voiceChat != null) {
-                    voiceChat.refreshVoiceMute(onlineTarget.getUniqueId(), onlineTarget.getName());
-                }
-                onlineTarget.sendMessage(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            }
-        }
-    }
-
-    private String buildPunishmentMessage(PunishmentRecord record) {
-        return plugin.getConfigManager().getMessageOrDefault(
-                punishmentMessagePath(record.getType()),
-                defaultPunishmentMessage(record.getType()),
-                punishmentPlaceholders(record)
-        );
-    }
-
-    private String punishmentMessagePath(PunishmentType type) {
-        return switch (type) {
-            case BAN -> "PUNISHMENTS.BAN";
-            case KICK -> "PUNISHMENTS.KICK";
-            case MUTE -> "PUNISHMENTS.MUTE";
-            case VOICE_MUTE -> "PUNISHMENTS.VOICE-MUTE";
-            case BLACKLIST -> "PUNISHMENTS.BLACKLIST";
-            case WARN -> "PUNISHMENTS.WARN-RECEIVED";
-        };
-    }
-
-    private String defaultPunishmentMessage(PunishmentType type) {
-        return switch (type) {
-            case BAN -> "&c&lyou have been banned!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7banned by: &f%issuer%\n&8&m----------------------------";
-            case KICK -> "&c&lyou have been kicked!\n&8&m----------------------------\n&7reason: &f%reason%\n&7kicked by: &f%issuer%\n&8&m----------------------------";
-            case VOICE_MUTE -> "&c&lyou have been voice muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------";
-            case MUTE -> "&c&lyou have been muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------";
-            case BLACKLIST -> "&4&lyou have been blacklisted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7blacklisted by: &f%issuer%\n&8&m----------------------------";
-            case WARN -> "&cwarning: &f{reason}";
-        };
-    }
-
-    private String[] punishmentPlaceholders(PunishmentRecord record) {
-        String expires = formatExpires(record);
-        String issuer = formatIssuer(record);
-        String reason = record == null || record.getReason() == null ? "" : record.getReason();
-        String player = record == null || record.getTargetNameSnapshot() == null ? "" : record.getTargetNameSnapshot();
-        String id = record == null ? "" : String.valueOf(record.getId());
-        String type = record == null || record.getType() == null ? "" : record.getType().name();
-
-        return new String[]{
-                "%reason%", reason,
-                "{reason}", reason,
-
-                "%nicest_expiration%", expires,
-                "{nicest_expiration}", expires,
-                "%expires%", expires,
-                "{expires}", expires,
-                "%expires_at%", expires,
-                "{expires_at}", expires,
-                "%expiration%", expires,
-                "{expiration}", expires,
-                "%expiry%", expires,
-                "{expiry}", expires,
-                "%duration%", expires,
-                "{duration}", expires,
-
-                "%issuer%", issuer,
-                "{issuer}", issuer,
-                "%staff%", issuer,
-                "{staff}", issuer,
-                "%by%", issuer,
-                "{by}", issuer,
-
-                "%player%", player,
-                "{player}", player,
-                "%target%", player,
-                "{target}", player,
-
-                "%id%", id,
-                "{id}", id,
-
-                "%type%", type,
-                "{type}", type
-        };
-    }
-
-    private String formatExpires(PunishmentRecord record) {
-        if (record == null || record.getExpiresAt() == null) {
-            return "Permanent";
-        }
-        long remainingSeconds = Math.max(0L, (record.getExpiresAt() - System.currentTimeMillis()) / 1000L);
-        if (remainingSeconds <= 0L) {
-            return "Expired";
-        }
-        if (plugin != null && plugin.getLanguageManager() != null) {
-            return plugin.getLanguageManager().formatDuration(remainingSeconds, true);
-        }
-        return NumberUtils.formatCountdown(remainingSeconds);
-    }
-
-    private String formatIssuer(PunishmentRecord record) {
-        if (record == null) return "unknown";
-        String issuer = record.getIssuerNameSnapshot();
-        return issuer == null || issuer.isBlank() ? "unknown" : issuer;
     }
 
     private ResolvedTarget resolveTarget(String input) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentCommand.java
@@ -6,12 +6,10 @@ import com.bx.ultimateDonutSmp.utils.PunishmentExemptPolicy;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.managers.PunishmentManager;
-import com.bx.ultimateDonutSmp.managers.VoiceChatConsentManager;
 import com.bx.ultimateDonutSmp.models.PunishmentRecord;
 import com.bx.ultimateDonutSmp.models.PunishmentScope;
 import com.bx.ultimateDonutSmp.models.PunishmentType;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
-import com.bx.ultimateDonutSmp.utils.NumberUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -54,9 +52,11 @@ public class PunishmentCommand implements CommandExecutor {
     );
 
     private final UltimateDonutSmp plugin;
+    private final PunishmentMessages messages;
 
     public PunishmentCommand(UltimateDonutSmp plugin) {
         this.plugin = plugin;
+        this.messages = new PunishmentMessages(plugin, true);
     }
 
     @Override
@@ -185,7 +185,7 @@ public class PunishmentCommand implements CommandExecutor {
             return true;
         }
 
-        applyRuntimeEffect(type, onlineTarget, record);
+        messages.applyRuntimeEffect(type, onlineTarget, record);
         plugin.getDiscordWebhookManager().sendPunishment(record);
         send(sender, plugin.getConfigManager().getMessageOrDefault(
                 "PUNISHMENTS.CREATED",
@@ -249,7 +249,7 @@ public class PunishmentCommand implements CommandExecutor {
         }
 
         if (type == PunishmentType.VOICE_MUTE) {
-            refreshVoiceMute(targetUuid, targetName);
+            messages.refreshVoiceMute(targetUuid, targetName);
         }
 
         send(sender, plugin.getConfigManager().getMessageOrDefault(
@@ -259,134 +259,6 @@ public class PunishmentCommand implements CommandExecutor {
                 "{player}", targetName
         ));
         return true;
-    }
-
-    private void applyRuntimeEffect(PunishmentType type, Player onlineTarget, PunishmentRecord record) {
-        if (onlineTarget == null) {
-            return;
-        }
-
-        switch (type) {
-            case BAN, BLACKLIST, KICK -> onlineTarget.kickPlayer(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            case WARN -> onlineTarget.sendMessage(ColorUtils.toComponent(
-                    plugin.getConfigManager().getMessageOrDefault(
-                            "PUNISHMENTS.WARN-RECEIVED",
-                            "&cWarning: &f{reason}",
-                            "{reason}", record.getReason()
-                    )
-            ));
-            case MUTE -> onlineTarget.sendMessage(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            case VOICE_MUTE -> {
-                refreshVoiceMute(onlineTarget.getUniqueId(), onlineTarget.getName());
-                onlineTarget.sendMessage(ColorUtils.toComponent(buildPunishmentMessage(record)));
-            }
-        }
-    }
-
-    /**
-     * The microphone gate reads a cache rather than the database, so a voice mute only takes hold
-     * once that cache has been told about the record that was just written or removed.
-     */
-    private void refreshVoiceMute(UUID targetUuid, String targetName) {
-        VoiceChatConsentManager manager = plugin.getVoiceChatConsentManager();
-        if (manager != null) {
-            manager.refreshVoiceMute(targetUuid, targetName);
-        }
-    }
-
-    private String buildPunishmentMessage(PunishmentRecord record) {
-        return plugin.getConfigManager().getMessageOrDefault(
-                punishmentMessagePath(record.getType()),
-                defaultPunishmentMessage(record.getType()),
-                punishmentPlaceholders(record)
-        );
-    }
-
-    private String punishmentMessagePath(PunishmentType type) {
-        return switch (type) {
-            case BAN -> "PUNISHMENTS.BAN";
-            case KICK -> "PUNISHMENTS.KICK";
-            case MUTE -> "PUNISHMENTS.MUTE";
-            case VOICE_MUTE -> "PUNISHMENTS.VOICE-MUTE";
-            case BLACKLIST -> "PUNISHMENTS.BLACKLIST";
-            case WARN -> "PUNISHMENTS.WARN-RECEIVED";
-        };
-    }
-
-    private String defaultPunishmentMessage(PunishmentType type) {
-        return switch (type) {
-            case BAN -> "&c&lyou have been banned!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7banned by: &f%issuer%\n&8&m----------------------------\n&7appeal at: &fdiscord.example.space";
-            case KICK -> "&c&lyou have been kicked!\n&8&m----------------------------\n&7reason: &f%reason%\n&7kicked by: &f%issuer%\n&8&m----------------------------\n&7you may reconnect";
-            case VOICE_MUTE -> "&c&lyou have been voice muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------\n&7you cannot speak in voice chat";
-            case MUTE -> "&c&lyou have been muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------\n&7you cannot speak in chat";
-            case BLACKLIST -> "&4&lyou have been blacklisted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7blacklisted by: &f%issuer%\n&8&m----------------------------\n&4you cannot join the server";
-            case WARN -> "&cwarning: &f{reason}";
-        };
-    }
-
-    private String[] punishmentPlaceholders(PunishmentRecord record) {
-        String expires = formatExpires(record);
-        String issuer = formatIssuer(record);
-        String reason = record == null || record.getReason() == null ? "" : record.getReason();
-        String player = record == null || record.getTargetNameSnapshot() == null ? "" : record.getTargetNameSnapshot();
-        String id = record == null ? "" : String.valueOf(record.getId());
-        String type = record == null || record.getType() == null ? "" : record.getType().name();
-
-        return new String[]{
-                "%reason%", reason,
-                "{reason}", reason,
-
-                "%nicest_expiration%", expires,
-                "{nicest_expiration}", expires,
-                "%expires%", expires,
-                "{expires}", expires,
-                "%expires_at%", expires,
-                "{expires_at}", expires,
-                "%expiration%", expires,
-                "{expiration}", expires,
-                "%expiry%", expires,
-                "{expiry}", expires,
-                "%duration%", expires,
-                "{duration}", expires,
-
-                "%issuer%", issuer,
-                "{issuer}", issuer,
-                "%staff%", issuer,
-                "{staff}", issuer,
-                "%by%", issuer,
-                "{by}", issuer,
-
-                "%player%", player,
-                "{player}", player,
-                "%target%", player,
-                "{target}", player,
-
-                "%id%", id,
-                "{id}", id,
-
-                "%type%", type,
-                "{type}", type
-        };
-    }
-
-    private String formatExpires(PunishmentRecord record) {
-        if (record == null || record.getExpiresAt() == null) {
-            return "Permanent";
-        }
-        long remainingSeconds = Math.max(0L, (record.getExpiresAt() - System.currentTimeMillis()) / 1000L);
-        if (remainingSeconds <= 0L) {
-            return "Expired";
-        }
-        if (plugin != null && plugin.getLanguageManager() != null) {
-            return plugin.getLanguageManager().formatDuration(remainingSeconds, true);
-        }
-        return NumberUtils.formatCountdown(remainingSeconds);
-    }
-
-    private String formatIssuer(PunishmentRecord record) {
-        if (record == null) return "unknown";
-        String issuer = record.getIssuerNameSnapshot();
-        return issuer == null || issuer.isBlank() ? "unknown" : issuer;
     }
 
     private ResolvedTarget resolveTarget(String input) {

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentMessages.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/PunishmentMessages.java
@@ -1,0 +1,178 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.managers.VoiceChatConsentManager;
+import com.bx.ultimateDonutSmp.models.PunishmentRecord;
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * The punishment message text, and the delivery of it, shared by the direct punishment commands and
+ * by {@code /offend}. Both used to carry their own copy, so every new punishment type had to be
+ * added in two places, and the switch in {@link #applyRuntimeEffect} is a statement rather than an
+ * expression: the compiler never checked that the two copies handled the same set of types.
+ *
+ * <p>The two callers differ in one respect. The direct commands close the message with a line of
+ * advice ("appeal at", "you may reconnect"); {@code /offend} leaves it off. That is what
+ * {@code closingAdvice} selects between.
+ */
+class PunishmentMessages {
+
+    private final UltimateDonutSmp plugin;
+    private final boolean closingAdvice;
+
+    PunishmentMessages(UltimateDonutSmp plugin, boolean closingAdvice) {
+        this.plugin = plugin;
+        this.closingAdvice = closingAdvice;
+    }
+
+    void applyRuntimeEffect(PunishmentType type, Player onlineTarget, PunishmentRecord record) {
+        if (onlineTarget == null) {
+            return;
+        }
+
+        switch (type) {
+            case BAN, BLACKLIST, KICK -> onlineTarget.kickPlayer(ColorUtils.toComponent(build(record)));
+            case WARN -> onlineTarget.sendMessage(ColorUtils.toComponent(
+                    plugin.getConfigManager().getMessageOrDefault(
+                            "PUNISHMENTS.WARN-RECEIVED",
+                            "&cWarning: &f{reason}",
+                            "{reason}", record.getReason()
+                    )
+            ));
+            case MUTE -> onlineTarget.sendMessage(ColorUtils.toComponent(build(record)));
+            case VOICE_MUTE -> {
+                refreshVoiceMute(onlineTarget.getUniqueId(), onlineTarget.getName());
+                onlineTarget.sendMessage(ColorUtils.toComponent(build(record)));
+            }
+        }
+    }
+
+    /**
+     * The microphone gate reads a cache rather than the database, so a voice mute only takes hold
+     * once that cache has been told about the record that was just written or removed.
+     */
+    void refreshVoiceMute(UUID targetUuid, String targetName) {
+        VoiceChatConsentManager manager = plugin.getVoiceChatConsentManager();
+        if (manager != null) {
+            manager.refreshVoiceMute(targetUuid, targetName);
+        }
+    }
+
+    String build(PunishmentRecord record) {
+        return plugin.getConfigManager().getMessageOrDefault(
+                messagePath(record.getType()),
+                defaultMessage(record.getType()),
+                placeholders(record)
+        );
+    }
+
+    static String messagePath(PunishmentType type) {
+        return switch (type) {
+            case BAN -> "PUNISHMENTS.BAN";
+            case KICK -> "PUNISHMENTS.KICK";
+            case MUTE -> "PUNISHMENTS.MUTE";
+            case VOICE_MUTE -> "PUNISHMENTS.VOICE-MUTE";
+            case BLACKLIST -> "PUNISHMENTS.BLACKLIST";
+            case WARN -> "PUNISHMENTS.WARN-RECEIVED";
+        };
+    }
+
+    String defaultMessage(PunishmentType type) {
+        String advice = closingAdvice ? closingAdvice(type) : "";
+        return advice.isEmpty() ? messageBody(type) : messageBody(type) + "\n" + advice;
+    }
+
+    /** The message without the closing line of advice. */
+    static String messageBody(PunishmentType type) {
+        return switch (type) {
+            case BAN -> "&c&lyou have been banned!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7banned by: &f%issuer%\n&8&m----------------------------";
+            case KICK -> "&c&lyou have been kicked!\n&8&m----------------------------\n&7reason: &f%reason%\n&7kicked by: &f%issuer%\n&8&m----------------------------";
+            case VOICE_MUTE -> "&c&lyou have been voice muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------";
+            case MUTE -> "&c&lyou have been muted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7expires: &f%nicest_expiration%\n&7muted by: &f%issuer%\n&8&m----------------------------";
+            case BLACKLIST -> "&4&lyou have been blacklisted!\n&8&m----------------------------\n&7reason: &f%reason%\n&7blacklisted by: &f%issuer%\n&8&m----------------------------";
+            case WARN -> "&cwarning: &f{reason}";
+        };
+    }
+
+    /** The closing line the direct commands add. A warning carries none. */
+    static String closingAdvice(PunishmentType type) {
+        return switch (type) {
+            case BAN -> "&7appeal at: &fdiscord.example.space";
+            case KICK -> "&7you may reconnect";
+            case VOICE_MUTE -> "&7you cannot speak in voice chat";
+            case MUTE -> "&7you cannot speak in chat";
+            case BLACKLIST -> "&4you cannot join the server";
+            case WARN -> "";
+        };
+    }
+
+    String[] placeholders(PunishmentRecord record) {
+        String expires = formatExpires(record);
+        String issuer = formatIssuer(record);
+        String reason = record == null || record.getReason() == null ? "" : record.getReason();
+        String player = record == null || record.getTargetNameSnapshot() == null ? "" : record.getTargetNameSnapshot();
+        String id = record == null ? "" : String.valueOf(record.getId());
+        String type = record == null || record.getType() == null ? "" : record.getType().name();
+
+        return new String[]{
+                "%reason%", reason,
+                "{reason}", reason,
+
+                "%nicest_expiration%", expires,
+                "{nicest_expiration}", expires,
+                "%expires%", expires,
+                "{expires}", expires,
+                "%expires_at%", expires,
+                "{expires_at}", expires,
+                "%expiration%", expires,
+                "{expiration}", expires,
+                "%expiry%", expires,
+                "{expiry}", expires,
+                "%duration%", expires,
+                "{duration}", expires,
+
+                "%issuer%", issuer,
+                "{issuer}", issuer,
+                "%staff%", issuer,
+                "{staff}", issuer,
+                "%by%", issuer,
+                "{by}", issuer,
+
+                "%player%", player,
+                "{player}", player,
+                "%target%", player,
+                "{target}", player,
+
+                "%id%", id,
+                "{id}", id,
+
+                "%type%", type,
+                "{type}", type
+        };
+    }
+
+    private String formatExpires(PunishmentRecord record) {
+        if (record == null || record.getExpiresAt() == null) {
+            return "Permanent";
+        }
+        long remainingSeconds = Math.max(0L, (record.getExpiresAt() - System.currentTimeMillis()) / 1000L);
+        if (remainingSeconds <= 0L) {
+            return "Expired";
+        }
+        if (plugin != null && plugin.getLanguageManager() != null) {
+            return plugin.getLanguageManager().formatDuration(remainingSeconds, true);
+        }
+        return NumberUtils.formatCountdown(remainingSeconds);
+    }
+
+    private static String formatIssuer(PunishmentRecord record) {
+        if (record == null) return "unknown";
+        String issuer = record.getIssuerNameSnapshot();
+        return issuer == null || issuer.isBlank() ? "unknown" : issuer;
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/OffendPlaceholderTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/OffendPlaceholderTest.java
@@ -5,7 +5,6 @@ import com.bx.ultimateDonutSmp.models.PunishmentScope;
 import com.bx.ultimateDonutSmp.models.PunishmentType;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -15,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class OffendPlaceholderTest {
 
     @Test
-    void testPunishmentPlaceholdersContainAllExpiryVariants() throws Exception {
+    void testPunishmentPlaceholdersContainAllExpiryVariants() {
         PunishmentRecord record = new PunishmentRecord(
                 101L,
                 UUID.randomUUID(),
@@ -34,10 +33,7 @@ class OffendPlaceholderTest {
                 PunishmentScope.SERVER
         );
 
-        OffendCommand command = new OffendCommand(null);
-        Method method = OffendCommand.class.getDeclaredMethod("punishmentPlaceholders", PunishmentRecord.class);
-        method.setAccessible(true);
-        String[] placeholdersArray = (String[]) method.invoke(command, record);
+        String[] placeholdersArray = new PunishmentMessages(null, false).placeholders(record);
 
         assertNotNull(placeholdersArray);
         assertTrue(placeholdersArray.length >= 10);
@@ -76,7 +72,7 @@ class OffendPlaceholderTest {
     }
 
     @Test
-    void testPermanentPunishmentExpirationFormat() throws Exception {
+    void testPermanentPunishmentExpirationFormat() {
         PunishmentRecord record = new PunishmentRecord(
                 102L,
                 UUID.randomUUID(),
@@ -95,10 +91,7 @@ class OffendPlaceholderTest {
                 PunishmentScope.SERVER
         );
 
-        OffendCommand command = new OffendCommand(null);
-        Method method = OffendCommand.class.getDeclaredMethod("punishmentPlaceholders", PunishmentRecord.class);
-        method.setAccessible(true);
-        String[] placeholdersArray = (String[]) method.invoke(command, record);
+        String[] placeholdersArray = new PunishmentMessages(null, false).placeholders(record);
 
         Map<String, String> map = new HashMap<>();
         for (int i = 0; i + 1 < placeholdersArray.length; i += 2) {

--- a/src/test/java/com/bx/ultimateDonutSmp/commands/PunishmentMessagesTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/commands/PunishmentMessagesTest.java
@@ -1,0 +1,64 @@
+package com.bx.ultimateDonutSmp.commands;
+
+import com.bx.ultimateDonutSmp.models.PunishmentType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This text used to be copied into two command classes, and adding a punishment type meant editing
+ * both. These walk every constant instead, so the next type cannot reach a player with nothing to
+ * say.
+ */
+class PunishmentMessagesTest {
+
+    private final PunishmentMessages withAdvice = new PunishmentMessages(null, true);
+    private final PunishmentMessages withoutAdvice = new PunishmentMessages(null, false);
+
+    @Test
+    void everyTypeHasAMessagePathUnderPunishments() {
+        for (PunishmentType type : PunishmentType.values()) {
+            String path = PunishmentMessages.messagePath(type);
+            assertNotNull(path, type.name());
+            assertTrue(path.startsWith("PUNISHMENTS."), type + " maps to " + path);
+        }
+    }
+
+    @Test
+    void everyTypeHasSomethingToSayInBothForms() {
+        for (PunishmentType type : PunishmentType.values()) {
+            assertFalse(PunishmentMessages.messageBody(type).isBlank(), type.name());
+            assertFalse(withAdvice.defaultMessage(type).isBlank(), type.name());
+            assertFalse(withoutAdvice.defaultMessage(type).isBlank(), type.name());
+        }
+    }
+
+    @Test
+    void theClosingAdviceIsAddedToTheBodyRatherThanReplacingIt() {
+        for (PunishmentType type : PunishmentType.values()) {
+            String body = PunishmentMessages.messageBody(type);
+            assertEquals(body, withoutAdvice.defaultMessage(type), type.name());
+            assertTrue(withAdvice.defaultMessage(type).startsWith(body), type.name());
+        }
+    }
+
+    @Test
+    void everyTypeButAWarningCarriesClosingAdvice() {
+        for (PunishmentType type : PunishmentType.values()) {
+            String advice = PunishmentMessages.closingAdvice(type);
+            assertNotNull(advice, type.name());
+
+            if (type == PunishmentType.WARN) {
+                assertTrue(advice.isEmpty(), "a warning needs no closing line");
+                assertEquals(withoutAdvice.defaultMessage(type), withAdvice.defaultMessage(type));
+            } else {
+                assertFalse(advice.isBlank(), type.name());
+                assertNotEquals(withoutAdvice.defaultMessage(type), withAdvice.defaultMessage(type), type.name());
+            }
+        }
+    }
+}


### PR DESCRIPTION
`PunishmentCommand` and `OffendCommand` each kept their own copy of the punishment message text and the code that delivers it: `applyRuntimeEffect`, `buildPunishmentMessage`, `punishmentMessagePath`, `defaultPunishmentMessage`, `punishmentPlaceholders`, `formatExpires` and `formatIssuer`. Adding `VOICE_MUTE` in #383 meant writing the same three edits twice, and only two of them were caught by the compiler.

That is the part worth fixing. `punishmentMessagePath` and `defaultPunishmentMessage` are switch expressions, so a missing type fails the build. `applyRuntimeEffect` is an arrow switch statement, which does not have to be exhaustive: a punishment type added later could quietly get no runtime effect in one of the two classes and still compile.

## PunishmentMessages

The seven helpers now live in one package-private class beside the commands, and each command holds one instance of it.

The two callers were not quite identical. The direct commands close the message with a line of advice ("appeal at", "you may reconnect", "you cannot speak in chat") and `/offend` leaves it off, because its own reply to the staff member already covers it. That split is now the `closingAdvice` constructor flag: `PunishmentCommand` passes true, `OffendCommand` passes false, and `messageBody` holds the shared text with `closingAdvice` holding the extra line per type.

Everything else was character-identical between the two copies and moved across unchanged.

## Notes

No text changes. I checked every one of the six punishment types by composing the new output and diffing it against both old versions on `main`: byte-identical for both call sites, message paths included.

`PunishmentMessagesTest` is new, four cases walking `PunishmentType.values()` rather than naming types one by one, so a type added later cannot reach a player with a blank message. It also pins the advice as something appended to the body rather than replacing it, and that a warning is the one type carrying no closing line.

`OffendPlaceholderTest` used reflection to reach `punishmentPlaceholders`, which is no longer on `OffendCommand`. It calls `PunishmentMessages.placeholders` directly now, since the test sits in the same package, so two `throws Exception` and a `java.lang.reflect.Method` import went away with it.

Net 264 lines deleted against 253 added, most of the additions being the new test and the class header. Suite is at 633, green.
