### PR TITLE
feat(notifications): let each rank have its own join and leave wording

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -734,6 +734,11 @@ Server-wide announcement lines for joins, leaves, first joins, and the two marke
 line ships switched off, so updating the jar never changes how an existing server's chat looks —
 turn on the ones you want.
 
+The join, leave and first-join lines can each read differently per rank. Put the permission a rank
+carries under that line's `BY-PERMISSION` map with the wording it should get; the first entry a
+player matches wins, so the highest rank goes first. A player matching nothing keeps the plain
+`MESSAGE`, which is also what an empty map gives you.
+
 ### 1. Commented Setup Code Example
 
 ```yaml
@@ -743,13 +748,26 @@ SERVER-NOTIFICATIONS:
   JOIN:
     ENABLED: false
     MESSAGE: '&8[&a+&8] &a{player} &7joined the server.'
+    # Per-rank wording. The first node the player holds wins, so list the highest rank first.
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.join.vip++": '&8[&a+&8] &6{player} &7joined the server.'
+      "ultimatedonutsmp.notifications.join.vip+": '&8[&a+&8] &b{player} &7joined the server.'
+      "ultimatedonutsmp.notifications.join.vip": '&8[&a+&8] &e{player} &7joined the server.'
   LEAVE:
     ENABLED: false
     MESSAGE: '&8[&c-&8] &c{player} &7left the server.'
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.leave.vip++": '&8[&c-&8] &6{player} &7left the server.'
+      "ultimatedonutsmp.notifications.leave.vip+": '&8[&c-&8] &b{player} &7left the server.'
+      "ultimatedonutsmp.notifications.leave.vip": '&8[&c-&8] &e{player} &7left the server.'
   # Sent in place of the join line the very first time a player ever connects.
   FIRST-JOIN:
     ENABLED: false
     MESSAGE: '&aWelcome &e{player} &ato the server for the first time!'
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.first-join.vip++": '&aWelcome &6{player} &ato the server for the first time!'
+      "ultimatedonutsmp.notifications.first-join.vip+": '&aWelcome &b{player} &ato the server for the first time!'
+      "ultimatedonutsmp.notifications.first-join.vip": '&aWelcome &e{player} &ato the server for the first time!'
   AUCTION-HOUSE:
     ENABLED: true
     LISTING:
@@ -773,11 +791,14 @@ SERVER-NOTIFICATIONS:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `SERVER-NOTIFICATIONS.JOIN.ENABLED` | `bool` | `true`, `false` | `false` | `true` replaces the server's own join line with `JOIN.MESSAGE`. `false` relays the server's line unchanged. |
-| `SERVER-NOTIFICATIONS.JOIN.MESSAGE` | `str` | Any string text | `'&8[&a+&8] &a{player} &7joined the server.'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.JOIN.MESSAGE` | `str` | Any string text | `'&8[&a+&8] &a{player} &7joined the server.'` | Supports `{player}`. Used for any player no `JOIN.BY-PERMISSION` entry applies to. |
+| `SERVER-NOTIFICATIONS.JOIN.BY-PERMISSION` | `map` | Permission node to wording | Three `vip` examples | Per-rank join wording. Supports `{player}` like `MESSAGE`. The first node the player holds wins, so list the highest rank first. Matching is on the exact node, so a wildcard such as `ultimatedonutsmp.*` does not pick these up. Deleted entries are never merged back. |
 | `SERVER-NOTIFICATIONS.LEAVE.ENABLED` | `bool` | `true`, `false` | `false` | `true` replaces the server's own quit line with `LEAVE.MESSAGE`. |
-| `SERVER-NOTIFICATIONS.LEAVE.MESSAGE` | `str` | Any string text | `'&8[&c-&8] &c{player} &7left the server.'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.LEAVE.MESSAGE` | `str` | Any string text | `'&8[&c-&8] &c{player} &7left the server.'` | Supports `{player}`. Used for any player no `LEAVE.BY-PERMISSION` entry applies to. |
+| `SERVER-NOTIFICATIONS.LEAVE.BY-PERMISSION` | `map` | Permission node to wording | Three `vip` examples | Per-rank leave wording, resolved exactly as `JOIN.BY-PERMISSION` is. |
 | `SERVER-NOTIFICATIONS.FIRST-JOIN.ENABLED` | `bool` | `true`, `false` | `false` | `true` sends `FIRST-JOIN.MESSAGE` instead of the join line the first time a player ever connects, so nobody is announced twice. It works on its own — `JOIN` does not have to be on. |
-| `SERVER-NOTIFICATIONS.FIRST-JOIN.MESSAGE` | `str` | Any string text | `'&aWelcome &e{player} &ato the server for the first time!'` | Supports `{player}`. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.MESSAGE` | `str` | Any string text | `'&aWelcome &e{player} &ato the server for the first time!'` | Supports `{player}`. Used for any player no `FIRST-JOIN.BY-PERMISSION` entry applies to. |
+| `SERVER-NOTIFICATIONS.FIRST-JOIN.BY-PERMISSION` | `map` | Permission node to wording | Three `vip` examples | Per-rank first-join wording, resolved exactly as `JOIN.BY-PERMISSION` is. |
 | `SERVER-NOTIFICATIONS.AUCTION-HOUSE.ENABLED` | `bool` | `true`, `false` | `true` | Master switch for both Auction House lines. Turning it off silences them whatever `LISTING` and `PURCHASE` say. |
 | `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.ENABLED` | `bool` | `true`, `false` | `false` | Announces every item a player puts up for sale. Bot listings are never announced. |
 | `SERVER-NOTIFICATIONS.AUCTION-HOUSE.LISTING.MESSAGE` | `str` | Any string text | `'&8[&6AH&8] &f{player} &7listed &e{amount}x {item} &7for &a{price_formatted}&7.'` | Supports `{player}`, `{item}`, `{amount}`, `{price}`, `{price_formatted}` and `{category}`. |
@@ -796,6 +817,11 @@ SERVER-NOTIFICATIONS:
   JOIN:
     ENABLED: true
     MESSAGE: '&#57F287+ &f{player}'
+    # Donors get announced in their rank colour, everyone else gets the plain line above.
+    # Highest rank first: the first node the player holds is the one that wins.
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.join.mvp": '&#FEE75C✦ &e{player}'
+      "ultimatedonutsmp.notifications.join.vip": '&#57F287+ &a{player}'
   LEAVE:
     ENABLED: true
     MESSAGE: '&#ED4245- &f{player}'

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ConfigManager.java
@@ -812,6 +812,17 @@ public class ConfigManager {
             return true;
         }
 
+        // Per-rank join, leave and first-join wording is keyed by a server's own ranks too, so the
+        // bundled vip examples must not come back once admins delete or replace them. Each
+        // BY-PERMISSION section itself stays mergeable so configs that predate the feature still
+        // receive it once.
+        if ("config.yml".equals(resourceName)
+                && (path.startsWith("SERVER-NOTIFICATIONS.JOIN.BY-PERMISSION.")
+                || path.startsWith("SERVER-NOTIFICATIONS.LEAVE.BY-PERMISSION.")
+                || path.startsWith("SERVER-NOTIFICATIONS.FIRST-JOIN.BY-PERMISSION."))) {
+            return true;
+        }
+
         // Ranks menu buttons, rules pages and servers menu entries are each keyed by something
         // the server owns rather than the plugin: a rank it sells, a rules page it wrote, a
         // network id whose network.yml counterpart is already excluded below. A renamed or

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ServerNotificationManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ServerNotificationManager.java
@@ -5,10 +5,15 @@ import com.bx.ultimateDonutSmp.models.AuctionListing;
 import com.bx.ultimateDonutSmp.models.Order;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.NumberUtils;
+import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Builds and sends the server-wide announcements configured under SERVER-NOTIFICATIONS.
@@ -34,12 +39,12 @@ public class ServerNotificationManager {
      */
     public String joinAnnouncement(Player player, boolean firstJoin) {
         if (firstJoin && isEnabled("FIRST-JOIN")) {
-            return format(message("FIRST-JOIN"), "{player}", publicName(player));
+            return format(message("FIRST-JOIN", player), "{player}", publicName(player));
         }
         if (!isEnabled("JOIN")) {
             return null;
         }
-        return format(message("JOIN"), "{player}", publicName(player));
+        return format(message("JOIN", player), "{player}", publicName(player));
     }
 
     /** The leave line for a player, or null to relay the server's own message. */
@@ -47,7 +52,7 @@ public class ServerNotificationManager {
         if (!isEnabled("LEAVE")) {
             return null;
         }
-        return format(message("LEAVE"), "{player}", publicName(player));
+        return format(message("LEAVE", player), "{player}", publicName(player));
     }
 
     public void announceAuctionListing(Player seller, AuctionListing listing) {
@@ -207,6 +212,58 @@ public class ServerNotificationManager {
 
     private String message(String path) {
         return config().getString(ROOT + path + ".MESSAGE", "");
+    }
+
+    /**
+     * The wording for one announcement, taking the player's rank into account.
+     *
+     * <p>An announcement may carry a BY-PERMISSION map of permission node to wording. The first
+     * node the player holds wins, so a server lists its highest rank first, and a player holding
+     * none of them falls back to the plain MESSAGE.</p>
+     */
+    private String message(String path, Player player) {
+        return resolveByPermission(
+                config().getConfigurationSection(ROOT + path + ".BY-PERMISSION"),
+                message(path),
+                permission -> PermissionUtils.hasExact(player, permission)
+        );
+    }
+
+    /**
+     * Picks the wording for the first permission in the section that the player holds, falling
+     * back to {@code fallback} when the section is absent, empty, or matches nothing.
+     *
+     * <p>The section's own order decides the winner because there is no way to rank two pieces of
+     * wording against each other the way a home limit picks its highest number. Config order is
+     * the one ordering the admin can see and change, and Bukkit hands the keys back in the order
+     * the file lists them.</p>
+     *
+     * <p>The values are read deeply, exactly as the home limits are, because a permission node
+     * carries dots and Bukkit reads those as a path. A node written as one quoted key arrives as a
+     * tree of sections, so only a deep read hands back the whole node again; the sections it walks
+     * through on the way are not wording and are skipped.</p>
+     *
+     * <p>Matching is deliberately on the exact node rather than the usual inherited check: these
+     * maps are keyed by a server's own ranks, and a wildcard would otherwise match every entry and
+     * hand the top rank's wording to anybody holding it.</p>
+     */
+    static String resolveByPermission(
+            ConfigurationSection byPermission,
+            String fallback,
+            Predicate<String> holdsPermission
+    ) {
+        if (byPermission == null || holdsPermission == null) {
+            return fallback;
+        }
+        for (Map.Entry<String, Object> entry : byPermission.getValues(true).entrySet()) {
+            if (!(entry.getValue() instanceof String wording) || wording.isBlank()) {
+                continue;
+            }
+            if (holdsPermission.test(entry.getKey())) {
+                return wording;
+            }
+        }
+        return fallback;
     }
 
     private FileConfiguration config() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -277,6 +277,14 @@ CHAT:
 # updating the jar never changes how an existing server's chat looks - turn on the ones you
 # want. Join, leave and first-join lines still follow each player's Join/Leave Messages choice
 # under /settings, and the marketplace lines follow their Server Broadcasts switch.
+#
+# Each of the three lines below can also read differently per rank. Put the permission a rank
+# carries under BY-PERMISSION with the wording that rank should get. The first entry a player
+# matches wins, so list your highest rank first, exactly as the examples do. A player matching
+# nothing gets the plain MESSAGE above it, which is also what happens while BY-PERMISSION is
+# empty, so leaving it alone keeps the wording every server has today. Matching is on the exact
+# node: a wildcard such as ultimatedonutsmp.* does not pick these up, so an operator is
+# announced with the plain line unless you grant them one of these nodes yourself.
 SERVER-NOTIFICATIONS:
   # The line everyone sees when a player connects. While this is off the server's own join
   # message is relayed instead, exactly as it is today.
@@ -285,6 +293,12 @@ SERVER-NOTIFICATIONS:
     ENABLED: false
     # The text or value for Message. Supports {player}. Available options: Any valid string text
     MESSAGE: '&8[&a+&8] &a{player} &7joined the server.'
+    # Per-rank wording, resolved from permissions. Supports {player} like MESSAGE above.
+    # Delete the examples you do not want; they are never merged back once removed.
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.join.vip++": '&8[&a+&8] &6{player} &7joined the server.'
+      "ultimatedonutsmp.notifications.join.vip+": '&8[&a+&8] &b{player} &7joined the server.'
+      "ultimatedonutsmp.notifications.join.vip": '&8[&a+&8] &e{player} &7joined the server.'
   # The line everyone sees when a player disconnects. While this is off the server's own quit
   # message is relayed instead, exactly as it is today.
   LEAVE:
@@ -292,6 +306,12 @@ SERVER-NOTIFICATIONS:
     ENABLED: false
     # The text or value for Message. Supports {player}. Available options: Any valid string text
     MESSAGE: '&8[&c-&8] &c{player} &7left the server.'
+    # Per-rank wording, resolved from permissions. Supports {player} like MESSAGE above.
+    # Delete the examples you do not want; they are never merged back once removed.
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.leave.vip++": '&8[&c-&8] &6{player} &7left the server.'
+      "ultimatedonutsmp.notifications.leave.vip+": '&8[&c-&8] &b{player} &7left the server.'
+      "ultimatedonutsmp.notifications.leave.vip": '&8[&c-&8] &e{player} &7left the server.'
   # Sent in place of the join line the very first time a player ever connects. It replaces the
   # join message rather than arriving alongside it, so nobody gets announced twice.
   FIRST-JOIN:
@@ -299,6 +319,12 @@ SERVER-NOTIFICATIONS:
     ENABLED: false
     # The text or value for Message. Supports {player}. Available options: Any valid string text
     MESSAGE: '&aWelcome &e{player} &ato the server for the first time!'
+    # Per-rank wording, resolved from permissions. Supports {player} like MESSAGE above.
+    # Delete the examples you do not want; they are never merged back once removed.
+    BY-PERMISSION:
+      "ultimatedonutsmp.notifications.first-join.vip++": '&aWelcome &6{player} &ato the server for the first time!'
+      "ultimatedonutsmp.notifications.first-join.vip+": '&aWelcome &b{player} &ato the server for the first time!'
+      "ultimatedonutsmp.notifications.first-join.vip": '&aWelcome &e{player} &ato the server for the first time!'
   # Announcements for the Auction House. Bot listings are never announced.
   AUCTION-HOUSE:
     # Determines whether Auction House announcements are enabled or disabled. Turning this off

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ConfigManagerTest.java
@@ -576,6 +576,58 @@ class ConfigManagerTest {
     }
 
     @Test
+    void mergeBundledDefaultsKeepsDeletedJoinRankWordingDeleted() throws Exception {
+        List<String> currentLines = lines(
+                "SERVER-NOTIFICATIONS:",
+                "  JOIN:",
+                "    ENABLED: true",
+                "    MESSAGE: '{player} joined'",
+                "    BY-PERMISSION:",
+                "      \"ultimatedonutsmp.notifications.join.owner\": '&4{player} joined'"
+        );
+        List<String> bundledLines = lines(
+                "SERVER-NOTIFICATIONS:",
+                "  JOIN:",
+                "    ENABLED: false",
+                "    MESSAGE: '{player} joined the server'",
+                "    BY-PERMISSION:",
+                "      \"ultimatedonutsmp.notifications.join.vip++\": '&6{player} joined'",
+                "      \"ultimatedonutsmp.notifications.join.vip\": '&e{player} joined'"
+        );
+
+        int changes = mergeBundledDefaults("config.yml", currentLines, bundledLines);
+
+        assertEquals(0, changes);
+        assertFalse(currentLines.stream().anyMatch(line -> line.contains("vip++")));
+        assertFalse(currentLines.stream().anyMatch(line -> line.contains("vip\"")));
+        assertTrue(currentLines.stream().anyMatch(line -> line.contains("join.owner")));
+    }
+
+    @Test
+    void mergeBundledDefaultsStillAddsPerRankWordingToConfigsThatPredateIt() throws Exception {
+        List<String> currentLines = lines(
+                "SERVER-NOTIFICATIONS:",
+                "  JOIN:",
+                "    ENABLED: true",
+                "    MESSAGE: '{player} joined'"
+        );
+        List<String> bundledLines = lines(
+                "SERVER-NOTIFICATIONS:",
+                "  JOIN:",
+                "    ENABLED: false",
+                "    MESSAGE: '{player} joined the server'",
+                "    BY-PERMISSION:",
+                "      \"ultimatedonutsmp.notifications.join.vip\": '&e{player} joined'"
+        );
+
+        int changes = mergeBundledDefaults("config.yml", currentLines, bundledLines);
+
+        assertTrue(changes > 0);
+        assertTrue(currentLines.stream().anyMatch(line -> line.contains("BY-PERMISSION")));
+        assertTrue(currentLines.contains("    MESSAGE: '{player} joined'"));
+    }
+
+    @Test
     void repairsMiscasedPlaceholdersLeftInExistingMenus() throws Exception {
         List<String> currentLines = lines(
                 "SELL-MENU:",

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ServerNotificationConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ServerNotificationConfigurationTest.java
@@ -5,7 +5,9 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,6 +102,127 @@ class ServerNotificationConfigurationTest {
         assertNull(ServerNotificationManager.format(null, "{player}", "Steve"));
         assertNull(ServerNotificationManager.format("", "{player}", "Steve"));
         assertNull(ServerNotificationManager.format("   ", "{player}", "Steve"));
+    }
+
+    @Test
+    void everyJoinAndLeaveLineOffersPerRankWordingKeyedByPermission() throws Exception {
+        ConfigurationSection section = notifications();
+
+        for (String announcement : List.of("JOIN", "LEAVE", "FIRST-JOIN")) {
+            ConfigurationSection byPermission =
+                    section.getConfigurationSection(announcement + ".BY-PERMISSION");
+            assertNotNull(byPermission, announcement + " has no BY-PERMISSION section");
+
+            Map<String, String> wordingByNode = wordingByNode(byPermission);
+            assertFalse(wordingByNode.isEmpty(), announcement + " ships no rank examples");
+            wordingByNode.forEach((permission, wording) -> {
+                assertFalse(wording.isBlank(), permission + " has blank wording");
+                assertTrue(wording.contains("{player}"), permission + " never names the player");
+                assertTrue(
+                        permission.startsWith("ultimatedonutsmp.notifications."),
+                        permission + " is not under the plugin's own permission root"
+                );
+            });
+        }
+    }
+
+    @Test
+    void theBundledRanksAreListedHighestFirstSoTheFirstMatchIsTheBestOne() throws Exception {
+        ConfigurationSection section = notifications();
+
+        for (String announcement : List.of("JOIN", "LEAVE", "FIRST-JOIN")) {
+            List<String> permissions = List.copyOf(
+                    wordingByNode(section.getConfigurationSection(announcement + ".BY-PERMISSION"))
+                            .keySet()
+            );
+            assertEquals(3, permissions.size(), announcement + " should ship three rank examples");
+            assertTrue(permissions.get(0).endsWith("vip++"), announcement + " does not lead with vip++");
+            assertTrue(permissions.get(1).endsWith("vip+"), announcement + " has vip+ out of order");
+            assertTrue(permissions.get(2).endsWith("vip"), announcement + " has vip out of order");
+        }
+    }
+
+    /**
+     * The rank wording, keyed by the whole permission node. A node carries dots and Bukkit reads
+     * those as a path, so the bundled keys arrive as a tree and only a deep read puts them back
+     * together.
+     */
+    private static Map<String, String> wordingByNode(ConfigurationSection byPermission) {
+        Map<String, String> wording = new LinkedHashMap<>();
+        byPermission.getValues(true).forEach((node, value) -> {
+            if (value instanceof String text) {
+                wording.put(node, text);
+            }
+        });
+        return wording;
+    }
+
+    @Test
+    void theFirstRankThePlayerHoldsDecidesTheWording() {
+        ConfigurationSection ranks = ranks();
+
+        assertEquals(
+                "top",
+                ServerNotificationManager.resolveByPermission(ranks, "plain", permission -> true),
+                "holding everything should take the first entry, not the last"
+        );
+        assertEquals(
+                "middle",
+                ServerNotificationManager.resolveByPermission(
+                        ranks, "plain", permission -> !permission.endsWith("vip++")
+                )
+        );
+        assertEquals(
+                "bottom",
+                ServerNotificationManager.resolveByPermission(
+                        ranks, "plain", permission -> permission.endsWith(".vip")
+                )
+        );
+    }
+
+    @Test
+    void aPlayerMatchingNoRankKeepsThePlainWording() {
+        assertEquals(
+                "plain",
+                ServerNotificationManager.resolveByPermission(ranks(), "plain", permission -> false)
+        );
+        assertEquals(
+                "plain",
+                ServerNotificationManager.resolveByPermission(null, "plain", permission -> true),
+                "an announcement without a BY-PERMISSION section still announces"
+        );
+        assertEquals(
+                "plain",
+                ServerNotificationManager.resolveByPermission(
+                        new YamlConfiguration().createSection("BY-PERMISSION"),
+                        "plain",
+                        permission -> true
+                ),
+                "an emptied BY-PERMISSION section still announces"
+        );
+    }
+
+    @Test
+    void blankWordingIsSkippedRatherThanAnnouncedAsAnEmptyLine() {
+        YamlConfiguration config = new YamlConfiguration();
+        ConfigurationSection ranks = config.createSection("BY-PERMISSION");
+        ranks.set("ultimatedonutsmp.notifications.join.vip++", "   ");
+        ranks.set("ultimatedonutsmp.notifications.join.vip", "bottom");
+
+        assertEquals(
+                "bottom",
+                ServerNotificationManager.resolveByPermission(ranks, "plain", permission -> true),
+                "a rank left blank should fall through to the next one"
+        );
+    }
+
+    private static ConfigurationSection ranks() {
+        YamlConfiguration config = new YamlConfiguration();
+        ConfigurationSection ranks = config.createSection("BY-PERMISSION");
+        ranks.set("ultimatedonutsmp.notifications.join.vip++", "top");
+        ranks.set("ultimatedonutsmp.notifications.join.vip+", "middle");
+        ranks.set("ultimatedonutsmp.notifications.join.vip", "bottom");
+        return ranks;
     }
 
     private static ConfigurationSection notifications() throws Exception {


### PR DESCRIPTION
Join, leave and first-join announcements had one wording each, applied to everyone. This adds a `BY-PERMISSION` map to all three so a server can announce its donors differently from everyone else. Asked for on #353, alongside a lot of other things that already existed; this was the one part that genuinely did not.

Nothing changes for an existing server. The three announcements still ship switched off, the plain `MESSAGE` is still what a player gets when no rank applies, and an empty or deleted `BY-PERMISSION` map behaves exactly like the old code.

## How a rank is picked

The first entry the player matches wins, so the config lists the highest rank first. Home limits resolve their map by taking the largest number, and there is no equivalent for two pieces of wording: nothing about `'&6{player} joined'` makes it greater than `'&e{player} joined'`. Config order is the one ordering an admin can see and change, so that is what decides it, and the comments say so in the file rather than leaving people to guess.

Matching is on the exact node, the same call the home limits use. That matters more here than it looks: a server running `ultimatedonutsmp.*` would otherwise match every entry in the map and hand the top rank's wording to anybody holding the wildcard, including console operators.

## Reading a map whose keys contain dots

A permission node has dots in it and Bukkit reads those as a path, so `"ultimatedonutsmp.notifications.join.vip"` written as one quoted key arrives as four nested sections rather than one key. Reading the section shallowly hands back `ultimatedonutsmp` and nothing else, which is why the resolver reads deeply and skips the sections it walks through on the way. The home limits already do this; I had it wrong first and the tests caught it, which is the main reason two of them assert on ordering rather than just on lookup.

## Notes

Deleted example entries stay deleted. The three `BY-PERMISSION` maps are excluded from the bundled-defaults merge the same way the home, rtp and ender chest rank maps are, while the sections themselves stay mergeable so a config predating this still receives them once. Two tests in `ConfigManagerTest` cover both halves of that.

The permission nodes are config-driven and stay out of `plugin.yml`, matching how the other rank maps do it, so nothing about the plugin's declared permissions changed.

`SERVER-NOTIFICATIONS` lives only in `config.yml` and has no counterpart in the language files, so no translation work came with this.

Seven new tests, 661 green.
