### PR TITLE
feat(chat): require a permission for colour codes typed into messages

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -718,6 +718,14 @@ prefix ending in `&c` gives you a red name unless the format sets a colour of it
 characters they are. Staff chat is assembled in one piece rather than around a clickable name, and
 `STAFFCHAT.FORMAT` in `messages.yml` has always taken gradients the same way.
 
+Private messages and staff chat part company with public chat on one point. Both colour the whole
+line after the typed message has been put into it, so a code somebody typed would otherwise take
+effect, and `ultimatedonutsmp.chat.color` decides whether it does. The node defaults to `op` and
+ships inside the `ultimatedonutsmp.admin` and `ultimatedonutsmp.staff.mode` bundles, so staff keep
+the colours they already had. For anyone without it the codes come out of the message before the
+line is built, which stops a player hiding a private message behind `&k` or wiping the format's own
+colours with `&r`. Grant the node to a rank to hand those colours back.
+
 ---
 
 ## Section: `SERVER-NOTIFICATIONS`

--- a/docs/wiki/Config-network.yml.md
+++ b/docs/wiki/Config-network.yml.md
@@ -132,6 +132,11 @@ unfilled.
 
 A placeholder typed into the message itself is not expanded; it prints as the text that was typed.
 
+Colour codes typed into the message follow `ultimatedonutsmp.chat.color`, which defaults to `op` and
+comes with the `ultimatedonutsmp.admin` and `ultimatedonutsmp.staff.mode` bundles. A sender holding
+it can colour their own staff chat text; for anyone else the codes are removed before the line goes
+out, on the server the message was sent from rather than the ones it arrives at.
+
 ```yaml
 NETWORK:
   STAFF_CHAT: '&8[&dNetwork&8] &7[%server%] %luckperms_prefix%&e%player%&8: &f%message%'

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/NetworkStaffChatManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/NetworkStaffChatManager.java
@@ -6,6 +6,7 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.StaffChatPayload;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.StaffChatFormatPolicy;
+import com.bx.ultimateDonutSmp.utils.TypedColorPolicy;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.command.CommandSender;
@@ -98,12 +99,16 @@ public class NetworkStaffChatManager {
             senderUuid = player.getUniqueId().toString();
         }
 
+        // Decided here rather than in broadcastStaffChat: a message coming off Redis was sent by
+        // somebody who is not on this server, so their permissions cannot be read at that end.
+        String outgoing = TypedColorPolicy.apply(sender, message);
+
         StaffChatPayload payload = StaffChatPayload.staffChat(
                 getLocalServerId(),
                 getLocalDisplayName(),
                 senderUuid,
                 sender.getName(),
-                message
+                outgoing
         );
 
         markSeen(payload.messageId());

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/PrivateMessageManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/PrivateMessageManager.java
@@ -5,6 +5,7 @@ import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.models.PlayerData;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.TypedColorPolicy;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -28,6 +29,10 @@ public class PrivateMessageManager {
         if (sender == null || target == null || message == null || message.isBlank()) {
             return false;
         }
+
+        // Both formats colour the whole line after the message goes into it, so the codes have to
+        // come out here for anyone not allowed to colour their own text. reply() lands here too.
+        message = TypedColorPolicy.apply(sender, message);
 
         String senderName = sender instanceof Player player ? player.getName() : "console";
         if (sender instanceof Player publicSender) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/TypedColorPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/TypedColorPolicy.java
@@ -1,0 +1,39 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.permissions.Permissible;
+
+/**
+ * Decides whether the colour codes a player typed into their own message survive into the line it
+ * is printed as.
+ *
+ * <p>Public chat never colours what a player typed, so it needs none of this. Private messages and
+ * staff chat both drop the message into their format and colour the whole line afterwards, which
+ * handed anyone able to use them a way to colour their own text, hide it behind {@code &k}, or wipe
+ * the format's own colours from that point on with {@code &r}. Those codes now come out of the
+ * message unless the sender holds {@link #PERMISSION}.
+ *
+ * <p>Staff chat crosses servers, so this runs where a message is sent rather than where it is
+ * printed: the sender's permissions only exist on the server they are actually on.
+ */
+public final class TypedColorPolicy {
+
+    public static final String PERMISSION = "ultimatedonutsmp.chat.color";
+
+    private TypedColorPolicy() {
+    }
+
+    /**
+     * Returns the message as it should travel onward: unchanged for a sender allowed to colour
+     * their own text, and with every colour code and tag taken out for anyone else.
+     */
+    public static String apply(Permissible sender, String message) {
+        if (message == null || message.isEmpty() || mayColour(sender)) {
+            return message;
+        }
+        return ColorUtils.strip(message);
+    }
+
+    public static boolean mayColour(Permissible sender) {
+        return PermissionUtils.has(sender, PERMISSION);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -875,6 +875,7 @@ permissions:
       ultimatedonutsmp.staff.chat.bypass.mute: true
       ultimatedonutsmp.staff.chat.bypass.delay: true
       ultimatedonutsmp.staff.chat.bypass.filter: true
+      ultimatedonutsmp.chat.color: true
       ultimatedonutsmp.staff.alerts.receive: true
       ultimatedonutsmp.staff.alerts.bypass-cooldown: true
       ultimatedonutsmp.staff.teleport: true
@@ -1052,6 +1053,7 @@ permissions:
       ultimatedonutsmp.staff.mode.seevanished: true
       ultimatedonutsmp.staff.mode.others: true
       ultimatedonutsmp.staff.chat.use: true
+      ultimatedonutsmp.chat.color: true
       ultimatedonutsmp.staff.teleport: true
       ultimatedonutsmp.staff.rename: true
       ultimatedonutsmp.staff.alts: true
@@ -1199,6 +1201,9 @@ permissions:
     default: true
   ultimatedonutsmp.message.bypass-disabled:
     description: Bypass target private-message disabled checks
+    default: op
+  ultimatedonutsmp.chat.color:
+    description: Use colour codes and gradients in private messages and staff chat
     default: op
   ultimatedonutsmp.staff.punishments.ban:
     default: false

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/TypedColorPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/TypedColorPolicyTest.java
@@ -1,0 +1,102 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.permissions.Permissible;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Private messages and staff chat colour the whole line after the typed message has gone into it,
+ * so anyone who could use them could colour their own text, hide it with {@code &k}, or clear the
+ * format's colours with {@code &r}. Public chat never did, because it leaves the typed text alone.
+ */
+class TypedColorPolicyTest {
+
+    @Test
+    void aSenderWithoutThePermissionLosesTheColourCodesTheyTyped() {
+        assertEquals("hello", TypedColorPolicy.apply(sender(), "&chello"));
+    }
+
+    @Test
+    void obfuscatedAndResetCodesComeOutToo() {
+        assertEquals("hello", TypedColorPolicy.apply(sender(), "&khello"));
+        assertEquals("hello", TypedColorPolicy.apply(sender(), "&rhello"));
+    }
+
+    @Test
+    void gradientAndMiniMessageTagsComeOutAsWell() {
+        assertEquals("hello", TypedColorPolicy.apply(
+                sender(), "<gradient:#FF0000:#0000FF>hello</gradient>"));
+        assertEquals("hello", TypedColorPolicy.apply(sender(), "<red>hello"));
+        assertEquals("hello", TypedColorPolicy.apply(sender(), "&#FF0000hello"));
+    }
+
+    @Test
+    void aSenderHoldingThePermissionKeepsEveryCharacterTheyTyped() {
+        String typed = "<gradient:#FF0000:#0000FF>hey</gradient> &kthere &rok";
+
+        assertEquals(typed, TypedColorPolicy.apply(sender(TypedColorPolicy.PERMISSION), typed));
+    }
+
+    @Test
+    void ordinaryTextIsLeftAloneEitherWay() {
+        assertEquals("anyone on?", TypedColorPolicy.apply(sender(), "anyone on?"));
+        assertEquals("anyone on?", TypedColorPolicy.apply(sender(TypedColorPolicy.PERMISSION), "anyone on?"));
+    }
+
+    @Test
+    void nullAndEmptyMessagesSurviveUntouched() {
+        assertEquals(null, TypedColorPolicy.apply(sender(), null));
+        assertEquals("", TypedColorPolicy.apply(sender(), ""));
+    }
+
+    @Test
+    void aMissingSenderIsNotAllowedToColour() {
+        assertFalse(TypedColorPolicy.mayColour(null));
+        assertEquals("hello", TypedColorPolicy.apply(null, "&chello"));
+    }
+
+    @Test
+    void thePermissionIsTheOneDeclaredInPluginYml() {
+        assertEquals("ultimatedonutsmp.chat.color", TypedColorPolicy.PERMISSION);
+        assertTrue(TypedColorPolicy.mayColour(sender(TypedColorPolicy.PERMISSION)));
+        assertFalse(TypedColorPolicy.mayColour(sender()));
+    }
+
+    @Test
+    void pluginYmlDeclaresTheNodeAndKeepsItOffByDefault() throws Exception {
+        YamlConfiguration plugin = new YamlConfiguration();
+        plugin.load(new File("src/main/resources/plugin.yml"));
+
+        String node = "permissions." + TypedColorPolicy.PERMISSION;
+        assertTrue(plugin.isConfigurationSection(node), node);
+        assertEquals("op", plugin.getString(node + ".default"));
+
+        // Staff pick it up through the bundles they already hold, so staff chat keeps working.
+        assertTrue(plugin.getBoolean("permissions.ultimatedonutsmp.admin.children."
+                + TypedColorPolicy.PERMISSION));
+        assertTrue(plugin.getBoolean("permissions.ultimatedonutsmp.staff.mode.children."
+                + TypedColorPolicy.PERMISSION));
+    }
+
+    private static Permissible sender(String... permissions) {
+        Set<String> held = new HashSet<>(Set.of(permissions));
+        return (Permissible) Proxy.newProxyInstance(
+                Permissible.class.getClassLoader(),
+                new Class<?>[]{Permissible.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "hasPermission" -> held.contains(String.valueOf(args[0]));
+                    case "getEffectivePermissions" -> new HashSet<>();
+                    default -> null;
+                }
+        );
+    }
+}


### PR DESCRIPTION
Public chat never colours what a player typed. Private messages and staff chat do, and not on purpose: both drop the message into their format and colour the whole line afterwards, so any code in the typed text takes effect on the way through. Anyone who can run `/msg` could therefore colour their own text or hide it behind `&k`, and a typed `&r` cut the format's colours off from that point on. Staff chat handed the same thing to every server on the network.

`ultimatedonutsmp.chat.color` now decides it. The node defaults to `op` and sits in the `ultimatedonutsmp.admin` and `ultimatedonutsmp.staff.mode` bundles, so staff keep what they had; for anyone else the codes come out of the message before the line is built.

## Where the check goes

`TypedColorPolicy` holds the rule, next to `StaffChatFormatPolicy` from #397, which fixed the neighbouring problem of a typed `%player%` being substituted into.

Staff chat crosses servers, so the check runs in `sendStaffChat` where the message starts out rather than in `broadcastStaffChat` where it is printed. A line arriving over Redis was sent by somebody who is usually not online locally, so their permissions cannot be read at that end. The payload travels already decided, and no field was added to it.

Private messages needed one hook: `reply()` hands off to `sendPrivateMessage`, so `/msg` and `/reply` are both covered by the same line.

## What a blocked message looks like

The codes are removed rather than escaped, so `&chello` arrives as `hello`. Public chat would print `&chello` with the ampersand intact, so the two still differ. Escaping would need an escape mechanism `ColorUtils` does not have, and stripping is never worse than today: those characters already vanished into a colour code, they just took the rest of the line's colour with them.

Nothing changes for a sender who holds the node. Their message goes through the path it always did, so all-caps text is not retitled and PlaceholderAPI behaves as before.

## Notes

Nine tests in `TypedColorPolicyTest` cover the permitted and blocked senders, `&k` and `&r`, gradient and MiniMessage tags, a missing sender, and the `plugin.yml` declaration with both bundles. Suite is at 648 and green.

The two wiki pages describing these formats pick up the rule: `Config-config.yml.md` in the chat colours section, and `Config-network.yml.md` beside the note about typed placeholders.
