### PR TITLE
feat(homes): confirm before a right-click deletes a home (#401)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -590,6 +590,11 @@ HOME-MENU:
 | `HOME-MENU.TELEPORT.HOME-1.LORE.NO-USED` | `list` | List of configured items/strings | `['&7Click to create a home.']` | Configures the technical `NO-USED` parameter for `HOME-MENU.TELEPORT.HOME-1.LORE.NO-USED` in `menus.yml`. |
 | *(56 additional sub-keys configured in section)* | | | | |
 
+Both `&cRight-click to delete` lines mean what they say, but the click opens a confirmation screen
+rather than removing anything on the spot, so a missed left-click no longer costs a player a home.
+Cancelling puts them back on the page they were reading. Bedrock players get the Floodgate form
+instead, which asks the same question.
+
 ### 3. Practical Setup Example
 
 ```yaml

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HomeBedrockManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HomeBedrockManager.java
@@ -304,7 +304,7 @@ public final class HomeBedrockManager {
         send(player, form.build());
     }
 
-    private void openDeleteTeamHomeConfirmation(Player player, Team team) {
+    public void openDeleteTeamHomeConfirmation(Player player, Team team) {
         ModalForm.Builder form = ModalForm.builder()
                 .title(plain("Delete Team Home"))
                 .content(plain("Are you sure you want to delete your team home?"))

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/HomeDeleteConfirmMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/HomeDeleteConfirmMenu.java
@@ -12,15 +12,45 @@ import org.bukkit.event.inventory.ClickType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class HomeDeleteConfirmMenu extends BaseMenu {
 
-    private final Home home;
+    private final String subject;
+    private final int returnPage;
+    private final Consumer<Player> onConfirm;
     private final Map<Integer, Runnable> slotActions = new HashMap<>();
 
     public HomeDeleteConfirmMenu(UltimateDonutSmp plugin, Home home) {
-        super(plugin, "&8Delete Home: &c" + (home != null ? home.getName() : "") + "?", 27);
-        this.home = home;
+        this(plugin, home, 0);
+    }
+
+    public HomeDeleteConfirmMenu(UltimateDonutSmp plugin, Home home, int returnPage) {
+        this(
+                plugin,
+                "&8Delete Home: &c" + homeName(home) + "?",
+                home == null ? null : "home &f" + home.getName(),
+                returnPage,
+                home == null ? null : player -> deleteHome(plugin, player, home)
+        );
+    }
+
+    private HomeDeleteConfirmMenu(UltimateDonutSmp plugin, String title, String subject,
+                                  int returnPage, Consumer<Player> onConfirm) {
+        super(plugin, title, 27);
+        this.subject = subject;
+        this.returnPage = returnPage;
+        this.onConfirm = onConfirm;
+    }
+
+    /**
+     * There is no Home behind the shared team home, and deleting it needs the team permission
+     * checks the caller already does, so the caller hands its own delete in.
+     */
+    public static HomeDeleteConfirmMenu forTeamHome(UltimateDonutSmp plugin, int returnPage,
+                                                    Consumer<Player> onConfirm) {
+        return new HomeDeleteConfirmMenu(
+                plugin, "&8Delete Team Home?", "your team home", returnPage, onConfirm);
     }
 
     @Override
@@ -29,20 +59,17 @@ public class HomeDeleteConfirmMenu extends BaseMenu {
         slotActions.clear();
         fill(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
 
-        if (home == null) return;
+        if (onConfirm == null) return;
 
         // Confirm Delete - Slot 11
         set(11, ItemUtils.createItem(
                 Material.LIME_TERRACOTTA,
                 "&aConfirm Delete",
-                List.of("&7Permanently delete home &f" + home.getName())
+                List.of("&7Permanently delete " + subject)
         ));
         slotActions.put(11, () -> {
-            boolean removed = plugin.getHomeManager().deleteHome(player.getUniqueId(), home.getName());
-            player.sendMessage(ColorUtils.toComponent(removed
-                    ? plugin.getConfigManager().getMessage("HOME.DELETED")
-                    : "&cHome not found."));
-            new HomeMenu(plugin).open(player);
+            onConfirm.accept(player);
+            new HomeMenu(plugin, returnPage).open(player);
         });
 
         // Cancel - Slot 15
@@ -51,7 +78,7 @@ public class HomeDeleteConfirmMenu extends BaseMenu {
                 "&cCancel",
                 List.of("&7Do not delete this home")
         ));
-        slotActions.put(15, () -> new HomeMenu(plugin).open(player));
+        slotActions.put(15, () -> new HomeMenu(plugin, returnPage).open(player));
     }
 
     @Override
@@ -61,5 +88,16 @@ public class HomeDeleteConfirmMenu extends BaseMenu {
             SoundUtils.play(player, plugin.getConfigManager().getSound("MENUS.BUTTON-CLICK"));
             action.run();
         }
+    }
+
+    private static void deleteHome(UltimateDonutSmp plugin, Player player, Home home) {
+        boolean removed = plugin.getHomeManager().deleteHome(player.getUniqueId(), home.getName());
+        player.sendMessage(ColorUtils.toComponent(removed
+                ? plugin.getConfigManager().getMessage("HOME.DELETED")
+                : "&cHome not found."));
+    }
+
+    private static String homeName(Home home) {
+        return home == null ? "" : home.getName();
     }
 }

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/HomeMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/HomeMenu.java
@@ -39,7 +39,13 @@ public class HomeMenu extends BaseMenu {
     private int page = 0;
 
     public HomeMenu(UltimateDonutSmp plugin) {
+        this(plugin, 0);
+    }
+
+    /** The delete confirmation reopens the menu through this, on the page the player left. */
+    public HomeMenu(UltimateDonutSmp plugin, int page) {
         super(plugin, configuredTitle(plugin), configuredSize(plugin));
+        this.page = Math.max(0, page);
     }
 
     @Override
@@ -54,7 +60,7 @@ public class HomeMenu extends BaseMenu {
 
         int maxHomes = plugin.getHomeManager().getMaxHomes(player);
         int totalPages = plugin.getHomeManager().getMaxHomePages(player);
-        page = Math.max(0, Math.min(page, totalPages - 1));
+        page = clampPage(page, totalPages);
 
         buildPageButtons(totalPages);
         buildTeamButtons(player);
@@ -147,8 +153,8 @@ public class HomeMenu extends BaseMenu {
         if (team.hasHome()) {
             slotActions.put(TEAM_ACTION_SLOT, (p, click) -> {
                 if (click.isRightClick()) {
-                    deleteTeamHome(p, team);
-                } else if (plugin.getHomeBedrockManager() != null && plugin.getHomeBedrockManager().isBedrockPlayer(p)) {
+                    confirmTeamHomeDelete(p, team);
+                } else if (isBedrock(p)) {
                     plugin.getHomeBedrockManager().openTeamHomeOptions(p);
                 } else {
                     setTeamHome(p, team);
@@ -206,8 +212,8 @@ public class HomeMenu extends BaseMenu {
         ));
         slotActions.put(actionSlot, (p, click) -> {
             if (click.isRightClick()) {
-                deleteHome(p, home);
-            } else if (plugin.getHomeBedrockManager() != null && plugin.getHomeBedrockManager().isBedrockPlayer(p)) {
+                confirmHomeDelete(p, home);
+            } else if (isBedrock(p)) {
                 plugin.getHomeBedrockManager().openHomeOptions(p, home);
             } else {
                 new HomeActionMenu(plugin, home).open(p);
@@ -261,14 +267,30 @@ public class HomeMenu extends BaseMenu {
         ));
     }
 
-    private void deleteHome(Player player, Home home) {
-        if (!plugin.getHomeManager().deleteHome(player.getUniqueId(), home.getName())) {
-            player.sendMessage(ColorUtils.toComponent("&cHome not found."));
+    /**
+     * Right-clicking a home button destroys it, so it asks first instead of acting on a misclick.
+     * Bedrock players get the Floodgate form, which already confirms.
+     */
+    private void confirmHomeDelete(Player player, Home home) {
+        if (isBedrock(player)) {
+            plugin.getHomeBedrockManager().openDeleteConfirmation(player, home);
             return;
         }
 
-        player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessage("HOME.DELETED")));
-        build(player);
+        new HomeDeleteConfirmMenu(plugin, home, page).open(player);
+    }
+
+    private void confirmTeamHomeDelete(Player player, Team team) {
+        if (isBedrock(player)) {
+            plugin.getHomeBedrockManager().openDeleteTeamHomeConfirmation(player, team);
+            return;
+        }
+
+        HomeDeleteConfirmMenu.forTeamHome(plugin, page, target -> deleteTeamHome(target, team)).open(player);
+    }
+
+    private boolean isBedrock(Player player) {
+        return plugin.getHomeBedrockManager() != null && plugin.getHomeBedrockManager().isBedrockPlayer(player);
     }
 
     private void setTeamHome(Player player, Team team) {
@@ -296,7 +318,6 @@ public class HomeMenu extends BaseMenu {
         team.setHome(null);
         plugin.getTeamManager().save(team);
         player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessage("TEAM.TEAM-HOME-DELETED")));
-        build(player);
     }
 
     private boolean canEditTeamHome(Player player, Team team) {
@@ -412,6 +433,11 @@ public class HomeMenu extends BaseMenu {
 
     private static String configuredTitle(UltimateDonutSmp plugin) {
         return plugin.getConfigManager().getMenus().getString("HOME-MENU.TITLE", "&8Homes");
+    }
+
+    /** A player who loses a rank can hold a page number their homes no longer stretch to. */
+    static int clampPage(int page, int totalPages) {
+        return Math.max(0, Math.min(page, totalPages - 1));
     }
 
     private static int configuredSize(UltimateDonutSmp plugin) {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/HomeDeleteConfirmationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/HomeDeleteConfirmationTest.java
@@ -1,0 +1,66 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Right-clicking a button in the /home menu deleted on the spot, so missing the left-click cost a
+ * player a home with nothing to undo it. Both deletes the menu offers now open a confirmation,
+ * which is how every other destructive click in the plugin already behaves.
+ */
+class HomeDeleteConfirmationTest {
+
+    private static final Path HOME_MENU =
+            Path.of("src", "main", "java", "com", "bx", "ultimateDonutSmp", "menus", "HomeMenu.java");
+
+    @Test
+    void everyRightClickBranchOpensAConfirmationFirst() throws Exception {
+        List<String> lines = Files.readAllLines(HOME_MENU, StandardCharsets.UTF_8);
+        List<String> offenders = new ArrayList<>();
+        int branches = 0;
+
+        for (int i = 0; i < lines.size(); i++) {
+            if (!lines.get(i).contains("isRightClick()")) {
+                continue;
+            }
+            branches++;
+            String next = i + 1 < lines.size() ? lines.get(i + 1) : "";
+            if (!next.contains("confirm")) {
+                offenders.add("HomeMenu.java:" + (i + 2) + " -> " + next.trim());
+            }
+        }
+
+        assertEquals(2, branches,
+                "the menu right-click deletes a personal home and the team home, so both branches"
+                        + " have to stay covered by this test");
+        assertEquals(List.of(), offenders,
+                "a right-click here destroys something, so it has to open a confirmation instead");
+    }
+
+    @Test
+    void theMenuNoLongerDeletesAHomeOnItsOwn() throws Exception {
+        String source = Files.readString(HOME_MENU, StandardCharsets.UTF_8);
+
+        assertFalse(
+                source.contains("getHomeManager().deleteHome("),
+                "HomeDeleteConfirmMenu owns the delete now; a call here would be a route around it"
+        );
+    }
+
+    @Test
+    void aRememberedPageIsPulledBackToOneThePlayerStillHas() {
+        assertEquals(0, HomeMenu.clampPage(0, 1));
+        assertEquals(2, HomeMenu.clampPage(2, 3));
+        assertEquals(2, HomeMenu.clampPage(7, 3), "a page past the last one lands on the last one");
+        assertEquals(0, HomeMenu.clampPage(-4, 3), "cancelling can never scroll backwards off the menu");
+        assertEquals(0, HomeMenu.clampPage(3, 0), "with no pages counted there is still a first page to draw");
+    }
+}


### PR DESCRIPTION
Closes #401

Right-clicking a home in `/home` deleted it immediately, with nothing to confirm and no way back, so
missing the left-click on the dye cost a player their home. That click now opens the same
confirmation screen the menu already uses everywhere else.

## Where the confirmation was missing

`HomeDeleteConfirmMenu` has been in the plugin all along, and every other route into deleting a home
already went through it: the Java left-click opens `HomeActionMenu`, whose Delete button opens the
confirmation, and Bedrock's Floodgate path calls `openDeleteConfirmation`. Only the right-click
shortcut in `HomeMenu` skipped it and deleted directly. The team home button one row up had the same
hole, so it is covered too; losing a shared team home to a slip is worse than losing a personal one.

`TeleportAreaMenu` already handles its own right-click-to-delete this way, so this brings `/home`
into line rather than inventing a pattern for it.

## Reusing the screen instead of copying it

The confirmation now takes the delete to run rather than owning it. That keeps the team home's
permission checks where they already live and avoids a second near-identical menu class. The old
copy of the delete inside `HomeMenu` is gone, which leaves `HomeDeleteConfirmMenu` as the only place
the menu removes a home.

Cancelling or confirming reopens the menu on the page the player was reading. The old delete rebuilt
in place and kept the page, so dropping everyone back on page one would have been a step backwards
for anyone past their fifth home.

Bedrock players get the Floodgate form for the same click, which asks the same question. That meant
making `openDeleteTeamHomeConfirmation` public, matching `openDeleteConfirmation` beside it.

## Notes

No new config or language keys. The confirmation screen already existed and its wording has not
changed, so nothing in the eight language files moved, and the `&cRight-click to delete` lore still
describes what the button does.

`HomeDeleteConfirmationTest` checks that both right-click branches in `HomeMenu` open a confirmation,
that the menu no longer deletes a home itself, and where cancelling lands once a player's page count
has shrunk. 651 tests pass.
