### PR TITLE
docs(wiki): write the config sections these guides skipped

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -3,12 +3,6 @@
 This is the official technical setup guide for `config.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
-Six sections have no write-up here yet: `OPTIMIZATION`, `RTP-ZONE`, `TELEPORT-COOLDOWN`, `BOUNTY`,
-`AMETHYST-TOOLS` and `COMMANDS`. Nothing is wrong with them; they simply have no entry below, and
-the comments above each key in `config.yml` say what they do. Watch the names on two of those: this
-file's `RTP-ZONE` and `AMETHYST-TOOLS` are separate settings from `rtp.yml` and `amethyst-tools.yml`,
-which have guides of their own.
-
 A line whose visible letters are all uppercase is shown in Title Case instead, so long as it also
 carries a colour code or a placeholder. That reaches the tablist header and the `SERVER-LIST`
 MOTD among others, and [FAQ entry 16](FAQ) explains the rule and how to keep your capitals.
@@ -2104,6 +2098,105 @@ SERVER-LIST:
 
 ---
 
+## Section: `OPTIMIZATION`
+
+### 1. Commented Setup Code Example
+
+```yaml
+OPTIMIZATION:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: true
+  # The numerical value for Monitor Interval Ticks. Available options: Any valid integer
+  MONITOR-INTERVAL-TICKS: 100
+  # The decimal value for Tps Warn Threshold. Available options: Any decimal number
+  TPS-WARN-THRESHOLD: 18.5
+  # The decimal value for Tps Critical Threshold. Available options: Any decimal number
+  TPS-CRITICAL-THRESHOLD: 16.0
+  # The decimal value for Mspt Warn Threshold. Available options: Any decimal number
+  MSPT-WARN-THRESHOLD: 45.0
+  # The decimal value for Mspt Critical Threshold. Available options: Any decimal number
+  MSPT-CRITICAL-THRESHOLD: 55.0
+  # The numerical value for Recovery Samples. Available options: Any valid integer
+  RECOVERY-SAMPLES: 3
+  # Determines whether Log State Changes is enabled or disabled. Available options: true, false
+  LOG-STATE-CHANGES: true
+  # Configuration section for Adaptive Tasks. Each entry below decides how often one task is
+  # allowed to run while the server is struggling. None of them switch a feature on or off; the
+  # switches for that live in their own sections, either at the top level of this file or in the
+  # file named after the feature.
+  ADAPTIVE-TASKS:
+    # Configuration section for Scoreboard.
+    SCOREBOARD:
+      # Whether the scoreboard task may be slowed down while the server is under load. Setting this
+      # to false removes the slowdown and lets the task keep running at full rate; it does not turn
+      # the scoreboard off. That switch is SCOREBOARD.ENABLED in scoreboard.yml.
+      # Available options: true, false
+      ENABLED: true
+      # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
+      WARN-MIN-INTERVAL-TICKS: 4
+      # The numerical value for Critical Min Interval Ticks. Available options: Any valid integer
+      CRITICAL-MIN-INTERVAL-TICKS: 10
+    # Configuration section for Tablist.
+    TABLIST:
+      # Whether the tablist task may be slowed down while the server is under load. Setting this to
+      # false removes the slowdown and lets the task keep running at full rate; it does not turn the
+      # tablist off. That switch is the TABLIST section near the top of this file.
+      # Available options: true, false
+      ENABLED: true
+      # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
+      WARN-MIN-INTERVAL-TICKS: 80
+      # The numerical value for Critical Min Interval Ticks. Available options: Any valid integer
+      CRITICAL-MIN-INTERVAL-TICKS: 140
+    # Configuration section for Lunar Teammates.
+    LUNAR-TEAMMATES:
+      # Whether the lunar teammates task may be slowed down while the server is under load. Setting
+      # this to false removes the slowdown and lets the task keep running at full rate; it does not
+      # turn the lunar teammate overlay off.
+      # Available options: true, false
+      ENABLED: true
+      # The numerical value for Warn Min Interval Ticks. Available options: Any valid integer
+      WARN-MIN-INTERVAL-TICKS: 40
+      # The numerical value for Critical Min Interval Ticks. Available options: Any valid integer
+      CRITICAL-MIN-INTERVAL-TICKS: 100
+# Configuration section for Clear Lag.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `OPTIMIZATION.ENABLED` | `bool` | `true`, `false` | `true` | Whether the load monitor runs. With it off nothing is throttled and every task below keeps its normal rate no matter what the server is doing. |
+| `OPTIMIZATION.MONITOR-INTERVAL-TICKS` | `int` | `20` or more | `100` | How often TPS and MSPT are sampled. Anything under `20` is raised to `20`, so it checks at most once a second. |
+| `OPTIMIZATION.TPS-WARN-THRESHOLD` | `float` | Any decimal number | `18.5` | TPS below this moves the server into the warning state. |
+| `OPTIMIZATION.TPS-CRITICAL-THRESHOLD` | `float` | Any decimal number | `16.0` | TPS below this goes straight to critical. |
+| `OPTIMIZATION.MSPT-WARN-THRESHOLD` | `float` | Any decimal number | `45.0` | Milliseconds per tick above this moves the server into the warning state. TPS and MSPT are judged separately and the worse of the two decides. |
+| `OPTIMIZATION.MSPT-CRITICAL-THRESHOLD` | `float` | Any decimal number | `55.0` | Milliseconds per tick above this goes to critical. |
+| `OPTIMIZATION.RECOVERY-SAMPLES` | `int` | `1` or more | `3` | How many calm samples in a row are needed before the state drops back down. Climbing happens on the first bad sample; only the way down waits. At the default that is three quiet checks, which stops a server hovering on the threshold from flipping the throttle on and off. |
+| `OPTIMIZATION.LOG-STATE-CHANGES` | `bool` | `true`, `false` | `true` | Writes a console line on each state change, quoting the TPS and MSPT that triggered it. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.SCOREBOARD.ENABLED` | `bool` | `true`, `false` | `true` | Whether the scoreboard task may be slowed down while the server is struggling. Setting it to `false` removes the slowdown only; the scoreboard itself is switched off with `SCOREBOARD.ENABLED` in `scoreboard.yml`. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.SCOREBOARD.WARN-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `4` | Smallest gap allowed between runs of that task while the server sits in the warning state. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.SCOREBOARD.CRITICAL-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `10` | The same floor for the critical state. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.TABLIST.ENABLED` | `bool` | `true`, `false` | `true` | Whether the tablist task may be slowed down while the server is struggling. Setting it to `false` removes the slowdown only; the tablist itself is switched off in the `TABLIST` section of this file. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.TABLIST.WARN-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `80` | Smallest gap allowed between runs of that task while the server sits in the warning state. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.TABLIST.CRITICAL-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `140` | The same floor for the critical state. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.LUNAR-TEAMMATES.ENABLED` | `bool` | `true`, `false` | `true` | Whether the lunar teammates task may be slowed down while the server is struggling. Setting it to `false` removes the slowdown only; the teammate overlay itself stays on. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.LUNAR-TEAMMATES.WARN-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `40` | Smallest gap allowed between runs of that task while the server sits in the warning state. |
+| `OPTIMIZATION.ADAPTIVE-TASKS.LUNAR-TEAMMATES.CRITICAL-MIN-INTERVAL-TICKS` | `int` | Any valid integer | `100` | The same floor for the critical state. |
+
+### 3. Practical Setup Example
+
+```yaml
+OPTIMIZATION:
+  ENABLED: true
+  # sample twice as often, and give ground sooner on a busy server
+  MONITOR-INTERVAL-TICKS: 50
+  TPS-WARN-THRESHOLD: 19.0
+  TPS-CRITICAL-THRESHOLD: 17.0
+  # wait longer before easing off, so the throttle stops flapping
+  RECOVERY-SAMPLES: 6
+```
+
+---
 ## Section: `CLEAR-LAG`
 
 ### 1. Commented Setup Code Example
@@ -2274,6 +2367,345 @@ COMBAT-MANAGER:
 
 ---
 
+## Section: `RTP-ZONE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+RTP-ZONE:
+  # Determines whether Enabled is enabled or disabled. Available options: true, false
+  ENABLED: true
+  # The text or value for Cuboid. Available options: Any valid string text
+  CUBOID: ''
+  # The numerical value for Every. Available options: Any valid integer
+  EVERY: 30
+  TITLE: '&c&lRTP Zone'
+  # The text or value for Sub Title. Available options: Any valid string text
+  SUB-TITLE: '&fTeleporting in %countdown%'
+  # The text or value for Cancelled Message. Available options: Any valid string text
+  CANCELLED-MESSAGE: '&cRTP cancelled because you left the zone.'
+  # The text or value for Failed Message. Available options: Any valid string text
+  FAILED-MESSAGE: '&cCould not find a safe RTP zone location.'
+  # The text or value for Success Message. Available options: Any valid string text
+  SUCCESS-MESSAGE: ''
+  # Configuration section for World.
+  WORLD:
+    NAME: world
+    # The numerical value for Center X. Available options: Any valid integer
+    CENTER-X: 0
+    # The numerical value for Center Z. Available options: Any valid integer
+    CENTER-Z: 0
+    # The numerical value for Min Radius. Available options: Any valid integer
+    MIN-RADIUS: 500
+    # The numerical value for Max Radius. Available options: Any valid integer
+    MAX-RADIUS: 2000
+  # The numerical value for Title Fade Out Ticks. Available options: Any valid integer
+  TITLE-FADE-OUT-TICKS: 10
+# Configuration section for First Join Rtp. Drops brand new players at a random location
+# the first time they join instead of leaving them on the vanilla world spawn. The search
+# ignores RTP cooldowns, playtime requirements, and the RTP queue, but it does require the
+# RTP feature itself to be enabled.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RTP-ZONE.ENABLED` | `bool` | `true`, `false` | `true` | Whether the zone runs. The RTP Zone feature toggle has to be on as well, so turning that off disables the zone regardless of this key. |
+| `RTP-ZONE.CUBOID` | `str` | The name of a cuboid | `''` | The cuboid that acts as the zone; standing inside it starts the countdown. You normally set this with `/cuboid` rather than by hand, which writes the name in for you. Blank means no zone is bound. |
+| `RTP-ZONE.EVERY` | `int` | `1` or more | `30` | Seconds a player has to stay inside the cuboid before they are teleported. Values below `1` are raised to `1`. |
+| `RTP-ZONE.TITLE` | `str` | Any string text | `'&c&lRTP Zone'` | The title shown while the countdown runs. |
+| `RTP-ZONE.SUB-TITLE` | `str` | Any string text | `'&fTeleporting in %countdown%'` | The subtitle under it. `%countdown%` becomes the seconds left. |
+| `RTP-ZONE.CANCELLED-MESSAGE` | `str` | Any string text | `'&cRTP cancelled because you left the zone.'` | Sent when someone walks out before the countdown finishes. |
+| `RTP-ZONE.FAILED-MESSAGE` | `str` | Any string text | `'&cCould not find a safe RTP zone location.'` | Sent when the search ran out of attempts without finding anywhere safe. |
+| `RTP-ZONE.SUCCESS-MESSAGE` | `str` | Any string text | `''` | Sent after a successful teleport. Blank by default, which sends nothing at all. |
+| `RTP-ZONE.WORLD.NAME` | `str` | A world name | `world` | The world the zone drops people into. It does not have to be the world the cuboid sits in. |
+| `RTP-ZONE.WORLD.CENTER-X` | `int` | Any valid integer | `0` | X coordinate the search ring is measured from. |
+| `RTP-ZONE.WORLD.CENTER-Z` | `int` | Any valid integer | `0` | Z coordinate the search ring is measured from. |
+| `RTP-ZONE.WORLD.MIN-RADIUS` | `int` | Any valid integer | `500` | Closest the destination may land to that centre. |
+| `RTP-ZONE.WORLD.MAX-RADIUS` | `int` | Any valid integer | `2000` | Furthest it may land. Set it below the minimum and the minimum wins, so the ring can never invert. |
+| `RTP-ZONE.TITLE-FADE-OUT-TICKS` | `int` | Any valid integer | `10` | How long the countdown title takes to fade once it is cleared or replaced. |
+
+### 3. Practical Setup Example
+
+```yaml
+RTP-ZONE:
+  ENABLED: true
+  CUBOID: 'spawn-rtp-pad'
+  # ten seconds of standing on the pad is enough
+  EVERY: 10
+  WORLD:
+    NAME: world
+    MIN-RADIUS: 1000
+    MAX-RADIUS: 15000
+```
+
+---
+## Section: `TELEPORT-COOLDOWN`
+
+### 1. Commented Setup Code Example
+
+```yaml
+TELEPORT-COOLDOWN:
+  # The numerical value for Home. Available options: Any valid integer
+  HOME: 5
+  # The numerical value for Team Home. Available options: Any valid integer
+  TEAM-HOME: 5
+  # The numerical value for Spawn. Available options: Any valid integer
+  SPAWN: 5
+  # The numerical value for Afk. Available options: Any valid integer
+  AFK: 5
+  # The numerical value for Tpa. Available options: Any valid integer
+  TPA: 5
+  # The numerical value for Warp. Available options: Any valid integer
+  WARP: 5
+  # The numerical value for Rtp. Available options: Any valid integer
+  RTP: 5
+# Configuration section for Bounty.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `TELEPORT-COOLDOWN.HOME` | `int` | Any valid integer | `5` | Seconds the player has to stand still before `/home` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.TEAM-HOME` | `int` | Any valid integer | `5` | Seconds the player has to stand still before `/teamhome` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.SPAWN` | `int` | Any valid integer | `5` | Seconds the player has to stand still before `/spawn` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.AFK` | `int` | Any valid integer | `5` | Seconds the player has to stand still before the AFK teleport completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.TPA` | `int` | Any valid integer | `5` | Seconds the player has to stand still before an accepted `/tpa` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.WARP` | `int` | Any valid integer | `5` | Seconds the player has to stand still before `/warp` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+| `TELEPORT-COOLDOWN.RTP` | `int` | Any valid integer | `5` | Seconds the player has to stand still before `/rtp` completes. Moving more than half a block cancels the teleport and sends `TELEPORT.CANCELED`. |
+
+### 3. Practical Setup Example
+
+```yaml
+TELEPORT-COOLDOWN:
+  # instant for the everyday ones
+  HOME: 0
+  TEAM-HOME: 0
+  SPAWN: 0
+  AFK: 5
+  TPA: 3
+  WARP: 3
+  # keep a warmup on rtp so it cannot be used to run from a fight
+  RTP: 10
+```
+
+---
+## Section: `BOUNTY`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BOUNTY:
+  # Configuration section for Excluded Worlds.
+  EXCLUDED-WORLDS:
+  - duels
+# Configuration section for Amethyst Tools.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BOUNTY.EXCLUDED-WORLDS` | `list` | List of world names | `['duels']` | Worlds where a bounty is not paid out. Kill someone with a bounty on their head in one of these and the killer gets nothing, while the bounty stays on the victim for somebody to claim elsewhere. `duels` is listed so arena matches cannot be used to farm bounties off a friend. |
+
+### 3. Practical Setup Example
+
+```yaml
+BOUNTY:
+  EXCLUDED-WORLDS:
+  - duels
+  - ffa
+```
+
+---
+## Section: `AMETHYST-TOOLS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+AMETHYST-TOOLS:
+  # Configuration section for Excluded Worlds.
+  EXCLUDED-WORLDS:
+  - duels
+  # Configuration section for Pickaxe.
+  PICKAXE:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    # Configuration section for Disabled Blocks.
+    DISABLED-BLOCKS:
+    - GRASS_BLOCK
+    - DIRT_PATH
+    - DIRT
+    - COARSE_DIRT
+    - ROOTED_DIRT
+    - CLAY
+    - FARMLAND
+    - SAND
+    - RED_SAND
+    - GRAVEL
+    - SPAWNER
+    NAME: '&#A303F9Amethyst Pickaxe'
+    LORE:
+    - '&79 Blocks Per Break'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # Configuration section for Enchantments.
+    ENCHANTMENTS:
+    - MENDING:1
+    - EFFICIENCY:5
+    - UNBREAKING:3
+  # Configuration section for Axe.
+  AXE:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    NAME: '&#A303F9Amethyst Axe'
+    LORE:
+    - '&7Breaks Trees Instantly'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # Configuration section for Enchantments.
+    ENCHANTMENTS:
+    - MENDING:1
+    - EFFICIENCY:5
+    - UNBREAKING:3
+    - SILK_TOUCH:1
+  # Configuration section for Sellaxe.
+  SELLAXE:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    NAME: '&#A303F9Amethyst Sell Axe'
+    LORE:
+    - '&7Instantly Sells All Items in A Chest'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # Configuration section for Enchantments.
+    ENCHANTMENTS:
+    - MENDING:1
+    - EFFICIENCY:5
+    - UNBREAKING:3
+  # Configuration section for Shovel.
+  SHOVEL:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    # Configuration section for Allowed Blocks.
+    ALLOWED-BLOCKS:
+    - GRASS_BLOCK
+    - DIRT_PATH
+    - DIRT
+    - COARSE_DIRT
+    - ROOTED_DIRT
+    - CLAY
+    - FARMLAND
+    - SAND
+    - RED_SAND
+    - GRAVEL
+    NAME: '&#A303F9Amethyst Shovel'
+    LORE:
+    - '&79 Blocks Per Break'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # Configuration section for Enchantments.
+    ENCHANTMENTS:
+    - MENDING:1
+    - EFFICIENCY:5
+    - UNBREAKING:3
+  # Configuration section for Bucket.
+  BUCKET:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    NAME: '&#A303F9Amethyst Bucket'
+    LORE:
+    - '&7Drains 27 Water At Once'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # A list configuration for Enchantments. Available options: Multiple items
+    ENCHANTMENTS: []
+  # Configuration section for Booster.
+  BOOSTER:
+    # Configuration section for Particle.
+    PARTICLE:
+      NAME: FALLING_DUST
+      MATERIAL: PURPLE_CONCRETE_POWDER
+      # The numerical value for Amount. Available options: Any valid integer
+      AMOUNT: 10
+    NAME: '&#A303F9Shard Booster'
+    LORE:
+    - '&74x Shard Production for 24 hours'
+    - '&8Self Destruct'
+    - '&8{time}'
+    # A list configuration for Enchantments. Available options: Multiple items
+    ENCHANTMENTS: []
+# Configuration section for Commands.
+# Configuration section for Voice Chat.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `AMETHYST-TOOLS.EXCLUDED-WORLDS` | `list` | List of world names | `['duels']` | Worlds where the amethyst tools do nothing. Their special break behaviour is skipped there, so a sell axe carried into an arena is an ordinary axe. |
+| `AMETHYST-TOOLS.<TOOL>.PARTICLE.NAME` | `str` | Any particle name | `FALLING_DUST` | The particle trailed from the tool while it works. |
+| `AMETHYST-TOOLS.<TOOL>.PARTICLE.MATERIAL` | `str` | Any block material | `PURPLE_CONCRETE_POWDER` | The block the particle is tinted from. Only used by particles that take a block, such as `FALLING_DUST`; other particles ignore it. |
+| `AMETHYST-TOOLS.<TOOL>.PARTICLE.AMOUNT` | `int` | Any valid integer | `10` | How many particles are spawned per effect. Raise it for a heavier trail, drop it to nothing if players complain about the clutter. |
+| `AMETHYST-TOOLS.<TOOL>.NAME` | `str` | Any string text | `'&#A303F9Amethyst Pickaxe'` | The item name. Hex colours in `&#RRGGBB` form work here, which is where the purple comes from. |
+| `AMETHYST-TOOLS.<TOOL>.LORE` | `list` | Lines of text | `['&79 Blocks Per Break', '&8Self Destruct', '&8{time}']` | The item lore. A line containing `{time}` is rewritten with the time the tool has left and keeps counting down while it sits in the inventory, so keep that placeholder on a line of its own. |
+| `AMETHYST-TOOLS.<TOOL>.ENCHANTMENTS` | `list` | `ENCHANTMENT:LEVEL` entries | `['MENDING:1', 'EFFICIENCY:5', 'UNBREAKING:3']` | Enchantments applied when the tool is handed out. Levels beyond the vanilla maximum are allowed. An empty list, as the bucket and booster ship with, gives a clean item. |
+| `AMETHYST-TOOLS.PICKAXE.DISABLED-BLOCKS` | `list` | Block materials | `['GRASS_BLOCK', 'DIRT_PATH', ...]` | Blocks the pickaxe refuses to area-break. The list is the soft ground the shovel is meant for, plus `SPAWNER` so a stray swing cannot wipe out a spawner. |
+| `AMETHYST-TOOLS.SHOVEL.ALLOWED-BLOCKS` | `list` | Block materials | `['GRASS_BLOCK', 'DIRT_PATH', ...]` | The opposite arrangement: the shovel area-breaks only what is listed here, so it cannot be used as a second pickaxe. |
+
+`<TOOL>` above stands for any of `PICKAXE`, `AXE`, `SELLAXE`, `SHOVEL`, `BUCKET` or `BOOSTER`.
+Every one of them takes the same `PARTICLE`, `NAME`, `LORE` and `ENCHANTMENTS` keys; only the
+pickaxe adds `DISABLED-BLOCKS` and only the shovel adds `ALLOWED-BLOCKS`.
+
+This section covers how the tools look and which blocks they act on. What they cost, how long
+they last and the messages they send live in `amethyst-tools.yml`, which confusingly also has a
+root key called `AMETHYST-TOOLS`. The two are separate: the plugin reads the cosmetic and block
+settings from this file and the sounds, particles and security settings from that one, so a key
+put in the wrong file is simply never read.
+
+### 3. Practical Setup Example
+
+```yaml
+AMETHYST-TOOLS:
+  EXCLUDED-WORLDS:
+  - duels
+  - ffa
+  PICKAXE:
+    PARTICLE:
+      # quieter trail on a busy server
+      AMOUNT: 3
+    NAME: '&#A303F9Amethyst Pickaxe'
+    LORE:
+    - '&79 Blocks Per Break'
+    - '&8Expires in &f{time}'
+    ENCHANTMENTS:
+    - EFFICIENCY:5
+    - UNBREAKING:3
+```
+
+---
 ## Section: `VOICE-CHAT`
 
 Shows every player a consent menu before their microphone works. The menu opens on its own the first
@@ -2326,6 +2758,139 @@ VOICE-CHAT:
   PROMPT-ON-JOIN: true
   PROMPT-DELAY-TICKS: 60
   MUTE-UNTIL-ACCEPTED: true
+```
+
+---
+## Section: `COMMANDS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+COMMANDS:
+  # Determines whether Chat is enabled or disabled. Available options: true, false
+  CHAT: true
+  # Determines whether Ignore is enabled or disabled. Available options: true, false
+  IGNORE: true
+  # Determines whether Message is enabled or disabled. Available options: true, false
+  MESSAGE: true
+  # Determines whether Bounty is enabled or disabled. Available options: true, false
+  BOUNTY: true
+  # Determines whether Cuboid is enabled or disabled. Available options: true, false
+  CUBOID: true
+  # Determines whether Afk is enabled or disabled. Available options: true, false
+  AFK: true
+  # Determines whether Shards is enabled or disabled. Available options: true, false
+  SHARDS: true
+  # Determines whether Warp is enabled or disabled. Available options: true, false
+  WARP: true
+  # Determines whether Team is enabled or disabled. Available options: true, false
+  TEAM: true
+  # Determines whether Billford is enabled or disabled. Available options: true, false
+  BILLFORD: true
+  # Determines whether Home is enabled or disabled. Available options: true, false
+  HOME: true
+  # Determines whether Leaderboards is enabled or disabled. Available options: true, false
+  LEADERBOARDS: true
+  # Determines whether Night Vision is enabled or disabled. Available options: true, false
+  NIGHT-VISION: true
+  # Determines whether Phantom is enabled or disabled. Available options: true, false
+  PHANTOM: true
+  # Determines whether Rtp is enabled or disabled. Available options: true, false
+  RTP: true
+  # Determines whether Sell is enabled or disabled. Available options: true, false
+  SELL: true
+  # Determines whether Settings is enabled or disabled. Available options: true, false
+  SETTINGS: true
+  # Determines whether Shop is enabled or disabled. Available options: true, false
+  SHOP: true
+  # Determines whether Enderchest is enabled or disabled. Available options: true, false
+  ENDERCHEST: true
+  # Determines whether Gamemode is enabled or disabled. Available options: true, false
+  GAMEMODE: true
+  # Determines whether Social is enabled or disabled. Available options: true, false
+  SOCIAL: true
+  # Determines whether Spawn is enabled or disabled. Available options: true, false
+  SPAWN: true
+  # Determines whether Stats is enabled or disabled. Available options: true, false
+  STATS: true
+  # Determines whether Tpa is enabled or disabled. Available options: true, false
+  TPA: true
+  # Determines whether Tpauto is enabled or disabled. Available options: true, false
+  TPAUTO: true
+  # Determines whether Findplayer is enabled or disabled. Available options: true, false
+  FINDPLAYER: true
+  # Determines whether Crate is enabled or disabled. Available options: true, false
+  CRATE: true
+  # Determines whether Shardpay is enabled or disabled. Available options: true, false
+  SHARDPAY: false
+  # Determines whether Ranks is enabled or disabled. Available options: true, false
+  RANKS: true
+  # Determines whether Rules is enabled or disabled. Available options: true, false
+  RULES: true
+  # Determines whether Help is enabled or disabled. Available options: true, false
+  HELP: true
+  # Determines whether Servers is enabled or disabled. Available options: true, false
+  SERVERS: true
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `COMMANDS.CHAT` | `bool` | `true`, `false` | `true` | Enables global chat commands and the chat moderation controls. |
+| `COMMANDS.IGNORE` | `bool` | `true`, `false` | `true` | Enables the ignore and unignore commands. |
+| `COMMANDS.MESSAGE` | `bool` | `true`, `false` | `true` | Enables private messages, replies and the private message toggle. |
+| `COMMANDS.BOUNTY` | `bool` | `true`, `false` | `true` | Enables the bounty command and its menus. |
+| `COMMANDS.CUBOID` | `bool` | `true`, `false` | `true` | Enables cuboid region management and the helpers that bind a region to a feature. |
+| `COMMANDS.AFK` | `bool` | `true`, `false` | `true` | Enables the afk command, its menus and the afk movement task. |
+| `COMMANDS.SHARDS` | `bool` | `true`, `false` | `true` | Enables shard balances, shard pay, passive rewards and shard cuboids. |
+| `COMMANDS.WARP` | `bool` | `true`, `false` | `true` | Enables the warp commands and the warp manager commands. |
+| `COMMANDS.TEAM` | `bool` | `true`, `false` | `true` | Enables the team command, team homes and the team menus. |
+| `COMMANDS.BILLFORD` | `bool` | `true`, `false` | `true` | Enables the Billford trade menu and its rotation task. |
+| `COMMANDS.HOME` | `bool` | `true`, `false` | `true` | Enables the home commands and the home menu. |
+| `COMMANDS.LEADERBOARDS` | `bool` | `true`, `false` | `true` | Enables the leaderboard commands and leaderboard menus. |
+| `COMMANDS.NIGHT-VISION` | `bool` | `true`, `false` | `true` | Enables the night vision player toggle. |
+| `COMMANDS.PHANTOM` | `bool` | `true`, `false` | `true` | Enables the phantom spawning toggle. |
+| `COMMANDS.RTP` | `bool` | `true`, `false` | `true` | Enables the random teleport command, its queue command and the rtp menu. |
+| `COMMANDS.SELL` | `bool` | `true`, `false` | `true` | Enables the worth browser and the worth display helpers. |
+| `COMMANDS.SETTINGS` | `bool` | `true`, `false` | `true` | Enables the player settings menu. |
+| `COMMANDS.SHOP` | `bool` | `true`, `false` | `true` | Enables the shop command and its purchase menus. |
+| `COMMANDS.ENDERCHEST` | `bool` | `true`, `false` | `true` | Enables the custom ender chest command and its listener. |
+| `COMMANDS.GAMEMODE` | `bool` | `true`, `false` | `true` | Enables the staff gamemode commands. |
+| `COMMANDS.SOCIAL` | `bool` | `true`, `false` | `true` | Enables the discord, twitter/x, store and media commands. |
+| `COMMANDS.SPAWN` | `bool` | `true`, `false` | `true` | Enables the spawn command and spawn menu. |
+| `COMMANDS.STATS` | `bool` | `true`, `false` | `true` | Enables the stats, ping and playtime commands. |
+| `COMMANDS.TPA` | `bool` | `true`, `false` | `true` | Enables the teleport request commands and the confirm menu. |
+| `COMMANDS.TPAUTO` | `bool` | `true`, `false` | `true` | Enables the tpa auto-accept commands. |
+| `COMMANDS.FINDPLAYER` | `bool` | `true`, `false` | `true` | Enables the staff find player command. |
+| `COMMANDS.CRATE` | `bool` | `true`, `false` | `true` | Enables crate commands, crate menus, key-all and the crate visual effects. |
+| `COMMANDS.SHARDPAY` | `bool` | `true`, `false` | `false` | Enables paying shards to another player. This is the one entry that ships off, so shard transfers are opt-in. |
+| `COMMANDS.RANKS` | `bool` | `true`, `false` | `true` | Enables the ranks command and ranks menu. |
+| `COMMANDS.RULES` | `bool` | `true`, `false` | `true` | Enables the rules command and rules menu. |
+| `COMMANDS.HELP` | `bool` | `true`, `false` | `true` | Enables the help command and the server info menu. |
+| `COMMANDS.SERVERS` | `bool` | `true`, `false` | `true` | Enables the network server status command and menu. |
+
+These are switches, not a list of what exists: setting one to `false` takes the matching commands
+away rather than hiding them. What a blocked command looks like to the player is set by
+`FEATURES_SETTINGS.DISABLED_COMMAND_ACTION` near the top of this file, which can show a message,
+reply as though the command were unknown, or unregister it from the server outright.
+
+One thing to know before editing here. Most of these keys have a newer counterpart at
+`FEATURES.<name>.ENABLED`, and when that path exists it wins; the `COMMANDS` entry is only read as
+a fallback. `FEATURES` is not in the shipped file, so on a fresh install these keys are the live
+switches, but on a server where the feature toggles have been used the value here can look
+ignored. `SHARDPAY` has no feature counterpart at all and is always read from this section.
+
+### 3. Practical Setup Example
+
+```yaml
+COMMANDS:
+  # a survival server that runs its economy elsewhere
+  SHOP: false
+  SELL: false
+  BILLFORD: false
+  # and lets players move shards between accounts
+  SHARDPAY: true
 ```
 
 ---

--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -3,12 +3,6 @@
 This is the official technical setup guide for `messages.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
-Twenty-five sections have no write-up here yet: `BILLFORD`, `BALANCE`, `SHARD_PAY`, `FINDPLAYER`,
-`PUNISHMENTS`, `SOCIAL`, `AUCTION_HOUSE`, `ORDERS`, `STATS-WIPE`, `STAFF`, `FLY`, `FLYSPEED`,
-`WALKSPEED`, `HEAL`, `FEED`, `GAMEMODE`, `RANDOMTP`, `RENAME`, `PING`, `PLAYTIME`, `STAFFCHAT`,
-`HELPOP`, `REPORT`, `ALTS` and `VOICE-CHAT`. Every key in them behaves like the ones covered below,
-and `messages.yml` carries a comment above each one saying what it is.
-
 One formatting rule catches people out. A line whose visible letters are all uppercase is shown
 in Title Case instead, whenever that line also carries a colour code or a placeholder.
 [FAQ entry 16](FAQ) covers why, and how to write a shouting line that survives it.
@@ -353,7 +347,7 @@ IGNORE:
 | :--- | :--- | :--- | :--- | :--- |
 | `IGNORE.ADDED` | `str` | Any string text | `'&7%player% &chas been added to your...'` | Configures the technical `ADDED` parameter for `IGNORE.ADDED` in `messages.yml`. |
 | `IGNORE.REMOVED` | `str` | Any string text | `'&7%player% &chas been removed from ...'` | Configures the technical `REMOVED` parameter for `IGNORE.REMOVED` in `messages.yml`. |
-| `IGNORE.USAGE` | `str` | Any string text | `'&cUsage: /ignore <player|list>'` | Configures the technical `USAGE` parameter for `IGNORE.USAGE` in `messages.yml`. |
+| `IGNORE.USAGE` | `str` | Any string text | `'&cUsage: /ignore <player\|list>'` | Configures the technical `USAGE` parameter for `IGNORE.USAGE` in `messages.yml`. |
 | `IGNORE.UNIGNORE-USAGE` | `str` | Any string text | `'&cUsage: /unignore <player>'` | Configures the technical `UNIGNORE-USAGE` parameter for `IGNORE.UNIGNORE-USAGE` in `messages.yml`. |
 | `IGNORE.PLAYER-ONLY` | `str` | Any string text | `'&cOnly players can use this command...'` | Configures the technical `PLAYER-ONLY` parameter for `IGNORE.PLAYER-ONLY` in `messages.yml`. |
 | `IGNORE.NO-PERMISSION` | `str` | Any string text | `'&cYou do not have permission.'` | Configures the technical `NO-PERMISSION` parameter for `IGNORE.NO-PERMISSION` in `messages.yml`. |
@@ -1133,7 +1127,7 @@ WARPMANAGER:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `WARPMANAGER.USAGE` | `str` | Any string text | `'&cUsage: /warpmanager <create|delet...'` | Configures the technical `USAGE` parameter for `WARPMANAGER.USAGE` in `messages.yml`. |
+| `WARPMANAGER.USAGE` | `str` | Any string text | `'&cUsage: /warpmanager <create\|delet...'` | Configures the technical `USAGE` parameter for `WARPMANAGER.USAGE` in `messages.yml`. |
 | `WARPMANAGER.CREATE-USAGE` | `str` | Any string text | `'&cUsage: /warpmanager create <name>'` | Configures the technical `CREATE-USAGE` parameter for `WARPMANAGER.CREATE-USAGE` in `messages.yml`. |
 | `WARPMANAGER.DELETE-USAGE` | `str` | Any string text | `'&cUsage: /warpmanager delete <name>'` | Configures the technical `DELETE-USAGE` parameter for `WARPMANAGER.DELETE-USAGE` in `messages.yml`. |
 | `WARPMANAGER.CREATE-USAGE-ALIAS` | `str` | Any string text | `'&cUsage: /setwarp <name>'` | Configures the technical `CREATE-USAGE-ALIAS` parameter for `WARPMANAGER.CREATE-USAGE-ALIAS` in `messages.yml`. |
@@ -1328,7 +1322,7 @@ PORTALMANAGER:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `PORTALMANAGER.USAGE` | `str` | Any string text | `'&cUsage: /portalmanager <list|info|...'` | Configures the technical `USAGE` parameter for `PORTALMANAGER.USAGE` in `messages.yml`. |
+| `PORTALMANAGER.USAGE` | `str` | Any string text | `'&cUsage: /portalmanager <list\|info\|...'` | Configures the technical `USAGE` parameter for `PORTALMANAGER.USAGE` in `messages.yml`. |
 | `PORTALMANAGER.NO-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to man...'` | Configures the technical `NO-PERMISSION` parameter for `PORTALMANAGER.NO-PERMISSION` in `messages.yml`. |
 | `PORTALMANAGER.PLAYER-ONLY` | `str` | Any string text | `'&cOnly players can use this command...'` | Configures the technical `PLAYER-ONLY` parameter for `PORTALMANAGER.PLAYER-ONLY` in `messages.yml`. |
 | `PORTALMANAGER.CREATE-USAGE` | `str` | Any string text | `'&cUsage: /portalmanager create <id>...'` | Configures the technical `CREATE-USAGE` parameter for `PORTALMANAGER.CREATE-USAGE` in `messages.yml`. |
@@ -1473,7 +1467,7 @@ WORTH:
 | `WORTH.DEFAULT` | `str` | Any string text | `'&b1 {item} &fis worth &a{price_form...'` | Configures the technical `DEFAULT` parameter for `WORTH.DEFAULT` in `messages.yml`. |
 | `WORTH.HAND-ITEM` | `str` | Any string text | `'&b{amount} {item} &fis worth &a{tot...'` | Configures the technical `HAND-ITEM` parameter for `WORTH.HAND-ITEM` in `messages.yml`. |
 | `WORTH.NO-SELLABLE` | `str` | Any string text | `'&cThis item is not sellable.'` | Configures the technical `NO-SELLABLE` parameter for `WORTH.NO-SELLABLE` in `messages.yml`. |
-| `WORTH.CONTAINER-BREAKDOWN` | `str` | Any string text | `'&7Base: &f${base} &8| &7Contents: &...'` | Configures the technical `CONTAINER-BREAKDOWN` parameter for `WORTH.CONTAINER-BREAKDOWN` in `messages.yml`. |
+| `WORTH.CONTAINER-BREAKDOWN` | `str` | Any string text | `'&7Base: &f${base} &8\| &7Contents: &...'` | Configures the technical `CONTAINER-BREAKDOWN` parameter for `WORTH.CONTAINER-BREAKDOWN` in `messages.yml`. |
 | `WORTH.RELOADED` | `str` | Any string text | `'&aWorth config reloaded.'` | Configures the technical `RELOADED` parameter for `WORTH.RELOADED` in `messages.yml`. |
 | `WORTH.NO-ADMIN-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rel...'` | Configures the technical `NO-ADMIN-PERMISSION` parameter for `WORTH.NO-ADMIN-PERMISSION` in `messages.yml`. |
 | `WORTH.META-CURRENT` | `str` | Any string text | `'&b{item} &fis the farming meta at &a{mult...'` | Answer to `/meta` while a rotation is running. Supports `{item}`, `{multiplier}`, `{base}`, `{base_formatted}`, `{price}`, `{price_formatted}`, and `{countdown}`. |
@@ -1575,3 +1569,1996 @@ BOUNTY:
 
 ---
 
+## Section: `BILLFORD`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BILLFORD:
+  # The text or value for Required Contents. Available options: Any valid string text
+  REQUIRED_CONTENTS: '&cYou don''t have all the required items for this trade.'
+  # The text or value for Full Inventory. Available options: Any valid string text
+  FULL-INVENTORY: '&cYour inventory is full! Free up a slot before confirming the
+    trade.'
+  # The text or value for Trade Completed. Available options: Any valid string text
+  TRADE-COMPLETED: '&aTrade complete! You received &f{reward}&a. &7Shards: &#A303F9{shard_bonus}&7, Money: &a${money_bonus}&7. &8Next refresh in &f{next_rotation}&8.'
+  # The text or value for Limit Reached. Available options: Any valid string text
+  LIMIT-REACHED: '&cYou''ve reached the trade limit for this rotation. Come back after
+    the next trade change!'
+  # The text or value for Click Cooldown. Available options: Any valid string text
+  CLICK-COOLDOWN: '&cSlow down. Billford is still processing your last click.'
+  # The text or value for Trade Changed. Available options: Any valid string text
+  TRADE-CHANGED: '&eBillford rotated to a new offer while you had the menu open. &7Next
+    change in &b{countdown}&7.'
+  # The text or value for Busy. Available options: Any valid string text
+  BUSY: '&cBillford is already processing your last click.'
+  # The text or value for Not Configured. Available options: Any valid string text
+  NOT-CONFIGURED: '&cBillford does not have an active trade configured right now.'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou need &f{permission} &cto use Billford.'
+# Configuration section for Balance.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BILLFORD.REQUIRED_CONTENTS` | `str` | Any string text | `'&cYou don't have all the required i...'` | Sent when the player confirms a trade without every item the offer asks for. |
+| `BILLFORD.FULL-INVENTORY` | `str` | Any string text | `'&cYour inventory is full! Free up a...'` | Sent when the reward has nowhere to go. The trade is not taken, so nothing is lost. |
+| `BILLFORD.TRADE-COMPLETED` | `str` | Any string text | `'&aTrade complete! You received &f{r...'` | The receipt after a successful trade. `{reward}` is the item, `{shard_bonus}` and the money placeholder carry the extras paid on top. |
+| `BILLFORD.LIMIT-REACHED` | `str` | Any string text | `'&cYou've reached the trade limit fo...'` | Sent once the player has traded as often as this rotation allows. They can trade again after the next rotation. |
+| `BILLFORD.CLICK-COOLDOWN` | `str` | Any string text | `'&cSlow down. Billford is still proc...'` | Sent when clicks arrive faster than the trade can be processed. Guards against double-spending a click. |
+| `BILLFORD.TRADE-CHANGED` | `str` | Any string text | `'&eBillford rotated to a new offer w...'` | Sent when the rotation moved on while the menu was still open, so the offer on screen is stale. |
+| `BILLFORD.BUSY` | `str` | Any string text | `'&cBillford is already processing yo...'` | Sent when a previous click from the same player is still being handled. |
+| `BILLFORD.NOT-CONFIGURED` | `str` | Any string text | `'&cBillford does not have an active ...'` | Sent when no trade is set up at all, so there is nothing for Billford to offer. |
+| `BILLFORD.NO-PERMISSION` | `str` | Any string text | `'&cYou need &f{permission} &cto use ...'` | Sent when the player lacks the node. `{permission}` is filled with the node they need, so they can be told exactly what to ask for. |
+
+Billford is the rotating trade NPC. These cover the refusals and the receipt.
+
+### 3. Practical Setup Example
+
+```yaml
+BILLFORD:
+  # The text or value for Required Contents. Available options: Any valid string text
+  REQUIRED_CONTENTS: '&cYou don''t have all the required items for this trade.'
+  # The text or value for Full Inventory. Available options: Any valid string text
+  FULL-INVENTORY: '&cYour inventory is full! Free up a slot before confirming the
+    trade.'
+  # The text or value for Trade Completed. Available options: Any valid string text
+  TRADE-COMPLETED: '&aTrade complete! You received &f{reward}&a. &7Shards: &#A303F9{shard_bonus}&7, Money: &a${money_bonus}&7. &8Next refresh in &f{next_rotation}&8.'
+  # The text or value for Limit Reached. Available options: Any valid string text
+  LIMIT-REACHED: '&cYou''ve reached the trade limit for this rotation. Come back after
+    the next trade change!'
+  # The text or value for Click Cooldown. Available options: Any valid string text
+  CLICK-COOLDOWN: '&cSlow down. Billford is still processing your last click.'
+  # The text or value for Trade Changed. Available options: Any valid string text
+  TRADE-CHANGED: '&eBillford rotated to a new offer while you had the menu open. &7Next
+    change in &b{countdown}&7.'
+  # The text or value for Busy. Available options: Any valid string text
+  BUSY: '&cBillford is already processing your last click.'
+  # The text or value for Not Configured. Available options: Any valid string text
+  NOT-CONFIGURED: '&cBillford does not have an active trade configured right now.'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou need &f{permission} &cto use Billford.'
+# Configuration section for Balance.
+```
+
+---
+## Section: `BALANCE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+BALANCE:
+  # The text or value for Your Balance. Available options: Any valid string text
+  YOUR-BALANCE: '&7You have &a${amount}&7.'
+  # The text or value for Other Balance. Available options: Any valid string text
+  OTHER-BALANCE: '&b{player} &7has &a${amount}&7.'
+  # The text or value for Your Shards. Available options: Any valid string text
+  YOUR-SHARDS: '&7Your shards: &#A303F9{amount}'
+  # The text or value for Other Shards. Available options: Any valid string text
+  OTHER-SHARDS: '&7{player}''s shards: &#A303F9{amount}'
+  # Configuration section for Admin.
+  ADMIN:
+    # The text or value for Invalid Amount. Available options: Any valid string text
+    INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B
+      suffix (e.g. 100K, 1.5M, 2B)'
+    # The text or value for Must Be Positive. Available options: Any valid string text
+    MUST-BE-POSITIVE: '&cThe amount must be positive.'
+    # The text or value for Must Be Non Negative. Available options: Any valid string text
+    MUST-BE-NON-NEGATIVE: '&cThe amount must be zero or positive.'
+    # The text or value for Player Not Found. Available options: Any valid string text
+    PLAYER-NOT-FOUND: '&cPlayer not found.'
+    # The text or value for Target Not Enough Money. Available options: Any valid string text
+    TARGET-NOT-ENOUGH-MONEY: '&c{player} does not have enough money. Current balance:
+      &f${balance}&c.'
+    # The text or value for Add Money Success. Available options: Any valid string text
+    ADD-MONEY-SUCCESS: '&aAdded &f${amount} &ato &b{player}&a. New balance: &f${balance}&a.'
+    # The text or value for Add Money Received. Available options: Any valid string text
+    ADD-MONEY-RECEIVED: '&a{admin} added &f${amount} &ato your balance. New balance:
+      &f${balance}&a.'
+    # The text or value for Remove Money Success. Available options: Any valid string text
+    REMOVE-MONEY-SUCCESS: '&aRemoved &f${amount} &afrom &b{player}&a. New balance:
+      &f${balance}&a.'
+    # The text or value for Remove Money Received. Available options: Any valid string text
+    REMOVE-MONEY-RECEIVED: '&c{admin} removed &f${amount} &cfrom your balance. New balance: &f${balance}&c.'
+    # The text or value for Set Money Success. Available options: Any valid string text
+    SET-MONEY-SUCCESS: '&aSet &b{player}&a''s balance to &f${amount}&a. Previous balance:
+      &f${previous_balance}&a.'
+    # The text or value for Set Money Received. Available options: Any valid string text
+    SET-MONEY-RECEIVED: '&e{admin} set your balance to &f${amount}&e. Previous balance:
+      &f${previous_balance}&e.'
+  # Configuration section for Pay.
+  PAY:
+    # The text or value for Cant Pay Self. Available options: Any valid string text
+    CANT-PAY-SELF: '&cYou cannot pay yourself.'
+    # The text or value for Invalid Amount. Available options: Any valid string text
+    INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B
+      suffix (e.g. 100K, 1.5M, 2B)'
+    # The text or value for Must Be Positive. Available options: Any valid string text
+    MUST-BE-POSITIVE: '&cThe amount must be positive.'
+    # The text or value for Not Enough Money. Available options: Any valid string text
+    NOT-ENOUGH-MONEY: '&cYou don''t have enough money.'
+    # The text or value for Transaction Error. Available options: Any valid string text
+    TRANSACTION-ERROR: '&cError occurred during transaction. Your money has been refunded.'
+    # The text or value for Player Not Online. Available options: Any valid string text
+    PLAYER-NOT-ONLINE: '&cPlayer not online.'
+    # The text or value for Target Profile Not Found. Available options: Any valid string text
+    TARGET-PROFILE-NOT-FOUND: '&cTarget profile not found.'
+    # The text or value for Success Sender. Available options: Any valid string text
+    SUCCESS-SENDER: '&7You paid &b{player} &a${amount}&7.'
+    # The text or value for Success Receiver. Available options: Any valid string text
+    SUCCESS-RECEIVER: '&7You received &a${amount}&7 from &b{player}&7.'
+    # The text or value for Target Disabled Payments. Available options: Any valid string text
+    TARGET-DISABLED-PAYMENTS: '&cThe target player has the payments disabled.'
+# Configuration section for Shard Pay.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `BALANCE.YOUR-BALANCE` | `str` | Any string text | `'&7You have &a${amount}&7.'` | Reply to checking your own money. `{amount}` is the balance. |
+| `BALANCE.OTHER-BALANCE` | `str` | Any string text | `'&b{player} &7has &a${amount}&7.'` | Reply to checking somebody else's money. `{player}` and `{amount}`. |
+| `BALANCE.YOUR-SHARDS` | `str` | Any string text | `'&7Your shards: &#A303F9{amount}'` | Reply to checking your own shard balance. |
+| `BALANCE.OTHER-SHARDS` | `str` | Any string text | `'&7{player}'s shards: &#A303F9{amoun...'` | Reply to checking somebody else's shard balance. |
+| `BALANCE.ADMIN.INVALID-AMOUNT` | `str` | Any string text | `'&cInvalid amount format. Use number...'` | Sent when an admin types an amount the parser cannot read. The suffix forms it does accept are listed in the message itself. |
+| `BALANCE.ADMIN.MUST-BE-POSITIVE` | `str` | Any string text | `'&cThe amount must be positive.'` | Sent when an add or remove is given zero or a negative amount. |
+| `BALANCE.ADMIN.MUST-BE-NON-NEGATIVE` | `str` | Any string text | `'&cThe amount must be zero or positi...'` | The set variant, which does allow zero but not a negative balance. |
+| `BALANCE.ADMIN.PLAYER-NOT-FOUND` | `str` | Any string text | `'&cPlayer not found.'` | Sent when the named target has no profile on this server. |
+| `BALANCE.ADMIN.TARGET-NOT-ENOUGH-MONEY` | `str` | Any string text | `'&c{player} does not have enough mon...'` | Sent when removing more money than the target holds. `{player}` and `{balance}`. |
+| `BALANCE.ADMIN.ADD-MONEY-SUCCESS` | `str` | Any string text | `'&aAdded &f${amount} &ato &b{player}...'` | Confirmation to the admin after adding money. `{amount}`, `{player}` and the resulting `{balance}`. |
+| `BALANCE.ADMIN.ADD-MONEY-RECEIVED` | `str` | Any string text | `'&a{admin} added &f${amount} &ato yo...'` | What the target sees. `{admin}` names who did it. |
+| `BALANCE.ADMIN.REMOVE-MONEY-SUCCESS` | `str` | Any string text | `'&aRemoved &f${amount} &afrom &b{pla...'` | Confirmation to the admin after taking money away. |
+| `BALANCE.ADMIN.REMOVE-MONEY-RECEIVED` | `str` | Any string text | `'&c{admin} removed &f${amount} &cfro...'` | What the target sees when money is taken from them. |
+| `BALANCE.ADMIN.SET-MONEY-SUCCESS` | `str` | Any string text | `'&aSet &b{player}&a's balance to &f$...'` | Confirmation after setting a balance outright. `{previous_balance}` is what it was before. |
+| `BALANCE.ADMIN.SET-MONEY-RECEIVED` | `str` | Any string text | `'&e{admin} set your balance to &f${a...'` | What the target sees when their balance is set. |
+| `BALANCE.PAY.CANT-PAY-SELF` | `str` | Any string text | `'&cYou cannot pay yourself.'` | Sent when somebody tries to pay themselves. |
+| `BALANCE.PAY.INVALID-AMOUNT` | `str` | Any string text | `'&cInvalid amount format. Use number...'` | Sent when the amount cannot be parsed. |
+| `BALANCE.PAY.MUST-BE-POSITIVE` | `str` | Any string text | `'&cThe amount must be positive.'` | Sent when the amount is zero or negative. |
+| `BALANCE.PAY.NOT-ENOUGH-MONEY` | `str` | Any string text | `'&cYou don't have enough money.'` | Sent when the sender cannot cover the payment. |
+| `BALANCE.PAY.TRANSACTION-ERROR` | `str` | Any string text | `'&cError occurred during transaction...'` | Sent when the transfer failed part way through. The money is refunded, which is why the message says so. |
+| `BALANCE.PAY.PLAYER-NOT-ONLINE` | `str` | Any string text | `'&cPlayer not online.'` | Sent when the target is offline. Payments need both players present. |
+| `BALANCE.PAY.TARGET-PROFILE-NOT-FOUND` | `str` | Any string text | `'&cTarget profile not found.'` | Sent when the target is online but has no economy profile loaded. |
+| `BALANCE.PAY.SUCCESS-SENDER` | `str` | Any string text | `'&7You paid &b{player} &a${amount}&7...'` | Receipt for the payer. |
+| `BALANCE.PAY.SUCCESS-RECEIVER` | `str` | Any string text | `'&7You received &a${amount}&7 from &...'` | Notice to the player being paid. |
+| `BALANCE.PAY.TARGET-DISABLED-PAYMENTS` | `str` | Any string text | `'&cThe target player has the payment...'` | Sent when the target has turned payments off in their own settings. |
+
+Balance lookups, the admin money commands, and player to player payments.
+
+### 3. Practical Setup Example
+
+```yaml
+BALANCE:
+  # The text or value for Your Balance. Available options: Any valid string text
+  YOUR-BALANCE: '&7You have &a${amount}&7.'
+  # The text or value for Other Balance. Available options: Any valid string text
+  OTHER-BALANCE: '&b{player} &7has &a${amount}&7.'
+  # The text or value for Your Shards. Available options: Any valid string text
+  YOUR-SHARDS: '&7Your shards: &#A303F9{amount}'
+  # The text or value for Other Shards. Available options: Any valid string text
+  OTHER-SHARDS: '&7{player}''s shards: &#A303F9{amount}'
+  # Configuration section for Admin.
+  ADMIN:
+    # The text or value for Invalid Amount. Available options: Any valid string text
+    INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B
+      suffix (e.g. 100K, 1.5M, 2B)'
+    # The text or value for Must Be Positive. Available options: Any valid string text
+    MUST-BE-POSITIVE: '&cThe amount must be positive.'
+    # The text or value for Must Be Non Negative. Available options: Any valid string text
+    MUST-BE-NON-NEGATIVE: '&cThe amount must be zero or positive.'
+    # The text or value for Player Not Found. Available options: Any valid string text
+    PLAYER-NOT-FOUND: '&cPlayer not found.'
+    # The text or value for Target Not Enough Money. Available options: Any valid string text
+    TARGET-NOT-ENOUGH-MONEY: '&c{player} does not have enough money. Current balance:
+      &f${balance}&c.'
+    # The text or value for Add Money Success. Available options: Any valid string text
+    ADD-MONEY-SUCCESS: '&aAdded &f${amount} &ato &b{player}&a. New balance: &f${balance}&a.'
+    # The text or value for Add Money Received. Available options: Any valid string text
+    ADD-MONEY-RECEIVED: '&a{admin} added &f${amount} &ato your balance. New balance:
+      &f${balance}&a.'
+    # The text or value for Remove Money Success. Available options: Any valid string text
+    REMOVE-MONEY-SUCCESS: '&aRemoved &f${amount} &afrom &b{player}&a. New balance:
+      &f${balance}&a.'
+    # The text or value for Remove Money Received. Available options: Any valid string text
+    REMOVE-MONEY-RECEIVED: '&c{admin} removed &f${amount} &cfrom your balance. New balance: &f${balance}&c.'
+    # The text or value for Set Money Success. Available options: Any valid string text
+    SET-MONEY-SUCCESS: '&aSet &b{player}&a''s balance to &f${amount}&a. Previous balance:
+      &f${previous_balance}&a.'
+    # The text or value for Set Money Received. Available options: Any valid string text
+    SET-MONEY-RECEIVED: '&e{admin} set your balance to &f${amount}&e. Previous balance:
+      &f${previous_balance}&e.'
+  # Configuration section for Pay.
+  PAY:
+    # The text or value for Cant Pay Self. Available options: Any valid string text
+    CANT-PAY-SELF: '&cYou cannot pay yourself.'
+    # The text or value for Invalid Amount. Available options: Any valid string text
+    INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B
+      suffix (e.g. 100K, 1.5M, 2B)'
+    # The text or value for Must Be Positive. Available options: Any valid string text
+    MUST-BE-POSITIVE: '&cThe amount must be positive.'
+    # The text or value for Not Enough Money. Available options: Any valid string text
+    NOT-ENOUGH-MONEY: '&cYou don''t have enough money.'
+    # The text or value for Transaction Error. Available options: Any valid string text
+    TRANSACTION-ERROR: '&cError occurred during transaction. Your money has been refunded.'
+    # The text or value for Player Not Online. Available options: Any valid string text
+    PLAYER-NOT-ONLINE: '&cPlayer not online.'
+    # The text or value for Target Profile Not Found. Available options: Any valid string text
+    TARGET-PROFILE-NOT-FOUND: '&cTarget profile not found.'
+    # The text or value for Success Sender. Available options: Any valid string text
+    SUCCESS-SENDER: '&7You paid &b{player} &a${amount}&7.'
+    # The text or value for Success Receiver. Available options: Any valid string text
+    SUCCESS-RECEIVER: '&7You received &a${amount}&7 from &b{player}&7.'
+    # The text or value for Target Disabled Payments. Available options: Any valid string text
+    TARGET-DISABLED-PAYMENTS: '&cThe target player has the payments disabled.'
+# Configuration section for Shard Pay.
+```
+
+---
+## Section: `SHARD_PAY`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SHARD_PAY:
+  # The text or value for Cant Pay Self. Available options: Any valid string text
+  CANT-PAY-SELF: '&cYou cannot pay yourself.'
+  # The text or value for Invalid Amount. Available options: Any valid string text
+  INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B suffix
+    (e.g. 100K, 1.5M, 2B)'
+  # The text or value for Must Be Positive. Available options: Any valid string text
+  MUST-BE-POSITIVE: '&cThe amount must be positive.'
+  # The text or value for Not Enough Shards. Available options: Any valid string text
+  NOT-ENOUGH-SHARDS: '&cYou don''t have enough shards.'
+  # The text or value for Target Profile Not Found. Available options: Any valid string text
+  TARGET-PROFILE-NOT-FOUND: '&cTarget profile not found.'
+  # The text or value for Target Disabled Payments. Available options: Any valid string text
+  TARGET-DISABLED-PAYMENTS: '&cThe target player has the payments disabled.'
+  # The text or value for Success Sender. Available options: Any valid string text
+  SUCCESS-SENDER: '&7You paid &b{player} &#A303F9{amount}&7 shards.'
+  # The text or value for Success Receiver. Available options: Any valid string text
+  SUCCESS-RECEIVER: '&7You received &#A303F9{amount}&7 shards from &b{player}&7.'
+# Configuration section for Findplayer.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SHARD_PAY.CANT-PAY-SELF` | `str` | Any string text | `'&cYou cannot pay yourself.'` | Sent when somebody tries to pay themselves shards. |
+| `SHARD_PAY.INVALID-AMOUNT` | `str` | Any string text | `'&cInvalid amount format. Use number...'` | Sent when the amount cannot be parsed. |
+| `SHARD_PAY.MUST-BE-POSITIVE` | `str` | Any string text | `'&cThe amount must be positive.'` | Sent when the amount is zero or negative. |
+| `SHARD_PAY.NOT-ENOUGH-SHARDS` | `str` | Any string text | `'&cYou don't have enough shards.'` | Sent when the sender does not hold that many shards. |
+| `SHARD_PAY.TARGET-PROFILE-NOT-FOUND` | `str` | Any string text | `'&cTarget profile not found.'` | Sent when the target has no profile to pay into. |
+| `SHARD_PAY.TARGET-DISABLED-PAYMENTS` | `str` | Any string text | `'&cThe target player has the payment...'` | Sent when the target has payments switched off. |
+| `SHARD_PAY.SUCCESS-SENDER` | `str` | Any string text | `'&7You paid &b{player} &#A303F9{amou...'` | Receipt for the sender. |
+| `SHARD_PAY.SUCCESS-RECEIVER` | `str` | Any string text | `'&7You received &#A303F9{amount}&7 s...'` | Notice to the player receiving the shards. |
+
+The shard equivalent of paying money. Note the command itself ships disabled at `COMMANDS.SHARDPAY` in `config.yml`.
+
+### 3. Practical Setup Example
+
+```yaml
+SHARD_PAY:
+  # The text or value for Cant Pay Self. Available options: Any valid string text
+  CANT-PAY-SELF: '&cYou cannot pay yourself.'
+  # The text or value for Invalid Amount. Available options: Any valid string text
+  INVALID-AMOUNT: '&cInvalid amount format. Use numbers with optional K, M, or B suffix
+    (e.g. 100K, 1.5M, 2B)'
+  # The text or value for Must Be Positive. Available options: Any valid string text
+  MUST-BE-POSITIVE: '&cThe amount must be positive.'
+  # The text or value for Not Enough Shards. Available options: Any valid string text
+  NOT-ENOUGH-SHARDS: '&cYou don''t have enough shards.'
+  # The text or value for Target Profile Not Found. Available options: Any valid string text
+  TARGET-PROFILE-NOT-FOUND: '&cTarget profile not found.'
+  # The text or value for Target Disabled Payments. Available options: Any valid string text
+  TARGET-DISABLED-PAYMENTS: '&cThe target player has the payments disabled.'
+  # The text or value for Success Sender. Available options: Any valid string text
+  SUCCESS-SENDER: '&7You paid &b{player} &#A303F9{amount}&7 shards.'
+  # The text or value for Success Receiver. Available options: Any valid string text
+  SUCCESS-RECEIVER: '&7You received &#A303F9{amount}&7 shards from &b{player}&7.'
+# Configuration section for Findplayer.
+```
+
+---
+## Section: `FINDPLAYER`
+
+### 1. Commented Setup Code Example
+
+```yaml
+FINDPLAYER:
+  # The text or value for Afk. Available options: Any valid string text
+  AFK: '&7{player}''s in the &#A303F9afk'
+  # The text or value for Rtp Zone. Available options: Any valid string text
+  RTP_ZONE: '&7{player}''s in the &crtpzone'
+  # The text or value for Spawn. Available options: Any valid string text
+  SPAWN: '&7{player}''s in the &bspawn'
+  # The text or value for Overworld. Available options: Any valid string text
+  OVERWORLD: '&7{player}''s in the &boverworld &7(&b{biome}&7)'
+  # The text or value for Nether. Available options: Any valid string text
+  NETHER: '&7{player}''s in the &bnether &7(&b{biome}&7)'
+  # The text or value for The End. Available options: Any valid string text
+  THE_END: '&7{player}''s in the &bthe end &7(&b{biome}&7)'
+  # The text or value for Unknown. Available options: Any valid string text
+  UNKNOWN: '&7{player}''s in the &b{world}'
+# Configuration section for Punishments.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FINDPLAYER.AFK` | `str` | Any string text | `'&7{player}'s in the &#A303F9afk'` | Used when the target is inside the AFK area. |
+| `FINDPLAYER.RTP_ZONE` | `str` | Any string text | `'&7{player}'s in the &crtpzone'` | Used when the target is standing in the RTP zone cuboid. |
+| `FINDPLAYER.SPAWN` | `str` | Any string text | `'&7{player}'s in the &bspawn'` | Used when the target is at spawn. |
+| `FINDPLAYER.OVERWORLD` | `str` | Any string text | `'&7{player}'s in the &boverworld &7(...'` | Used for the overworld. `{biome}` is filled in alongside `{player}`. |
+| `FINDPLAYER.NETHER` | `str` | Any string text | `'&7{player}'s in the &bnether &7(&b{...'` | The nether variant. |
+| `FINDPLAYER.THE_END` | `str` | Any string text | `'&7{player}'s in the &bthe end &7(&b...'` | The end variant. |
+| `FINDPLAYER.UNKNOWN` | `str` | Any string text | `'&7{player}'s in the &b{world}'` | The fallback for any other world, where `{world}` is used instead of a friendly name. |
+
+One line per place the staff find command can report. The plugin picks the entry matching where the target actually is.
+
+### 3. Practical Setup Example
+
+```yaml
+FINDPLAYER:
+  # The text or value for Afk. Available options: Any valid string text
+  AFK: '&7{player}''s in the &#A303F9afk'
+  # The text or value for Rtp Zone. Available options: Any valid string text
+  RTP_ZONE: '&7{player}''s in the &crtpzone'
+  # The text or value for Spawn. Available options: Any valid string text
+  SPAWN: '&7{player}''s in the &bspawn'
+  # The text or value for Overworld. Available options: Any valid string text
+  OVERWORLD: '&7{player}''s in the &boverworld &7(&b{biome}&7)'
+  # The text or value for Nether. Available options: Any valid string text
+  NETHER: '&7{player}''s in the &bnether &7(&b{biome}&7)'
+  # The text or value for The End. Available options: Any valid string text
+  THE_END: '&7{player}''s in the &bthe end &7(&b{biome}&7)'
+  # The text or value for Unknown. Available options: Any valid string text
+  UNKNOWN: '&7{player}''s in the &b{world}'
+# Configuration section for Punishments.
+```
+
+---
+## Section: `PUNISHMENTS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+PUNISHMENTS:
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER-ONLY: '&cOnly players can use this command.'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou do not have permission to view punishment history.'
+  # The text or value for No Create Permission. Available options: Any valid string text
+  NO-CREATE-PERMISSION: '&cYou do not have permission to create punishments.'
+  # The text or value for No Remove Permission. Available options: Any valid string text
+  NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
+  # The text or value for No Delete Permission. Available options: Any valid string text
+  NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
+    records.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /punishments [player]'
+  # The text or value for Usage Ban. Available options: Any valid string text
+  USAGE-BAN: '&cUsage: /ban <player> [reason]'
+  # The text or value for Usage Tempban. Available options: Any valid string text
+  USAGE-TEMPBAN: '&cUsage: /tempban <player> <time> [reason] &7(Time: 30s, 15m, 2h,
+    5d, or 5d 15m 30s)'
+  # The text or value for Usage Mute. Available options: Any valid string text
+  USAGE-MUTE: '&cUsage: /mute <player> [reason]'
+  # The text or value for Usage Tempmute. Available options: Any valid string text
+  USAGE-TEMPMUTE: '&cUsage: /tempmute <player> <time> [reason] &7(Time: 30s, 15m,
+    2h, 5d, or 5d 15m 30s)'
+  # The text or value for Usage Vcmute. Available options: Any valid string text
+  USAGE-VCMUTE: '&cUsage: /vcmute <player> [reason]'
+  # The text or value for Usage Warn. Available options: Any valid string text
+  USAGE-WARN: '&cUsage: /warn <player> [reason]'
+  # The text or value for Usage Kick. Available options: Any valid string text
+  USAGE-KICK: '&cUsage: /kick <player> [reason]'
+  # The text or value for Usage Blacklist. Available options: Any valid string text
+  USAGE-BLACKLIST: '&cUsage: /blacklist <player> [reason]'
+  # The text or value for Usage Unban. Available options: Any valid string text
+  USAGE-UNBAN: '&cUsage: /unban <player> [reason]'
+  # The text or value for Usage Pardon. Available options: Any valid string text
+  USAGE-PARDON: '&cUsage: /pardon <player> [reason]'
+  # The text or value for Usage Unmute. Available options: Any valid string text
+  USAGE-UNMUTE: '&cUsage: /unmute <player> [reason]'
+  # The text or value for Usage Vcunmute. Available options: Any valid string text
+  USAGE-VCUNMUTE: '&cUsage: /vcunmute <player> [reason]'
+  # The text or value for Usage Unblacklist. Available options: Any valid string text
+  USAGE-UNBLACKLIST: '&cUsage: /unblacklist <player> [reason]'
+  # The text or value for Not Found. Available options: Any valid string text
+  NOT-FOUND: '&cPlayer not found.'
+  # The text or value for Target Offline. Available options: Any valid string text
+  TARGET-OFFLINE: '&cThat player is not online.'
+  # The text or value for Target Exempt. Available options: Any valid string text
+  TARGET-EXEMPT: '&cYou cannot punish that player.'
+  # The text or value for Invalid Duration. Available options: Any valid string text
+  INVALID-DURATION: '&cInvalid time. Use values like 30s, 15m, 2h, 5d, or combine:
+    5d 15m 30s.'
+  # The text or value for Create Failed. Available options: Any valid string text
+  CREATE-FAILED: '&cFailed to create punishment record.'
+  # The text or value for Delete Failed. Available options: Any valid string text
+  DELETE-FAILED: '&cFailed to delete punishment record #{id}.'
+  # The text or value for Created. Available options: Any valid string text
+  CREATED: '&aCreated &f{type} &apunishment for &b{player}&a. ID: &f#{id}'
+  # The text or value for Deleted Record. Available options: Any valid string text
+  DELETED-RECORD: '&aDeleted punishment history record &f#{id}&a.'
+  # The text or value for Removed. Available options: Any valid string text
+  REMOVED: '&aRemoved active &f{type} &apunishment(s) for &b{player}&a.'
+  # The text or value for No Active. Available options: Any valid string text
+  NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
+  # The text or value for Warn Received. Available options: Any valid string text
+  WARN-RECEIVED: '&cWarning: &f{reason}'
+  # The text or value for Mute Received. Available options: Any valid string text
+  MUTE-RECEIVED: '&cYou have been muted. Reason: &f{reason}'
+  # The text or value for Muted Chat. Available options: Any valid string text
+  MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
+  # The text or value for Ban Kick. Available options: Any valid string text
+  BAN-KICK: |-
+    &cYou are banned from this server.
+    &7Reason: &f{reason}
+    &7Expires: &f{expires}
+  # The text or value for Blacklist Kick. Available options: Any valid string text
+  BLACKLIST-KICK: |-
+    &cYou are blacklisted from this server.
+    &7Reason: &f{reason}
+  # The text or value for Ban. Available options: Any valid string text
+  BAN: |
+    &c&lYou have been banned!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Banned by: &f%issuer%
+    &8&m----------------------------
+    &7Appeal at: &fdiscord.example.space
+  # The text or value for Kick. Available options: Any valid string text
+  KICK: |
+    &c&lYou have been kicked!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Kicked by: &f%issuer%
+    &8&m----------------------------
+    &7You may reconnect
+  # The text or value for Mute. Available options: Any valid string text
+  MUTE: |
+    &c&lYou have been muted!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Muted by: &f%issuer%
+    &8&m----------------------------
+    &7You cannot speak in chat
+  # The text or value for Voice Mute. Available options: Any valid string text
+  VOICE-MUTE: |
+    &c&lYou have been voice muted!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Muted by: &f%issuer%
+    &8&m----------------------------
+    &7You cannot speak in voice chat
+  # The text or value for Blacklist. Available options: Any valid string text
+  BLACKLIST: |
+    &4&lYOU HAVE BEEN BLACKLISTED!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Blacklisted by: &f%issuer%
+    &8&m----------------------------
+    &4You cannot join the server
+# Configuration section for Social.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `PUNISHMENTS.PLAYER-ONLY` | `str` | Any string text | `'&cOnly players can use this command...'` | Sent when the console runs a subcommand that needs a player. |
+| `PUNISHMENTS.NO-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to vie...'` | Sent when somebody without the node tries to view punishment history. |
+| `PUNISHMENTS.NO-CREATE-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to cre...'` | Sent when they may look but not issue punishments. |
+| `PUNISHMENTS.NO-REMOVE-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rem...'` | Sent when they may not lift an active punishment. |
+| `PUNISHMENTS.NO-DELETE-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to del...'` | Sent when they may not delete a history record. Deleting differs from removing: it erases the record rather than ending the punishment. |
+| `PUNISHMENTS.USAGE` | `str` | Any string text | `'&cUsage: /punishments [player]'` | Usage line for the history command. |
+| `PUNISHMENTS.USAGE-BAN` | `str` | Any string text | `'&cUsage: /ban <player> [reason]'` | Usage line for `/ban`. |
+| `PUNISHMENTS.USAGE-TEMPBAN` | `str` | Any string text | `'&cUsage: /tempban <player> <time> [...'` | Usage line for `/tempban`, including the duration formats accepted. |
+| `PUNISHMENTS.USAGE-MUTE` | `str` | Any string text | `'&cUsage: /mute <player> [reason]'` | Usage line for `/mute`. |
+| `PUNISHMENTS.USAGE-TEMPMUTE` | `str` | Any string text | `'&cUsage: /tempmute <player> <time> ...'` | Usage line for `/tempmute`. |
+| `PUNISHMENTS.USAGE-VCMUTE` | `str` | Any string text | `'&cUsage: /vcmute <player> [reason]'` | Usage line for `/vcmute`, the voice chat mute. |
+| `PUNISHMENTS.USAGE-WARN` | `str` | Any string text | `'&cUsage: /warn <player> [reason]'` | Usage line for `/warn`. |
+| `PUNISHMENTS.USAGE-KICK` | `str` | Any string text | `'&cUsage: /kick <player> [reason]'` | Usage line for `/kick`. |
+| `PUNISHMENTS.USAGE-BLACKLIST` | `str` | Any string text | `'&cUsage: /blacklist <player> [reaso...'` | Usage line for `/blacklist`. |
+| `PUNISHMENTS.USAGE-UNBAN` | `str` | Any string text | `'&cUsage: /unban <player> [reason]'` | Usage line for `/unban`. |
+| `PUNISHMENTS.USAGE-PARDON` | `str` | Any string text | `'&cUsage: /pardon <player> [reason]'` | Usage line for `/pardon`. |
+| `PUNISHMENTS.USAGE-UNMUTE` | `str` | Any string text | `'&cUsage: /unmute <player> [reason]'` | Usage line for `/unmute`. |
+| `PUNISHMENTS.USAGE-VCUNMUTE` | `str` | Any string text | `'&cUsage: /vcunmute <player> [reason...'` | Usage line for `/vcunmute`. |
+| `PUNISHMENTS.USAGE-UNBLACKLIST` | `str` | Any string text | `'&cUsage: /unblacklist <player> [rea...'` | Usage line for `/unblacklist`. |
+| `PUNISHMENTS.NOT-FOUND` | `str` | Any string text | `'&cPlayer not found.'` | Sent when no player by that name is known. |
+| `PUNISHMENTS.TARGET-OFFLINE` | `str` | Any string text | `'&cThat player is not online.'` | Sent when the action needs the target online and they are not. |
+| `PUNISHMENTS.TARGET-EXEMPT` | `str` | Any string text | `'&cYou cannot punish that player.'` | Sent when the target is protected from punishment, so staff cannot punish each other by accident. |
+| `PUNISHMENTS.INVALID-DURATION` | `str` | Any string text | `'&cInvalid time. Use values like 30s...'` | Sent when a duration cannot be read. The accepted forms are spelled out in the message. |
+| `PUNISHMENTS.CREATE-FAILED` | `str` | Any string text | `'&cFailed to create punishment recor...'` | Sent when the record could not be written, usually a database problem. |
+| `PUNISHMENTS.DELETE-FAILED` | `str` | Any string text | `'&cFailed to delete punishment recor...'` | Sent when a record could not be deleted. `{id}` is the record number. |
+| `PUNISHMENTS.CREATED` | `str` | Any string text | `'&aCreated &f{type} &apunishment for...'` | Confirmation after issuing a punishment, quoting `{type}`, `{player}` and the new `{id}`. |
+| `PUNISHMENTS.DELETED-RECORD` | `str` | Any string text | `'&aDeleted punishment history record...'` | Confirmation after erasing a history record. |
+| `PUNISHMENTS.REMOVED` | `str` | Any string text | `'&aRemoved active &f{type} &apunishm...'` | Confirmation after lifting an active punishment. |
+| `PUNISHMENTS.NO-ACTIVE` | `str` | Any string text | `'&cNo active {type} punishment found...'` | Sent when there was nothing of that type to lift. |
+| `PUNISHMENTS.WARN-RECEIVED` | `str` | Any string text | `'&cWarning: &f{reason}'` | What a warned player sees. `{reason}` carries the staff note. |
+| `PUNISHMENTS.MUTE-RECEIVED` | `str` | Any string text | `'&cYou have been muted. Reason: &f{r...'` | Not read by any code. The mute notice a player actually sees comes from `PUNISHMENTS.MUTE`, so editing this key changes nothing. |
+| `PUNISHMENTS.MUTED-CHAT` | `str` | Any string text | `'&cYou are muted. Reason: &f{reason}...'` | Not read by any code. What a muted player sees each time they try to talk comes from `PUNISHMENTS.MUTE` instead, so editing this key changes nothing. |
+| `PUNISHMENTS.BAN-KICK` | `str` | Any string text | `'&cYou are banned from this server. ...'` | Not read by any code. The ban screen a player actually sees comes from `PUNISHMENTS.BAN`, so editing this key changes nothing. |
+| `PUNISHMENTS.BLACKLIST-KICK` | `str` | Any string text | `'&cYou are blacklisted from this ser...'` | Not read by any code. The blacklist screen a player actually sees comes from `PUNISHMENTS.BLACKLIST`, so editing this key changes nothing. |
+| `PUNISHMENTS.BAN` | `str` | Any string text | `'&c&lYou have been banned! &8&m-----...'` | The screen a banned player is disconnected with, and what they see on every attempt to rejoin. Takes `%reason%`, `%nicest_expiration%` and `%issuer%`, each of which also works in `{brace}` form. |
+| `PUNISHMENTS.KICK` | `str` | Any string text | `'&c&lYou have been kicked! &8&m-----...'` | Shown to a player as they are kicked, with `%reason%` and `%issuer%`. |
+| `PUNISHMENTS.MUTE` | `str` | Any string text | `'&c&lYou have been muted! &8&m------...'` | Shown when the mute lands and again every time the muted player tries to speak, so it carries the whole explanation rather than a one-liner. Takes `%reason%`, `%nicest_expiration%` and `%issuer%`. |
+| `PUNISHMENTS.VOICE-MUTE` | `str` | Any string text | `'&c&lYou have been voice muted! &8&m...'` | Shown to a player when a voice chat mute lands on them. |
+| `PUNISHMENTS.BLACKLIST` | `str` | Any string text | `'&4&lYOU HAVE BEEN BLACKLISTED! &8&m...'` | The screen a blacklisted player is disconnected with, and what they see if they try to come back. |
+
+Everything the punishment commands say, from the usage lines through to the screens a banned player sees.
+
+### 3. Practical Setup Example
+
+```yaml
+PUNISHMENTS:
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER-ONLY: '&cOnly players can use this command.'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou do not have permission to view punishment history.'
+  # The text or value for No Create Permission. Available options: Any valid string text
+  NO-CREATE-PERMISSION: '&cYou do not have permission to create punishments.'
+  # The text or value for No Remove Permission. Available options: Any valid string text
+  NO-REMOVE-PERMISSION: '&cYou do not have permission to remove punishments.'
+  # The text or value for No Delete Permission. Available options: Any valid string text
+  NO-DELETE-PERMISSION: '&cYou do not have permission to delete punishment history
+    records.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /punishments [player]'
+  # The text or value for Usage Ban. Available options: Any valid string text
+  USAGE-BAN: '&cUsage: /ban <player> [reason]'
+  # The text or value for Usage Tempban. Available options: Any valid string text
+  USAGE-TEMPBAN: '&cUsage: /tempban <player> <time> [reason] &7(Time: 30s, 15m, 2h,
+    5d, or 5d 15m 30s)'
+  # The text or value for Usage Mute. Available options: Any valid string text
+  USAGE-MUTE: '&cUsage: /mute <player> [reason]'
+  # The text or value for Usage Tempmute. Available options: Any valid string text
+  USAGE-TEMPMUTE: '&cUsage: /tempmute <player> <time> [reason] &7(Time: 30s, 15m,
+    2h, 5d, or 5d 15m 30s)'
+  # The text or value for Usage Vcmute. Available options: Any valid string text
+  USAGE-VCMUTE: '&cUsage: /vcmute <player> [reason]'
+  # The text or value for Usage Warn. Available options: Any valid string text
+  USAGE-WARN: '&cUsage: /warn <player> [reason]'
+  # The text or value for Usage Kick. Available options: Any valid string text
+  USAGE-KICK: '&cUsage: /kick <player> [reason]'
+  # The text or value for Usage Blacklist. Available options: Any valid string text
+  USAGE-BLACKLIST: '&cUsage: /blacklist <player> [reason]'
+  # The text or value for Usage Unban. Available options: Any valid string text
+  USAGE-UNBAN: '&cUsage: /unban <player> [reason]'
+  # The text or value for Usage Pardon. Available options: Any valid string text
+  USAGE-PARDON: '&cUsage: /pardon <player> [reason]'
+  # The text or value for Usage Unmute. Available options: Any valid string text
+  USAGE-UNMUTE: '&cUsage: /unmute <player> [reason]'
+  # The text or value for Usage Vcunmute. Available options: Any valid string text
+  USAGE-VCUNMUTE: '&cUsage: /vcunmute <player> [reason]'
+  # The text or value for Usage Unblacklist. Available options: Any valid string text
+  USAGE-UNBLACKLIST: '&cUsage: /unblacklist <player> [reason]'
+  # The text or value for Not Found. Available options: Any valid string text
+  NOT-FOUND: '&cPlayer not found.'
+  # The text or value for Target Offline. Available options: Any valid string text
+  TARGET-OFFLINE: '&cThat player is not online.'
+  # The text or value for Target Exempt. Available options: Any valid string text
+  TARGET-EXEMPT: '&cYou cannot punish that player.'
+  # The text or value for Invalid Duration. Available options: Any valid string text
+  INVALID-DURATION: '&cInvalid time. Use values like 30s, 15m, 2h, 5d, or combine:
+    5d 15m 30s.'
+  # The text or value for Create Failed. Available options: Any valid string text
+  CREATE-FAILED: '&cFailed to create punishment record.'
+  # The text or value for Delete Failed. Available options: Any valid string text
+  DELETE-FAILED: '&cFailed to delete punishment record #{id}.'
+  # The text or value for Created. Available options: Any valid string text
+  CREATED: '&aCreated &f{type} &apunishment for &b{player}&a. ID: &f#{id}'
+  # The text or value for Deleted Record. Available options: Any valid string text
+  DELETED-RECORD: '&aDeleted punishment history record &f#{id}&a.'
+  # The text or value for Removed. Available options: Any valid string text
+  REMOVED: '&aRemoved active &f{type} &apunishment(s) for &b{player}&a.'
+  # The text or value for No Active. Available options: Any valid string text
+  NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
+  # The text or value for Warn Received. Available options: Any valid string text
+  WARN-RECEIVED: '&cWarning: &f{reason}'
+  # The text or value for Mute Received. Available options: Any valid string text
+  MUTE-RECEIVED: '&cYou have been muted. Reason: &f{reason}'
+  # The text or value for Muted Chat. Available options: Any valid string text
+  MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
+  # The text or value for Ban Kick. Available options: Any valid string text
+  BAN-KICK: |-
+    &cYou are banned from this server.
+    &7Reason: &f{reason}
+    &7Expires: &f{expires}
+  # The text or value for Blacklist Kick. Available options: Any valid string text
+  BLACKLIST-KICK: |-
+    &cYou are blacklisted from this server.
+    &7Reason: &f{reason}
+  # The text or value for Ban. Available options: Any valid string text
+  BAN: |
+    &c&lYou have been banned!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Banned by: &f%issuer%
+    &8&m----------------------------
+    &7Appeal at: &fdiscord.example.space
+  # The text or value for Kick. Available options: Any valid string text
+  KICK: |
+    &c&lYou have been kicked!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Kicked by: &f%issuer%
+    &8&m----------------------------
+    &7You may reconnect
+  # The text or value for Mute. Available options: Any valid string text
+  MUTE: |
+    &c&lYou have been muted!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Muted by: &f%issuer%
+    &8&m----------------------------
+    &7You cannot speak in chat
+  # The text or value for Voice Mute. Available options: Any valid string text
+  VOICE-MUTE: |
+    &c&lYou have been voice muted!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Expires: &f%nicest_expiration%
+    &7Muted by: &f%issuer%
+    &8&m----------------------------
+    &7You cannot speak in voice chat
+  # The text or value for Blacklist. Available options: Any valid string text
+  BLACKLIST: |
+    &4&lYOU HAVE BEEN BLACKLISTED!
+    &8&m----------------------------
+    &7Reason: &f%reason%
+    &7Blacklisted by: &f%issuer%
+    &8&m----------------------------
+    &4You cannot join the server
+# Configuration section for Social.
+```
+
+---
+## Section: `SOCIAL`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SOCIAL:
+  # Configuration section for Discord.
+  DISCORD:
+  - ''
+  - '&fJoin our discord: &#6BF18Ddiscord.example.space'
+  - ''
+  # Configuration section for Twitter.
+  TWITTER:
+  - ''
+  - '&fFollow on X: &#6BF18D@ElonMusk'
+  - ''
+  # Configuration section for Store.
+  STORE:
+  - ''
+  - '&fVisit our store: &#6BF18Dstore.example.space'
+  - ''
+# Configuration section for Auction House.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SOCIAL.DISCORD` | `list` | Lines of text | `['', '&fJoin our discord: &#6BF18Ddiscord.examp...]` | Printed by the discord command. Put your own invite here; the shipped address is a placeholder. |
+| `SOCIAL.TWITTER` | `list` | Lines of text | `['', '&fFollow on X: &#6BF18D@ElonMusk', '']` | Printed by the twitter command. The shipped handle is a placeholder. |
+| `SOCIAL.STORE` | `list` | Lines of text | `['', '&fVisit our store: &#6BF18Dstore.example....]` | Printed by the store command. The shipped address is a placeholder. |
+
+The blocks of text the social commands print. Each is a list, so a line is one line in chat, and blank entries give the spacing.
+
+### 3. Practical Setup Example
+
+```yaml
+SOCIAL:
+  # Configuration section for Discord.
+  DISCORD:
+  - ''
+  - '&fJoin our discord: &#6BF18Ddiscord.example.space'
+  - ''
+  # Configuration section for Twitter.
+  TWITTER:
+  - ''
+  - '&fFollow on X: &#6BF18D@ElonMusk'
+  - ''
+  # Configuration section for Store.
+  STORE:
+  - ''
+  - '&fVisit our store: &#6BF18Dstore.example.space'
+  - ''
+# Configuration section for Auction House.
+```
+
+---
+## Section: `AUCTION_HOUSE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+AUCTION_HOUSE:
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cAuction House is currently disabled.'
+  # The text or value for Sell Usage. Available options: Any valid string text
+  SELL_USAGE: '&cUsage: /ah sell <price>'
+  # The text or value for Cancel Usage. Available options: Any valid string text
+  CANCEL_USAGE: '&cUsage: /ah cancel <listingId>'
+  # The text or value for Invalid Price. Available options: Any valid string text
+  INVALID_PRICE: '&cInvalid price format. Use numbers like 100, 5K, or 1.5M.'
+  # The text or value for Invalid Listing Id. Available options: Any valid string text
+  INVALID_LISTING_ID: '&cInvalid listing id.'
+  # The text or value for No Admin Permission. Available options: Any valid string text
+  NO_ADMIN_PERMISSION: '&cYou do not have permission to reload Auction House settings.'
+  # The text or value for Reloaded. Available options: Any valid string text
+  RELOADED: '&aAuction House config reloaded.'
+  # The text or value for No Item In Hand. Available options: Any valid string text
+  NO_ITEM_IN_HAND: '&cHold the item you want to list in your main hand.'
+  # The text or value for Item Blocked. Available options: Any valid string text
+  ITEM_BLOCKED: '&cThat item cannot be listed in the Auction House.'
+  # The text or value for Price Out Of Range. Available options: Any valid string text
+  PRICE_OUT_OF_RANGE: '&cThat price is outside the allowed range.'
+  # The text or value for No Money For Fee. Available options: Any valid string text
+  NO_MONEY_FOR_FEE: '&cYou do not have enough money to pay the listing fee.'
+  # The text or value for Max Listings Reached. Available options: Any valid string text
+  MAX_LISTINGS_REACHED: '&cYou have reached your active listing limit.'
+  # The text or value for Listing Created. Available options: Any valid string text
+  LISTING_CREATED: '&aListing created! &7#{listing_id} &f{item} &7for &a${price}&7. Fee: &a${fee}&7. Expires in &f{expires}&7.'
+  # The text or value for Listing Cancelled. Available options: Any valid string text
+  LISTING_CANCELLED: '&eListing #{listing_id} &f({item}) &ehas been moved to your
+    claim queue.'
+  # The text or value for Listing Not Found. Available options: Any valid string text
+  LISTING_NOT_FOUND: '&cThat listing no longer exists.'
+  # The text or value for Listing Not Active. Available options: Any valid string text
+  LISTING_NOT_ACTIVE: '&cThat listing is no longer active.'
+  # The text or value for Not Your Listing. Available options: Any valid string text
+  NOT_YOUR_LISTING: '&cThat listing does not belong to you.'
+  # The text or value for Cannot Buy Own. Available options: Any valid string text
+  CANNOT_BUY_OWN: '&cYou cannot buy your own listing.'
+  # The text or value for Not Enough Money. Available options: Any valid string text
+  NOT_ENOUGH_MONEY: '&cYou do not have enough money.'
+  # The text or value for Full Inventory. Available options: Any valid string text
+  FULL_INVENTORY: '&cYou need free inventory space to buy that item.'
+  # The text or value for Purchase Success. Available options: Any valid string text
+  PURCHASE_SUCCESS: '&aPurchased &f{item} &afor &a${price} &afrom &f{seller}&a.'
+  # The text or value for Item Sold. Available options: Any valid string text
+  ITEM_SOLD: '&aYour listing sold! &f{buyer} &abought &f{item} &afor &a${price}&a. Claimable payout: &a${payout}&a.'
+  # The text or value for Claim Not Found. Available options: Any valid string text
+  CLAIM_NOT_FOUND: '&cThat claim no longer exists.'
+  # The text or value for Not Your Claim. Available options: Any valid string text
+  NOT_YOUR_CLAIM: '&cThat claim does not belong to you.'
+  # The text or value for Claim Already Claimed. Available options: Any valid string text
+  CLAIM_ALREADY_CLAIMED: '&cThat claim was already collected.'
+  # The text or value for Claim Inventory Full. Available options: Any valid string text
+  CLAIM_INVENTORY_FULL: '&cYou need a free inventory slot to claim that item.'
+  # The text or value for Claimed Money. Available options: Any valid string text
+  CLAIMED_MONEY: '&aClaimed &a${amount} &afrom your Auction House sales.'
+  # The text or value for Claimed Item. Available options: Any valid string text
+  CLAIMED_ITEM: '&aClaimed returned item: &f{item}&a.'
+# Configuration section for Orders.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `AUCTION_HOUSE.DISABLED` | `str` | Any string text | `'&cAuction House is currently disabl...'` | Sent when the auction house is switched off. |
+| `AUCTION_HOUSE.SELL_USAGE` | `str` | Any string text | `'&cUsage: /ah sell <price>'` | Usage line for listing an item. |
+| `AUCTION_HOUSE.CANCEL_USAGE` | `str` | Any string text | `'&cUsage: /ah cancel <listingId>'` | Usage line for cancelling a listing. |
+| `AUCTION_HOUSE.INVALID_PRICE` | `str` | Any string text | `'&cInvalid price format. Use numbers...'` | Sent when the price cannot be parsed. |
+| `AUCTION_HOUSE.INVALID_LISTING_ID` | `str` | Any string text | `'&cInvalid listing id.'` | Sent when the listing id is not a number. |
+| `AUCTION_HOUSE.NO_ADMIN_PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rel...'` | Sent when somebody without the node tries to reload the settings. |
+| `AUCTION_HOUSE.RELOADED` | `str` | Any string text | `'&aAuction House config reloaded.'` | Confirmation after a successful reload. |
+| `AUCTION_HOUSE.NO_ITEM_IN_HAND` | `str` | Any string text | `'&cHold the item you want to list in...'` | Sent when listing with an empty hand. |
+| `AUCTION_HOUSE.ITEM_BLOCKED` | `str` | Any string text | `'&cThat item cannot be listed in the...'` | Sent when the item is on the blocked list. |
+| `AUCTION_HOUSE.PRICE_OUT_OF_RANGE` | `str` | Any string text | `'&cThat price is outside the allowed...'` | Sent when the price sits outside the configured minimum and maximum. |
+| `AUCTION_HOUSE.NO_MONEY_FOR_FEE` | `str` | Any string text | `'&cYou do not have enough money to p...'` | Sent when the seller cannot pay the listing fee. |
+| `AUCTION_HOUSE.MAX_LISTINGS_REACHED` | `str` | Any string text | `'&cYou have reached your active list...'` | Sent when the seller already has as many active listings as they are allowed. |
+| `AUCTION_HOUSE.LISTING_CREATED` | `str` | Any string text | `'&aListing created! &7#{listing_id} ...'` | The receipt for a new listing, with `{listing_id}`, `{item}`, `{price}` and the `{fee}` charged. |
+| `AUCTION_HOUSE.LISTING_CANCELLED` | `str` | Any string text | `'&eListing #{listing_id} &f({item}) ...'` | Sent when a listing is pulled. The item goes to the claim store rather than straight back to the inventory. |
+| `AUCTION_HOUSE.LISTING_NOT_FOUND` | `str` | Any string text | `'&cThat listing no longer exists.'` | Sent when the listing has already gone. |
+| `AUCTION_HOUSE.LISTING_NOT_ACTIVE` | `str` | Any string text | `'&cThat listing is no longer active.'` | Sent when the listing exists but is no longer on sale. |
+| `AUCTION_HOUSE.NOT_YOUR_LISTING` | `str` | Any string text | `'&cThat listing does not belong to y...'` | Sent when acting on somebody else s listing. |
+| `AUCTION_HOUSE.CANNOT_BUY_OWN` | `str` | Any string text | `'&cYou cannot buy your own listing.'` | Sent when a seller tries to buy their own listing. |
+| `AUCTION_HOUSE.NOT_ENOUGH_MONEY` | `str` | Any string text | `'&cYou do not have enough money.'` | Sent when the buyer cannot afford it. |
+| `AUCTION_HOUSE.FULL_INVENTORY` | `str` | Any string text | `'&cYou need free inventory space to ...'` | Sent when the buyer has no room. The purchase does not go through. |
+| `AUCTION_HOUSE.PURCHASE_SUCCESS` | `str` | Any string text | `'&aPurchased &f{item} &afor &a${pric...'` | Receipt for the buyer, naming the `{seller}`. |
+| `AUCTION_HOUSE.ITEM_SOLD` | `str` | Any string text | `'&aYour listing sold! &f{buyer} &abo...'` | Notice to the seller when their listing sells, including the payout waiting to be claimed. |
+| `AUCTION_HOUSE.CLAIM_NOT_FOUND` | `str` | Any string text | `'&cThat claim no longer exists.'` | Sent when the claim has already gone. |
+| `AUCTION_HOUSE.NOT_YOUR_CLAIM` | `str` | Any string text | `'&cThat claim does not belong to you...'` | Sent when claiming something belonging to somebody else. |
+| `AUCTION_HOUSE.CLAIM_ALREADY_CLAIMED` | `str` | Any string text | `'&cThat claim was already collected.'` | Sent when the claim was collected already. |
+| `AUCTION_HOUSE.CLAIM_INVENTORY_FULL` | `str` | Any string text | `'&cYou need a free inventory slot to...'` | Sent when there is no free slot for the item being claimed. |
+| `AUCTION_HOUSE.CLAIMED_MONEY` | `str` | Any string text | `'&aClaimed &a${amount} &afrom your A...'` | Receipt for collecting sale proceeds. |
+| `AUCTION_HOUSE.CLAIMED_ITEM` | `str` | Any string text | `'&aClaimed returned item: &f{item}&a...'` | Receipt for collecting a returned or bought item. |
+
+Listing, buying and claiming in the auction house.
+
+### 3. Practical Setup Example
+
+```yaml
+AUCTION_HOUSE:
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cAuction House is currently disabled.'
+  # The text or value for Sell Usage. Available options: Any valid string text
+  SELL_USAGE: '&cUsage: /ah sell <price>'
+  # The text or value for Cancel Usage. Available options: Any valid string text
+  CANCEL_USAGE: '&cUsage: /ah cancel <listingId>'
+  # The text or value for Invalid Price. Available options: Any valid string text
+  INVALID_PRICE: '&cInvalid price format. Use numbers like 100, 5K, or 1.5M.'
+  # The text or value for Invalid Listing Id. Available options: Any valid string text
+  INVALID_LISTING_ID: '&cInvalid listing id.'
+  # The text or value for No Admin Permission. Available options: Any valid string text
+  NO_ADMIN_PERMISSION: '&cYou do not have permission to reload Auction House settings.'
+  # The text or value for Reloaded. Available options: Any valid string text
+  RELOADED: '&aAuction House config reloaded.'
+  # The text or value for No Item In Hand. Available options: Any valid string text
+  NO_ITEM_IN_HAND: '&cHold the item you want to list in your main hand.'
+  # The text or value for Item Blocked. Available options: Any valid string text
+  ITEM_BLOCKED: '&cThat item cannot be listed in the Auction House.'
+  # The text or value for Price Out Of Range. Available options: Any valid string text
+  PRICE_OUT_OF_RANGE: '&cThat price is outside the allowed range.'
+  # The text or value for No Money For Fee. Available options: Any valid string text
+  NO_MONEY_FOR_FEE: '&cYou do not have enough money to pay the listing fee.'
+  # The text or value for Max Listings Reached. Available options: Any valid string text
+  MAX_LISTINGS_REACHED: '&cYou have reached your active listing limit.'
+  # The text or value for Listing Created. Available options: Any valid string text
+  LISTING_CREATED: '&aListing created! &7#{listing_id} &f{item} &7for &a${price}&7. Fee: &a${fee}&7. Expires in &f{expires}&7.'
+  # The text or value for Listing Cancelled. Available options: Any valid string text
+  LISTING_CANCELLED: '&eListing #{listing_id} &f({item}) &ehas been moved to your
+    claim queue.'
+  # The text or value for Listing Not Found. Available options: Any valid string text
+  LISTING_NOT_FOUND: '&cThat listing no longer exists.'
+  # The text or value for Listing Not Active. Available options: Any valid string text
+  LISTING_NOT_ACTIVE: '&cThat listing is no longer active.'
+  # The text or value for Not Your Listing. Available options: Any valid string text
+  NOT_YOUR_LISTING: '&cThat listing does not belong to you.'
+  # The text or value for Cannot Buy Own. Available options: Any valid string text
+  CANNOT_BUY_OWN: '&cYou cannot buy your own listing.'
+  # The text or value for Not Enough Money. Available options: Any valid string text
+  NOT_ENOUGH_MONEY: '&cYou do not have enough money.'
+  # The text or value for Full Inventory. Available options: Any valid string text
+  FULL_INVENTORY: '&cYou need free inventory space to buy that item.'
+  # The text or value for Purchase Success. Available options: Any valid string text
+  PURCHASE_SUCCESS: '&aPurchased &f{item} &afor &a${price} &afrom &f{seller}&a.'
+  # The text or value for Item Sold. Available options: Any valid string text
+  ITEM_SOLD: '&aYour listing sold! &f{buyer} &abought &f{item} &afor &a${price}&a. Claimable payout: &a${payout}&a.'
+  # The text or value for Claim Not Found. Available options: Any valid string text
+  CLAIM_NOT_FOUND: '&cThat claim no longer exists.'
+  # The text or value for Not Your Claim. Available options: Any valid string text
+  NOT_YOUR_CLAIM: '&cThat claim does not belong to you.'
+  # The text or value for Claim Already Claimed. Available options: Any valid string text
+  CLAIM_ALREADY_CLAIMED: '&cThat claim was already collected.'
+  # The text or value for Claim Inventory Full. Available options: Any valid string text
+  CLAIM_INVENTORY_FULL: '&cYou need a free inventory slot to claim that item.'
+  # The text or value for Claimed Money. Available options: Any valid string text
+  CLAIMED_MONEY: '&aClaimed &a${amount} &afrom your Auction House sales.'
+  # The text or value for Claimed Item. Available options: Any valid string text
+  CLAIMED_ITEM: '&aClaimed returned item: &f{item}&a.'
+# Configuration section for Orders.
+```
+
+---
+## Section: `ORDERS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+ORDERS:
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cOrders is currently disabled.'
+  # The text or value for No Admin Permission. Available options: Any valid string text
+  NO_ADMIN_PERMISSION: '&cYou do not have permission to reload Orders settings.'
+  # The text or value for Reloaded. Available options: Any valid string text
+  RELOADED: '&aOrders config reloaded.'
+  # The text or value for Prompt Quantity. Available options: Any valid string text
+  PROMPT_QUANTITY: '&7Enter the order quantity for &f{item}&7 in chat. Type &ccancel&7
+    to abort.'
+  # The text or value for Prompt Price. Available options: Any valid string text
+  PROMPT_PRICE: '&7Enter the price each for &f{item}&7 in chat. Type &ccancel&7 to
+    abort.'
+  # The text or value for Input Cancelled. Available options: Any valid string text
+  INPUT_CANCELLED: '&7Order creation cancelled.'
+  # The text or value for No Pending Order. Available options: Any valid string text
+  NO_PENDING_ORDER: '&cThere is no pending order draft to confirm.'
+  # The text or value for Item Blocked. Available options: Any valid string text
+  ITEM_BLOCKED: '&cThat item cannot be ordered.'
+  # The text or value for Invalid Quantity. Available options: Any valid string text
+  INVALID_QUANTITY: '&cInvalid quantity. Use a whole number greater than 0.'
+  # The text or value for Quantity Out Of Range. Available options: Any valid string text
+  QUANTITY_OUT_OF_RANGE: '&cQuantity must be between 1 and {max}.'
+  # The text or value for Invalid Price. Available options: Any valid string text
+  INVALID_PRICE: '&cInvalid price format. Use numbers like 100, 5K, or 1.5M.'
+  # The text or value for Price Out Of Range. Available options: Any valid string text
+  PRICE_OUT_OF_RANGE: '&cPrice each must be between &f{min_formatted}&c and &f{max_formatted}&c.'
+  # The text or value for Total Too High. Available options: Any valid string text
+  TOTAL_TOO_HIGH: '&cTotal order budget cannot exceed &f{max_formatted}&c.'
+  # The text or value for Not Enough Money. Available options: Any valid string text
+  NOT_ENOUGH_MONEY: '&cYou do not have enough money for that order.'
+  # The text or value for Max Active Reached. Available options: Any valid string text
+  MAX_ACTIVE_REACHED: '&cYou have reached your active order limit.'
+  # The text or value for Created. Available options: Any valid string text
+  CREATED: '&aOrder created! &7#{order_id} &ffor &e{quantity} {item}&7 at &a${price_each} &7each. Budget locked: &a${budget}&7.'
+  # The text or value for Order Not Found. Available options: Any valid string text
+  ORDER_NOT_FOUND: '&cThat order no longer exists.'
+  # The text or value for Order Not Active. Available options: Any valid string text
+  ORDER_NOT_ACTIVE: '&cThat order is no longer active.'
+  # The text or value for Not Your Order. Available options: Any valid string text
+  NOT_YOUR_ORDER: '&cThat order does not belong to you.'
+  # The text or value for Cannot Deliver Own. Available options: Any valid string text
+  CANNOT_DELIVER_OWN: '&cYou cannot deliver to your own order.'
+  # The text or value for No Matching Items. Available options: Any valid string text
+  NO_MATCHING_ITEMS: '&cYou do not have the required items to deliver.'
+  # The text or value for Order Full. Available options: Any valid string text
+  ORDER_FULL: '&cThat order is already full.'
+  # The text or value for Delivery Success. Available options: Any valid string text
+  DELIVERY_SUCCESS: '&aDelivered &e{quantity} {item}&a and received &a${payout}&a.'
+  # The text or value for Cancelled. Available options: Any valid string text
+  CANCELLED: '&eOrder #{order_id} &ehas been closed. Remaining escrow was moved to
+    your collect queue.'
+  # The text or value for Claim Not Found. Available options: Any valid string text
+  CLAIM_NOT_FOUND: '&cThat claim no longer exists.'
+  # The text or value for Not Your Claim. Available options: Any valid string text
+  NOT_YOUR_CLAIM: '&cThat claim does not belong to you.'
+  # The text or value for Claim Already Claimed. Available options: Any valid string text
+  CLAIM_ALREADY_CLAIMED: '&cThat claim was already collected.'
+  # The text or value for Claim Inventory Full. Available options: Any valid string text
+  CLAIM_INVENTORY_FULL: '&cYou need a free inventory slot to claim that item.'
+  # The text or value for Claimed Refund. Available options: Any valid string text
+  CLAIMED_REFUND: '&aClaimed escrow refund of &a${amount}&a.'
+  # The text or value for Claimed Item. Available options: Any valid string text
+  CLAIMED_ITEM: '&aClaimed delivered item: &f{item}&a.'
+# Configuration section for Stats Wipe.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ORDERS.DISABLED` | `str` | Any string text | `'&cOrders is currently disabled.'` | Sent when orders are switched off. |
+| `ORDERS.NO_ADMIN_PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rel...'` | Sent when somebody without the node tries to reload the settings. |
+| `ORDERS.RELOADED` | `str` | Any string text | `'&aOrders config reloaded.'` | Confirmation after a successful reload. |
+| `ORDERS.PROMPT_QUANTITY` | `str` | Any string text | `'&7Enter the order quantity for &f{i...'` | Asks how many of `{item}` the order should be for. Typing cancel backs out. |
+| `ORDERS.PROMPT_PRICE` | `str` | Any string text | `'&7Enter the price each for &f{item}...'` | Asks the price per item. |
+| `ORDERS.INPUT_CANCELLED` | `str` | Any string text | `'&7Order creation cancelled.'` | Sent when the player cancels part way through creating an order. |
+| `ORDERS.NO_PENDING_ORDER` | `str` | Any string text | `'&cThere is no pending order draft t...'` | Sent when confirming with no draft in progress. |
+| `ORDERS.ITEM_BLOCKED` | `str` | Any string text | `'&cThat item cannot be ordered.'` | Sent when the item may not be ordered. |
+| `ORDERS.INVALID_QUANTITY` | `str` | Any string text | `'&cInvalid quantity. Use a whole num...'` | Sent when the quantity is not a whole number above zero. |
+| `ORDERS.QUANTITY_OUT_OF_RANGE` | `str` | Any string text | `'&cQuantity must be between 1 and {m...'` | Sent when the quantity is above the configured `{max}`. |
+| `ORDERS.INVALID_PRICE` | `str` | Any string text | `'&cInvalid price format. Use numbers...'` | Sent when the price cannot be parsed. |
+| `ORDERS.PRICE_OUT_OF_RANGE` | `str` | Any string text | `'&cPrice each must be between &f{min...'` | Sent when the price each falls outside the allowed band. |
+| `ORDERS.TOTAL_TOO_HIGH` | `str` | Any string text | `'&cTotal order budget cannot exceed ...'` | Sent when quantity times price exceeds the maximum budget for one order. |
+| `ORDERS.NOT_ENOUGH_MONEY` | `str` | Any string text | `'&cYou do not have enough money for ...'` | Sent when the buyer cannot fund the order. The whole budget is taken up front and held in escrow. |
+| `ORDERS.MAX_ACTIVE_REACHED` | `str` | Any string text | `'&cYou have reached your active orde...'` | Sent when the buyer already has as many open orders as they are allowed. |
+| `ORDERS.CREATED` | `str` | Any string text | `'&aOrder created! &7#{order_id} &ffo...'` | The receipt for a new order. |
+| `ORDERS.ORDER_NOT_FOUND` | `str` | Any string text | `'&cThat order no longer exists.'` | Sent when the order has already gone. |
+| `ORDERS.ORDER_NOT_ACTIVE` | `str` | Any string text | `'&cThat order is no longer active.'` | Sent when the order exists but is closed. |
+| `ORDERS.NOT_YOUR_ORDER` | `str` | Any string text | `'&cThat order does not belong to you...'` | Sent when acting on somebody else s order. |
+| `ORDERS.CANNOT_DELIVER_OWN` | `str` | Any string text | `'&cYou cannot deliver to your own or...'` | Sent when the buyer tries to fill their own order. |
+| `ORDERS.NO_MATCHING_ITEMS` | `str` | Any string text | `'&cYou do not have the required item...'` | Sent when the deliverer is not carrying what the order asks for. |
+| `ORDERS.ORDER_FULL` | `str` | Any string text | `'&cThat order is already full.'` | Sent when the order has already been filled. |
+| `ORDERS.DELIVERY_SUCCESS` | `str` | Any string text | `'&aDelivered &e{quantity} {item}&a a...'` | Receipt for delivering into an order, with the `{payout}` earned. |
+| `ORDERS.CANCELLED` | `str` | Any string text | `'&eOrder #{order_id} &ehas been clos...'` | Sent when an order is closed early. Whatever escrow is left becomes a claim. |
+| `ORDERS.CLAIM_NOT_FOUND` | `str` | Any string text | `'&cThat claim no longer exists.'` | Sent when the claim has already gone. |
+| `ORDERS.NOT_YOUR_CLAIM` | `str` | Any string text | `'&cThat claim does not belong to you...'` | Sent when claiming something belonging to somebody else. |
+| `ORDERS.CLAIM_ALREADY_CLAIMED` | `str` | Any string text | `'&cThat claim was already collected.'` | Sent when the claim was collected already. |
+| `ORDERS.CLAIM_INVENTORY_FULL` | `str` | Any string text | `'&cYou need a free inventory slot to...'` | Sent when there is no free slot for the item being claimed. |
+| `ORDERS.CLAIMED_REFUND` | `str` | Any string text | `'&aClaimed escrow refund of &a${amou...'` | Receipt for collecting escrow back off a closed order. |
+| `ORDERS.CLAIMED_ITEM` | `str` | Any string text | `'&aClaimed delivered item: &f{item}&...'` | Receipt for collecting items delivered into your order. |
+
+Buy orders: creating one, delivering into somebody else s, and claiming afterwards.
+
+### 3. Practical Setup Example
+
+```yaml
+ORDERS:
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cOrders is currently disabled.'
+  # The text or value for No Admin Permission. Available options: Any valid string text
+  NO_ADMIN_PERMISSION: '&cYou do not have permission to reload Orders settings.'
+  # The text or value for Reloaded. Available options: Any valid string text
+  RELOADED: '&aOrders config reloaded.'
+  # The text or value for Prompt Quantity. Available options: Any valid string text
+  PROMPT_QUANTITY: '&7Enter the order quantity for &f{item}&7 in chat. Type &ccancel&7
+    to abort.'
+  # The text or value for Prompt Price. Available options: Any valid string text
+  PROMPT_PRICE: '&7Enter the price each for &f{item}&7 in chat. Type &ccancel&7 to
+    abort.'
+  # The text or value for Input Cancelled. Available options: Any valid string text
+  INPUT_CANCELLED: '&7Order creation cancelled.'
+  # The text or value for No Pending Order. Available options: Any valid string text
+  NO_PENDING_ORDER: '&cThere is no pending order draft to confirm.'
+  # The text or value for Item Blocked. Available options: Any valid string text
+  ITEM_BLOCKED: '&cThat item cannot be ordered.'
+  # The text or value for Invalid Quantity. Available options: Any valid string text
+  INVALID_QUANTITY: '&cInvalid quantity. Use a whole number greater than 0.'
+  # The text or value for Quantity Out Of Range. Available options: Any valid string text
+  QUANTITY_OUT_OF_RANGE: '&cQuantity must be between 1 and {max}.'
+  # The text or value for Invalid Price. Available options: Any valid string text
+  INVALID_PRICE: '&cInvalid price format. Use numbers like 100, 5K, or 1.5M.'
+  # The text or value for Price Out Of Range. Available options: Any valid string text
+  PRICE_OUT_OF_RANGE: '&cPrice each must be between &f{min_formatted}&c and &f{max_formatted}&c.'
+  # The text or value for Total Too High. Available options: Any valid string text
+  TOTAL_TOO_HIGH: '&cTotal order budget cannot exceed &f{max_formatted}&c.'
+  # The text or value for Not Enough Money. Available options: Any valid string text
+  NOT_ENOUGH_MONEY: '&cYou do not have enough money for that order.'
+  # The text or value for Max Active Reached. Available options: Any valid string text
+  MAX_ACTIVE_REACHED: '&cYou have reached your active order limit.'
+  # The text or value for Created. Available options: Any valid string text
+  CREATED: '&aOrder created! &7#{order_id} &ffor &e{quantity} {item}&7 at &a${price_each} &7each. Budget locked: &a${budget}&7.'
+  # The text or value for Order Not Found. Available options: Any valid string text
+  ORDER_NOT_FOUND: '&cThat order no longer exists.'
+  # The text or value for Order Not Active. Available options: Any valid string text
+  ORDER_NOT_ACTIVE: '&cThat order is no longer active.'
+  # The text or value for Not Your Order. Available options: Any valid string text
+  NOT_YOUR_ORDER: '&cThat order does not belong to you.'
+  # The text or value for Cannot Deliver Own. Available options: Any valid string text
+  CANNOT_DELIVER_OWN: '&cYou cannot deliver to your own order.'
+  # The text or value for No Matching Items. Available options: Any valid string text
+  NO_MATCHING_ITEMS: '&cYou do not have the required items to deliver.'
+  # The text or value for Order Full. Available options: Any valid string text
+  ORDER_FULL: '&cThat order is already full.'
+  # The text or value for Delivery Success. Available options: Any valid string text
+  DELIVERY_SUCCESS: '&aDelivered &e{quantity} {item}&a and received &a${payout}&a.'
+  # The text or value for Cancelled. Available options: Any valid string text
+  CANCELLED: '&eOrder #{order_id} &ehas been closed. Remaining escrow was moved to
+    your collect queue.'
+  # The text or value for Claim Not Found. Available options: Any valid string text
+  CLAIM_NOT_FOUND: '&cThat claim no longer exists.'
+  # The text or value for Not Your Claim. Available options: Any valid string text
+  NOT_YOUR_CLAIM: '&cThat claim does not belong to you.'
+  # The text or value for Claim Already Claimed. Available options: Any valid string text
+  CLAIM_ALREADY_CLAIMED: '&cThat claim was already collected.'
+  # The text or value for Claim Inventory Full. Available options: Any valid string text
+  CLAIM_INVENTORY_FULL: '&cYou need a free inventory slot to claim that item.'
+  # The text or value for Claimed Refund. Available options: Any valid string text
+  CLAIMED_REFUND: '&aClaimed escrow refund of &a${amount}&a.'
+  # The text or value for Claimed Item. Available options: Any valid string text
+  CLAIMED_ITEM: '&aClaimed delivered item: &f{item}&a.'
+# Configuration section for Stats Wipe.
+```
+
+---
+## Section: `STATS-WIPE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+STATS-WIPE:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou do not have permission to use Stats Wipe.'
+  # The text or value for Player Only Gui. Available options: Any valid string text
+  PLAYER-ONLY-GUI: '&cOpen the Stats Wipe GUI in-game, or use /uds statswipe <target>
+    confirm.'
+  # The text or value for Invalid Target. Available options: Any valid string text
+  INVALID-TARGET: '&cInvalid Stats Wipe target. Available: {targets}'
+  # The text or value for Direct Usage. Available options: Any valid string text
+  DIRECT-USAGE: '&cUse /uds statswipe <target> confirm to run directly, or /uds statswipe
+    to open the GUI.'
+  # The text or value for Busy. Available options: Any valid string text
+  BUSY: '&cA wipe is already in progress.'
+  # The text or value for Failed. Available options: Any valid string text
+  FAILED: '&cStats Wipe failed: {error}'
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&aWipe complete: &f{target}&a. Affected records: &f{count}&a.'
+# Configuration section for Staff.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `STATS-WIPE.NO-PERMISSION` | `str` | Any string text | `'&cYou do not have permission to use...'` | Sent when somebody without the node tries to use it. |
+| `STATS-WIPE.PLAYER-ONLY-GUI` | `str` | Any string text | `'&cOpen the Stats Wipe GUI in-game, ...'` | Sent when the console asks for the menu, which only exists in game. |
+| `STATS-WIPE.INVALID-TARGET` | `str` | Any string text | `'&cInvalid Stats Wipe target. Availa...'` | Sent when the named target is not one the wipe understands. `{targets}` lists the valid ones. |
+| `STATS-WIPE.DIRECT-USAGE` | `str` | Any string text | `'&cUse /uds statswipe <target> confi...'` | The usage line, spelling out both the direct form and the menu. |
+| `STATS-WIPE.BUSY` | `str` | Any string text | `'&cA wipe is already in progress.'` | Sent when a wipe is already running. They do not queue. |
+| `STATS-WIPE.FAILED` | `str` | Any string text | `'&cStats Wipe failed: {error}'` | Sent when the wipe stopped part way. `{error}` carries the reason. |
+| `STATS-WIPE.SUCCESS` | `str` | Any string text | `'&aWipe complete: &f{target}&a. Affe...'` | Confirmation, with `{target}` and the `{count}` of records affected. |
+
+The season stats wipe, which is guarded because it destroys records.
+
+### 3. Practical Setup Example
+
+```yaml
+STATS-WIPE:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO-PERMISSION: '&cYou do not have permission to use Stats Wipe.'
+  # The text or value for Player Only Gui. Available options: Any valid string text
+  PLAYER-ONLY-GUI: '&cOpen the Stats Wipe GUI in-game, or use /uds statswipe <target>
+    confirm.'
+  # The text or value for Invalid Target. Available options: Any valid string text
+  INVALID-TARGET: '&cInvalid Stats Wipe target. Available: {targets}'
+  # The text or value for Direct Usage. Available options: Any valid string text
+  DIRECT-USAGE: '&cUse /uds statswipe <target> confirm to run directly, or /uds statswipe
+    to open the GUI.'
+  # The text or value for Busy. Available options: Any valid string text
+  BUSY: '&cA wipe is already in progress.'
+  # The text or value for Failed. Available options: Any valid string text
+  FAILED: '&cStats Wipe failed: {error}'
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&aWipe complete: &f{target}&a. Affected records: &f{count}&a.'
+# Configuration section for Staff.
+```
+
+---
+## Section: `STAFF`
+
+### 1. Commented Setup Code Example
+
+```yaml
+STAFF:
+  # The text or value for No Permission Others. Available options: Any valid string text
+  NO_PERMISSION_OTHERS: '&c&lERROR &7» &cYou don''t have permission to manage other
+    players'' staff mode!'
+  # The text or value for Toggle Error. Available options: Any valid string text
+  TOGGLE_ERROR: '&c&lERROR &7» &cFailed to toggle staff mode!'
+  # The text or value for Status Enabled. Available options: Any valid string text
+  STATUS_ENABLED: '&aEnabled'
+  # The text or value for Status Disabled. Available options: Any valid string text
+  STATUS_DISABLED: '&cDisabled'
+  # The text or value for Icon Enabled. Available options: Any valid string text
+  ICON_ENABLED: '&a✓'
+  # The text or value for Icon Disabled. Available options: Any valid string text
+  ICON_DISABLED: '&c✗'
+  # The text or value for State Active. Available options: Any valid string text
+  STATE_ACTIVE: '&aActive'
+  # The text or value for State Inactive. Available options: Any valid string text
+  STATE_INACTIVE: '&cInactive'
+  # The text or value for Self Toggle. Available options: Any valid string text
+  SELF_TOGGLE: '&6&lSTAFF MODE &7» %status%&7!'
+  # The text or value for Self Status. Available options: Any valid string text
+  SELF_STATUS: '&7Status: %icon% %status%'
+  # The text or value for Other Toggle. Available options: Any valid string text
+  OTHER_TOGGLE: '&6&lSTAFF MODE &7» %status% &7staff mode for &e%target%&7!'
+  # The text or value for Target Notify. Available options: Any valid string text
+  TARGET_NOTIFY: '&6&lSTAFF MODE &7» Your staff mode has been %status% &7by &e%staff%&7!'
+  # The text or value for Broadcast. Available options: Any valid string text
+  BROADCAST: '&8[&6STAFF&8] &e%staff% &7has %status% &7staff mode for &e%target%'
+  # Configuration section for Activation Messages.
+  ACTIVATION_MESSAGES:
+  - '&7&m------------------------------'
+  - '&6&lSTAFF MODE ACTIVATED'
+  - '&7• Inventory cleared and saved'
+  - '&7• Game mode set to Creative'
+  - '&7• Flight enabled'
+  - '&7• Use &e/vanish &7to become invisible'
+  - '&7&m------------------------------'
+# Configuration section for Fly.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `STAFF.NO_PERMISSION_OTHERS` | `str` | Any string text | `'&c&lERROR &7» &cYou don't have perm...'` | Sent when somebody may toggle their own staff mode but not other people's. |
+| `STAFF.TOGGLE_ERROR` | `str` | Any string text | `'&c&lERROR &7» &cFailed to toggle st...'` | Sent when the toggle failed outright. |
+| `STAFF.STATUS_ENABLED` | `str` | Any string text | `'&aEnabled'` | The word substituted for `%status%` when staff mode is being turned on. |
+| `STAFF.STATUS_DISABLED` | `str` | Any string text | `'&cDisabled'` | The same for turning it off. |
+| `STAFF.ICON_ENABLED` | `str` | Any string text | `'&a✓'` | The symbol substituted for `%icon%` in the on state. |
+| `STAFF.ICON_DISABLED` | `str` | Any string text | `'&c✗'` | The symbol for the off state. |
+| `STAFF.STATE_ACTIVE` | `str` | Any string text | `'&aActive'` | Wording used where a state rather than an action is shown. |
+| `STAFF.STATE_INACTIVE` | `str` | Any string text | `'&cInactive'` | The inactive counterpart. |
+| `STAFF.SELF_TOGGLE` | `str` | Any string text | `'&6&lSTAFF MODE &7» %status%&7!'` | Shown to staff toggling their own mode. |
+| `STAFF.SELF_STATUS` | `str` | Any string text | `'&7Status: %icon% %status%'` | The status line that follows it, using both `%icon%` and `%status%`. |
+| `STAFF.OTHER_TOGGLE` | `str` | Any string text | `'&6&lSTAFF MODE &7» %status% &7staff...'` | Shown to staff toggling somebody else's mode. `%target%` is that player. |
+| `STAFF.TARGET_NOTIFY` | `str` | Any string text | `'&6&lSTAFF MODE &7» Your staff mode ...'` | Shown to the player whose mode was changed, naming the `%staff%` who did it. |
+| `STAFF.BROADCAST` | `str` | Any string text | `'&8[&6STAFF&8] &e%staff% &7has %stat...'` | The announcement other staff see. |
+| `STAFF.ACTIVATION_MESSAGES` | `list` | Lines of text | `['&7&m------------------------------', '&6&lSTA...]` | The block printed on entering staff mode. It describes what staff mode did to the inventory and game mode, so keep it in step if you change that behaviour. |
+
+Staff mode toggling. Several of these are fragments rather than whole messages: the status and icon values are substituted into the others through `%status%` and `%icon%`.
+
+### 3. Practical Setup Example
+
+```yaml
+STAFF:
+  # The text or value for No Permission Others. Available options: Any valid string text
+  NO_PERMISSION_OTHERS: '&c&lERROR &7» &cYou don''t have permission to manage other
+    players'' staff mode!'
+  # The text or value for Toggle Error. Available options: Any valid string text
+  TOGGLE_ERROR: '&c&lERROR &7» &cFailed to toggle staff mode!'
+  # The text or value for Status Enabled. Available options: Any valid string text
+  STATUS_ENABLED: '&aEnabled'
+  # The text or value for Status Disabled. Available options: Any valid string text
+  STATUS_DISABLED: '&cDisabled'
+  # The text or value for Icon Enabled. Available options: Any valid string text
+  ICON_ENABLED: '&a✓'
+  # The text or value for Icon Disabled. Available options: Any valid string text
+  ICON_DISABLED: '&c✗'
+  # The text or value for State Active. Available options: Any valid string text
+  STATE_ACTIVE: '&aActive'
+  # The text or value for State Inactive. Available options: Any valid string text
+  STATE_INACTIVE: '&cInactive'
+  # The text or value for Self Toggle. Available options: Any valid string text
+  SELF_TOGGLE: '&6&lSTAFF MODE &7» %status%&7!'
+  # The text or value for Self Status. Available options: Any valid string text
+  SELF_STATUS: '&7Status: %icon% %status%'
+  # The text or value for Other Toggle. Available options: Any valid string text
+  OTHER_TOGGLE: '&6&lSTAFF MODE &7» %status% &7staff mode for &e%target%&7!'
+  # The text or value for Target Notify. Available options: Any valid string text
+  TARGET_NOTIFY: '&6&lSTAFF MODE &7» Your staff mode has been %status% &7by &e%staff%&7!'
+  # The text or value for Broadcast. Available options: Any valid string text
+  BROADCAST: '&8[&6STAFF&8] &e%staff% &7has %status% &7staff mode for &e%target%'
+  # Configuration section for Activation Messages.
+  ACTIVATION_MESSAGES:
+  - '&7&m------------------------------'
+  - '&6&lSTAFF MODE ACTIVATED'
+  - '&7• Inventory cleared and saved'
+  - '&7• Game mode set to Creative'
+  - '&7• Flight enabled'
+  - '&7• Use &e/vanish &7to become invisible'
+  - '&7&m------------------------------'
+# Configuration section for Fly.
+```
+
+---
+## Section: `FLY`
+
+### 1. Commented Setup Code Example
+
+```yaml
+FLY:
+  # The text or value for Enabled. Available options: Any valid string text
+  ENABLED: '&a✈ &7Flight mode &aactivated'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&c✗ &7Flight mode &cdeactivated'
+  # Message when player tries to enable fly outside spawn/cuboids
+  PLAYER_RESTRICTED: '&c✗ &7You can only use flight in spawn or cuboids.'
+  # Message when player tries to enable fly in combat
+  PLAYER_IN_COMBAT: '&c✗ &7You cannot fly while in combat.'
+  # Message when player flight is automatically disabled
+  PLAYER_DISABLED: '&c✗ &7Flight deactivated because you left the allowed area or entered combat.'
+# Configuration section for Flyspeed.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FLY.ENABLED` | `str` | Any string text | `'&a✈ &7Flight mode &aactivated'` | Shown when flight turns on. |
+| `FLY.DISABLED` | `str` | Any string text | `'&c✗ &7Flight mode &cdeactivated'` | Shown when the player turns it off themselves. |
+| `FLY.PLAYER_RESTRICTED` | `str` | Any string text | `'&c✗ &7You can only use flight in sp...'` | Sent when flight is not allowed where they are standing. |
+| `FLY.PLAYER_IN_COMBAT` | `str` | Any string text | `'&c✗ &7You cannot fly while in comba...'` | Sent when they are combat tagged. |
+| `FLY.PLAYER_DISABLED` | `str` | Any string text | `'&c✗ &7Flight deactivated because yo...'` | Sent when flight is taken away mid-flight, because they left the allowed area or were pulled into combat. |
+
+The flight toggle and the reasons it can refuse or switch itself off.
+
+### 3. Practical Setup Example
+
+```yaml
+FLY:
+  # The text or value for Enabled. Available options: Any valid string text
+  ENABLED: '&a✈ &7Flight mode &aactivated'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&c✗ &7Flight mode &cdeactivated'
+  # Message when player tries to enable fly outside spawn/cuboids
+  PLAYER_RESTRICTED: '&c✗ &7You can only use flight in spawn or cuboids.'
+  # Message when player tries to enable fly in combat
+  PLAYER_IN_COMBAT: '&c✗ &7You cannot fly while in combat.'
+  # Message when player flight is automatically disabled
+  PLAYER_DISABLED: '&c✗ &7Flight deactivated because you left the allowed area or entered combat.'
+# Configuration section for Flyspeed.
+```
+
+---
+## Section: `FLYSPEED`
+
+### 1. Commented Setup Code Example
+
+```yaml
+FLYSPEED:
+  # The text or value for Set. Available options: Any valid string text
+  SET: '&aFly speed set to &f{speed}&a.'
+  # The text or value for Invalid. Available options: Any valid string text
+  INVALID: '&cInvalid speed. Please enter a number from 1 to 10.'
+# Configuration section for Walkspeed.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FLYSPEED.SET` | `str` | Any string text | `'&aFly speed set to &f{speed}&a.'` | Confirmation, with the `{speed}` applied. |
+| `FLYSPEED.INVALID` | `str` | Any string text | `'&cInvalid speed. Please enter a num...'` | Sent when the value is outside the range the message names. |
+
+Setting fly speed.
+
+### 3. Practical Setup Example
+
+```yaml
+FLYSPEED:
+  # The text or value for Set. Available options: Any valid string text
+  SET: '&aFly speed set to &f{speed}&a.'
+  # The text or value for Invalid. Available options: Any valid string text
+  INVALID: '&cInvalid speed. Please enter a number from 1 to 10.'
+# Configuration section for Walkspeed.
+```
+
+---
+## Section: `WALKSPEED`
+
+### 1. Commented Setup Code Example
+
+```yaml
+WALKSPEED:
+  # The text or value for Set. Available options: Any valid string text
+  SET: '&aWalk speed set to &f{speed}&a.'
+  # The text or value for Invalid. Available options: Any valid string text
+  INVALID: '&cInvalid speed. Please enter a number from 1 to 10.'
+# Configuration section for Heal.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `WALKSPEED.SET` | `str` | Any string text | `'&aWalk speed set to &f{speed}&a.'` | Confirmation, with the `{speed}` applied. |
+| `WALKSPEED.INVALID` | `str` | Any string text | `'&cInvalid speed. Please enter a num...'` | Sent when the value is outside the accepted range. |
+
+Setting walk speed.
+
+### 3. Practical Setup Example
+
+```yaml
+WALKSPEED:
+  # The text or value for Set. Available options: Any valid string text
+  SET: '&aWalk speed set to &f{speed}&a.'
+  # The text or value for Invalid. Available options: Any valid string text
+  INVALID: '&cInvalid speed. Please enter a number from 1 to 10.'
+# Configuration section for Heal.
+```
+
+---
+## Section: `HEAL`
+
+### 1. Commented Setup Code Example
+
+```yaml
+HEAL:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&a♡ &7Your health has been restored!'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&8[&cHeal&8] &7You healed &d%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&cHeal&8] &d%sender% &7restored your health'
+# Configuration section for Feed.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `HEAL.SELF` | `str` | Any string text | `'&a♡ &7Your health has been restored...'` | Shown when healing yourself. |
+| `HEAL.OTHER` | `str` | Any string text | `'&8[&cHeal&8] &7You healed &d%player...'` | Shown to the staff member who healed somebody else. |
+| `HEAL.NOTIFY` | `str` | Any string text | `'&8[&cHeal&8] &d%sender% &7restored ...'` | Shown to the player who was healed, naming the `%sender%`. |
+
+The heal command.
+
+### 3. Practical Setup Example
+
+```yaml
+HEAL:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&a♡ &7Your health has been restored!'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&8[&cHeal&8] &7You healed &d%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&cHeal&8] &d%sender% &7restored your health'
+# Configuration section for Feed.
+```
+
+---
+## Section: `FEED`
+
+### 1. Commented Setup Code Example
+
+```yaml
+FEED:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&7Your hunger has been satisfied!'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&8[&6Feed&8] &7You fed &d%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&6Feed&8] &d%sender% &7restored your hunger'
+# Configuration section for Gamemode.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FEED.SELF` | `str` | Any string text | `'&7Your hunger has been satisfied!'` | Shown when feeding yourself. |
+| `FEED.OTHER` | `str` | Any string text | `'&8[&6Feed&8] &7You fed &d%player%'` | Shown to the staff member who fed somebody else. |
+| `FEED.NOTIFY` | `str` | Any string text | `'&8[&6Feed&8] &d%sender% &7restored ...'` | Shown to the player who was fed. |
+
+The feed command, arranged the same way as heal.
+
+### 3. Practical Setup Example
+
+```yaml
+FEED:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&7Your hunger has been satisfied!'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&8[&6Feed&8] &7You fed &d%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&6Feed&8] &d%sender% &7restored your hunger'
+# Configuration section for Gamemode.
+```
+
+---
+## Section: `GAMEMODE`
+
+### 1. Commented Setup Code Example
+
+```yaml
+GAMEMODE:
+  # The text or value for Message. Available options: Any valid string text
+  MESSAGE: '&d%player% &7is now in &e%mode% mode'
+  # The text or value for Target Message. Available options: Any valid string text
+  TARGET_MESSAGE: '&7Your gamemode has been changed to &e%mode% &7by &d%sender%'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission.'
+  # The text or value for No Permission Others. Available options: Any valid string text
+  NO_PERMISSION_OTHERS: '&cYou do not have permission to change other players'' gamemode.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use this command without a target.'
+  # The text or value for Player Not Online. Available options: Any valid string text
+  PLAYER_NOT_ONLINE: '&cPlayer not online.'
+  # The text or value for Invalid Mode. Available options: Any valid string text
+  INVALID_MODE: '&cInvalid gamemode. Use survival, creative, adventure, or spectator.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /%label% <survival|creative|adventure|spectator> [player]'
+  # The text or value for Usage Short. Available options: Any valid string text
+  USAGE_SHORT: '&cUsage: /%label% [player]'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cGamemode commands are currently disabled.'
+# Configuration section for Randomtp.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `GAMEMODE.MESSAGE` | `str` | Any string text | `'&d%player% &7is now in &e%mode% mod...'` | The confirmation, naming the `%player%` and the `%mode%`. |
+| `GAMEMODE.TARGET_MESSAGE` | `str` | Any string text | `'&7Your gamemode has been changed to...'` | Shown to a player whose mode somebody else changed. |
+| `GAMEMODE.NO_PERMISSION` | `str` | Any string text | `'&cYou do not have permission.'` | Sent when they may not change their own mode. |
+| `GAMEMODE.NO_PERMISSION_OTHERS` | `str` | Any string text | `'&cYou do not have permission to cha...'` | Sent when they may not change other people's. |
+| `GAMEMODE.PLAYER_ONLY` | `str` | Any string text | `'&cOnly players can use this command...'` | Sent when the console runs it without naming a target. |
+| `GAMEMODE.PLAYER_NOT_ONLINE` | `str` | Any string text | `'&cPlayer not online.'` | Sent when the named target is not online. |
+| `GAMEMODE.INVALID_MODE` | `str` | Any string text | `'&cInvalid gamemode. Use survival, c...'` | Sent when the mode is not one of the four. |
+| `GAMEMODE.USAGE` | `str` | Any string text | `'&cUsage: /%label% <survival\|creativ...'` | The usage line for the general command. `%label%` is the alias actually typed, so aliases show their own name. |
+| `GAMEMODE.USAGE_SHORT` | `str` | Any string text | `'&cUsage: /%label% [player]'` | The usage line for the per-mode aliases, which take only a player. |
+| `GAMEMODE.DISABLED` | `str` | Any string text | `'&cGamemode commands are currently d...'` | Sent when the gamemode commands are switched off. |
+
+The staff gamemode commands.
+
+### 3. Practical Setup Example
+
+```yaml
+GAMEMODE:
+  # The text or value for Message. Available options: Any valid string text
+  MESSAGE: '&d%player% &7is now in &e%mode% mode'
+  # The text or value for Target Message. Available options: Any valid string text
+  TARGET_MESSAGE: '&7Your gamemode has been changed to &e%mode% &7by &d%sender%'
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission.'
+  # The text or value for No Permission Others. Available options: Any valid string text
+  NO_PERMISSION_OTHERS: '&cYou do not have permission to change other players'' gamemode.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use this command without a target.'
+  # The text or value for Player Not Online. Available options: Any valid string text
+  PLAYER_NOT_ONLINE: '&cPlayer not online.'
+  # The text or value for Invalid Mode. Available options: Any valid string text
+  INVALID_MODE: '&cInvalid gamemode. Use survival, creative, adventure, or spectator.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /%label% <survival|creative|adventure|spectator> [player]'
+  # The text or value for Usage Short. Available options: Any valid string text
+  USAGE_SHORT: '&cUsage: /%label% [player]'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cGamemode commands are currently disabled.'
+# Configuration section for Randomtp.
+```
+
+---
+## Section: `RANDOMTP`
+
+### 1. Commented Setup Code Example
+
+```yaml
+RANDOMTP:
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&8[&dRTP&8] &7You were teleported to &e%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&dRTP&8] &e%player% &7appeared near you!'
+  # The text or value for No Players. Available options: Any valid string text
+  NO_PLAYERS: '&c✖ &7No other players available for random teleport'
+# Configuration section for Rename.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RANDOMTP.SUCCESS` | `str` | Any string text | `'&8[&dRTP&8] &7You were teleported t...'` | Shown to the player who teleported, naming who they landed on. |
+| `RANDOMTP.NOTIFY` | `str` | Any string text | `'&8[&dRTP&8] &e%player% &7appeared n...'` | Shown to the player who was teleported to. |
+| `RANDOMTP.NO_PLAYERS` | `str` | Any string text | `'&c✖ &7No other players available fo...'` | Sent when nobody else is online to pick. |
+
+Teleporting to a random online player, which is separate from `/rtp` to a random location.
+
+### 3. Practical Setup Example
+
+```yaml
+RANDOMTP:
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&8[&dRTP&8] &7You were teleported to &e%player%'
+  # The text or value for Notify. Available options: Any valid string text
+  NOTIFY: '&8[&dRTP&8] &e%player% &7appeared near you!'
+  # The text or value for No Players. Available options: Any valid string text
+  NO_PLAYERS: '&c✖ &7No other players available for random teleport'
+# Configuration section for Rename.
+```
+
+---
+## Section: `RENAME`
+
+### 1. Commented Setup Code Example
+
+```yaml
+RENAME:
+  # The text or value for No Item. Available options: Any valid string text
+  NO_ITEM: '&c✖ &7You must hold an item to rename it'
+  # The text or value for Meta Error. Available options: Any valid string text
+  META_ERROR: '&c⚠ &7This item cannot be renamed'
+  # The text or value for Staffmode Blocked. Available options: Any valid string text
+  STAFFMODE_BLOCKED: '&c✖ &7Staff mode items cannot be renamed'
+  # The text or value for Reset Success. Available options: Any valid string text
+  RESET_SUCCESS: '&8[&aRename&8] &7Item name has been reset'
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&8[&aRename&8] &7New name: &f%name%'
+# Configuration section for Ping.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `RENAME.NO_ITEM` | `str` | Any string text | `'&c✖ &7You must hold an item to rena...'` | Sent when their hand is empty. |
+| `RENAME.META_ERROR` | `str` | Any string text | `'&c⚠ &7This item cannot be renamed'` | Sent when the item cannot carry a name. |
+| `RENAME.STAFFMODE_BLOCKED` | `str` | Any string text | `'&c✖ &7Staff mode items cannot be re...'` | Sent when the item is a staff mode tool, which is protected so the toolbar cannot be disguised. |
+| `RENAME.RESET_SUCCESS` | `str` | Any string text | `'&8[&aRename&8] &7Item name has been...'` | Confirmation after clearing a custom name. |
+| `RENAME.SUCCESS` | `str` | Any string text | `'&8[&aRename&8] &7New name: &f%name%'` | Confirmation after setting one, echoing the `%name%`. |
+
+Renaming a held item.
+
+### 3. Practical Setup Example
+
+```yaml
+RENAME:
+  # The text or value for No Item. Available options: Any valid string text
+  NO_ITEM: '&c✖ &7You must hold an item to rename it'
+  # The text or value for Meta Error. Available options: Any valid string text
+  META_ERROR: '&c⚠ &7This item cannot be renamed'
+  # The text or value for Staffmode Blocked. Available options: Any valid string text
+  STAFFMODE_BLOCKED: '&c✖ &7Staff mode items cannot be renamed'
+  # The text or value for Reset Success. Available options: Any valid string text
+  RESET_SUCCESS: '&8[&aRename&8] &7Item name has been reset'
+  # The text or value for Success. Available options: Any valid string text
+  SUCCESS: '&8[&aRename&8] &7New name: &f%name%'
+# Configuration section for Ping.
+```
+
+---
+## Section: `PING`
+
+### 1. Commented Setup Code Example
+
+```yaml
+PING:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&7Your ping is &b%ping%ms'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&e%player%''s &7ping is &b%ping%ms'
+# Configuration section for Playtime.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `PING.SELF` | `str` | Any string text | `'&7Your ping is &b%ping%ms'` | Reply when checking your own ping. |
+| `PING.OTHER` | `str` | Any string text | `'&e%player%'s &7ping is &b%ping%ms'` | Reply when checking somebody else's. |
+
+The ping command.
+
+### 3. Practical Setup Example
+
+```yaml
+PING:
+  # The text or value for Self. Available options: Any valid string text
+  SELF: '&7Your ping is &b%ping%ms'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&e%player%''s &7ping is &b%ping%ms'
+# Configuration section for Playtime.
+```
+
+---
+## Section: `PLAYTIME`
+
+### 1. Commented Setup Code Example
+
+```yaml
+PLAYTIME:
+  # The text or value for Message. Available options: Any valid string text
+  MESSAGE: '&a%time% &eplaying on &a%server%'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&e%player% &7has played for &a%time% &7on &a%server%'
+# Configuration section for Staffchat.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `PLAYTIME.MESSAGE` | `str` | Any string text | `'&a%time% &eplaying on &a%server%'` | Reply when checking your own playtime. |
+| `PLAYTIME.OTHER` | `str` | Any string text | `'&e%player% &7has played for &a%time...'` | Reply when checking somebody else's. |
+
+The playtime command. `%server%` lets a network name each server in the reply.
+
+### 3. Practical Setup Example
+
+```yaml
+PLAYTIME:
+  # The text or value for Message. Available options: Any valid string text
+  MESSAGE: '&a%time% &eplaying on &a%server%'
+  # The text or value for Other. Available options: Any valid string text
+  OTHER: '&e%player% &7has played for &a%time% &7on &a%server%'
+# Configuration section for Staffchat.
+```
+
+---
+## Section: `STAFFCHAT`
+
+### 1. Commented Setup Code Example
+
+```yaml
+STAFFCHAT:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to use staff chat.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /staffchat <message>'
+  # The text or value for Format. Available options: Any valid string text
+  FORMAT: '&8[&6StaffChat&8] &e%player%&7: %message%'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cNetwork staff chat is currently disabled.'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cStaff chat message is too long. Max: %max% characters.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eStaff chat was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+# Configuration section for Helpop.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `STAFFCHAT.NO_PERMISSION` | `str` | Any string text | `'&cYou do not have permission to use...'` | Sent when somebody without the node tries to use it. |
+| `STAFFCHAT.USAGE` | `str` | Any string text | `'&cUsage: /staffchat <message>'` | The usage line. |
+| `STAFFCHAT.FORMAT` | `str` | Any string text | `'&8[&6StaffChat&8] &e%player%&7: %me...'` | How a staff chat line is rendered, with `%player%` and `%message%`. |
+| `STAFFCHAT.DISABLED` | `str` | Any string text | `'&cNetwork staff chat is currently d...'` | Sent when network staff chat is switched off. |
+| `STAFFCHAT.MESSAGE_TOO_LONG` | `str` | Any string text | `'&cStaff chat message is too long. M...'` | Sent when the message passes the configured limit, quoted as `%max%`. |
+| `STAFFCHAT.REDIS_UNAVAILABLE` | `str` | Any string text | `'&eStaff chat was delivered locally,...'` | Warns the sender that their message reached this server but not the others. Whether it is sent at all is `NETWORK.SEND_LOCAL_FALLBACK_ON_REDIS_ERROR` in `network.yml`, and each player sees it once per session. |
+
+The staff chat channel, which spans servers over Redis when networking is on.
+
+### 3. Practical Setup Example
+
+```yaml
+STAFFCHAT:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to use staff chat.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /staffchat <message>'
+  # The text or value for Format. Available options: Any valid string text
+  FORMAT: '&8[&6StaffChat&8] &e%player%&7: %message%'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cNetwork staff chat is currently disabled.'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cStaff chat message is too long. Max: %max% characters.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eStaff chat was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+# Configuration section for Helpop.
+```
+
+---
+## Section: `HELPOP`
+
+### 1. Commented Setup Code Example
+
+```yaml
+HELPOP:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to request staff assistance.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use helpop.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /helpop <message>'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cHelpop is currently disabled.'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cYour request is too long. Max: %max% characters.'
+  # The text or value for Cooldown. Available options: Any valid string text
+  COOLDOWN: '&cPlease wait %seconds%s before using helpop again.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eYour request was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+  # Configuration section for Format.
+  FORMAT:
+  - ''
+  - '&9[request] &7[%server%] &a%player% &bhas requested assistance'
+  - '     &9reason: &b%message%'
+  - ''
+  # The text or value for Confirmation. Available options: Any valid string text
+  CONFIRMATION: '&aYour request has been sent to all staff members.'
+# Configuration section for Report.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `HELPOP.NO_PERMISSION` | `str` | Any string text | `'&cYou do not have permission to req...'` | Sent when the player may not ask for help. |
+| `HELPOP.PLAYER_ONLY` | `str` | Any string text | `'&cOnly players can use helpop.'` | Sent when the console tries to use it. |
+| `HELPOP.USAGE` | `str` | Any string text | `'&cUsage: /helpop <message>'` | The usage line. |
+| `HELPOP.DISABLED` | `str` | Any string text | `'&cHelpop is currently disabled.'` | Sent when helpop is switched off. |
+| `HELPOP.MESSAGE_TOO_LONG` | `str` | Any string text | `'&cYour request is too long. Max: %m...'` | Sent when the request exceeds `%max%` characters. |
+| `HELPOP.COOLDOWN` | `str` | Any string text | `'&cPlease wait %seconds%s before usi...'` | Sent when asking again too soon, with `%seconds%` left. |
+| `HELPOP.REDIS_UNAVAILABLE` | `str` | Any string text | `'&eYour request was delivered locall...'` | Warns that the request reached local staff but not the other servers. Controlled by `NETWORK.STAFF_ALERTS_WARN_SENDER_ON_REDIS_ERROR`, which ships off. |
+| `HELPOP.FORMAT` | `list` | Lines of text | `['', '&9[request] &7[%server%] &a%player% &bhas...]` | The block staff see, with `%server%`, `%player%` and `%message%`. |
+| `HELPOP.CONFIRMATION` | `str` | Any string text | `'&aYour request has been sent to all...'` | The acknowledgement back to the player who asked. |
+
+Player requests for staff help.
+
+### 3. Practical Setup Example
+
+```yaml
+HELPOP:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to request staff assistance.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use helpop.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /helpop <message>'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cHelpop is currently disabled.'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cYour request is too long. Max: %max% characters.'
+  # The text or value for Cooldown. Available options: Any valid string text
+  COOLDOWN: '&cPlease wait %seconds%s before using helpop again.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eYour request was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+  # Configuration section for Format.
+  FORMAT:
+  - ''
+  - '&9[request] &7[%server%] &a%player% &bhas requested assistance'
+  - '     &9reason: &b%message%'
+  - ''
+  # The text or value for Confirmation. Available options: Any valid string text
+  CONFIRMATION: '&aYour request has been sent to all staff members.'
+# Configuration section for Report.
+```
+
+---
+## Section: `REPORT`
+
+### 1. Commented Setup Code Example
+
+```yaml
+REPORT:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to report players.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use report.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /report <player> <reason>'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cReports are currently disabled.'
+  # The text or value for Player Not Found. Available options: Any valid string text
+  PLAYER_NOT_FOUND: '&cPlayer not found.'
+  # The text or value for Cannot Report Self. Available options: Any valid string text
+  CANNOT_REPORT_SELF: '&cYou can''t report yourself!'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cYour report reason is too long. Max: %max% characters.'
+  # The text or value for Cooldown. Available options: Any valid string text
+  COOLDOWN: '&cPlease wait %seconds%s before reporting again.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eYour report was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+  # Configuration section for Format.
+  FORMAT:
+  - ''
+  - '&9[report] &7[%server%] &c%reported% &bhas been reported by &a%reporter%'
+  - '     &9reason: &b%reason%'
+  - ''
+  # The text or value for Confirmation. Available options: Any valid string text
+  CONFIRMATION: '&aYour report has been sent to all staff members.'
+# Configuration section for Alts.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `REPORT.NO_PERMISSION` | `str` | Any string text | `'&cYou do not have permission to rep...'` | Sent when the player may not report. |
+| `REPORT.PLAYER_ONLY` | `str` | Any string text | `'&cOnly players can use report.'` | Sent when the console tries to use it. |
+| `REPORT.USAGE` | `str` | Any string text | `'&cUsage: /report <player> <reason>'` | The usage line. |
+| `REPORT.DISABLED` | `str` | Any string text | `'&cReports are currently disabled.'` | Sent when reports are switched off. |
+| `REPORT.PLAYER_NOT_FOUND` | `str` | Any string text | `'&cPlayer not found.'` | Sent when the reported name is not known. |
+| `REPORT.CANNOT_REPORT_SELF` | `str` | Any string text | `'&cYou can't report yourself!'` | Sent when somebody reports themselves. |
+| `REPORT.MESSAGE_TOO_LONG` | `str` | Any string text | `'&cYour report reason is too long. M...'` | Sent when the reason exceeds `%max%` characters. |
+| `REPORT.COOLDOWN` | `str` | Any string text | `'&cPlease wait %seconds%s before rep...'` | Sent when reporting again too soon. |
+| `REPORT.REDIS_UNAVAILABLE` | `str` | Any string text | `'&eYour report was delivered locally...'` | Warns that the report reached local staff but not the other servers. |
+| `REPORT.FORMAT` | `list` | Lines of text | `['', '&9[report] &7[%server%] &c%reported% &bha...]` | The block staff see, with `%reported%`, `%reporter%` and `%reason%`. |
+| `REPORT.CONFIRMATION` | `str` | Any string text | `'&aYour report has been sent to all ...'` | The acknowledgement back to the reporter. |
+
+Player reports, arranged like helpop but naming a target.
+
+### 3. Practical Setup Example
+
+```yaml
+REPORT:
+  # The text or value for No Permission. Available options: Any valid string text
+  NO_PERMISSION: '&cYou do not have permission to report players.'
+  # The text or value for Player Only. Available options: Any valid string text
+  PLAYER_ONLY: '&cOnly players can use report.'
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /report <player> <reason>'
+  # The text or value for Disabled. Available options: Any valid string text
+  DISABLED: '&cReports are currently disabled.'
+  # The text or value for Player Not Found. Available options: Any valid string text
+  PLAYER_NOT_FOUND: '&cPlayer not found.'
+  # The text or value for Cannot Report Self. Available options: Any valid string text
+  CANNOT_REPORT_SELF: '&cYou can''t report yourself!'
+  # The text or value for Message Too Long. Available options: Any valid string text
+  MESSAGE_TOO_LONG: '&cYour report reason is too long. Max: %max% characters.'
+  # The text or value for Cooldown. Available options: Any valid string text
+  COOLDOWN: '&cPlease wait %seconds%s before reporting again.'
+  # The text or value for Redis Unavailable. Available options: Any valid string text
+  REDIS_UNAVAILABLE: '&eYour report was delivered locally, but Redis is unavailable
+    for cross-server delivery.'
+  # Configuration section for Format.
+  FORMAT:
+  - ''
+  - '&9[report] &7[%server%] &c%reported% &bhas been reported by &a%reporter%'
+  - '     &9reason: &b%reason%'
+  - ''
+  # The text or value for Confirmation. Available options: Any valid string text
+  CONFIRMATION: '&aYour report has been sent to all staff members.'
+# Configuration section for Alts.
+```
+
+---
+## Section: `ALTS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+ALTS:
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /alts <player>'
+  # The text or value for Not Found. Available options: Any valid string text
+  NOT_FOUND: '&cPlayer not found.'
+  # The text or value for No Data. Available options: Any valid string text
+  NO_DATA: '&cNo IP history found for that player.'
+  # The text or value for None. Available options: Any valid string text
+  NONE: '&7No alternate accounts found.'
+  # The text or value for Header. Available options: Any valid string text
+  HEADER: '&8[&6Alts&8] &e%player%'
+  # The text or value for Known Ips. Available options: Any valid string text
+  KNOWN_IPS: '&7Known IPs: &f%ips%'
+  # The text or value for Entry. Available options: Any valid string text
+  ENTRY: '&8- &e%player% &7[%status%&7] &fshared: %ips%'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `ALTS.USAGE` | `str` | Any string text | `'&cUsage: /alts <player>'` | The usage line. |
+| `ALTS.NOT_FOUND` | `str` | Any string text | `'&cPlayer not found.'` | Sent when the name is not known. |
+| `ALTS.NO_DATA` | `str` | Any string text | `'&cNo IP history found for that play...'` | Sent when the player is known but has no recorded IP history to match on. |
+| `ALTS.NONE` | `str` | Any string text | `'&7No alternate accounts found.'` | Sent when the history exists but nobody else shares it. |
+| `ALTS.HEADER` | `str` | Any string text | `'&8[&6Alts&8] &e%player%'` | The heading above the results. |
+| `ALTS.KNOWN_IPS` | `str` | Any string text | `'&7Known IPs: &f%ips%'` | The line listing the addresses the lookup matched on. |
+| `ALTS.ENTRY` | `str` | Any string text | `'&8- &e%player% &7[%status%&7] &fsha...'` | One result row, repeated per match, with `%status%` showing whether that account is banned. |
+
+The alt account lookup, which matches players by shared IP history.
+
+### 3. Practical Setup Example
+
+```yaml
+ALTS:
+  # The text or value for Usage. Available options: Any valid string text
+  USAGE: '&cUsage: /alts <player>'
+  # The text or value for Not Found. Available options: Any valid string text
+  NOT_FOUND: '&cPlayer not found.'
+  # The text or value for No Data. Available options: Any valid string text
+  NO_DATA: '&cNo IP history found for that player.'
+  # The text or value for None. Available options: Any valid string text
+  NONE: '&7No alternate accounts found.'
+  # The text or value for Header. Available options: Any valid string text
+  HEADER: '&8[&6Alts&8] &e%player%'
+  # The text or value for Known Ips. Available options: Any valid string text
+  KNOWN_IPS: '&7Known IPs: &f%ips%'
+  # The text or value for Entry. Available options: Any valid string text
+  ENTRY: '&8- &e%player% &7[%status%&7] &fshared: %ips%'
+```
+
+---
+## Section: `VOICE-CHAT`
+
+### 1. Commented Setup Code Example
+
+```yaml
+VOICE-CHAT:
+  ACCEPTED: '&aVoice chat is now enabled for you.'
+  DECLINED: '&cVoice chat will stay disabled.'
+  REVOKED: '&cYou withdrew your voice chat consent. Voice chat is disabled again.'
+  NOTHING-TO-REVOKE: '&cYou have not agreed to the voice chat policy yet.'
+  PLAYERS-ONLY: '&cOnly players can use this command.'
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `VOICE-CHAT.ACCEPTED` | `str` | Any string text | `'&aVoice chat is now enabled for you...'` | Shown when they agree. |
+| `VOICE-CHAT.DECLINED` | `str` | Any string text | `'&cVoice chat will stay disabled.'` | Shown when they decline. Voice chat stays off rather than being blocked permanently. |
+| `VOICE-CHAT.REVOKED` | `str` | Any string text | `'&cYou withdrew your voice chat cons...'` | Shown when they withdraw consent later. |
+| `VOICE-CHAT.NOTHING-TO-REVOKE` | `str` | Any string text | `'&cYou have not agreed to the voice ...'` | Sent when they try to withdraw without having agreed. |
+| `VOICE-CHAT.PLAYERS-ONLY` | `str` | Any string text | `'&cOnly players can use this command...'` | Sent when the console tries to use the command. |
+
+The consent prompt players answer before voice chat turns on for them.
+
+### 3. Practical Setup Example
+
+```yaml
+VOICE-CHAT:
+  ACCEPTED: '&aVoice chat is now enabled for you.'
+  DECLINED: '&cVoice chat will stay disabled.'
+  REVOKED: '&cYou withdrew your voice chat consent. Voice chat is disabled again.'
+  NOTHING-TO-REVOKE: '&cYou have not agreed to the voice chat policy yet.'
+  PLAYERS-ONLY: '&cOnly players can use this command.'
+```
+
+---

--- a/docs/wiki/Config-orders.yml.md
+++ b/docs/wiki/Config-orders.yml.md
@@ -3,10 +3,6 @@
 This is the official technical setup guide for `orders.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
-Three sections have no write-up here yet: `SEARCH_SIGN`, `AMOUNT_SIGN` and `PRICE_SIGN`. Each sets
-the four lines of the sign an order menu opens when it asks for a search term, an amount or a price,
-plus the `input-line` that decides which line the player types on.
-
 ---
 
 ## Section: `SETTINGS`
@@ -559,6 +555,110 @@ NETWORK:
 
 ---
 
+## Section: `SEARCH_SIGN`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SEARCH_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "Search"
+    - ""
+  input-line: 0
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SEARCH_SIGN.lines` | `list` | Up to four lines of text | `['', '^^^^^^^^^^^^^^', 'Search', '']` | The four lines the sign shows when the order browser asks for a search term. A shorter list is padded out with blanks and anything past the fourth line is dropped. Colour codes are translated and then stripped, so `&c` and friends change nothing on these signs. Leave all four blank and the plugin falls back to `^^^^^^^^^^^^^^` on the second line and `Enter Value` on the third. |
+| `SEARCH_SIGN.input-line` | `int` | `0` to `3` | `0` | Which line the typed value is read back from, counting from zero. Anything outside that range is clamped into it. At the default of `0` the player types on the top line and the carets underneath point up at it. Set it to `2` and the player would type on the third line instead, where `Search` currently sits. |
+
+### 3. Practical Setup Example
+
+```yaml
+SEARCH_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "Item name"
+    - "or part of one"
+  input-line: 0
+```
+
+---
+## Section: `AMOUNT_SIGN`
+
+### 1. Commented Setup Code Example
+
+```yaml
+AMOUNT_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "Amount"
+    - ""
+  input-line: 0
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `AMOUNT_SIGN.lines` | `list` | Up to four lines of text | `['', '^^^^^^^^^^^^^^', 'Amount', '']` | The four lines the sign shows when a new order asks how many items you want. A shorter list is padded out with blanks and anything past the fourth line is dropped. Colour codes are translated and then stripped, so `&c` and friends change nothing on these signs. Leave all four blank and the plugin falls back to `^^^^^^^^^^^^^^` on the second line and `Enter Value` on the third. |
+| `AMOUNT_SIGN.input-line` | `int` | `0` to `3` | `0` | Which line the typed value is read back from, counting from zero. Anything outside that range is clamped into it. At the default of `0` the player types on the top line and the carets underneath point up at it. Whatever the player types is read as a quantity, so the label matters more than the layout here. |
+
+### 3. Practical Setup Example
+
+```yaml
+AMOUNT_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "How many?"
+    - ""
+  input-line: 0
+```
+
+---
+## Section: `PRICE_SIGN`
+
+### 1. Commented Setup Code Example
+
+```yaml
+PRICE_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "Price"
+    - ""
+  input-line: 0
+
+# Automated Order Bot System Configuration
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `PRICE_SIGN.lines` | `list` | Up to four lines of text | `['', '^^^^^^^^^^^^^^', 'Price', '']` | The four lines the sign shows when a new order asks what you will pay per item. A shorter list is padded out with blanks and anything past the fourth line is dropped. Colour codes are translated and then stripped, so `&c` and friends change nothing on these signs. Leave all four blank and the plugin falls back to `^^^^^^^^^^^^^^` on the second line and `Enter Value` on the third. |
+| `PRICE_SIGN.input-line` | `int` | `0` to `3` | `0` | Which line the typed value is read back from, counting from zero. Anything outside that range is clamped into it. At the default of `0` the player types on the top line and the carets underneath point up at it. The value is read as money, so leave the label clear enough that nobody types a total by mistake. |
+
+### 3. Practical Setup Example
+
+```yaml
+PRICE_SIGN:
+  lines:
+    - ""
+    - "^^^^^^^^^^^^^^"
+    - "Price per item"
+    - ""
+  input-line: 0
+```
+
+---
 ## Section: `BOTS`
 
 ### 1. Commented Setup Code Example

--- a/docs/wiki/Config-sounds.yml.md
+++ b/docs/wiki/Config-sounds.yml.md
@@ -3,10 +3,6 @@
 This is the official technical setup guide for `sounds.yml` in **UltimateDonutSMP**.
 Each section details the exact commented setup code block, allowed option values, data types, default values, and in-depth functional behavior.
 
-Two sections have no write-up here yet: `CRATES` and `SPAWNERS`. Both take the same
-`sound|volume|pitch` value as every entry covered below, so the examples here apply to them
-unchanged.
-
 ---
 
 ## Section: `MENUS`
@@ -26,8 +22,8 @@ MENUS:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `MENUS.BUTTON-CLICK` | `str` | Any string text | `'minecraft:ui.button.click|1.0|1.0'` | Configures the technical `BUTTON-CLICK` parameter for `MENUS.BUTTON-CLICK` in `sounds.yml`. |
-| `MENUS.PAGE-TURN` | `str` | Any string text | `'minecraft:item.book.page_turn|2.0|0...'` | Configures the technical `PAGE-TURN` parameter for `MENUS.PAGE-TURN` in `sounds.yml`. |
+| `MENUS.BUTTON-CLICK` | `str` | Any string text | `'minecraft:ui.button.click\|1.0\|1.0'` | Configures the technical `BUTTON-CLICK` parameter for `MENUS.BUTTON-CLICK` in `sounds.yml`. |
+| `MENUS.PAGE-TURN` | `str` | Any string text | `'minecraft:item.book.page_turn\|2.0\|0...'` | Configures the technical `PAGE-TURN` parameter for `MENUS.PAGE-TURN` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -57,7 +53,7 @@ SPAWN:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `SPAWN.SLIME-JUMP` | `str` | Any string text | `'minecraft:entity.slime.jump|1.0|1.0'` | Configures the technical `SLIME-JUMP` parameter for `SPAWN.SLIME-JUMP` in `sounds.yml`. |
+| `SPAWN.SLIME-JUMP` | `str` | Any string text | `'minecraft:entity.slime.jump\|1.0\|1.0'` | Configures the technical `SLIME-JUMP` parameter for `SPAWN.SLIME-JUMP` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -85,7 +81,7 @@ SELL:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `SELL.LEVEL-UP` | `str` | Any string text | `'minecraft:entity.player.levelup|1.0...'` | Configures the technical `LEVEL-UP` parameter for `SELL.LEVEL-UP` in `sounds.yml`. |
+| `SELL.LEVEL-UP` | `str` | Any string text | `'minecraft:entity.player.levelup\|1.0...'` | Configures the technical `LEVEL-UP` parameter for `SELL.LEVEL-UP` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -115,7 +111,7 @@ AMETHYST:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `AMETHYST.EXPIRED` | `str` | Any string text | `'minecraft:entity.item.break|1.0|1.0'` | Configures the technical `EXPIRED` parameter for `AMETHYST.EXPIRED` in `sounds.yml`. |
+| `AMETHYST.EXPIRED` | `str` | Any string text | `'minecraft:entity.item.break\|1.0\|1.0'` | Configures the technical `EXPIRED` parameter for `AMETHYST.EXPIRED` in `sounds.yml`. |
 | `AMETHYST.BREAK` | `str` | Any string text | `'minecraft:block.amethyst_block.brea...'` | Configures the technical `BREAK` parameter for `AMETHYST.BREAK` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
@@ -148,8 +144,8 @@ BOOSTER:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `BOOSTER.ERROR` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `ERROR` parameter for `BOOSTER.ERROR` in `sounds.yml`. |
-| `BOOSTER.SUCCESS` | `str` | Any string text | `'minecraft:entity.player.levelup|1.0...'` | Configures the technical `SUCCESS` parameter for `BOOSTER.SUCCESS` in `sounds.yml`. |
+| `BOOSTER.ERROR` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `ERROR` parameter for `BOOSTER.ERROR` in `sounds.yml`. |
+| `BOOSTER.SUCCESS` | `str` | Any string text | `'minecraft:entity.player.levelup\|1.0...'` | Configures the technical `SUCCESS` parameter for `BOOSTER.SUCCESS` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -184,8 +180,8 @@ SHARDS:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `SHARDS.REWARD` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `REWARD` parameter for `SHARDS.REWARD` in `sounds.yml`. |
-| `SHARDS.REWARD-BOOSTED` | `str` | Any string text | `'minecraft:entity.player.levelup|0.8...'` | Configures the technical `REWARD-BOOSTED` parameter for `SHARDS.REWARD-BOOSTED` in `sounds.yml`. |
-| `SHARDS.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no|0.8|1....'` | Configures the technical `CANCELLED` parameter for `SHARDS.CANCELLED` in `sounds.yml`. |
+| `SHARDS.REWARD-BOOSTED` | `str` | Any string text | `'minecraft:entity.player.levelup\|0.8...'` | Configures the technical `REWARD-BOOSTED` parameter for `SHARDS.REWARD-BOOSTED` in `sounds.yml`. |
+| `SHARDS.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no\|0.8\|1....'` | Configures the technical `CANCELLED` parameter for `SHARDS.CANCELLED` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -217,7 +213,7 @@ COMMANDS:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `COMMANDS.ERROR` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `ERROR` parameter for `COMMANDS.ERROR` in `sounds.yml`. |
+| `COMMANDS.ERROR` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `ERROR` parameter for `COMMANDS.ERROR` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -245,7 +241,7 @@ BUCKET:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `BUCKET.FILL` | `str` | Any string text | `'minecraft:item.bucket.fill|1.0|1.0'` | Configures the technical `FILL` parameter for `BUCKET.FILL` in `sounds.yml`. |
+| `BUCKET.FILL` | `str` | Any string text | `'minecraft:item.bucket.fill\|1.0\|1.0'` | Configures the technical `FILL` parameter for `BUCKET.FILL` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -275,8 +271,8 @@ TPAUTO:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `TPAUTO.ACTIVATE` | `str` | Any string text | `'minecraft:block.beacon.activate|1.0...'` | Configures the technical `ACTIVATE` parameter for `TPAUTO.ACTIVATE` in `sounds.yml`. |
-| `TPAUTO.DEACTIVATE` | `str` | Any string text | `'minecraft:block.beacon.deactivate|1...'` | Configures the technical `DEACTIVATE` parameter for `TPAUTO.DEACTIVATE` in `sounds.yml`. |
+| `TPAUTO.ACTIVATE` | `str` | Any string text | `'minecraft:block.beacon.activate\|1.0...'` | Configures the technical `ACTIVATE` parameter for `TPAUTO.ACTIVATE` in `sounds.yml`. |
+| `TPAUTO.DEACTIVATE` | `str` | Any string text | `'minecraft:block.beacon.deactivate\|1...'` | Configures the technical `DEACTIVATE` parameter for `TPAUTO.DEACTIVATE` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -314,10 +310,10 @@ TPA:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `TPA.REQUEST-RECEIVED` | `str` | Any string text | `'minecraft:block.note_block.chime|1....'` | Configures the technical `REQUEST-RECEIVED` parameter for `TPA.REQUEST-RECEIVED` in `sounds.yml`. |
-| `TPA.REQUEST-SENT` | `str` | Any string text | `'minecraft:block.note_block.bit|1.0|...'` | Configures the technical `REQUEST-SENT` parameter for `TPA.REQUEST-SENT` in `sounds.yml`. |
+| `TPA.REQUEST-RECEIVED` | `str` | Any string text | `'minecraft:block.note_block.chime\|1....'` | Configures the technical `REQUEST-RECEIVED` parameter for `TPA.REQUEST-RECEIVED` in `sounds.yml`. |
+| `TPA.REQUEST-SENT` | `str` | Any string text | `'minecraft:block.note_block.bit\|1.0\|...'` | Configures the technical `REQUEST-SENT` parameter for `TPA.REQUEST-SENT` in `sounds.yml`. |
 | `TPA.REQUEST-SENT-EXTRA` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `REQUEST-SENT-EXTRA` parameter for `TPA.REQUEST-SENT-EXTRA` in `sounds.yml`. |
-| `TPA.NO-REQUEST` | `str` | Any string text | `'minecraft:entity.ender_pearl.throw|...'` | Configures the technical `NO-REQUEST` parameter for `TPA.NO-REQUEST` in `sounds.yml`. |
+| `TPA.NO-REQUEST` | `str` | Any string text | `'minecraft:entity.ender_pearl.throw\|...'` | Configures the technical `NO-REQUEST` parameter for `TPA.NO-REQUEST` in `sounds.yml`. |
 | `TPA.CONFIRM` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `CONFIRM` parameter for `TPA.CONFIRM` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
@@ -359,8 +355,8 @@ TELEPORT:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `TELEPORT.SUCCESS` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `SUCCESS` parameter for `TELEPORT.SUCCESS` in `sounds.yml`. |
-| `TELEPORT.COUNTDOWN` | `str` | Any string text | `'minecraft:entity.enderman.teleport|...'` | Configures the technical `COUNTDOWN` parameter for `TELEPORT.COUNTDOWN` in `sounds.yml`. |
-| `TELEPORT.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `CANCELLED` parameter for `TELEPORT.CANCELLED` in `sounds.yml`. |
+| `TELEPORT.COUNTDOWN` | `str` | Any string text | `'minecraft:entity.enderman.teleport\|...'` | Configures the technical `COUNTDOWN` parameter for `TELEPORT.COUNTDOWN` in `sounds.yml`. |
+| `TELEPORT.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `CANCELLED` parameter for `TELEPORT.CANCELLED` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -394,8 +390,8 @@ RTP-ZONE:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `RTP-ZONE.COUNTDOWN` | `str` | Any string text | `'minecraft:block.note_block.hat|0.9|...'` | Configures the technical `COUNTDOWN` parameter for `RTP-ZONE.COUNTDOWN` in `sounds.yml`. |
-| `RTP-ZONE.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `CANCELLED` parameter for `RTP-ZONE.CANCELLED` in `sounds.yml`. |
+| `RTP-ZONE.COUNTDOWN` | `str` | Any string text | `'minecraft:block.note_block.hat\|0.9\|...'` | Configures the technical `COUNTDOWN` parameter for `RTP-ZONE.COUNTDOWN` in `sounds.yml`. |
+| `RTP-ZONE.CANCELLED` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `CANCELLED` parameter for `RTP-ZONE.CANCELLED` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -431,10 +427,10 @@ RTP:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `RTP.SEARCH-START` | `str` | Any string text | `'minecraft:block.note_block.pling|0....'` | Configures the technical `SEARCH-START` parameter for `RTP.SEARCH-START` in `sounds.yml`. |
-| `RTP.SEARCH-TICK` | `str` | Any string text | `'minecraft:block.note_block.hat|0.5|...'` | Configures the technical `SEARCH-TICK` parameter for `RTP.SEARCH-TICK` in `sounds.yml`. |
+| `RTP.SEARCH-START` | `str` | Any string text | `'minecraft:block.note_block.pling\|0....'` | Configures the technical `SEARCH-START` parameter for `RTP.SEARCH-START` in `sounds.yml`. |
+| `RTP.SEARCH-TICK` | `str` | Any string text | `'minecraft:block.note_block.hat\|0.5\|...'` | Configures the technical `SEARCH-TICK` parameter for `RTP.SEARCH-TICK` in `sounds.yml`. |
 | `RTP.SEARCH-FOUND` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `SEARCH-FOUND` parameter for `RTP.SEARCH-FOUND` in `sounds.yml`. |
-| `RTP.SEARCH-FAIL` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `SEARCH-FAIL` parameter for `RTP.SEARCH-FAIL` in `sounds.yml`. |
+| `RTP.SEARCH-FAIL` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `SEARCH-FAIL` parameter for `RTP.SEARCH-FAIL` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -470,7 +466,7 @@ SHOP:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `SHOP.NO-MONEY` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `NO-MONEY` parameter for `SHOP.NO-MONEY` in `sounds.yml`. |
+| `SHOP.NO-MONEY` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `NO-MONEY` parameter for `SHOP.NO-MONEY` in `sounds.yml`. |
 | `SHOP.BUY-SUCCESS` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `BUY-SUCCESS` parameter for `SHOP.BUY-SUCCESS` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
@@ -503,7 +499,7 @@ DRILL:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `DRILL.ITEM-BREAK` | `str` | Any string text | `'minecraft:entity.item.break|1.0|1.0'` | Configures the technical `ITEM-BREAK` parameter for `DRILL.ITEM-BREAK` in `sounds.yml`. |
+| `DRILL.ITEM-BREAK` | `str` | Any string text | `'minecraft:entity.item.break\|1.0\|1.0'` | Configures the technical `ITEM-BREAK` parameter for `DRILL.ITEM-BREAK` in `sounds.yml`. |
 | `DRILL.AMETHYST-BREAK` | `str` | Any string text | `'minecraft:block.amethyst_block.brea...'` | Configures the technical `AMETHYST-BREAK` parameter for `DRILL.AMETHYST-BREAK` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
@@ -540,10 +536,10 @@ BILLFORD:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `BILLFORD.OPEN` | `str` | Any string text | `'minecraft:entity.villager.trade|1.0...'` | Configures the technical `OPEN` parameter for `BILLFORD.OPEN` in `sounds.yml`. |
-| `BILLFORD.ROTATE` | `str` | Any string text | `'minecraft:block.beacon.activate|0.8...'` | Configures the technical `ROTATE` parameter for `BILLFORD.ROTATE` in `sounds.yml`. |
-| `BILLFORD.SUCCESS` | `str` | Any string text | `'minecraft:entity.player.levelup|1.0...'` | Configures the technical `SUCCESS` parameter for `BILLFORD.SUCCESS` in `sounds.yml`. |
-| `BILLFORD.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `FAIL` parameter for `BILLFORD.FAIL` in `sounds.yml`. |
+| `BILLFORD.OPEN` | `str` | Any string text | `'minecraft:entity.villager.trade\|1.0...'` | Configures the technical `OPEN` parameter for `BILLFORD.OPEN` in `sounds.yml`. |
+| `BILLFORD.ROTATE` | `str` | Any string text | `'minecraft:block.beacon.activate\|0.8...'` | Configures the technical `ROTATE` parameter for `BILLFORD.ROTATE` in `sounds.yml`. |
+| `BILLFORD.SUCCESS` | `str` | Any string text | `'minecraft:entity.player.levelup\|1.0...'` | Configures the technical `SUCCESS` parameter for `BILLFORD.SUCCESS` in `sounds.yml`. |
+| `BILLFORD.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `FAIL` parameter for `BILLFORD.FAIL` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -580,7 +576,7 @@ AUCTION_HOUSE:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `AUCTION_HOUSE.SUCCESS` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `SUCCESS` parameter for `AUCTION_HOUSE.SUCCESS` in `sounds.yml`. |
-| `AUCTION_HOUSE.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `FAIL` parameter for `AUCTION_HOUSE.FAIL` in `sounds.yml`. |
+| `AUCTION_HOUSE.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `FAIL` parameter for `AUCTION_HOUSE.FAIL` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -613,7 +609,7 @@ ORDERS:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `ORDERS.SUCCESS` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `SUCCESS` parameter for `ORDERS.SUCCESS` in `sounds.yml`. |
-| `ORDERS.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `FAIL` parameter for `ORDERS.FAIL` in `sounds.yml`. |
+| `ORDERS.FAIL` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `FAIL` parameter for `ORDERS.FAIL` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -675,21 +671,21 @@ DUELS:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `DUELS.CLICK` | `str` | Any string text | `'minecraft:ui.button.click|1.0|1.0'` | Configures the technical `CLICK` parameter for `DUELS.CLICK` in `sounds.yml`. |
+| `DUELS.CLICK` | `str` | Any string text | `'minecraft:ui.button.click\|1.0\|1.0'` | Configures the technical `CLICK` parameter for `DUELS.CLICK` in `sounds.yml`. |
 | `DUELS.REQUEST-SENT` | `str` | Any string text | `'minecraft:entity.experience_orb.pic...'` | Configures the technical `REQUEST-SENT` parameter for `DUELS.REQUEST-SENT` in `sounds.yml`. |
-| `DUELS.REQUEST-RECEIVED` | `str` | Any string text | `'minecraft:block.note_block.pling|1....'` | Configures the technical `REQUEST-RECEIVED` parameter for `DUELS.REQUEST-RECEIVED` in `sounds.yml`. |
-| `DUELS.QUEUE-JOIN` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `QUEUE-JOIN` parameter for `DUELS.QUEUE-JOIN` in `sounds.yml`. |
-| `DUELS.START-COUNTDOWN.PER-SECOND.5` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `5` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.5` in `sounds.yml`. |
-| `DUELS.START-COUNTDOWN.PER-SECOND.4` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `4` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.4` in `sounds.yml`. |
-| `DUELS.START-COUNTDOWN.PER-SECOND.3` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `3` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.3` in `sounds.yml`. |
-| `DUELS.START-COUNTDOWN.PER-SECOND.2` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `2` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.2` in `sounds.yml`. |
-| `DUELS.START-COUNTDOWN.PER-SECOND.1` | `str` | Any string text | `'minecraft:block.note_block.hat|1.0|...'` | Configures the technical `1` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.1` in `sounds.yml`. |
+| `DUELS.REQUEST-RECEIVED` | `str` | Any string text | `'minecraft:block.note_block.pling\|1....'` | Configures the technical `REQUEST-RECEIVED` parameter for `DUELS.REQUEST-RECEIVED` in `sounds.yml`. |
+| `DUELS.QUEUE-JOIN` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `QUEUE-JOIN` parameter for `DUELS.QUEUE-JOIN` in `sounds.yml`. |
+| `DUELS.START-COUNTDOWN.PER-SECOND.5` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `5` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.5` in `sounds.yml`. |
+| `DUELS.START-COUNTDOWN.PER-SECOND.4` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `4` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.4` in `sounds.yml`. |
+| `DUELS.START-COUNTDOWN.PER-SECOND.3` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `3` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.3` in `sounds.yml`. |
+| `DUELS.START-COUNTDOWN.PER-SECOND.2` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `2` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.2` in `sounds.yml`. |
+| `DUELS.START-COUNTDOWN.PER-SECOND.1` | `str` | Any string text | `'minecraft:block.note_block.hat\|1.0\|...'` | Configures the technical `1` parameter for `DUELS.START-COUNTDOWN.PER-SECOND.1` in `sounds.yml`. |
 | `DUELS.START-COUNTDOWN.START-SOUND` | `str` | Any string text | `'minecraft:entity.firework_rocket.bl...'` | Configures the technical `START-SOUND` parameter for `DUELS.START-COUNTDOWN.START-SOUND` in `sounds.yml`. |
-| `DUELS.MATCH-FOUND` | `str` | Any string text | `'minecraft:block.beacon.activate|1.0...'` | Configures the technical `MATCH-FOUND` parameter for `DUELS.MATCH-FOUND` in `sounds.yml`. |
-| `DUELS.MATCH-START` | `str` | Any string text | `'minecraft:entity.player.levelup|1.0...'` | Configures the technical `MATCH-START` parameter for `DUELS.MATCH-START` in `sounds.yml`. |
+| `DUELS.MATCH-FOUND` | `str` | Any string text | `'minecraft:block.beacon.activate\|1.0...'` | Configures the technical `MATCH-FOUND` parameter for `DUELS.MATCH-FOUND` in `sounds.yml`. |
+| `DUELS.MATCH-START` | `str` | Any string text | `'minecraft:entity.player.levelup\|1.0...'` | Configures the technical `MATCH-START` parameter for `DUELS.MATCH-START` in `sounds.yml`. |
 | `DUELS.VICTORY` | `str` | Any string text | `'minecraft:ui.toast.challenge_comple...'` | Configures the technical `VICTORY` parameter for `DUELS.VICTORY` in `sounds.yml`. |
-| `DUELS.DEFEAT` | `str` | Any string text | `'minecraft:entity.villager.no|1.0|1....'` | Configures the technical `DEFEAT` parameter for `DUELS.DEFEAT` in `sounds.yml`. |
-| `DUELS.CLAIM` | `str` | Any string text | `'minecraft:entity.item.pickup|1.0|1....'` | Configures the technical `CLAIM` parameter for `DUELS.CLAIM` in `sounds.yml`. |
+| `DUELS.DEFEAT` | `str` | Any string text | `'minecraft:entity.villager.no\|1.0\|1....'` | Configures the technical `DEFEAT` parameter for `DUELS.DEFEAT` in `sounds.yml`. |
+| `DUELS.CLAIM` | `str` | Any string text | `'minecraft:entity.item.pickup\|1.0\|1....'` | Configures the technical `CLAIM` parameter for `DUELS.CLAIM` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -749,7 +745,7 @@ KEY-ALL:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `KEY-ALL.REWARD` | `str` | Any string text | `'minecraft:entity.player.levelup|1.0...'` | Configures the technical `REWARD` parameter for `KEY-ALL.REWARD` in `sounds.yml`. |
+| `KEY-ALL.REWARD` | `str` | Any string text | `'minecraft:entity.player.levelup\|1.0...'` | Configures the technical `REWARD` parameter for `KEY-ALL.REWARD` in `sounds.yml`. |
 
 ### 3. Practical Setup Example
 
@@ -762,3 +758,97 @@ KEY-ALL:
 
 ---
 
+## Section: `CRATES`
+
+### 1. Commented Setup Code Example
+
+```yaml
+CRATES:
+  # The text or value for Open. Available options: Any valid string text
+  OPEN: minecraft:block.ender_chest.open|1.0|1.05
+  # The text or value for Claim. Available options: Any valid string text
+  CLAIM: minecraft:entity.player.levelup|1.0|1.25
+  # The text or value for No Key. Available options: Any valid string text
+  NO-KEY: minecraft:entity.villager.no|1.0|1.0
+  # The text or value for Spin Tick. Available options: Any valid string text
+  SPIN-TICK: minecraft:block.note_block.hat|0.55|1.55
+  # The text or value for Spin End. Available options: Any valid string text
+  SPIN-END: minecraft:entity.experience_orb.pickup|1.0|1.35
+# Configuration section for Spawners.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `CRATES.OPEN` | `str` | sound\|volume\|pitch | `'minecraft:block.ender_chest.open\|1.0\|1.05'` | Plays to the player who opens a crate, alongside the lid animation and the particles above the block. |
+| `CRATES.CLAIM` | `str` | sound\|volume\|pitch | `'minecraft:entity.player.levelup\|1.0\|1.25'` | Plays when the player takes the reward the spin landed on. |
+| `CRATES.NO-KEY` | `str` | sound\|volume\|pitch | `'minecraft:entity.villager.no\|1.0\|1.0'` | Plays when someone clicks a crate without holding the key it asks for. |
+| `CRATES.SPIN-TICK` | `str` | sound\|volume\|pitch | `'minecraft:block.note_block.hat\|0.55\|1.55'` | Plays on every step of the reel as it scrolls, so how fast you hear it follows that crate's own tick interval. Pick something short and quiet; a long sample overlaps itself. |
+| `CRATES.SPIN-END` | `str` | sound\|volume\|pitch | `'minecraft:entity.experience_orb.pickup\|1.0\|1.35'` | Plays once as the reel locks onto the winning reward, just before the reward is handed over. |
+
+### 3. Practical Setup Example
+
+```yaml
+CRATES:
+  # The text or value for Open. Available options: Any valid string text
+  OPEN: minecraft:block.ender_chest.open|1.0|1.05
+  # The text or value for Claim. Available options: Any valid string text
+  CLAIM: minecraft:entity.player.levelup|1.0|1.25
+  # The text or value for No Key. Available options: Any valid string text
+  NO-KEY: minecraft:entity.villager.no|1.0|1.0
+  # The text or value for Spin Tick. Available options: Any valid string text
+  SPIN-TICK: minecraft:block.note_block.hat|0.55|1.55
+  # The text or value for Spin End. Available options: Any valid string text
+  SPIN-END: minecraft:entity.experience_orb.pickup|1.0|1.35
+# Configuration section for Spawners.
+```
+
+---
+## Section: `SPAWNERS`
+
+### 1. Commented Setup Code Example
+
+```yaml
+SPAWNERS:
+  OPEN-MENU: minecraft:block.chest.open|1.0|1.0
+  COLLECT-LOOT: minecraft:entity.item.pickup|1.0|1.0
+  DROP-LOOT: minecraft:entity.item.pickup|1.0|1.2
+  COLLECT-XP: minecraft:entity.experience_orb.pickup|1.0|1.0
+  SELL-CONFIRM-OPEN: minecraft:ui.button.click|1.0|1.0
+  SELL-SUCCESS: minecraft:entity.villager.yes|1.0|1.0
+  SELL-CANCEL: minecraft:ui.button.click|1.0|0.8
+  FILTER-OPEN: minecraft:ui.button.click|1.0|1.2
+  FILTER-TOGGLE: minecraft:ui.button.click|1.0|1.0
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `SPAWNERS.OPEN-MENU` | `str` | sound\|volume\|pitch | `'minecraft:block.chest.open\|1.0\|1.0'` | Plays when the spawner menu opens. |
+| `SPAWNERS.COLLECT-LOOT` | `str` | sound\|volume\|pitch | `'minecraft:entity.item.pickup\|1.0\|1.0'` | Plays when stored loot goes into the player's inventory, whether they took one entry or used Collect All. |
+| `SPAWNERS.DROP-LOOT` | `str` | sound\|volume\|pitch | `'minecraft:entity.item.pickup\|1.0\|1.2'` | Plays when a page of stored loot is dropped on the ground instead of collected. |
+| `SPAWNERS.COLLECT-XP` | `str` | sound\|volume\|pitch | `'minecraft:entity.experience_orb.pickup\|1.0\|1.0'` | Plays when stored experience is claimed. Only reachable while the spawner XP option is on. |
+| `SPAWNERS.SELL-CONFIRM-OPEN` | `str` | sound\|volume\|pitch | `'minecraft:ui.button.click\|1.0\|1.0'` | Plays when the sell confirmation screen opens. |
+| `SPAWNERS.SELL-SUCCESS` | `str` | sound\|volume\|pitch | `'minecraft:entity.villager.yes\|1.0\|1.0'` | Plays once the sale goes through and the money is paid. |
+| `SPAWNERS.SELL-CANCEL` | `str` | sound\|volume\|pitch | `'minecraft:ui.button.click\|1.0\|0.8'` | Plays when the player backs out of the sell confirmation. |
+| `SPAWNERS.FILTER-OPEN` | `str` | sound\|volume\|pitch | `'minecraft:ui.button.click\|1.0\|1.2'` | Plays when the loot filter screen opens. |
+| `SPAWNERS.FILTER-TOGGLE` | `str` | sound\|volume\|pitch | `'minecraft:ui.button.click\|1.0\|1.0'` | Plays each time a filter entry is switched on or off, so it fires repeatedly while someone sets a filter up. |
+
+### 3. Practical Setup Example
+
+```yaml
+SPAWNERS:
+  OPEN-MENU: minecraft:block.chest.open|1.0|1.0
+  COLLECT-LOOT: minecraft:entity.item.pickup|1.0|1.0
+  DROP-LOOT: minecraft:entity.item.pickup|1.0|1.2
+  COLLECT-XP: minecraft:entity.experience_orb.pickup|1.0|1.0
+  SELL-CONFIRM-OPEN: minecraft:ui.button.click|1.0|1.0
+  SELL-SUCCESS: minecraft:entity.villager.yes|1.0|1.0
+  SELL-CANCEL: minecraft:ui.button.click|1.0|0.8
+  FILTER-OPEN: minecraft:ui.button.click|1.0|1.2
+  FILTER-TOGGLE: minecraft:ui.button.click|1.0|1.0
+```
+
+---


### PR DESCRIPTION
The four guides that admitted to skipping sections now cover every section in their file. That is 36 written, and the "no write-up here yet" paragraph is gone from each page.

- `Config-messages.yml.md` goes from 20 sections to 45, so 25 written, `BILLFORD` through `VOICE-CHAT`.
- `Config-config.yml.md` goes from 30 to 36: `OPTIMIZATION`, `RTP-ZONE`, `TELEPORT-COOLDOWN`, `BOUNTY`, `AMETHYST-TOOLS` and `COMMANDS`.
- `Config-orders.yml.md` gains the three sign prompts.
- `Config-sounds.yml.md` gains `CRATES` and `SPAWNERS`.

Each one follows the shape already on those pages: the shipped YAML quoted as it stands, the key table, then a practical example. The YAML blocks and the whole default column are pulled out of `src/main/resources` rather than retyped, so they cannot drift from the file. Descriptions are written per key instead of the "Configures the technical X parameter" filler.

## What reading the code turned up

Nine keys in `PUNISHMENTS` are not what their names suggest, and four of them do nothing at all:

- `BAN-KICK`, `BLACKLIST-KICK`, `MUTE-RECEIVED` and `MUTED-CHAT` are read by no code. What a punished player actually sees comes from `PUNISHMENTS.BAN`, `BLACKLIST` and `MUTE`. Those four rows now say so, rather than describing a setting a server owner could edit all afternoon without effect.
- `BAN`, `KICK`, `MUTE`, `VOICE-MUTE` and `BLACKLIST` go to the punished player, not to the server. I had them down as broadcasts until `PunishmentMessages.messagePath` and `ChatListener.mutedChatMessage` said otherwise. `MUTE` in particular is shown both when the mute lands and on every blocked chat attempt.

A few more worth having on the page: `BOUNTY.EXCLUDED-WORLDS` gates the payout on a PvP death rather than stopping bounties being placed, so a bounty survives a kill in the duels world; `RTP-ZONE.WORLD.*` is read by `RTPManager` rather than the zone manager, and its `MAX-RADIUS` is floored at `MIN-RADIUS` so the ring cannot invert; and `COMMANDS.*` is a fallback that `FEATURES.<name>.ENABLED` overrides wherever that path exists, which explains why an edit there can look ignored.

## Table rendering

48 rows across `Config-sounds.yml.md` and `Config-messages.yml.md` carried an unescaped `|` inside a code span. GitHub splits table cells before it parses inline code, so those rows were rendering with extra columns and the description quietly truncated. 44 of the 71 rows on the sounds page were affected, every sound value being `sound|volume|pitch`. All 48 escape the pipe now, and all 921 table rows across the four pages come out with the right cell count.

## Notes

No completeness claim went back onto any page, for the reason it came off. Prose and tables only, no keys, defaults or behaviour touched. `enchantments.yml` and `offenses.yml` still have no guide of their own; that was optional here and is still open. Suite is at 671, green.
