### PR TITLE
fix(sell): stop selling a full shulker for the price of the box (#416)

### DIFF
--- a/docs/wiki/Config-worth.yml.md
+++ b/docs/wiki/Config-worth.yml.md
@@ -35,6 +35,11 @@ DISPLAY:
 
 ## Section: `CONTAINER`
 
+A container is bought and sold as one stack, so the plugin will not sell one whose contents it is
+not paying for. Whenever a setting here stops the contents being priced, a container holding
+something is treated as unsellable and comes back to the player instead of being cleared for the
+price of the empty box.
+
 ### 1. Commented Setup Code Example
 
 ```yaml
@@ -54,10 +59,10 @@ CONTAINER:
 
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
-| `CONTAINER.ENABLED` | `bool` | `true`, `false` | `true` | Global toggle for `CONTAINER` system. Set to `true` to enable, `false` to disable. |
-| `CONTAINER.INCLUDE-CONTAINER-BASE-PRICE` | `bool` | `true`, `false` | `true` | Configures the technical `INCLUDE-CONTAINER-BASE-PRICE` parameter for `CONTAINER.INCLUDE-CONTAINER-BASE-PRICE` in `worth.yml`. |
-| `CONTAINER.ALLOW-NESTED-CONTAINERS` | `bool` | `true`, `false` | `false` | Configures the technical `ALLOW-NESTED-CONTAINERS` parameter for `CONTAINER.ALLOW-NESTED-CONTAINERS` in `worth.yml`. |
-| `CONTAINER.MAX-CONTAINER-DEPTH` | `int` | Any valid integer number | `'1'` | Configures the technical `MAX-CONTAINER-DEPTH` parameter for `CONTAINER.MAX-CONTAINER-DEPTH` in `worth.yml`. |
+| `CONTAINER.ENABLED` | `bool` | `true`, `false` | `true` | `true` prices a container by its contents as well as the box, so selling a full shulker pays for what is inside it. `false` prices the box alone, and a container that still holds something then cannot be sold at all: `/sell` leaves it in the window and hands it back, so nothing inside is lost. An empty container always sells for its own price. |
+| `CONTAINER.INCLUDE-CONTAINER-BASE-PRICE` | `bool` | `true`, `false` | `true` | Whether the container's own price is added on top of its contents. `false` pays for the contents only. Read only while `ENABLED` is `true`. |
+| `CONTAINER.ALLOW-NESTED-CONTAINERS` | `bool` | `true`, `false` | `false` | Whether a container inside a container is opened up and priced too. While this is `false`, a nested container that still holds something makes the whole stack unsellable rather than selling for a price that ignores it. |
+| `CONTAINER.MAX-CONTAINER-DEPTH` | `int` | Any valid integer number | `'1'` | How many containers deep the pricing walks. A container sitting deeper than this keeps its contents unpriced, and is refused rather than sold for less than it holds. |
 
 ### 3. Practical Setup Example
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/WorthManager.java
@@ -670,6 +670,9 @@ public class WorthManager {
         if (isBlockedItem(item)) {
             return WorthResult.unsellable();
         }
+        if (isUnpricedFullContainer(item, depth, allowNestedExpansion)) {
+            return WorthResult.unsellable();
+        }
 
         DirectWorthData directWorth = resolveDirectWorth(item);
         if (isContainerWorthEnabled()
@@ -770,6 +773,9 @@ public class WorthManager {
         if (isBlockedItem(item)) {
             return;
         }
+        if (isUnpricedFullContainer(item, depth, allowNestedExpansion)) {
+            return;
+        }
 
         boolean container = isSupportedContainer(item);
         DirectWorthData directWorth = resolveDirectWorth(item);
@@ -856,6 +862,45 @@ public class WorthManager {
         return item != null
                 && item.getItemMeta() instanceof BlockStateMeta blockStateMeta
                 && blockStateMeta.getBlockState() instanceof Container;
+    }
+
+    /**
+     * Whether this item is a container that still holds something the sale would not pay for.
+     *
+     * <p>A shulker is bought and sold as a single stack, so a sale that prices the box on its own
+     * takes everything inside with it. That is what used to happen with CONTAINER.ENABLED off: the
+     * box kept its own price from worth.yml, the contents were skipped, and the whole slot was
+     * cleared for the price of an empty shulker. It went the same way for a container nested deeper
+     * than MAX-CONTAINER-DEPTH, or for any container at all once ALLOW-NESTED-CONTAINERS closed the
+     * expansion off.</p>
+     *
+     * <p>Treating it as unsellable is what stops that. The sell window puts back whatever it did not
+     * take, so a full shulker comes home and an empty one still sells for its own price.</p>
+     */
+    private boolean isUnpricedFullContainer(ItemStack item, int depth, boolean allowNestedExpansion) {
+        return isSupportedContainer(item)
+                && !willPriceContainerContents(depth, allowNestedExpansion)
+                && containerHasContents(item);
+    }
+
+    /** The same test the collectors use before they walk into a container. */
+    boolean willPriceContainerContents(int depth, boolean allowNestedExpansion) {
+        return isContainerWorthEnabled()
+                && allowNestedExpansion
+                && depth < getMaxContainerDepth();
+    }
+
+    private boolean containerHasContents(ItemStack item) {
+        if (!(item.getItemMeta() instanceof BlockStateMeta blockStateMeta)
+                || !(blockStateMeta.getBlockState() instanceof Container container)) {
+            return false;
+        }
+        for (ItemStack content : container.getInventory().getContents()) {
+            if (content != null && !content.getType().isAir()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isBlockedItem(ItemStack item) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/WorthManagerTest.java
@@ -121,6 +121,55 @@ class WorthManagerTest {
     }
 
     @Test
+    void anOrdinaryItemStillSellsWhileContainerPricingIsOff() throws Exception {
+        setupMockServer();
+
+        org.bukkit.configuration.file.YamlConfiguration worthConfig = new org.bukkit.configuration.file.YamlConfiguration();
+        worthConfig.set("CONTAINER.ENABLED", false);
+        worthConfig.set("TYPE.ORES.DIAMOND", 100.0);
+
+        WorthManager worthManager = new WorthManager(createMockPlugin(worthConfig));
+        WorthResult result = worthManager.resolveWorth(
+                new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND)
+        );
+
+        assertTrue(result.sellable(), "refusing unpriced containers must not stop ordinary items selling");
+        assertEquals(100.0, result.totalWorth());
+    }
+
+    @Test
+    void containerContentsArePricedWhileTheConfigLetsThemBe() throws Exception {
+        setupMockServer();
+
+        org.bukkit.configuration.file.YamlConfiguration worthConfig = new org.bukkit.configuration.file.YamlConfiguration();
+        worthConfig.set("CONTAINER.ENABLED", true);
+        worthConfig.set("CONTAINER.MAX-CONTAINER-DEPTH", 1);
+
+        WorthManager worthManager = new WorthManager(createMockPlugin(worthConfig));
+
+        assertTrue(worthManager.willPriceContainerContents(0, true));
+    }
+
+    @Test
+    void containerContentsGoUnpricedWheneverTheSaleWouldNotReachThem() throws Exception {
+        setupMockServer();
+
+        org.bukkit.configuration.file.YamlConfiguration off = new org.bukkit.configuration.file.YamlConfiguration();
+        off.set("CONTAINER.ENABLED", false);
+        assertFalse(
+                new WorthManager(createMockPlugin(off)).willPriceContainerContents(0, true),
+                "container pricing switched off"
+        );
+
+        org.bukkit.configuration.file.YamlConfiguration depth = new org.bukkit.configuration.file.YamlConfiguration();
+        depth.set("CONTAINER.ENABLED", true);
+        depth.set("CONTAINER.MAX-CONTAINER-DEPTH", 1);
+        WorthManager depthManager = new WorthManager(createMockPlugin(depth));
+        assertFalse(depthManager.willPriceContainerContents(1, true), "already at the depth limit");
+        assertFalse(depthManager.willPriceContainerContents(0, false), "nesting closed off");
+    }
+
+    @Test
     void screensThatHoldClientStateAreNotResynced() throws Exception {
         setupMockServer();
 


### PR DESCRIPTION
Closes #416

A shulker is bought and sold as one stack, so selling one for the price of the empty box takes everything inside with it. That is what happened on a server running `CONTAINER.ENABLED: false` in `worth.yml`: the box kept its own price, the contents were skipped, and the slot was cleared. Seventy five coins for a shulker of netherite.

A container whose contents are not being priced is now refused instead. The sell window already returns anything it does not take, so a full shulker comes back to the player and an empty one still sells for its own price.

## It was never only about that one key

The same hole opened up three different ways, because all three end with contents that never get priced while the box still has a price of its own:

`CONTAINER.ENABLED: false` is the obvious one, and a container sitting deeper than `MAX-CONTAINER-DEPTH` behaves the same way. The one worth worrying about is any nested container at all while `ALLOW-NESTED-CONTAINERS` stays `false`, because `false` is the shipped default: a shulker inside a shulker was losing its contents on a stock config as soon as somebody sold the outer one.

Rather than special-casing the config key from the report, the guard asks the question the collectors were already asking themselves further down: will this sale actually reach the contents? If not, and the container is holding something, it is unsellable. One predicate, and the two paths that price items both consult it.

## Both paths, not just the sale

The lore that shows an item's worth went through the same reasoning as the sale, so it now agrees with it. Without that, a full shulker would advertise a price and then refuse to sell, which is a worse bug than the one being fixed.

## Notes

`CONTAINER.ENABLED: false` now means something slightly different: it used to sell you the box and eat the contents, and it now declines the sale while the shulker has anything in it. Nobody was relying on the old behaviour on purpose. Empty containers are unaffected either way.

Defaults do not move. `CONTAINER.ENABLED` ships `true`, so a normal server prices contents and always did.

I could not test the whole path. Nothing in the suite builds a real shulker, because a working block state behind the item meta needs more of a server than the harness has, so the four new tests cover the decision itself across every config state that reaches it, plus a guard proving an ordinary diamond still sells while container pricing is off. That last one matters: the easy way to get this wrong is to make the guard too broad and quietly stop everything selling.

`docs/wiki/Config-worth.yml.md` now says what the four container keys do, rather than that each one configures itself.

684 green.
