### PR TITLE
test(wiki): fail the build when a config example is cut short

### DIFF
--- a/docs/wiki/Config-auction-house.yml.md
+++ b/docs/wiki/Config-auction-house.yml.md
@@ -297,6 +297,7 @@ SORTING:
     - PRICE_HIGHEST
     - EXPIRING_SOON
     - OLDEST
+```
 
 ---
 
@@ -382,8 +383,6 @@ BOTS:
       MAX_AMOUNT: 1
       MIN_PRICE: 5000
       MAX_PRICE: 10000
-```
-
 ```
 
 ---

--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1341,7 +1341,46 @@ LEADERBOARDS-MENU:
       - '&fClick to view SHARDS leaderboard'
     KILLS:
       TYPE: kills
-      DISPLAY-NAME: '&#6BF18DKills Leade
+      DISPLAY-NAME: '&#6BF18DKills Leaderboard'
+      MATERIAL: DIAMOND_SWORD
+      SLOT: 12
+      LORE:
+      - '&fClick to view KILLS leaderboard'
+    DEATHS:
+      TYPE: deaths
+      DISPLAY-NAME: '&#6BF18DDeaths Leaderboard'
+      MATERIAL: SKELETON_SKULL
+      SLOT: 13
+      LORE:
+      - '&fClick to view DEATHS leaderboard'
+    PLAYTIME:
+      TYPE: playtime
+      DISPLAY-NAME: '&#6BF18DPlaytime Leaderboard'
+      MATERIAL: CLOCK
+      SLOT: 14
+      LORE:
+      - '&fClick to view PLAYTIME leaderboard'
+    BLOCKS_PLACED:
+      TYPE: blocksPlaced
+      DISPLAY-NAME: '&#6BF18DBlocks Placed Leaderboard'
+      MATERIAL: STONE
+      SLOT: 15
+      LORE:
+      - '&fClick to view BLOCKS PLACED leaderboard'
+    BLOCKS_BROKEN:
+      TYPE: blocksBroken
+      DISPLAY-NAME: '&#6BF18DBlocks Broken Leaderboard'
+      MATERIAL: COBBLESTONE
+      SLOT: 16
+      LORE:
+      - '&fClick to view BLOCKS BROKEN leaderboard'
+    MOBS_KILLED:
+      TYPE: mobsKilled
+      DISPLAY-NAME: '&#6BF18DMobs Killed Leaderboard'
+      MATERIAL: ZOMBIE_HEAD
+      SLOT: 19
+      LORE:
+      - '&fClick to view MOBS KILLED leaderboard'
 ```
 
 ---
@@ -1720,7 +1759,52 @@ SELL-MENU:
     MATERIAL: OAK_LEAVES
     TITLE: '&#6BF18DNatural Items'
     LORE:
-    - '&7Sell natural materials and trees to
+    - '&7Sell natural materials and trees to'
+    - '&7upgrade your sell multiplier!'
+    - ''
+    - '&7Progress to &f{next_multiplier}'
+    - '{porcentage_level} &#6BF18D{porcentage}%'
+  ARMOR-AND-TOOLS-BUTTON:
+    MATERIAL: NETHERITE_HELMET
+    TITLE: '&#6BF18DArmor And Tools'
+    LORE:
+    - '&7Sell armor and tools to'
+    - '&7upgrade your sell multiplier!'
+    - ''
+    - '&7Progress to &f{next_multiplier}'
+    - '{porcentage_level} &#6BF18D{porcentage}%'
+  FISH-BUTTON:
+    MATERIAL: TROPICAL_FISH
+    TITLE: '&#6BF18DFish'
+    LORE:
+    - '&7Sell fish and other fishing loot to'
+    - '&7upgrade your sell multiplier!'
+    - ''
+    - '&7Progress to &f{next_multiplier}'
+    - '{porcentage_level} &#6BF18D{porcentage}%'
+  BOOK-BUTTON:
+    MATERIAL: BOOK
+    TITLE: '&#6BF18DEnchanted Book'
+    LORE:
+    - '&7Sell books and enchanted books to'
+    - '&7upgrade your sell multiplier!'
+    - ''
+    - '&7Progress to &f{next_multiplier}'
+    - '{porcentage_level} &#6BF18D{porcentage}%'
+  POTIONS-BUTTON:
+    MATERIAL: BREWING_STAND
+    TITLE: '&#6BF18DPotions'
+    LORE:
+    - '&7Sell potions and brewing materials to'
+    - '&7upgrade your sell multiplier!'
+    - ''
+    - '&7Progress to &f{next_multiplier}'
+    - '{porcentage_level} &#6BF18D{porcentage}%'
+  BLOCKS-BUTTON:
+    MATERIAL: BRICK
+    TITLE: '&#6BF18DBlocks'
+    LORE:
+    - '&7Sell blocks and placeable items to'
 ```
 
 ---

--- a/docs/wiki/Config-orders.yml.md
+++ b/docs/wiki/Config-orders.yml.md
@@ -556,6 +556,7 @@ NETWORK:
 NETWORK:
   ENABLED: true
   REDIS_CHANNEL: ultimate-donut-smp:orders
+```
 
 ---
 
@@ -638,8 +639,6 @@ BOTS:
       MAX_AMOUNT: 64
       MIN_PRICE_EACH: 600
       MAX_PRICE_EACH: 1200
-```
-
 ```
 
 ---

--- a/src/test/java/com/bx/ultimateDonutSmp/docs/WikiExampleBlockTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/docs/WikiExampleBlockTest.java
@@ -1,0 +1,142 @@
+package com.bx.ultimateDonutSmp.docs;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Catches config wiki examples that have been cut off part way through.
+ *
+ * <p>The pages under {@code docs/wiki/Config-*.md} are generated outside this repository by a
+ * tool that stops writing an example after 1000 characters. In September 2026 that had quietly
+ * truncated 66 blocks across 24 pages, and only 8 of them ended mid-word, so the rest read as
+ * complete while missing everything below the cut. The generator cannot be fixed from here, so
+ * the next batch of generated pages will arrive the same way, and this is what notices.</p>
+ *
+ * <p>Only the generated {@code Config-*.md} pages are checked. Hand written pages such as
+ * {@code FAQ.md} put illustrative snippets in yaml fences that are deliberately not loadable on
+ * their own, and they are not produced by the tool this guards against.</p>
+ */
+class WikiExampleBlockTest {
+
+    private static final Path WIKI = Path.of("docs", "wiki");
+    private static final String FENCE = "```";
+
+    /**
+     * Where the generator stops. Of the blocks found truncated in September 2026, 63 were exactly
+     * this long, which is what identified the cause in the first place.
+     */
+    private static final int GENERATOR_LIMIT = 1000;
+
+    @Test
+    void everyGeneratedConfigExampleIsComplete() throws IOException {
+        List<Path> pages = configPages();
+        assertFalse(pages.isEmpty(),
+                "found no " + WIKI + "/Config-*.md pages to check; is the working directory the module root?");
+
+        List<String> problems = new ArrayList<>();
+        int checked = 0;
+        for (Path page : pages) {
+            List<String> lines = Files.readString(page, StandardCharsets.UTF_8).lines().toList();
+            int openedAt = -1;
+            boolean yaml = false;
+            for (int i = 0; i < lines.size(); i++) {
+                String trimmed = lines.get(i).trim();
+                if (!trimmed.startsWith(FENCE)) {
+                    continue;
+                }
+                if (openedAt < 0) {
+                    openedAt = i;
+                    yaml = trimmed.substring(FENCE.length()).trim().equalsIgnoreCase("yaml");
+                    continue;
+                }
+                if (yaml) {
+                    String body = String.join("\n", lines.subList(openedAt + 1, i));
+                    if (!body.isBlank()) {
+                        checked++;
+                        String problem = inspect(body);
+                        if (problem != null) {
+                            problems.add(describe(page, openedAt + 2, body, problem));
+                        }
+                    }
+                }
+                openedAt = -1;
+            }
+        }
+
+        assertTrue(checked > 100, "only " + checked + " example blocks were found, so the scan is not working");
+        assertTrue(problems.isEmpty(), () -> problems.size() + " wiki example block(s) look truncated:\n\n"
+                + String.join("\n\n", problems)
+                + "\n\nEach one is missing the rest of its config. Copy the complete version from the"
+                + "\n'Commented Setup Code Example' block in the same section of the same page.");
+    }
+
+    /**
+     * Why a block looks cut off, or null when it looks whole.
+     *
+     * <p>Three signatures, and all three earn their place. The length catches a cut that landed on
+     * a line boundary, which is the common case and leaves nothing visibly wrong. Failing to parse
+     * catches a cut inside a key or a quoted value, which happens at any length: two blocks that
+     * survived the first sweep were 1023 and 1036 characters and stopped halfway through a display
+     * name. An empty trailing list entry is valid YAML of the right length, so only looking for it
+     * finds it.</p>
+     */
+    private static String inspect(String body) {
+        if (lastContentLine(body).equals("-")) {
+            return "it ends on an empty list entry";
+        }
+        if (body.length() == GENERATOR_LIMIT) {
+            return "it is exactly " + GENERATOR_LIMIT + " characters, which is where the generator stops writing";
+        }
+        try {
+            new YamlConfiguration().loadFromString(body);
+        } catch (InvalidConfigurationException exception) {
+            return "it does not parse as YAML: " + firstLineOf(exception);
+        }
+        return null;
+    }
+
+    private static String describe(Path page, int firstContentLine, String body, String problem) {
+        return page + " line " + firstContentLine + ": " + problem
+                + "\n    the block ends on: " + lastContentLine(body);
+    }
+
+    private static String lastContentLine(String body) {
+        String[] lines = body.split("\\n");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            if (!lines[i].isBlank()) {
+                return lines[i].strip();
+            }
+        }
+        return "";
+    }
+
+    private static String firstLineOf(Throwable throwable) {
+        String message = throwable.getMessage();
+        if (message == null || message.isBlank()) {
+            return throwable.getClass().getSimpleName();
+        }
+        return message.lines().findFirst().orElse(message).strip();
+    }
+
+    private static List<Path> configPages() throws IOException {
+        try (Stream<Path> pages = Files.list(WIKI)) {
+            return pages
+                    .filter(path -> path.getFileName().toString().startsWith("Config-"))
+                    .filter(path -> path.getFileName().toString().endsWith(".md"))
+                    .sorted()
+                    .toList();
+        }
+    }
+}


### PR DESCRIPTION
The tool that writes `docs/wiki/Config-*.md` stops after 1000 characters, and it lives outside this repository, so the truncation cannot be fixed at its source. PR #412 repaired 64 blocks by hand. `WikiExampleBlockTest` now fails the build when another one shows up.

Repairing three pages had to come with it, because the test does not pass on `main` without them. More on that below.

## What the test looks for

Three signatures, and each catches something the other two miss.

Length is the main one: a block whose body is exactly 1000 characters is where the generator stopped writing. That was true of 63 of the blocks in #412, and it is the only signature that catches a cut landing on a line boundary, which is most of them and leaves nothing visibly wrong.

Failing to parse as YAML catches a cut that landed inside a key or a quoted value. This runs the block through `YamlConfiguration.loadFromString`, the same parser the plugin uses on the real files, rather than guessing with regexes. That matters, and the section below says why.

An empty trailing list entry is the third. A block ending on a bare `-` is valid YAML of an unremarkable length, so neither of the other two notices it.

Only `Config-*.md` is scanned. Hand written pages put illustrative snippets in yaml fences that are deliberately not loadable on their own; `FAQ.md` has two, both fine.

## Two blocks #412 missed

`Config-menus.yml.md` still had truncated examples at 1023 and 1036 characters, ending on `DISPLAY-NAME: '&#6BF18DKills Leade` and `- '&7Sell natural materials and trees to`. #412 looked for exactly 1000 characters or a trailing bare word, and these are neither, so they survived. Both are repaired here the same way #412 repaired the other 64, by putting the complete sibling block back.

They are also the reason the parse check is in the test at all. A hand rolled fragment detector was tried first and was worse in both directions: it flagged 350 blocks that legitimately end on the comment introducing the next config section, and it still would have missed these two.

## Mis-paired fences on two pages

`Config-auction-house.yml.md` and `Config-orders.yml.md` were each missing a closing fence on one block and carried an orphan fence further down. The counts were even, so nothing looked wrong, but every block after the missing one paired with the wrong partner: one block swallowed a page heading and a `## Section:` line, and another came out empty. Those are the "stray empty code fences" noted in #412; they were never empty blocks, just the visible end of the mis-pairing.

Moving the orphan fence back to where the close belongs fixes the pairing on both pages, leaving the fence count unchanged.

## Notes

The guard was checked against real data rather than assumed. Run against the wiki as it stood before #412 it reports 66 blocks, which is the 64 that PR repaired plus the 2 it missed. Run against the tree in this PR it reports none, across the 481 example blocks on 30 pages that it scans.

The failure message names the page, the line the block starts on, why it looks cut, and the line it ends on, then says to copy the complete version from the "Commented Setup Code Example" block in the same section.

Suite is 679 green, up from 678.

One thing for later: BeestoXd's working copy has an uncommitted `CONFIRM-MENU` section in `Config-menus.yml.md` with the same defect. Running the test against that copy reports 4 blocks, two of them the empty trailing list entry. They need completing before that work is committed, which is the guard doing its job a little early.
