### PR TITLE
docs(network): say what the redis warning keys do

### DIFF
--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1394,8 +1394,8 @@ NETWORK:
 | `NETWORK.REDIS_CHANNEL` | `str` | Any string text | `ultimatedonutsmp:staff-chat` | Configures `REDIS_CHANNEL` for `NETWORK`. |
 | `NETWORK.HELPOP_REDIS_CHANNEL` | `str` | Any string text | `ultimatedonutsmp:staff-alerts` | Configures `HELPOP_REDIS_CHANNEL` for `NETWORK`. |
 | `NETWORK.REPORT_REDIS_CHANNEL` | `str` | Any string text | `ultimatedonutsmp:staff-alerts` | Configures `REPORT_REDIS_CHANNEL` for `NETWORK`. |
-| `NETWORK.SEND_LOCAL_FALLBACK_ON_REDIS_ERROR` | `bool` | true, false | `True` | Configures `SEND_LOCAL_FALLBACK_ON_REDIS_ERROR` for `NETWORK`. |
-| `NETWORK.STAFF_ALERTS_WARN_SENDER_ON_REDIS_ERROR` | `bool` | true, false | `False` | Configures `STAFF_ALERTS_WARN_SENDER_ON_REDIS_ERROR` for `NETWORK`. |
+| `NETWORK.SEND_LOCAL_FALLBACK_ON_REDIS_ERROR` | `bool` | true, false | `True` | The name oversells it: local delivery is not optional and never was. A staff chat message reaches the staff on this server before Redis is attempted at all, and this key decides only whether the sender is told, once per session, that it did not reach the other servers. |
+| `NETWORK.STAFF_ALERTS_WARN_SENDER_ON_REDIS_ERROR` | `bool` | true, false | `False` | The `/helpop` and `/report` counterpart of the key above. Warns a player, once per session, that their alert reached local staff but could not be published to the other servers. Off by default, since somebody did receive it. |
 | `NETWORK.LOG_TO_CONSOLE` | `bool` | true, false | `True` | Configures `LOG_TO_CONSOLE` for `NETWORK`. |
 | `NETWORK.STAFF_ALERTS_LOG_TO_CONSOLE` | `bool` | true, false | `True` | Configures `STAFF_ALERTS_LOG_TO_CONSOLE` for `NETWORK`. |
 | `NETWORK.MAX_MESSAGE_LENGTH` | `int` | Any valid integer | `512` | Configures `MAX_MESSAGE_LENGTH` for `NETWORK`. |


### PR DESCRIPTION
The drift this started from is already gone. `e047c0db` ("fix(network): make the redis fallback keys match what they do") landed while an unrelated docs sync was in flight, and it fixed the repo side: `docs/wiki/Configuration-Reference.md` and its wiki copy are now byte-identical, the dead `STAFF_ALERTS_LOCAL_FALLBACK_ON_REDIS_ERROR` key is gone from both, and `NetworkRedisFallbackConfigurationTest` keeps it gone.

What that fix didn't reach is the options table further down the same page. Both `_REDIS_ERROR` rows still read "Configures `X` for `NETWORK`", which is worse than saying nothing when a key is named the way this one is.

`SEND_LOCAL_FALLBACK_ON_REDIS_ERROR` sounds like it decides whether staff chat still gets delivered locally when Redis is down. It doesn't. `NetworkStaffChatManager.publishPayloadAsync` hands the message to local staff first and publishes afterwards, and the key is read by a method called `shouldWarnSenderOnRedisError`. All it gates is whether the sender sees `STAFFCHAT.REDIS_UNAVAILABLE`, once per session, tracked in `redisUnavailableWarnedPlayers` and cleared when they quit. `STAFF_ALERTS_WARN_SENDER_ON_REDIS_ERROR` is the same arrangement for `/helpop` and `/report`, off by default because the alert did reach somebody.

Both rows now say that, following `Config-network.yml.md`, which already had the explanation right.

## Notes

Prose only, two table cells. The YAML block above them already carried the corrected comment from `e047c0db`, so nothing there needed touching. Suite is at 665, green.
