### PR TITLE
refactor(rtp): keep one copy of the chunk preload sizing

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/RTPManager.java
@@ -4,6 +4,7 @@ import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.ItemUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
+import com.bx.ultimateDonutSmp.utils.RtpChunkPreloadPolicy;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.Bukkit;
@@ -85,11 +86,7 @@ public class RTPManager {
     private static final String MIN_SEARCH_DISPLAY_TICKS_SETTING = "SETTINGS.SEARCH-DISPLAY-MIN-TICKS";
     private static final String FOUND_DISPLAY_TICKS_SETTING = "SETTINGS.FOUND-DISPLAY-TICKS";
     private static final String PRELOAD_TELEPORT_CHUNKS_SETTING = "SETTINGS.PRELOAD-TELEPORT-CHUNKS";
-    private static final String PRELOAD_RADIUS_SETTING = "SETTINGS.PRELOAD-RADIUS";
-    private static final String PRELOAD_CHUNKS_PER_TICK_SETTING = "SETTINGS.PRELOAD-CHUNKS-PER-TICK";
     private static final String PRELOAD_MAX_TICKS_SETTING = "SETTINGS.PRELOAD-MAX-TICKS";
-    private static final String POST_TELEPORT_CHUNK_THROTTLE_SETTING = "SETTINGS.POST-TELEPORT-CHUNK-THROTTLE";
-    private static final String POST_TELEPORT_VIEW_DISTANCE_SETTING = "SETTINGS.POST-TELEPORT-VIEW-DISTANCE";
     private static final String COOLDOWN_PERMISSION_PREFIX = "ultimatedonutsmp.rtp.cooldown.";
     private static final int DEFAULT_GENERATE_FALLBACK_AFTER_SAMPLES = 32;
     private static final int DEFAULT_MAX_GENERATE_FALLBACK_SAMPLES = 32;
@@ -1882,30 +1879,15 @@ public class RTPManager {
     }
 
     private List<int[]> buildPreloadChunkOrder(int centerChunkX, int centerChunkZ, int radius) {
-        List<int[]> chunks = new ArrayList<>();
-        for (int dx = -radius; dx <= radius; dx++) {
-            for (int dz = -radius; dz <= radius; dz++) {
-                chunks.add(new int[]{centerChunkX + dx, centerChunkZ + dz});
-            }
-        }
-        chunks.sort(Comparator.comparingInt(chunk ->
-                Math.abs(chunk[0] - centerChunkX) + Math.abs(chunk[1] - centerChunkZ)));
-        return chunks;
+        return RtpChunkPreloadPolicy.chunkOrder(centerChunkX, centerChunkZ, radius);
     }
 
     private int getPreloadRadius() {
-        int configured = plugin.getConfigManager().getRtp().getInt(PRELOAD_RADIUS_SETTING, 2);
-        int radius = Math.max(0, Math.min(4, configured));
-        if (plugin.getConfigManager().getRtp().getBoolean(POST_TELEPORT_CHUNK_THROTTLE_SETTING, true)) {
-            int throttledViewDistance = Math.max(2, plugin.getConfigManager().getRtp()
-                    .getInt(POST_TELEPORT_VIEW_DISTANCE_SETTING, 4));
-            radius = Math.max(radius, Math.min(4, throttledViewDistance));
-        }
-        return Math.max(2, radius);
+        return RtpChunkPreloadPolicy.radius(plugin.getConfigManager().getRtp());
     }
 
     private int getPreloadChunksPerTick() {
-        return Math.max(2, plugin.getConfigManager().getRtp().getInt(PRELOAD_CHUNKS_PER_TICK_SETTING, 2));
+        return RtpChunkPreloadPolicy.chunksPerTick(plugin.getConfigManager().getRtp());
     }
 
     private int getPreloadMaxTicks() {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/TeleportManager.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.managers;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.PlayerSettingUtils;
+import com.bx.ultimateDonutSmp.utils.RtpChunkPreloadPolicy;
 import com.bx.ultimateDonutSmp.utils.SoundUtils;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.Location;
@@ -10,8 +11,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -447,28 +446,15 @@ public class TeleportManager {
     }
 
     private List<int[]> buildRtpChunkOrder(int centerChunkX, int centerChunkZ, int radius) {
-        List<int[]> chunks = new ArrayList<>();
-        for (int dx = -radius; dx <= radius; dx++) {
-            for (int dz = -radius; dz <= radius; dz++) {
-                chunks.add(new int[]{centerChunkX + dx, centerChunkZ + dz});
-            }
-        }
-        chunks.sort(Comparator.comparingInt(chunk ->
-                Math.abs(chunk[0] - centerChunkX) + Math.abs(chunk[1] - centerChunkZ)));
-        return chunks;
+        return RtpChunkPreloadPolicy.chunkOrder(centerChunkX, centerChunkZ, radius);
     }
 
     private int getRtpChunkStabilizationRadius() {
-        int configuredRadius = plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-RADIUS", 2);
-        int radius = Math.max(0, Math.min(4, configuredRadius));
-        if (plugin.getConfigManager().getRtp().getBoolean("SETTINGS.POST-TELEPORT-CHUNK-THROTTLE", true)) {
-            radius = Math.max(radius, Math.min(4, getRtpThrottleDistance("SETTINGS.POST-TELEPORT-VIEW-DISTANCE", 4)));
-        }
-        return Math.max(2, radius);
+        return RtpChunkPreloadPolicy.radius(plugin.getConfigManager().getRtp());
     }
 
     private int getRtpChunkStabilizationChunksPerTick() {
-        return Math.max(2, plugin.getConfigManager().getRtp().getInt("SETTINGS.PRELOAD-CHUNKS-PER-TICK", 2));
+        return RtpChunkPreloadPolicy.chunksPerTick(plugin.getConfigManager().getRtp());
     }
 
     private void refreshLoadedChunk(World world, int chunkX, int chunkZ) {

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/RtpChunkPreloadPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/RtpChunkPreloadPolicy.java
@@ -1,0 +1,99 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Sizes the chunk work on either side of an RTP teleport.
+ *
+ * <p>Two managers do that work at different moments. {@code RTPManager} loads the terrain around
+ * the destination before the player lands on it, and {@code TeleportManager} settles the same
+ * terrain again afterwards. Different moments, one area: both are sized from the single pair of
+ * config keys {@code PRELOAD-RADIUS} and {@code PRELOAD-CHUNKS-PER-TICK}, and both widen the
+ * radius to cover whatever the post teleport throttle is about to let the player see.</p>
+ *
+ * <p>The sizing lived as line-for-line copies in the two managers until a fix to the
+ * {@code PRELOAD-RADIUS} fallback had to be made in four places at once. Nothing broke, because
+ * the copies were still identical, and nothing would have broken loudly if only one of them had
+ * been changed either. Giving one side a size of its own means adding a config key for it, which
+ * is a deliberate decision, and the deliberate place to split this apart again.</p>
+ */
+public final class RtpChunkPreloadPolicy {
+
+    private static final String RADIUS_SETTING = "SETTINGS.PRELOAD-RADIUS";
+    private static final String CHUNKS_PER_TICK_SETTING = "SETTINGS.PRELOAD-CHUNKS-PER-TICK";
+    private static final String CHUNK_THROTTLE_SETTING = "SETTINGS.POST-TELEPORT-CHUNK-THROTTLE";
+    private static final String VIEW_DISTANCE_SETTING = "SETTINGS.POST-TELEPORT-VIEW-DISTANCE";
+
+    private static final int DEFAULT_RADIUS = 2;
+    private static final int MIN_RADIUS = 2;
+    private static final int MAX_RADIUS = 4;
+    private static final int DEFAULT_CHUNKS_PER_TICK = 2;
+    private static final int MIN_CHUNKS_PER_TICK = 2;
+    private static final int DEFAULT_VIEW_DISTANCE = 4;
+    private static final int MIN_VIEW_DISTANCE = 2;
+
+    private RtpChunkPreloadPolicy() {
+    }
+
+    /**
+     * Chunk radius to prepare around an RTP destination.
+     *
+     * <p>{@code PRELOAD-RADIUS} sets the floor rather than the ceiling. While the post teleport
+     * throttle is on, the radius is raised to the distance the player is about to be held at, so
+     * that the terrain they can see is the terrain that was made ready. On stock settings that
+     * lands on 4 whatever the key says.</p>
+     *
+     * @param rtp the rtp.yml configuration, or null while it is unavailable
+     */
+    public static int radius(ConfigurationSection rtp) {
+        if (rtp == null) {
+            return MIN_RADIUS;
+        }
+        int radius = Math.max(0, Math.min(MAX_RADIUS, rtp.getInt(RADIUS_SETTING, DEFAULT_RADIUS)));
+        if (rtp.getBoolean(CHUNK_THROTTLE_SETTING, true)) {
+            radius = Math.max(radius, Math.min(MAX_RADIUS, throttledViewDistance(rtp)));
+        }
+        return Math.max(MIN_RADIUS, radius);
+    }
+
+    /**
+     * Chunks to prepare per tick. Anything below {@value #MIN_CHUNKS_PER_TICK} is treated as that,
+     * since one chunk a tick stretches a full radius 4 warm-up past four seconds.
+     *
+     * @param rtp the rtp.yml configuration, or null while it is unavailable
+     */
+    public static int chunksPerTick(ConfigurationSection rtp) {
+        if (rtp == null) {
+            return MIN_CHUNKS_PER_TICK;
+        }
+        return Math.max(MIN_CHUNKS_PER_TICK, rtp.getInt(CHUNKS_PER_TICK_SETTING, DEFAULT_CHUNKS_PER_TICK));
+    }
+
+    /**
+     * The square of chunks around a centre, nearest first.
+     *
+     * <p>Ordering by walking distance from the middle matters when the work is spread over several
+     * ticks: the ground under the player is ready first, and a run that gives up early has still
+     * prepared the part they are standing on.</p>
+     */
+    public static List<int[]> chunkOrder(int centerChunkX, int centerChunkZ, int radius) {
+        List<int[]> chunks = new ArrayList<>();
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dz = -radius; dz <= radius; dz++) {
+                chunks.add(new int[]{centerChunkX + dx, centerChunkZ + dz});
+            }
+        }
+        chunks.sort(Comparator.comparingInt(chunk ->
+                Math.abs(chunk[0] - centerChunkX) + Math.abs(chunk[1] - centerChunkZ)));
+        return chunks;
+    }
+
+    /** The view distance the post teleport throttle holds a player at. */
+    private static int throttledViewDistance(ConfigurationSection rtp) {
+        return Math.max(MIN_VIEW_DISTANCE, rtp.getInt(VIEW_DISTANCE_SETTING, DEFAULT_VIEW_DISTANCE));
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/RtpChunkPreloadPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/RtpChunkPreloadPolicyTest.java
@@ -1,0 +1,129 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RtpChunkPreloadPolicyTest {
+
+    private static final String RADIUS = "SETTINGS.PRELOAD-RADIUS";
+    private static final String CHUNKS_PER_TICK = "SETTINGS.PRELOAD-CHUNKS-PER-TICK";
+    private static final String THROTTLE = "SETTINGS.POST-TELEPORT-CHUNK-THROTTLE";
+    private static final String VIEW_DISTANCE = "SETTINGS.POST-TELEPORT-VIEW-DISTANCE";
+
+    @Test
+    void anUntouchedConfigGetsTheSizesTheDocsPromise() {
+        YamlConfiguration rtp = new YamlConfiguration();
+
+        // The throttle is on by default and holds the player at 4, so the radius follows it there
+        // rather than staying at the 2 in PRELOAD-RADIUS.
+        assertEquals(4, RtpChunkPreloadPolicy.radius(rtp));
+        assertEquals(2, RtpChunkPreloadPolicy.chunksPerTick(rtp));
+    }
+
+    @Test
+    void aMissingConfigFallsBackToTheFloorsRatherThanFailing() {
+        assertEquals(2, RtpChunkPreloadPolicy.radius(null));
+        assertEquals(2, RtpChunkPreloadPolicy.chunksPerTick(null));
+    }
+
+    @Test
+    void withTheThrottleOffTheRadiusIsTheAdminsBetweenTwoAndFour() {
+        YamlConfiguration rtp = new YamlConfiguration();
+        rtp.set(THROTTLE, false);
+        assertEquals(2, RtpChunkPreloadPolicy.radius(rtp));
+
+        // A radius under 2 drops the player into terrain nothing has read yet, which is the whole
+        // thing preloading exists to stop, so the floor wins over the configured value.
+        rtp.set(RADIUS, 1);
+        assertEquals(2, RtpChunkPreloadPolicy.radius(rtp));
+        rtp.set(RADIUS, -5);
+        assertEquals(2, RtpChunkPreloadPolicy.radius(rtp));
+
+        rtp.set(RADIUS, 3);
+        assertEquals(3, RtpChunkPreloadPolicy.radius(rtp));
+
+        rtp.set(RADIUS, 9);
+        assertEquals(4, RtpChunkPreloadPolicy.radius(rtp));
+    }
+
+    @Test
+    void withTheThrottleOnTheViewDistanceRaisesTheRadiusButNeverLowersIt() {
+        YamlConfiguration rtp = new YamlConfiguration();
+        rtp.set(THROTTLE, true);
+        rtp.set(RADIUS, 2);
+
+        // This is why the config comment calls PRELOAD-RADIUS a floor rather than a cap.
+        assertEquals(4, RtpChunkPreloadPolicy.radius(rtp));
+
+        rtp.set(VIEW_DISTANCE, 2);
+        assertEquals(2, RtpChunkPreloadPolicy.radius(rtp));
+
+        // A bigger PRELOAD-RADIUS still wins when it asks for more than the throttle does.
+        rtp.set(RADIUS, 3);
+        assertEquals(3, RtpChunkPreloadPolicy.radius(rtp));
+
+        // Neither side can push past 4 chunks.
+        rtp.set(VIEW_DISTANCE, 32);
+        assertEquals(4, RtpChunkPreloadPolicy.radius(rtp));
+
+        // A view distance below 2 is treated as 2, so it cannot shrink the radius either.
+        rtp.set(RADIUS, 2);
+        rtp.set(VIEW_DISTANCE, 0);
+        assertEquals(2, RtpChunkPreloadPolicy.radius(rtp));
+    }
+
+    @Test
+    void chunksPerTickNeverDropsBelowTwo() {
+        YamlConfiguration rtp = new YamlConfiguration();
+
+        rtp.set(CHUNKS_PER_TICK, 1);
+        assertEquals(2, RtpChunkPreloadPolicy.chunksPerTick(rtp));
+        rtp.set(CHUNKS_PER_TICK, 0);
+        assertEquals(2, RtpChunkPreloadPolicy.chunksPerTick(rtp));
+        rtp.set(CHUNKS_PER_TICK, -8);
+        assertEquals(2, RtpChunkPreloadPolicy.chunksPerTick(rtp));
+
+        rtp.set(CHUNKS_PER_TICK, 6);
+        assertEquals(6, RtpChunkPreloadPolicy.chunksPerTick(rtp));
+    }
+
+    @Test
+    void chunkOrderCoversTheSquareOnceAndStartsInTheMiddle() {
+        List<int[]> chunks = RtpChunkPreloadPolicy.chunkOrder(10, -4, 2);
+
+        assertEquals(25, chunks.size());
+        assertEquals(10, chunks.get(0)[0]);
+        assertEquals(-4, chunks.get(0)[1]);
+
+        Set<String> seen = new HashSet<>();
+        for (int[] chunk : chunks) {
+            assertTrue(seen.add(chunk[0] + ":" + chunk[1]), "chunk visited twice");
+            assertTrue(Math.abs(chunk[0] - 10) <= 2 && Math.abs(chunk[1] + 4) <= 2);
+        }
+
+        // Nearest first is what makes a run that gives up early still leave the ground under the
+        // player ready, so the distances have to come back in order.
+        int previous = -1;
+        for (int[] chunk : chunks) {
+            int distance = Math.abs(chunk[0] - 10) + Math.abs(chunk[1] + 4);
+            assertTrue(distance >= previous, "chunk order jumped back towards the centre");
+            previous = distance;
+        }
+    }
+
+    @Test
+    void aZeroRadiusIsJustTheChunkUnderTheDestination() {
+        List<int[]> chunks = RtpChunkPreloadPolicy.chunkOrder(0, 0, 0);
+
+        assertEquals(1, chunks.size());
+        assertEquals(0, chunks.get(0)[0]);
+        assertEquals(0, chunks.get(0)[1]);
+    }
+}


### PR DESCRIPTION
`RTPManager` and `TeleportManager` each carried their own copy of the same three methods: the chunk radius to prepare around an RTP destination, how many chunks to prepare per tick, and the nearest-first ordering of the square. Byte for byte identical, down to the sort comparator. They now live in `RtpChunkPreloadPolicy` and both managers call it.

## Are they meant to stay in lockstep

Worth answering first, because if the two are allowed to drift then the duplication was deliberate and this should have been closed rather than merged.

They are. Both read the same pair of config keys, `PRELOAD-RADIUS` and `PRELOAD-CHUNKS-PER-TICK`, and there is no separate key for either side, so an admin has exactly one lever and is expressing one intent when they touch it. Both also widen the radius to whatever `POST-TELEPORT-VIEW-DISTANCE` is about to hold the player at, which is the giveaway: they are sizing the same physical area, the terrain a player will be looking at when they land. One manager prepares it before the teleport and the other settles it afterwards, but it is one area measured either side of one teleport.

Giving either side a size of its own means adding a config key for it. That is a deliberate change, and a deliberate place to split this apart again, which beats two copies drifting quietly.

## Why it was worth doing now

PR #407 changed a stale fallback from 1 to 2 and had to make that identical one word edit in four places across the two classes. Nothing broke, because the copies were still identical. Nothing would have broken loudly if only one had been changed either, and only one of the two had a test.

## What the policy owns

`radius`, `chunksPerTick` and `chunkOrder`, plus the setting paths and bounds that were previously spelled out as private constants in `RTPManager` and as inline string literals in `TeleportManager`. A null config returns the floors rather than throwing, where the old code would have hit a NullPointerException.

Deliberately left where it is: `TeleportManager.getRtpThrottleDistance`. It applies the throttle to a player's view and simulation distance, which is a different job from sizing chunk work, and it is called for two different keys. The policy reads the view distance key itself for the one place its radius depends on it.

## Notes

Behaviour is unchanged, and the existing `RTPManagerTest.testPreloadDefaultsMatchTheFloorsTheyPassThrough` is the check on that: it reflects on the private getters, which now delegate, and it passes untouched. The `TeleportManager` half had no test at all, which was half the point of this; it now runs the same code the policy test covers.

`RtpChunkPreloadPolicyTest` adds 7 tests: the stock config, a null one, the radius with the throttle off and on, the chunks-per-tick floor, and the chunk ordering, including that distances come back nearest first so a run that gives up early has still prepared the ground under the player. Suite is 678 green, up from 671. Net 40 lines of duplicated logic gone.
