### PR TITLE
docs(wiki): say what the configuration reference actually covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This README is the quick reference. The full documentation set lives in [`docs/w
 | [Home](docs/wiki/Home.md) | Documentation index and technical quick facts |
 | [Installation & Setup](docs/wiki/Installation-and-Setup.md) | Server engine setup, SQLite/MySQL/MongoDB storage, and Redis networking |
 | [Commands & Permissions](docs/wiki/Commands-and-Permissions.md) | Full command syntax, aliases, and permission nodes |
-| [Configuration Reference](docs/wiki/Configuration-Reference.md) | Every configuration file, plus a `Config-*.yml.md` page per file |
+| [Configuration Reference](docs/wiki/Configuration-Reference.md) | In-depth setup guidance for the larger config files, alongside the per-file `Config-*.yml.md` guides |
 | [Economy & Marketplaces](docs/wiki/Economy-and-Marketplaces.md) | Money, shards, shop, sell, Auction House, Orders, and Billford |
 | [Duels & FFA](docs/wiki/Duels-and-FFA.md) | Duel arenas, queues, rollbacks, and instanced FFA |
 | [Crates & Spawners](docs/wiki/Crates-and-Spawners.md) | Crate definitions, keys, and Donut-style spawners |

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1,7 +1,8 @@
-# Exhaustive Technical Configuration Reference & Setup Manual
+# Configuration Reference & Setup Manual
 
-This document provides a **100% complete, fully commented reference guide** for every configuration file and option key in **UltimateDonutSMP**.
-Each section details the exact YAML block with all comments, option keys, data types, allowed values, functional explanations, and step-by-step setup guides.
+Longer-form setup guidance for the configuration files that take the most explaining: duels, the main `config.yml`, database and Redis wiring, Discord webhooks, crates, the marketplaces, and a few others. Each one gets its own section below, with the YAML block quoted as it ships, then the keys, data types, allowed values, and notes on what changing them actually does.
+
+This page is a selection rather than a full listing. Several config files have no section here at all, and for the bigger files it covers the settings that are easy to get wrong instead of every key. If you want a straight run through one file, the per-file guides are the place to go: [config.yml](Config-config.yml), [messages.yml](Config-messages.yml), [menus.yml](Config-menus.yml), and one for each of the others in the sidebar.
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -52,7 +52,7 @@ Explore the complete feature guide and documentation pages:
   Full catalog of `%economy_*%` PlaceholderAPI placeholders, LuckPerms integration, Apollo (Lunar Client) support, and Bedrock/Floodgate compatibility.
 
 - **[Configuration Reference](Configuration-Reference)**  
-  In-depth guide to customizing `config.yml`, `messages.yml`, `menus.yml`, `duels.yml`, `crates.yml`, `spawners.yml`, `database.yml`, and `network.yml`.
+  In-depth setup guidance for `duels.yml`, `config.yml`, `database.yml`, `network.yml`, `crates.yml` and the marketplace files. Per-file guides for everything else are listed in the sidebar.
 
 - **[FAQ & Troubleshooting](FAQ)**  
   100% complete answers and troubleshooting steps for PlaceholderAPI issues, Vault hook failures, database persistence, cuboids, spawners, vanish, and fast crystal settings.


### PR DESCRIPTION
The configuration reference opened by calling itself a 100% complete guide to every configuration file and option key in the plugin. It isn't, and it's a long way off: there are sections for 14 of the 32 config files the plugin ships, and inside those it's often one section out of many. orders.yml gets 1 of its 13 top-level sections. config.yml gets 11 of 36. Nothing at all covers amethyst-tools.yml, filter.yml, hide.yml, menus.yml, messages.yml, pvp.yml, shop.yml, sounds.yml, or the ten other files with no section on the page.

The page isn't broken, it's mislabelled. What it does well is the long-form explanation for the settings people get wrong, and that's worth keeping exactly as it is. So the opening now says that, and anyone who wants a straight run through one file gets sent to the per-file Config-*.yml guides instead.

## The same claim in two other places

Home.md described the page as an in-depth guide to messages.yml and menus.yml among others, and neither of those appears anywhere in it, so that list now names files the page really has. The README row promised "Every configuration file, plus a `Config-*.yml.md` page per file". Both halves were wrong: enchantments.yml and offenses.yml have no per-file page either.

## Notes

Prose only. No keys, defaults or behaviour touched. The heading lost the word "Exhaustive" but the file name is untouched, so the wiki URL and every link pointing at it still resolve. Suite is at 651, green.
