### PR TITLE
feat(crates): let the hologram line spacing be configured

### DIFF
--- a/docs/wiki/Config-crates.yml.md
+++ b/docs/wiki/Config-crates.yml.md
@@ -68,6 +68,8 @@ SETTINGS:
   HOLOGRAM:
     # The decimal value for Offset Y. Available options: Any decimal number
     OFFSET-Y: 1.6
+    # The gap between one line and the next. Available options: 0.05 to 0.5
+    LINE-SPACING: 0.27
     # Configuration section for Lines.
     LINES:
     - '{crate}'
@@ -119,7 +121,8 @@ SETTINGS:
 | `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.MATERIAL` | `str` | Any string text | `'RED_STAINED_GLASS_PANE'` | Configures the technical `MATERIAL` parameter for `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.MATERIAL` in `crates.yml`. |
 | `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.DISPLAY-NAME` | `str` | Any string text | `'&cCancel'` | Configures the technical `DISPLAY-NAME` parameter for `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.DISPLAY-NAME` in `crates.yml`. |
 | `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.LORE` | `list` | List of configured items/strings | `['&7Return to the reward list.']` | Configures the technical `LORE` parameter for `SETTINGS.CONFIRM-MENU.CANCEL-BUTTON.LORE` in `crates.yml`. |
-| `SETTINGS.HOLOGRAM.OFFSET-Y` | `float` | Any decimal number | `'1.6'` | Configures the technical `OFFSET-Y` parameter for `SETTINGS.HOLOGRAM.OFFSET-Y` in `crates.yml`. |
+| `SETTINGS.HOLOGRAM.OFFSET-Y` | `float` | Any decimal number | `'1.6'` | Height of the first hologram line above the crate block. Raise it to lift the text away from the item spinning on top of the crate. |
+| `SETTINGS.HOLOGRAM.LINE-SPACING` | `float` | `0.05` to `0.5` | `'0.27'` | Vertical gap between one hologram line and the next, in blocks. The same option and default the portal holograms use in `config.yml`. Values outside the range are pulled back into it, which keeps the text inside the area the plugin searches when it checks its own holograms are still there and when it cleans them up. |
 | `SETTINGS.HOLOGRAM.LINES` | `list` | List of configured items/strings | `['{crate}', '&7Right-click to open']` | Configures the technical `LINES` parameter for `SETTINGS.HOLOGRAM.LINES` in `crates.yml`. |
 | `SETTINGS.HOLOGRAM.KEY-LINE` | `str` | Any string text | `'&7Keys: &f{keys}'` | Configures the technical `KEY-LINE` parameter for `SETTINGS.HOLOGRAM.KEY-LINE` in `crates.yml`. |
 | `SETTINGS.PARTICLES.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `SETTINGS` system. Set to `true` to enable, `false` to disable. |

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/CrateVisualManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/CrateVisualManager.java
@@ -39,6 +39,12 @@ public class CrateVisualManager {
     private static final String PERSONAL_TAG = "uds_crate_personal_hologram";
     private static final String PREVIEW_TAG = "uds_crate_preview";
     private static final long GATE_RECHECK_INTERVAL_MS = 1000L;
+    /** Matches PORTAL-SYSTEM.HOLOGRAM.LINE-SPACING in config.yml, so both holograms read alike. */
+    static final double DEFAULT_HOLOGRAM_LINE_SPACING = 0.27D;
+    static final double MIN_HOLOGRAM_LINE_SPACING = 0.05D;
+    static final double MAX_HOLOGRAM_LINE_SPACING = 0.5D;
+    /** Headroom kept above the top hologram line when looking for the text already in the world. */
+    private static final double HOLOGRAM_SEARCH_MARGIN_Y = 0.65D;
 
     private final UltimateDonutSmp plugin;
     private final Map<CrateManager.CrateBlockKey, List<UUID>> holograms = new HashMap<>();
@@ -223,9 +229,10 @@ public class CrateVisualManager {
 
         List<UUID> entityIds = new ArrayList<>();
         double baseY = block.getY() + getHologramOffsetY();
+        double lineSpacing = getHologramLineSpacing();
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
-            Location location = new Location(block.getWorld(), block.getX() + 0.5, baseY - (i * 0.27), block.getZ() + 0.5);
+            Location location = new Location(block.getWorld(), block.getX() + 0.5, baseY - (i * lineSpacing), block.getZ() + 0.5);
             TextDisplay display = block.getWorld().spawn(location, TextDisplay.class, textDisplay -> {
                 textDisplay.setText(com.bx.ultimateDonutSmp.utils.ColorUtils.toComponent(line));
                 configureHologramDisplay(textDisplay);
@@ -297,11 +304,22 @@ public class CrateVisualManager {
         if (displays.size() != requiredLines) {
             World world = Bukkit.getWorld(key.world());
             if (world != null) {
-                Location center = new Location(world, key.x() + 0.5, key.y() + getHologramOffsetY() - 0.35, key.z() + 0.5);
+                // Centre the search on the middle of the stack and make it tall enough to hold all
+                // of it. A fixed box stops reaching the bottom line once a crate carries either a
+                // wider LINE-SPACING or simply more lines, and text this misses is treated as gone
+                // and spawned again on the next pass.
+                double stackHeight = hologramStackHeight(requiredLines);
+                Location center = new Location(
+                        world,
+                        key.x() + 0.5,
+                        key.y() + getHologramOffsetY() - (stackHeight / 2),
+                        key.z() + 0.5
+                );
+                double searchHeight = (stackHeight / 2) + HOLOGRAM_SEARCH_MARGIN_Y;
                 String expectedKey = formatBlockKey(key);
 
                 List<TextDisplay> found = new ArrayList<>();
-                for (Entity entity : world.getNearbyEntities(center, 0.5, 1.0, 0.5, candidate -> candidate instanceof TextDisplay)) {
+                for (Entity entity : world.getNearbyEntities(center, 0.5, searchHeight, 0.5, candidate -> candidate instanceof TextDisplay)) {
                     if (!entity.getScoreboardTags().contains(HOLOGRAM_TAG) || entity.getScoreboardTags().contains(PERSONAL_TAG)) {
                         continue;
                     }
@@ -445,7 +463,8 @@ public class CrateVisualManager {
             if (configuredKeyLineOffset != -999.0D) {
                 baseY = key.y() + configuredKeyLineOffset;
             } else {
-                baseY = key.y() + getHologramOffsetY() - (getHologramLines(crate).size() * 0.27D);
+                baseY = key.y() + getHologramOffsetY()
+                        - (getHologramLines(crate).size() * getHologramLineSpacing());
             }
             Location location = new Location(world, key.x() + 0.5, baseY, key.z() + 0.5);
             display = world.spawn(location, TextDisplay.class, textDisplay -> {
@@ -500,7 +519,7 @@ public class CrateVisualManager {
                 }
 
                 String expected = formatBlockKey(key);
-                for (Entity entity : world.getNearbyEntities(center, 1.0, 3.0, 1.0, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
+                for (Entity entity : world.getNearbyEntities(center, 1.0, hologramSweepHeight(3.0), 1.0, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
                     String attachedKey = entity.getPersistentDataContainer().get(plugin.getKey("crate_hologram"), PersistentDataType.STRING);
                     if (attachedKey == null) {
                         attachedKey = entity.getPersistentDataContainer().get(plugin.getKey("crate_personal_hologram"), PersistentDataType.STRING);
@@ -634,7 +653,7 @@ public class CrateVisualManager {
         Location center = new Location(world, key.x() + 0.5, key.y() + getHologramOffsetY() - 0.35, key.z() + 0.5);
         if (!plugin.isEnabled()) {
             if (world.isChunkLoaded(center.getBlockX() >> 4, center.getBlockZ() >> 4)) {
-                for (Entity entity : world.getNearbyEntities(center, 0.4, 2.5, 0.4, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
+                for (Entity entity : world.getNearbyEntities(center, 0.4, hologramSweepHeight(2.5), 0.4, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
                     if (isAtCrateHologramColumn(entity, key) || isAtCratePreviewColumn(entity, key)) {
                         entity.remove();
                     }
@@ -643,7 +662,7 @@ public class CrateVisualManager {
             return;
         }
         plugin.getSpigotScheduler().runRegion(center, () -> {
-            for (Entity entity : world.getNearbyEntities(center, 0.4, 2.5, 0.4, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
+            for (Entity entity : world.getNearbyEntities(center, 0.4, hologramSweepHeight(2.5), 0.4, candidate -> candidate instanceof TextDisplay || candidate instanceof ItemDisplay)) {
                 if (isAtCrateHologramColumn(entity, key) || isAtCratePreviewColumn(entity, key)) {
                     entity.remove();
                 }
@@ -801,6 +820,52 @@ public class CrateVisualManager {
 
     private double getHologramOffsetY() {
         return plugin.getConfigManager().getCrates().getDouble("SETTINGS.HOLOGRAM.OFFSET-Y", 1.6D);
+    }
+
+    /**
+     * The gap between one hologram line and the next, in blocks.
+     *
+     * <p>Clamped rather than taken at face value. A zero or negative gap stacks every line on the
+     * same spot, and a very large one spreads the text further than the sweeps that clean a crate's
+     * displays up reach, which would strand the lowest lines in the world once the crate is
+     * unbound. The range is wide enough for any stack that is still readable.</p>
+     */
+    private double getHologramLineSpacing() {
+        return clampLineSpacing(plugin.getConfigManager().getCrates()
+                .getDouble("SETTINGS.HOLOGRAM.LINE-SPACING", DEFAULT_HOLOGRAM_LINE_SPACING));
+    }
+
+    /** Pulls a configured gap back into the range the rest of the class is safe for. */
+    static double clampLineSpacing(double configured) {
+        if (Double.isNaN(configured)) {
+            return DEFAULT_HOLOGRAM_LINE_SPACING;
+        }
+        return Math.min(MAX_HOLOGRAM_LINE_SPACING, Math.max(MIN_HOLOGRAM_LINE_SPACING, configured));
+    }
+
+    /**
+     * How far the bottom line of a hologram sits below the top one. Zero for a single line.
+     */
+    private double hologramStackHeight(int lines) {
+        return Math.max(0, lines - 1) * getHologramLineSpacing();
+    }
+
+    /**
+     * Half-height for a sweep that has to catch every display a crate owns, never smaller than the
+     * reach the sweep had before the spacing was configurable.
+     *
+     * <p>These sweeps run without a crate to hand, so the line count comes from the config rather
+     * than from a resolved hologram; the two agree because every crate draws the same
+     * SETTINGS.HOLOGRAM.LINES. The personal key line hangs one full gap below the last of them,
+     * which is what the count rather than the count minus one accounts for.</p>
+     */
+    private double hologramSweepHeight(double minimum) {
+        FileConfiguration cratesConfig = plugin.getConfigManager().getCrates();
+        int lines = cratesConfig.getStringList("SETTINGS.HOLOGRAM.LINES").size();
+        if (lines <= 0) {
+            lines = 2;
+        }
+        return Math.max(minimum, (lines * getHologramLineSpacing()) + HOLOGRAM_SEARCH_MARGIN_Y);
     }
 
     private long getHologramUpdateTicks() {

--- a/src/main/resources/crates.yml
+++ b/src/main/resources/crates.yml
@@ -46,7 +46,14 @@ SETTINGS:
       - '&7Return to the reward list.'
   
   HOLOGRAM:
+    # Height of the first line above the crate block. Raise it to lift the whole stack of text
+    # away from the item spinning on top of the crate.
     OFFSET-Y: 1.6
+    # Vertical gap between one line of the hologram and the next, in blocks. The same option the
+    # portal holograms use in config.yml, and the same default. Values outside 0.05 to 0.5 are
+    # pulled back into that range, which is wide enough for any readable stack and keeps the
+    # hologram inside the area the plugin searches when it checks its own text is still there.
+    LINE-SPACING: 0.27
     LINES:
     - '{crate}'
     - '&7Right-click to open'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/CrateHologramSpacingTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/CrateHologramSpacingTest.java
@@ -1,0 +1,102 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CrateHologramSpacingTest {
+
+    private static final double EPSILON = 1.0e-9;
+
+    @Test
+    void cratesShipTheSameLineSpacingThePortalHologramUses() throws Exception {
+        YamlConfiguration crates = load("crates.yml");
+        YamlConfiguration config = load("config.yml");
+
+        double crateSpacing = crates.getDouble("SETTINGS.HOLOGRAM.LINE-SPACING", -1);
+        double portalSpacing = config.getDouble("PORTAL-SYSTEM.HOLOGRAM.LINE-SPACING", -1);
+
+        assertEquals(
+                CrateVisualManager.DEFAULT_HOLOGRAM_LINE_SPACING,
+                crateSpacing,
+                EPSILON,
+                "crates.yml should ship the documented default"
+        );
+        assertEquals(
+                portalSpacing,
+                crateSpacing,
+                EPSILON,
+                "the two holograms should read the same out of the box"
+        );
+    }
+
+    @Test
+    void theBundledSpacingIsInsideTheRangeTheClampAllows() {
+        assertEquals(
+                CrateVisualManager.DEFAULT_HOLOGRAM_LINE_SPACING,
+                CrateVisualManager.clampLineSpacing(CrateVisualManager.DEFAULT_HOLOGRAM_LINE_SPACING),
+                EPSILON,
+                "shipping a default the clamp moves would change every server's holograms"
+        );
+    }
+
+    @Test
+    void aSpacingThatWouldStackEveryLineOnOneSpotIsPulledUp() {
+        assertEquals(
+                CrateVisualManager.MIN_HOLOGRAM_LINE_SPACING,
+                CrateVisualManager.clampLineSpacing(0),
+                EPSILON
+        );
+        assertEquals(
+                CrateVisualManager.MIN_HOLOGRAM_LINE_SPACING,
+                CrateVisualManager.clampLineSpacing(-5),
+                EPSILON,
+                "a negative gap would build the stack upside down"
+        );
+    }
+
+    @Test
+    void aSpacingWiderThanTheSweepsReachIsPulledDown() {
+        assertEquals(
+                CrateVisualManager.MAX_HOLOGRAM_LINE_SPACING,
+                CrateVisualManager.clampLineSpacing(40),
+                EPSILON,
+                "text spread past the cleanup sweep would be stranded when a crate is unbound"
+        );
+    }
+
+    @Test
+    void aSpacingInsideTheRangeIsLeftAlone() {
+        assertEquals(0.4D, CrateVisualManager.clampLineSpacing(0.4D), EPSILON);
+        assertEquals(
+                CrateVisualManager.DEFAULT_HOLOGRAM_LINE_SPACING,
+                CrateVisualManager.clampLineSpacing(Double.NaN),
+                EPSILON,
+                "an unreadable value should fall back rather than poison the maths"
+        );
+    }
+
+    @Test
+    void everyStackTheClampAllowsStaysInsideTheNarrowestSweep() throws Exception {
+        // The disable-time purge is the shallowest of the sweeps at 2.5 blocks, and the personal
+        // key line hangs a full gap below the last hologram line.
+        int bundledLines = load("crates.yml").getStringList("SETTINGS.HOLOGRAM.LINES").size();
+        double deepest = (bundledLines + 1) * CrateVisualManager.MAX_HOLOGRAM_LINE_SPACING;
+
+        assertTrue(
+                deepest <= 2.5D,
+                "the bundled line count at the widest allowed gap reaches " + deepest
+                        + " blocks, past the 2.5 the shallowest sweep covers"
+        );
+    }
+
+    private static YamlConfiguration load(String resource) throws Exception {
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.load(Path.of("src/main/resources", resource).toFile());
+        return configuration;
+    }
+}


### PR DESCRIPTION
Portal holograms let you set the gap between their lines with `PORTAL-SYSTEM.HOLOGRAM.LINE-SPACING`. Crate holograms had the same gap nailed shut at `0.27` in code, so `SETTINGS.HOLOGRAM` in `crates.yml` now takes `LINE-SPACING` under the same name and the same default. Noticed while looking at #353, where the reporter said the crate text sat too close to the item on top. That complaint is answered by `OFFSET-Y`, which they were pointed at; this is the inconsistency underneath it.

Nothing moves on an existing server. The default is the number that was hardcoded.

## The gap is clamped, and it has to be

`0.05` to `0.5`. A gap of zero or less would stack every line on one spot or build the stack upside down, and that much is obvious. The upper end is the interesting one: the plugin finds its own holograms again by searching a box around the crate, and it sweeps the same kind of box to clean displays up when a crate is unbound. Spread the text further than those boxes reach and the lowest lines are invisible to both, so the plugin decides its holograms are missing and spawns a fresh set every pass, and the originals are left floating in the world when the crate goes.

A test pins the ceiling to the shallowest of those sweeps, so if someone widens the range or adds a bundled hologram line without thinking about it, that test fails rather than the server growing text nobody can delete.

## The lookup box now follows the stack

The check that decides whether a crate's holograms are still there searched a box of fixed height, centred slightly below the top line. That was already too small before this change: at seven or more lines the bottom one fell outside it at the old fixed spacing, so the plugin never found it. It now centres on the middle of the stack and sizes itself to hold all of it, with the same headroom above the top line as before, which makes it correct at any spacing and at any line count.

The three cleanup sweeps grew the same way, never shrinking below the reach they had before. They run without a crate to hand, so the line count comes from the config, which works because every crate draws the same `SETTINGS.HOLOGRAM.LINES`.

## Notes

The `- 0.35` nudge sat in six places in this file and it was worth checking each one before touching any. Three only pick a region for the scheduler, where the height is never read, so those are left exactly as they were. The other three are the searches: the lookup box above, and the two centres behind the three sweep calls. The two particle calls that also contain `0.35` are a spread radius and have nothing to do with holograms.

`docs/wiki/Config-crates.yml.md` documents the new key and, while I was in there, says what `OFFSET-Y` actually does rather than that it configures itself.

Six new tests, 671 green.
