### PR TITLE
fix(punishments): drop the message keys nothing reads

### DIFF
--- a/docs/wiki/Config-messages.yml.md
+++ b/docs/wiki/Config-messages.yml.md
@@ -2010,19 +2010,6 @@ PUNISHMENTS:
   NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
   # The text or value for Warn Received. Available options: Any valid string text
   WARN-RECEIVED: '&cWarning: &f{reason}'
-  # The text or value for Mute Received. Available options: Any valid string text
-  MUTE-RECEIVED: '&cYou have been muted. Reason: &f{reason}'
-  # The text or value for Muted Chat. Available options: Any valid string text
-  MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
-  # The text or value for Ban Kick. Available options: Any valid string text
-  BAN-KICK: |-
-    &cYou are banned from this server.
-    &7Reason: &f{reason}
-    &7Expires: &f{expires}
-  # The text or value for Blacklist Kick. Available options: Any valid string text
-  BLACKLIST-KICK: |-
-    &cYou are blacklisted from this server.
-    &7Reason: &f{reason}
   # The text or value for Ban. Available options: Any valid string text
   BAN: |
     &c&lYou have been banned!
@@ -2103,10 +2090,6 @@ PUNISHMENTS:
 | `PUNISHMENTS.REMOVED` | `str` | Any string text | `'&aRemoved active &f{type} &apunishm...'` | Confirmation after lifting an active punishment. |
 | `PUNISHMENTS.NO-ACTIVE` | `str` | Any string text | `'&cNo active {type} punishment found...'` | Sent when there was nothing of that type to lift. |
 | `PUNISHMENTS.WARN-RECEIVED` | `str` | Any string text | `'&cWarning: &f{reason}'` | What a warned player sees. `{reason}` carries the staff note. |
-| `PUNISHMENTS.MUTE-RECEIVED` | `str` | Any string text | `'&cYou have been muted. Reason: &f{r...'` | Not read by any code. The mute notice a player actually sees comes from `PUNISHMENTS.MUTE`, so editing this key changes nothing. |
-| `PUNISHMENTS.MUTED-CHAT` | `str` | Any string text | `'&cYou are muted. Reason: &f{reason}...'` | Not read by any code. What a muted player sees each time they try to talk comes from `PUNISHMENTS.MUTE` instead, so editing this key changes nothing. |
-| `PUNISHMENTS.BAN-KICK` | `str` | Any string text | `'&cYou are banned from this server. ...'` | Not read by any code. The ban screen a player actually sees comes from `PUNISHMENTS.BAN`, so editing this key changes nothing. |
-| `PUNISHMENTS.BLACKLIST-KICK` | `str` | Any string text | `'&cYou are blacklisted from this ser...'` | Not read by any code. The blacklist screen a player actually sees comes from `PUNISHMENTS.BLACKLIST`, so editing this key changes nothing. |
 | `PUNISHMENTS.BAN` | `str` | Any string text | `'&c&lYou have been banned! &8&m-----...'` | The screen a banned player is disconnected with, and what they see on every attempt to rejoin. Takes `%reason%`, `%nicest_expiration%` and `%issuer%`, each of which also works in `{brace}` form. |
 | `PUNISHMENTS.KICK` | `str` | Any string text | `'&c&lYou have been kicked! &8&m-----...'` | Shown to a player as they are kicked, with `%reason%` and `%issuer%`. |
 | `PUNISHMENTS.MUTE` | `str` | Any string text | `'&c&lYou have been muted! &8&m------...'` | Shown when the mute lands and again every time the muted player tries to speak, so it carries the whole explanation rather than a one-liner. Takes `%reason%`, `%nicest_expiration%` and `%issuer%`. |
@@ -2183,19 +2166,6 @@ PUNISHMENTS:
   NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
   # The text or value for Warn Received. Available options: Any valid string text
   WARN-RECEIVED: '&cWarning: &f{reason}'
-  # The text or value for Mute Received. Available options: Any valid string text
-  MUTE-RECEIVED: '&cYou have been muted. Reason: &f{reason}'
-  # The text or value for Muted Chat. Available options: Any valid string text
-  MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
-  # The text or value for Ban Kick. Available options: Any valid string text
-  BAN-KICK: |-
-    &cYou are banned from this server.
-    &7Reason: &f{reason}
-    &7Expires: &f{expires}
-  # The text or value for Blacklist Kick. Available options: Any valid string text
-  BLACKLIST-KICK: |-
-    &cYou are blacklisted from this server.
-    &7Reason: &f{reason}
   # The text or value for Ban. Available options: Any valid string text
   BAN: |
     &c&lYou have been banned!

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -2605,11 +2605,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} punishment found for {player}."
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason: &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason: &f{reason}&7. expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned!\n&8&m---------------------------\n&7Reason: &f%reason%\n\
       &7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m---------------------------\n\
       &7Appeal at: &fdiscord.eXample.space"

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -2865,15 +2865,6 @@ MESSAGES:
     REMOVED: '&aRemoved active &f{type} &apunishment(s) for &b{player}&a.'
     NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
     WARN-RECEIVED: '&cWarning: &f{reason}'
-    MUTE-RECEIVED: '&cYou have been muted. reason: &f{reason}'
-    MUTED-CHAT: '&cYou are muted. reason: &f{reason}&7. expires: &f{expires}'
-    BAN-KICK: |-
-      &cYou are banned from this server.
-      &7Reason: &f{reason}
-      &7Expires: &f{expires}
-    BLACKLIST-KICK: |-
-      &cYou are blacklisted from this server.
-      &7Reason: &f{reason}
     BAN: |
       &c&lYou have been banned!
       &8&m----------------------------

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -2470,11 +2470,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} punishment found for {player}."
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason: &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason: &f{reason}&7. expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned!\n&8&m----------------------------\n&7Reason: &f%reason%\n\
       &7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m----------------------------\n\
       &7Appeal at: &fdiscord.ejemplo.espacio"

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -2470,11 +2470,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} punishment found for {player}."
     WARN-RECEIVED: "&cWarning : &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason : &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason : &f{reason}&7. expires : &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason : &f{reason}\n&7Expires :
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason : &f{reason}"
     BAN: "&c&lYou have been banned !\n&8&m----------------------------\n&7Reason :
       &f%reason%\n&7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m----------------------------\n\
       &7Appeal at : &fdiscord.eXample.space"

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -2603,11 +2603,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} dan {player}."
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason: &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason: &f{reason}&7. expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned!\n&8&m----------------------------\n&7Reason: &f%reason%\n\
       &7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m----------------------------\n\
       &7Appeal at: &fdiscord.eXample.space"

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -2471,11 +2471,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} punishment found for {player}."
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason: &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason: &f{reason}&7. expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned!\n&8&m----------------------------\n&7Reason: &f%reason%\n\
       &7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m----------------------------\n\
       &7Appeal at: &fdiscord.eXample.space"

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -2468,11 +2468,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a."
     NO-ACTIVE: "&cNo active {type} punishment found for {player}."
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted. reason: &f{reason}"
-    MUTED-CHAT: "&cYou are muted. reason: &f{reason}&7. expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server.\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server.\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned!\n&8&m----------------------------\n&7Reason: &f%reason%\n\
       &7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n&8&m----------------------------\n\
       &7Appeal at: &fdiscord.eXample.space"

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -2459,11 +2459,6 @@ MESSAGES:
     REMOVED: "&aRemoved active &f{type} &apunishment(s) for &b{player}&a。"
     NO-ACTIVE: "&cNo active {type} punishment found for {player}。"
     WARN-RECEIVED: "&cWarning: &f{reason}"
-    MUTE-RECEIVED: "&cYou have been muted。 reason: &f{reason}"
-    MUTED-CHAT: "&cYouaremuted。 reason：&f{reason}&7。 expires: &f{expires}"
-    BAN-KICK: "&cYou are banned from this server。\n&7Reason: &f{reason}\n&7Expires:
-      &f{expires}"
-    BLACKLIST-KICK: "&cYou are blacklisted from this server。\n&7Reason: &f{reason}"
     BAN: "&c&lYou have been banned！\n&8&m----------------------------------------\n\
       &7Reason：&f%reason%\n&7Expires: &f%nicest_expiration%\n&7Banned by: &f%issuer%\n\
       &8&m----------------------------\n&7Appealat：&fdiscord.eXample.space"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -670,19 +670,6 @@ PUNISHMENTS:
   NO-ACTIVE: '&cNo active {type} punishment found for {player}.'
   # The text or value for Warn Received. Available options: Any valid string text
   WARN-RECEIVED: '&cWarning: &f{reason}'
-  # The text or value for Mute Received. Available options: Any valid string text
-  MUTE-RECEIVED: '&cYou have been muted. Reason: &f{reason}'
-  # The text or value for Muted Chat. Available options: Any valid string text
-  MUTED-CHAT: '&cYou are muted. Reason: &f{reason}&7. Expires: &f{expires}'
-  # The text or value for Ban Kick. Available options: Any valid string text
-  BAN-KICK: |-
-    &cYou are banned from this server.
-    &7Reason: &f{reason}
-    &7Expires: &f{expires}
-  # The text or value for Blacklist Kick. Available options: Any valid string text
-  BLACKLIST-KICK: |-
-    &cYou are blacklisted from this server.
-    &7Reason: &f{reason}
   # The text or value for Ban. Available options: Any valid string text
   BAN: |
     &c&lYou have been banned!

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PunishmentMessageKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PunishmentMessageKeyTest.java
@@ -1,0 +1,67 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * messages.yml used to ship four PUNISHMENTS keys that no code read, and every bundled language
+ * carried a translation of each. A banned or blacklisted player is disconnected with
+ * PUNISHMENTS.BAN and PUNISHMENTS.BLACKLIST, and a muted player sees PUNISHMENTS.MUTE both when the
+ * mute lands and on every blocked chat attempt, so the four were text a server owner could edit all
+ * day without changing anything. These keep the shipped files honest about which messages exist.
+ */
+class PunishmentMessageKeyTest {
+
+    private static final List<String> REMOVED = List.of(
+            "BAN-KICK", "BLACKLIST-KICK", "MUTE-RECEIVED", "MUTED-CHAT"
+    );
+
+    private static final List<String> BUNDLED_LOCALES = List.of(
+            "en_US", "es_ES", "id_ID", "pt_BR", "de_DE", "fr_FR", "ru_RU", "zh_CN"
+    );
+
+    private static YamlConfiguration load(String path) {
+        return YamlConfiguration.loadConfiguration(new File(path));
+    }
+
+    @Test
+    void theDeadPunishmentKeysAreNoLongerShipped() {
+        YamlConfiguration messages = load("src/main/resources/messages.yml");
+        for (String key : REMOVED) {
+            assertFalse(
+                    messages.contains("PUNISHMENTS." + key),
+                    "no code reads PUNISHMENTS." + key + ", so shipping it advertises text that never appears"
+            );
+        }
+    }
+
+    @Test
+    void noBundledLanguageStillTranslatesThem() {
+        for (String locale : BUNDLED_LOCALES) {
+            YamlConfiguration language = load("src/main/resources/languages/" + locale + ".yml");
+            for (String key : REMOVED) {
+                assertFalse(
+                        language.contains("MESSAGES.PUNISHMENTS." + key),
+                        locale + " still translates the dead key " + key
+                );
+            }
+        }
+    }
+
+    @Test
+    void theKeysThatActuallyReachPlayersStayPut() {
+        YamlConfiguration messages = load("src/main/resources/messages.yml");
+        for (String key : List.of("BAN", "BLACKLIST", "MUTE", "KICK", "VOICE-MUTE", "WARN-RECEIVED")) {
+            assertTrue(
+                    messages.contains("PUNISHMENTS." + key),
+                    "PunishmentMessages reads PUNISHMENTS." + key + ", so removing it would blank a real message"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`messages.yml` shipped four `PUNISHMENTS` keys that no code has ever read, and all eight bundled languages carried a translation of each. A server owner could rewrite them all afternoon and nothing on screen would change.

- `BAN-KICK` and `BLACKLIST-KICK` look like the disconnect screens. The real ones come from `PUNISHMENTS.BAN` and `PUNISHMENTS.BLACKLIST`, through `PlayerJoinQuitListener.kickMessage` and `PunishmentMessages.messagePath`.
- `MUTE-RECEIVED` and `MUTED-CHAT` look like the mute notice and the line a muted player gets each time they try to talk. Both of those come from `PUNISHMENTS.MUTE`, through `PunishmentMessages` and `ChatListener.mutedChatMessage`.

`git log -S` puts all four in the very first commit with no Java reference at any point since, so they are original leftovers rather than something a refactor orphaned. There is nothing here to wire back up.

Same reasoning as `e047c0db`, which took `STAFF_ALERTS_LOCAL_FALLBACK_ON_REDIS_ERROR` out of `network.yml` and added a test to hold the line.

## What changed

The four keys come out of `messages.yml` and all eight `languages/*.yml` files, along with the four comment lines above them in `messages.yml` that would otherwise have been left pointing at nothing. Each removal was checked by parsing the file before and after: exactly those four paths disappear from each of the nine files, and no other value shifts.

`PunishmentMessageKeyTest` holds it in three directions. The keys stay out of `messages.yml`, no bundled language reintroduces them, and the six that do reach players (`BAN`, `BLACKLIST`, `MUTE`, `KICK`, `VOICE-MUTE`, `WARN-RECEIVED`) are still present, so a later tidy-up cannot quietly take a live message with it.

`Config-messages.yml.md` loses the four rows, and the YAML quoted in that section is regenerated from the file as it now ships, so page and resource still match line for line.

## Notes

Servers that already have a `messages.yml` keep their own copy of the four keys. The config merger inserts bundled paths that are missing but never prunes ones that are extra, so they sit there exactly as inert as they have always been, and a fresh install stops getting them. `en_US.yml` is regenerated by the suite, so I removed the keys from the resources first and confirmed afterwards that the regeneration did not put them back. Suite is at 684, green.
