### PR TITLE
docs(wiki): drop the completeness claim where it is not true

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -1,7 +1,13 @@
 # Detailed Configuration & Setup Guide: `config.yml`
 
-This is the official, 100% complete technical setup guide for `config.yml` in **UltimateDonutSMP**.
+This is the official technical setup guide for `config.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
+
+Six sections have no write-up here yet: `OPTIMIZATION`, `RTP-ZONE`, `TELEPORT-COOLDOWN`, `BOUNTY`,
+`AMETHYST-TOOLS` and `COMMANDS`. Nothing is wrong with them; they simply have no entry below, and
+the comments above each key in `config.yml` say what they do. Watch the names on two of those: this
+file's `RTP-ZONE` and `AMETHYST-TOOLS` are separate settings from `rtp.yml` and `amethyst-tools.yml`,
+which have guides of their own.
 
 A line whose visible letters are all uppercase is shown in Title Case instead, so long as it also
 carries a colour code or a placeholder. That reaches the tablist header and the `SERVER-LIST`

--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -1,7 +1,13 @@
 # Detailed Configuration & Setup Guide: `messages.yml`
 
-This is the official, 100% complete technical setup guide for `messages.yml` in **UltimateDonutSMP**.
+This is the official technical setup guide for `messages.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
+
+Twenty-five sections have no write-up here yet: `BILLFORD`, `BALANCE`, `SHARD_PAY`, `FINDPLAYER`,
+`PUNISHMENTS`, `SOCIAL`, `AUCTION_HOUSE`, `ORDERS`, `STATS-WIPE`, `STAFF`, `FLY`, `FLYSPEED`,
+`WALKSPEED`, `HEAL`, `FEED`, `GAMEMODE`, `RANDOMTP`, `RENAME`, `PING`, `PLAYTIME`, `STAFFCHAT`,
+`HELPOP`, `REPORT`, `ALTS` and `VOICE-CHAT`. Every key in them behaves like the ones covered below,
+and `messages.yml` carries a comment above each one saying what it is.
 
 One formatting rule catches people out. A line whose visible letters are all uppercase is shown
 in Title Case instead, whenever that line also carries a colour code or a placeholder.

--- a/docs/wiki/Config-orders.yml.md
+++ b/docs/wiki/Config-orders.yml.md
@@ -1,7 +1,11 @@
 # Detailed Configuration & Setup Guide: `orders.yml`
 
-This is the official, 100% complete technical setup guide for `orders.yml` in **UltimateDonutSMP**.
+This is the official technical setup guide for `orders.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
+
+Three sections have no write-up here yet: `SEARCH_SIGN`, `AMOUNT_SIGN` and `PRICE_SIGN`. Each sets
+the four lines of the sign an order menu opens when it asks for a search term, an amount or a price,
+plus the `input-line` that decides which line the player types on.
 
 ---
 

--- a/docs/wiki/Config-sounds.yml.md
+++ b/docs/wiki/Config-sounds.yml.md
@@ -1,7 +1,11 @@
 # Detailed Configuration & Setup Guide: `sounds.yml`
 
-This is the official, 100% complete technical setup guide for `sounds.yml` in **UltimateDonutSMP**.
+This is the official technical setup guide for `sounds.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
+
+Two sections have no write-up here yet: `CRATES` and `SPAWNERS`. Both take the same
+`sound|volume|pitch` value as every entry covered below, so the examples here apply to them
+unchanged.
 
 ---
 


### PR DESCRIPTION
Every `Config-*.yml.md` page opens by calling itself a "100% complete technical setup guide" for its file. On four of them that isn't true, so those four now say what they really cover and name the sections they skip.

- `Config-messages.yml.md` writes up 20 of 45 sections. The 25 with no entry include `PUNISHMENTS`, `SOCIAL`, `AUCTION_HOUSE` and `ORDERS`.
- `Config-config.yml.md` writes up 30 of 36. `OPTIMIZATION` appears nowhere on the page, not even in passing, and nor do `RTP-ZONE`, `TELEPORT-COOLDOWN`, `BOUNTY`, `AMETHYST-TOOLS` or `COMMANDS`.
- `Config-orders.yml.md` writes up 11 of 13, missing the three sign prompts.
- `Config-sounds.yml.md` writes up 20 of 22, missing `CRATES` and `SPAWNERS`.

Instead of just making the opening vaguer, each of the four lists the sections it skips and points at the comments in the YAML that do describe them. Someone hunting for `BALANCE` in `messages.yml` now learns in one line that it isn't there, rather than scrolling the whole page to find out.

## What I left alone

The other 26 per-file pages back the claim today, so they keep it. Worth saying out loud though: the claim decays by itself. Adding a section to a config file breaks it silently, which is how `OPTIMIZATION` and `BOUNTY` slipped out of the `config.yml` page to begin with. Whether that line is worth keeping at all is your call, not something to decide inside a docs fix.

Filling the 36 missing sections in is the other half of this and isn't in here. `messages.yml` alone accounts for 25.

## Notes

Two claims in the task I picked this up from were wrong, both my own errors from a script that stripped code fences badly and swallowed real headings along the way. `Config-auction-house.yml.md` is not missing `BOTS`; it documents all 7 of its sections. `Config-orders.yml.md` is short by three sections, not four, since `BOTS` is written up there too. The string `## Section:` never occurs inside a YAML block, so matching it on the raw file is both simpler and right.

Prose only. No keys, defaults or behaviour touched. Suite is at 658, green.
