### PR TITLE
docs(config): explain why all-caps text comes back title cased

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -3,6 +3,10 @@
 This is the official, 100% complete technical setup guide for `config.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
+A line whose visible letters are all uppercase is shown in Title Case instead, so long as it also
+carries a colour code or a placeholder. That reaches the tablist header and the `SERVER-LIST`
+MOTD among others, and [FAQ entry 16](FAQ) explains the rule and how to keep your capitals.
+
 ---
 
 ## Section: `LANGUAGE`

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -31,6 +31,11 @@ Anything the formatter doesn't recognise stays on screen exactly as you typed it
 `<player>` and `<amount>` in the message files still come through as placeholders instead of
 vanishing.
 
+One more thing it does, less obviously: a title, button name or lore line whose visible letters
+are all uppercase comes back in Title Case, so `'&cDONUT SMP'` reads `Donut Smp`. Mixed case is
+left alone. [FAQ entry 16](FAQ) covers when the rule applies and the unicode small caps trick
+that keeps a line shouting.
+
 ---
 
 ## Section: `GLOBAL`

--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -3,6 +3,10 @@
 This is the official, 100% complete technical setup guide for `messages.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
+One formatting rule catches people out. A line whose visible letters are all uppercase is shown
+in Title Case instead, whenever that line also carries a colour code or a placeholder.
+[FAQ entry 16](FAQ) covers why, and how to write a shouting line that survives it.
+
 ---
 
 ## Section: `TEAM`

--- a/docs/wiki/Config-scoreboard.yml.md
+++ b/docs/wiki/Config-scoreboard.yml.md
@@ -3,6 +3,10 @@
 This is the official, 100% complete technical setup guide for `scoreboard.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
+Rows typed entirely in capitals do not stay that way. Any line carrying a colour code or a
+placeholder gets retyped in Title Case first, which is worth knowing before you write a title in
+block capitals. [FAQ entry 16](FAQ) has the rule and the way around it.
+
 ---
 
 ## Section: `SCOREBOARD`

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -379,3 +379,48 @@ If you would rather write the label yourself, `{price_formatted}` renders the pr
 The full list of placeholders, and what the auto-filled line does with colour codes and small caps, is on the [`shop.yml` configuration page](Config-shop.yml).
 
 Wording you invented is still yours to maintain: effect lines, menu titles and anything else that mentions a currency by name does not update itself.
+
+---
+
+## 16. Text Written In Capitals Comes Back In Title Case
+
+### Question: I put `'&cWELCOME TO THE SERVER'` in my config and players see `Welcome To The Server`. What is rewriting it?
+
+The plugin is, on purpose. It checks every line it colours, and any line whose visible letters are
+all uppercase gets retyped in Title Case before it reaches the screen. The same check covers chat
+lines, menu titles and lore, scoreboard rows, the tablist and the server list MOTD, since all of
+them run through the one formatter.
+
+Two conditions have to hold before a line is touched. It needs at least one colour code, hex code,
+MiniMessage tag or placeholder in it, and every letter outside those markers has to be uppercase.
+Break either one and the line is printed exactly as you typed it:
+
+```yaml
+# shown as: Welcome To The Server
+'&cWELCOME TO THE SERVER'
+
+# shown as written, because no colour code or placeholder is there to trigger the check
+'WELCOME TO THE SERVER'
+
+# shown as written, because "to the server" is lowercase
+'&cWELCOME to the server'
+```
+
+Colour codes, hex codes and placeholders are stepped over rather than rewritten, so `%player%` and
+`&#FF0000` survive intact. Capitalisation starts again after a space, a hyphen, a slash or an
+underscore, which is why `'&cWELCOME-TO/THE_SERVER'` reads back as `Welcome-To/The_Server`.
+Acronyms come off worst: `'&c&lDONUT SMP'` lands as `Donut Smp`, and there is no list of words you
+can exempt.
+
+The check also ignores the words `currently` and `status` while it looks, so `'&aStatus: ONLINE'`
+counts as all caps even though it is not, and shows as `Status: Online`.
+
+If you want a shouty line and its colour at the same time, unicode small caps get through. The check
+does not read them as uppercase letters, so they survive untouched. Paste the characters straight
+in, or write them as escapes if your editor makes that awkward:
+
+```yaml
+# both shown as: ᴡᴇʟᴄᴏᴍᴇ
+'&cᴡᴇʟᴄᴏᴍᴇ'
+'&c\u1D21\u1D07\u029F\u1D04\u1D0F\u1D0D\u1D07'
+```

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/ColorUtilsTest.java
@@ -50,6 +50,24 @@ class ColorUtilsTest {
     }
 
     @Test
+    void testAllCapsWithoutAnyMarkerIsLeftAsTyped() {
+        String input = "WELCOME TO THE SERVER";
+        assertEquals(input, ColorUtils.colorize(input));
+    }
+
+    @Test
+    void testAllCapsIsRetypedWhenOnlyAPlaceholderCarriesTheLine() {
+        String input = "PLAIN CAPS %player%";
+        assertEquals("Plain Caps %player%", ColorUtils.colorize(input));
+    }
+
+    @Test
+    void testOneLowercaseWordKeepsTheCapitalsIntact() {
+        String input = "&cWELCOME to the server";
+        assertEquals("§cWELCOME to the server", ColorUtils.colorize(input));
+    }
+
+    @Test
     void testSmallCapsPreservation() {
         String input = "&fᴏᴡɴᴇʀ";
         String colorized = ColorUtils.colorize(input);


### PR DESCRIPTION
Writing `'&cWELCOME TO THE SERVER'` into a config file gets you `Welcome To The Server` on screen. `ColorUtils.transformAllCaps` does that on purpose and has done for a long time, but nothing under `docs/wiki/` said so, which left finding out to whoever shipped a shouty line and then wondered what ate it.

## Where the explanation lives

A new FAQ entry, number 16, carries the whole rule. The FAQ is where somebody holding this symptom actually looks, and its entries are already written symptom first as `Question: ...`. Four pages that admins pour coloured text into point at it in a line each: `Config-messages.yml`, `Config-menus.yml`, `Config-scoreboard.yml` and `Config-config.yml`. Since the rule is plugin wide, repeating the paragraph across all thirty config pages would have drifted the first time one copy got edited.

`Config-menus.yml` already had a `Text Formatting` section describing the formatter, so its pointer went there instead of into the page intro.

## What the entry says

Two conditions have to hold before a line is rewritten. It needs at least one colour code, hex code, MiniMessage tag or placeholder, and every letter outside those markers has to be uppercase. The first half is the surprising one: `'WELCOME TO THE SERVER'` with no colour code on it prints exactly as typed, while `'PLAIN CAPS %player%'` does not, because the placeholder on its own is enough to send the line through the formatter.

Then the parts that bite. Acronyms flatten, so `'&c&lDONUT SMP'` lands as `Donut Smp` with no exemption list to add to. Capitalisation restarts after a space, a hyphen, a slash and an underscore. The words `currently` and `status` are ignored while the check runs, which is why `'&aStatus: ONLINE'` counts as all caps despite the lowercase in it. The entry closes on the way out, unicode small caps, which the check does not read as uppercase letters.

## Notes

No behaviour changed. `transformAllCaps` is deliberate and stays exactly as it is.

`ColorUtilsTest` picks up three assertions covering the claims the docs now make that nothing tested: a fully capitalised line with no markers coming back as typed, the same line carrying only a placeholder being retyped, and a single lowercase word switching the rule off. Suite is at 657 tests, all green.

Every example in the entry went through `ColorUtils.colorize` before it was written down, the `\uXXXX` escape included, which decodes to the same string as the pasted small caps characters.
