### PR TITLE
docs(rtp): document the chunk preload and post teleport settings

### DIFF
--- a/docs/wiki/Config-rtp.yml.md
+++ b/docs/wiki/Config-rtp.yml.md
@@ -69,6 +69,29 @@ SETTINGS:
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
   LOADED-CHUNK-FALLBACK-AFTER-SAMPLES: 32
+  # Load the chunks around the destination before the teleport lands, so a player does not
+  # arrive in terrain the server has not read yet. Off teleports straight away and lets the
+  # client catch up on its own
+  PRELOAD-TELEPORT-CHUNKS: true
+  # Chunk radius loaded around the destination, from 2 to 4. This is a floor rather than a
+  # cap: while POST-TELEPORT-CHUNK-THROTTLE is on, the throttled view distance below raises
+  # it, so on stock settings the radius is 4 whatever you put here
+  PRELOAD-RADIUS: 2
+  # Chunks loaded per tick while preloading. Values below 2 are treated as 2
+  PRELOAD-CHUNKS-PER-TICK: 2
+  # Give up preloading after this many ticks. Raised on its own when the radius and the
+  # per-tick rate above need longer than this to finish
+  PRELOAD-MAX-TICKS: 40
+  # Hold a player at a shorter view and simulation distance for a moment after an RTP, so the
+  # server is not sending a full render of brand new terrain all at once
+  POST-TELEPORT-CHUNK-THROTTLE: true
+  # View distance to hold them at while the throttle is on. It only ever lowers a player's
+  # distance, never raises it, and values below 2 are treated as 2
+  POST-TELEPORT-VIEW-DISTANCE: 4
+  # Simulation distance to hold them at while the throttle is on. Same rules as above
+  POST-TELEPORT-SIMULATION-DISTANCE: 4
+  # Ticks before the throttled distances are handed back. Values below 20 are treated as 20
+  POST-TELEPORT-THROTTLE-TICKS: 80
   # Safe locations found ahead of time in the background so RTP can teleport without searching
   LOCATION-CACHE:
     # Enable or disable the background safe location cache
@@ -99,6 +122,14 @@ SETTINGS:
 | `SETTINGS.LOAD-GENERATED-CHUNKS` | `bool` | `true`, `false` | `true` | Whether a search may read terrain that already exists on disk. This is what makes a pregenerated RTP world work while `GENERATE-CHUNKS` stays off. Turning both off leaves the search nothing to read and nothing to make, so every sample comes back empty and the background cache stands down and says so in the console. |
 | `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` | `bool` | `true`, `false` | `true` | Configures the technical `FALLBACK-TO-LOADED-CHUNKS` parameter for `SETTINGS.FALLBACK-TO-LOADED-CHUNKS` in `rtp.yml`. |
 | `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` | `int` | Any valid integer number | `'32'` | Configures the technical `LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` parameter for `SETTINGS.LOADED-CHUNK-FALLBACK-AFTER-SAMPLES` in `rtp.yml`. |
+| `SETTINGS.PRELOAD-TELEPORT-CHUNKS` | `bool` | `true`, `false` | `true` | Whether the chunks around the destination are loaded before the teleport lands. On, a player arrives in terrain the server has already read. Off, they teleport straight away and the client catches up, which is faster but can drop them into a hole in the world for a moment. |
+| `SETTINGS.PRELOAD-RADIUS` | `int` | `2` to `4` | `'2'` | Chunk radius loaded around the destination. Values below 2 are treated as 2 and anything above 4 as 4. It behaves as a floor rather than a cap: while `POST-TELEPORT-CHUNK-THROTTLE` is on, the radius is raised to the throttled view distance, so with stock settings it lands on 4 no matter what is set here. Turn the throttle off, or lower `POST-TELEPORT-VIEW-DISTANCE`, before this value does anything on its own. |
+| `SETTINGS.PRELOAD-CHUNKS-PER-TICK` | `int` | `2` or higher | `'2'` | How many chunks are loaded per tick while preloading. Values below 2 are treated as 2. Higher finishes the warm-up sooner at the cost of more chunk work in a single tick. |
+| `SETTINGS.PRELOAD-MAX-TICKS` | `int` | `1` or higher | `'40'` | Preloading gives up after this many ticks so a slow world cannot hold a teleport open forever. It is raised automatically when the radius and the per-tick rate need longer than this to get through every chunk, so lowering it does not truncate a warm-up that was going to finish. |
+| `SETTINGS.POST-TELEPORT-CHUNK-THROTTLE` | `bool` | `true`, `false` | `true` | Whether a player is held at a shorter view and simulation distance for a moment after an RTP. It spreads the cost of sending brand new terrain instead of rendering all of it at once. Also raises the preload radius, as described above. |
+| `SETTINGS.POST-TELEPORT-VIEW-DISTANCE` | `int` | `2` or higher | `'4'` | View distance a player is held at while the throttle is on. It only lowers a player's distance and never raises it, so a client already below this value is left alone. Values below 2 are treated as 2. |
+| `SETTINGS.POST-TELEPORT-SIMULATION-DISTANCE` | `int` | `2` or higher | `'4'` | Simulation distance a player is held at while the throttle is on, under the same rules as the view distance above. |
+| `SETTINGS.POST-TELEPORT-THROTTLE-TICKS` | `int` | `20` or higher | `'80'` | How long the throttled distances are kept before the player's own settings are handed back. Values below 20 are treated as 20. |
 | `SETTINGS.LOCATION-CACHE` | `section` | See `SETTINGS.LOCATION-CACHE` below | See example | Keeps safe locations ready in the background so `/rtp` can teleport without running a search first. |
 
 ### 3. Practical Setup Example

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -1894,7 +1894,7 @@ public class RTPManager {
     }
 
     private int getPreloadRadius() {
-        int configured = plugin.getConfigManager().getRtp().getInt(PRELOAD_RADIUS_SETTING, 1);
+        int configured = plugin.getConfigManager().getRtp().getInt(PRELOAD_RADIUS_SETTING, 2);
         int radius = Math.max(0, Math.min(4, configured));
         if (plugin.getConfigManager().getRtp().getBoolean(POST_TELEPORT_CHUNK_THROTTLE_SETTING, true)) {
             int throttledViewDistance = Math.max(2, plugin.getConfigManager().getRtp()
@@ -1905,7 +1905,7 @@ public class RTPManager {
     }
 
     private int getPreloadChunksPerTick() {
-        return Math.max(2, plugin.getConfigManager().getRtp().getInt(PRELOAD_CHUNKS_PER_TICK_SETTING, 1));
+        return Math.max(2, plugin.getConfigManager().getRtp().getInt(PRELOAD_CHUNKS_PER_TICK_SETTING, 2));
     }
 
     private int getPreloadMaxTicks() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
@@ -459,7 +459,7 @@ public class TeleportManager {
     }
 
     private int getRtpChunkStabilizationRadius() {
-        int configuredRadius = plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-RADIUS", 1);
+        int configuredRadius = plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-RADIUS", 2);
         int radius = Math.max(0, Math.min(4, configuredRadius));
         if (plugin.getConfigManager().getRtp().getBoolean("SETTINGS.POST-TELEPORT-CHUNK-THROTTLE", true)) {
             radius = Math.max(radius, Math.min(4, getRtpThrottleDistance("SETTINGS.POST-TELEPORT-VIEW-DISTANCE", 4)));
@@ -468,7 +468,7 @@ public class TeleportManager {
     }
 
     private int getRtpChunkStabilizationChunksPerTick() {
-        return Math.max(2, plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-CHUNKS-PER-TICK", 1));
+        return Math.max(2, plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-CHUNKS-PER-TICK", 2));
     }
 
     private void refreshLoadedChunk(World world, int chunkX, int chunkZ) {

--- a/src/main/resources/rtp.yml
+++ b/src/main/resources/rtp.yml
@@ -39,6 +39,29 @@ SETTINGS:
   FALLBACK-TO-LOADED-CHUNKS: true
   # Chunk samples to try before loaded chunk fallback starts
   LOADED-CHUNK-FALLBACK-AFTER-SAMPLES: 32
+  # Load the chunks around the destination before the teleport lands, so a player does not
+  # arrive in terrain the server has not read yet. Off teleports straight away and lets the
+  # client catch up on its own
+  PRELOAD-TELEPORT-CHUNKS: true
+  # Chunk radius loaded around the destination, from 2 to 4. This is a floor rather than a
+  # cap: while POST-TELEPORT-CHUNK-THROTTLE is on, the throttled view distance below raises
+  # it, so on stock settings the radius is 4 whatever you put here
+  PRELOAD-RADIUS: 2
+  # Chunks loaded per tick while preloading. Values below 2 are treated as 2
+  PRELOAD-CHUNKS-PER-TICK: 2
+  # Give up preloading after this many ticks. Raised on its own when the radius and the
+  # per-tick rate above need longer than this to finish
+  PRELOAD-MAX-TICKS: 40
+  # Hold a player at a shorter view and simulation distance for a moment after an RTP, so the
+  # server is not sending a full render of brand new terrain all at once
+  POST-TELEPORT-CHUNK-THROTTLE: true
+  # View distance to hold them at while the throttle is on. It only ever lowers a player's
+  # distance, never raises it, and values below 2 are treated as 2
+  POST-TELEPORT-VIEW-DISTANCE: 4
+  # Simulation distance to hold them at while the throttle is on. Same rules as above
+  POST-TELEPORT-SIMULATION-DISTANCE: 4
+  # Ticks before the throttled distances are handed back. Values below 20 are treated as 20
+  POST-TELEPORT-THROTTLE-TICKS: 80
   # Safe locations found ahead of time in the background so RTP can teleport without searching
   LOCATION-CACHE:
     # Enable or disable the background safe location cache

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/RTPManagerTest.java
@@ -235,6 +235,17 @@ class RTPManagerTest {
         return (Location) pollPreCachedLocation.invoke(rtpManager, worldName);
     }
 
+    private int preloadRadius(RTPManager rtpManager) throws Exception {
+        Method method = RTPManager.class.getDeclaredMethod("getPreloadRadius");
+        method.setAccessible(true);
+        return (int) method.invoke(rtpManager);
+    }
+
+    private int preloadChunksPerTick(RTPManager rtpManager) throws Exception {
+        Method method = RTPManager.class.getDeclaredMethod("getPreloadChunksPerTick");
+        method.setAccessible(true);
+        return (int) method.invoke(rtpManager);
+    }
     private YamlConfiguration overworldRtpConfig() {
         YamlConfiguration rtpConfig = new YamlConfiguration();
         rtpConfig.set("WORLD-SETTINGS.world.MIN-RADIUS", 500);
@@ -287,6 +298,38 @@ class RTPManagerTest {
 
         rtpConfig.set("SETTINGS.FOUND-DISPLAY-TICKS", -20);
         assertEquals(0L, rtpManager.getFoundDisplayTicks());
+    }
+
+    @Test
+    void testPreloadDefaultsMatchTheFloorsTheyPassThrough() throws Exception {
+        YamlConfiguration rtpConfig = new YamlConfiguration();
+        RTPManager rtpManager = new RTPManager(createMockPlugin(rtpConfig));
+
+        // Both settings floor at 2, so a default below that could never be the value in use.
+        // These two assertions are what keeps the number in rtp.yml honest.
+        assertEquals(2, preloadChunksPerTick(rtpManager));
+        rtpConfig.set("SETTINGS.PRELOAD-CHUNKS-PER-TICK", 1);
+        assertEquals(2, preloadChunksPerTick(rtpManager));
+        rtpConfig.set("SETTINGS.PRELOAD-CHUNKS-PER-TICK", 6);
+        assertEquals(6, preloadChunksPerTick(rtpManager));
+
+        // With the throttle off the radius is the admin's, floored at 2 and capped at 4.
+        rtpConfig.set("SETTINGS.POST-TELEPORT-CHUNK-THROTTLE", false);
+        assertEquals(2, preloadRadius(rtpManager));
+        rtpConfig.set("SETTINGS.PRELOAD-RADIUS", 1);
+        assertEquals(2, preloadRadius(rtpManager));
+        rtpConfig.set("SETTINGS.PRELOAD-RADIUS", 3);
+        assertEquals(3, preloadRadius(rtpManager));
+        rtpConfig.set("SETTINGS.PRELOAD-RADIUS", 9);
+        assertEquals(4, preloadRadius(rtpManager));
+
+        // Back on, the throttled view distance raises the radius, which is why the config
+        // comment calls PRELOAD-RADIUS a floor rather than a cap.
+        rtpConfig.set("SETTINGS.POST-TELEPORT-CHUNK-THROTTLE", true);
+        rtpConfig.set("SETTINGS.PRELOAD-RADIUS", 2);
+        assertEquals(4, preloadRadius(rtpManager));
+        rtpConfig.set("SETTINGS.POST-TELEPORT-VIEW-DISTANCE", 2);
+        assertEquals(2, preloadRadius(rtpManager));
     }
 
     @Test


### PR DESCRIPTION
Eight settings under `SETTINGS` in `rtp.yml` were live in the code and invisible everywhere else. `RTPManager` and `TeleportManager` read them, they have defaults and clamps, and they change how an RTP teleport behaves, but not one of them appears in the bundled `rtp.yml` or on the wiki page. The only way to use one was to already know its name and type it in by hand. All eight are now in the config file and the wiki.

Found while working on #386, where the constants block got read alongside the rest of the search settings.

## The eight keys

`PRELOAD-TELEPORT-CHUNKS`, `PRELOAD-RADIUS`, `PRELOAD-CHUNKS-PER-TICK` and `PRELOAD-MAX-TICKS` cover loading the terrain around the destination before a player lands in it. `POST-TELEPORT-CHUNK-THROTTLE`, `POST-TELEPORT-VIEW-DISTANCE`, `POST-TELEPORT-SIMULATION-DISTANCE` and `POST-TELEPORT-THROTTLE-TICKS` hold a player at a shorter render distance for a moment afterwards, so the server isn't pushing brand new terrain out all at once.

The simulation distance and the throttle ticks live in `TeleportManager` rather than `RTPManager`, which is why a first count of this came out at six rather than eight.

## Two defaults that could never happen

`PRELOAD-RADIUS` and `PRELOAD-CHUNKS-PER-TICK` were each read with a fallback of 1 and then floored at 2, in four places across the two classes. The fallback of 1 could never reach anything: the value in use was always 2 or more. Writing `1` into the config file as the default would have documented a number the plugin cannot actually run.

The floors are the deliberate half. A preload radius under 2 leaves a player landing in terrain the server hasn't read, which is the exact thing preloading exists to prevent, and one chunk per tick would stretch an 81 chunk warm-up past four seconds. So the fallbacks are the stale half, and they now read 2 to match what the code already did.

That moves no behaviour, and I checked instead of assuming: the new test passes unmodified against both the old fallback of 1 and the new 2, because `Math.max(2, 1)` and `Math.max(2, 2)` are the same number and the radius path floors at 2 on every branch through it.

## PRELOAD-RADIUS is a floor, not a cap

Calling this out because the config comment now says it. While `POST-TELEPORT-CHUNK-THROTTLE` is on, which is the default, the preload radius is raised to the throttled view distance. With the stock view distance of 4 that pins the radius at 4 no matter what `PRELOAD-RADIUS` is set to, and it only starts mattering on its own once the throttle is off or the view distance is lowered. I documented the interaction rather than changing it: the behaviour is reasonable, and rewiring it is a separate decision nobody has asked for.

## Notes

Every one of the eight is a boolean or an int, so the language catalogue skips them and there's no eight file translation chore. The config updater merges new bundled `SETTINGS` paths into an existing `rtp.yml` and nothing excludes this tree, so servers pick the keys up on their next start with behaviour unchanged.

One new test in `RTPManagerTest` pins the effective values for both settings across the floor, the cap and the throttle interaction. Suite is 621 green, up from 620. `TeleportManager` carries its own copy of those two getters and took the same one word change, but it has no test class at all, so that half is covered by reading rather than by the suite.
