### PR TITLE
docs(wiki): add guides for enchantments.yml and offenses.yml

### DIFF
--- a/docs/wiki/Config-enchantments.yml.md
+++ b/docs/wiki/Config-enchantments.yml.md
@@ -1,0 +1,922 @@
+# Detailed Configuration & Setup Guide: `enchantments.yml`
+
+This is the technical setup guide for `enchantments.yml` in **UltimateDonutSMP**.
+The file drives the enchantment picker: which enchantments each kind of item can be given, at
+what level, and where each option sits in the menu.
+
+Two things are worth knowing before you edit it. The keys in this file are lower case, unlike
+every other config the plugin ships, and that is not cosmetic: the per item sections below are
+read exactly as written, while the `messages` and `gui` sections are looked up under upper case
+paths and so are never read at all. Each of those two sections says so again in place.
+
+The other is `trident`. The plugin looks for a `trident` section alongside the fourteen below,
+and the file does not ship one, so tridents have no options until you add it yourself.
+
+---
+
+## Section: `messages`
+
+### 1. Commented Setup Code Example
+
+```yaml
+messages:
+  # The text or value for Select. Available options: Any valid string text
+  select: '&fClick to select'
+  # The text or value for Selected. Available options: Any valid string text
+  selected: '&aSelected'
+  # The text or value for Cannot. Available options: Any valid string text
+  cannot: '&fCannot add this enchantment'
+# Configuration section for Gui.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `messages.select` | `str` | Any string text | `'&fClick to select'` | The lore line on an option the player has not picked yet. |
+| `messages.selected` | `str` | Any string text | `'&aSelected'` | The lore line on an option they have picked. |
+| `messages.cannot` | `str` | Any string text | `'&fCannot add this enchantment'` | The lore line on an option that conflicts with something already chosen. |
+
+Nothing below this heading is read by the plugin as it ships. `EnchantmentsManager` looks these
+values up under upper case paths (`GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT`), and Bukkit
+config paths are case sensitive, so the lower case keys in the file never match and the built in
+defaults are used instead. Editing them changes nothing today.
+
+### 3. Practical Setup Example
+
+```yaml
+messages:
+  # The text or value for Select. Available options: Any valid string text
+  select: '&fClick to select'
+  # The text or value for Selected. Available options: Any valid string text
+  selected: '&aSelected'
+  # The text or value for Cannot. Available options: Any valid string text
+  cannot: '&fCannot add this enchantment'
+# Configuration section for Gui.
+```
+
+---
+## Section: `gui`
+
+### 1. Commented Setup Code Example
+
+```yaml
+gui:
+  # The text or value for Title. Available options: Any valid string text
+  title: '&#444444pick enchantments'
+  # The numerical value for Rows. Available options: Any valid integer
+  rows: 6
+  # Configuration section for Slots.
+  slots:
+    # The numerical value for Item. Available options: Any valid integer
+    item: 0
+    # The numerical value for Cancel. Available options: Any valid integer
+    cancel: 46
+    # The numerical value for Prev. Available options: Any valid integer
+    prev: 45
+    # The numerical value for Next. Available options: Any valid integer
+    next: 53
+    # The numerical value for Confirm. Available options: Any valid integer
+    confirm: 52
+  # Configuration section for Buttons.
+  buttons:
+    # Configuration section for Cancel.
+    cancel:
+      # The text or value for Material. Available options: Any valid string text
+      material: RED_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&#39FF14cancel'
+      # Configuration section for Lore.
+      lore:
+      - '&fClick to return'
+    # Configuration section for Confirm.
+    confirm:
+      # The text or value for Material. Available options: Any valid string text
+      material: LIME_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&#39FF14confirm'
+      # Configuration section for Lore.
+      lore:
+      - '&fClick to confirm enchants'
+    # Configuration section for Page Filler.
+    page_filler:
+      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      enabled: false
+      # The text or value for Material. Available options: Any valid string text
+      material: GRAY_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&7 '
+    # Configuration section for Filler.
+    filler:
+      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      enabled: true
+      # The text or value for Slots. Available options: Any valid string text
+      slots: 1,9,10
+      # The text or value for Material. Available options: Any valid string text
+      material: GRAY_STAINED_GLASS_PANE
+      # The text or value for Displayname. Available options: Any valid string text
+      displayname: '&7 '
+  # Configuration section for Sounds.
+  sounds:
+    # Configuration section for Click.
+    click:
+      # The text or value for Name. Available options: Any valid string text
+      name: BLOCK_ENCHANTMENT_TABLE_USE
+      # The decimal value for Volume. Available options: Any decimal number
+      volume: 1.0
+      # The decimal value for Pitch. Available options: Any decimal number
+      pitch: 1.0
+# Configuration section for Helmet.
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `gui.title` | `str` | Any string text | `'&#444444pick enchantments'` | The menu title. |
+| `gui.rows` | `int` | `1` to `6` | `6` | How tall the menu is. Slot numbers are counted against this, so shrinking it can push options off the bottom. |
+| `gui.slots.item` | `int` | A slot number | `0` | Where the item being enchanted is previewed. |
+| `gui.slots.cancel` | `int` | A slot number | `46` | The cancel button. |
+| `gui.slots.prev` | `int` | A slot number | `45` | The previous page button. |
+| `gui.slots.next` | `int` | A slot number | `53` | The next page button. |
+| `gui.slots.confirm` | `int` | A slot number | `52` | The confirm button. |
+| `gui.buttons.*` | `section` | Materials, names, lore | see the block above | Intended to style the cancel, confirm and filler items. No code reads this subtree under any casing; the buttons are built in `EnchantSelectMenu` from fixed materials. |
+| `gui.sounds.*` | `section` | A sound, volume and pitch | `BLOCK_ENCHANTMENT_TABLE_USE` | Intended to set the click sound. Nothing reads this subtree either. |
+
+Nothing below this heading is read by the plugin as it ships. `EnchantmentsManager` looks these
+values up under upper case paths (`GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT`), and Bukkit
+config paths are case sensitive, so the lower case keys in the file never match and the built in
+defaults are used instead. Editing them changes nothing today.
+
+### 3. Practical Setup Example
+
+```yaml
+gui:
+  # The text or value for Title. Available options: Any valid string text
+  title: '&#444444pick enchantments'
+  # The numerical value for Rows. Available options: Any valid integer
+  rows: 6
+  # Configuration section for Slots.
+  slots:
+    # The numerical value for Item. Available options: Any valid integer
+    item: 0
+    # The numerical value for Cancel. Available options: Any valid integer
+    cancel: 46
+    # The numerical value for Prev. Available options: Any valid integer
+    prev: 45
+    # The numerical value for Next. Available options: Any valid integer
+    next: 53
+    # The numerical value for Confirm. Available options: Any valid integer
+    confirm: 52
+  # Configuration section for Buttons.
+  buttons:
+    # Configuration section for Cancel.
+    cancel:
+      # The text or value for Material. Available options: Any valid string text
+      material: RED_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&#39FF14cancel'
+      # Configuration section for Lore.
+      lore:
+      - '&fClick to return'
+    # Configuration section for Confirm.
+    confirm:
+      # The text or value for Material. Available options: Any valid string text
+      material: LIME_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&#39FF14confirm'
+      # Configuration section for Lore.
+      lore:
+      - '&fClick to confirm enchants'
+    # Configuration section for Page Filler.
+    page_filler:
+      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      enabled: false
+      # The text or value for Material. Available options: Any valid string text
+      material: GRAY_STAINED_GLASS_PANE
+      # The text or value for Name. Available options: Any valid string text
+      name: '&7 '
+    # Configuration section for Filler.
+    filler:
+      # Determines whether Enabled is enabled or disabled. Available options: true, false
+      enabled: true
+      # The text or value for Slots. Available options: Any valid string text
+      slots: 1,9,10
+      # The text or value for Material. Available options: Any valid string text
+      material: GRAY_STAINED_GLASS_PANE
+      # The text or value for Displayname. Available options: Any valid string text
+      displayname: '&7 '
+  # Configuration section for Sounds.
+  sounds:
+    # Configuration section for Click.
+    click:
+      # The text or value for Name. Available options: Any valid string text
+      name: BLOCK_ENCHANTMENT_TABLE_USE
+      # The decimal value for Volume. Available options: Any decimal number
+      volume: 1.0
+      # The decimal value for Pitch. Available options: Any decimal number
+      pitch: 1.0
+# Configuration section for Helmet.
+```
+
+---
+## Section: `helmet`
+
+### 1. Commented Setup Code Example
+
+```yaml
+helmet:
+  # Configuration section for Protection1.
+  protection1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Protection2.
+  protection2:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;2
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 3
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 31 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `helmet.<option>` | `section` | Any lower case id | 33 shipped | One clickable option in the menu for a helmet. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `helmet.<option>.enchantment` | `str` | `name;level` | for example `aqua_affinity;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `helmet.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `helmet.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a helmet 33 options across pages 1 and 2: `aqua_affinity` 1, `binding_curse` 1, `blast_protection` 1 to 4, `fire_protection` 1 to 4, `mending` 1, `projectile_protection` 1 to 4, `protection` 1 to 4, `respiration` 1 to 3, `thorns` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+helmet:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: aqua_affinity;1
+    slot: 10
+    page: 3
+```
+
+---
+## Section: `chestplate`
+
+### 1. Commented Setup Code Example
+
+```yaml
+chestplate:
+  # Configuration section for Protection1.
+  protection1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Protection2.
+  protection2:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;2
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 3
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 27 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `chestplate.<option>` | `section` | Any lower case id | 29 shipped | One clickable option in the menu for a chestplate. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `chestplate.<option>.enchantment` | `str` | `name;level` | for example `binding_curse;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `chestplate.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `chestplate.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a chestplate 29 options across pages 1 and 2: `binding_curse` 1, `blast_protection` 1 to 4, `fire_protection` 1 to 4, `mending` 1, `projectile_protection` 1 to 4, `protection` 1 to 4, `thorns` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+chestplate:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: binding_curse;1
+    slot: 10
+    page: 3
+```
+
+---
+## Section: `leggings`
+
+### 1. Commented Setup Code Example
+
+```yaml
+leggings:
+  # Configuration section for Protection1.
+  protection1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Protection2.
+  protection2:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;2
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 3
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 30 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `leggings.<option>` | `section` | Any lower case id | 32 shipped | One clickable option in the menu for a leggings. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `leggings.<option>.enchantment` | `str` | `name;level` | for example `binding_curse;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `leggings.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `leggings.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a leggings 32 options across pages 1 and 2: `binding_curse` 1, `blast_protection` 1 to 4, `fire_protection` 1 to 4, `mending` 1, `projectile_protection` 1 to 4, `protection` 1 to 4, `swift_sneak` 1 to 3, `thorns` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+leggings:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: binding_curse;1
+    slot: 10
+    page: 3
+```
+
+---
+## Section: `boots`
+
+### 1. Commented Setup Code Example
+
+```yaml
+boots:
+  # Configuration section for Protection1.
+  protection1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Protection2.
+  protection2:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: protection;2
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 3
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 42 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `boots.<option>` | `section` | Any lower case id | 44 shipped | One clickable option in the menu for a boots. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `boots.<option>.enchantment` | `str` | `name;level` | for example `binding_curse;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `boots.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `boots.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a boots 44 options across pages 1 and 2: `binding_curse` 1, `blast_protection` 1 to 4, `depth_strider` 1 to 3, `feather_falling` 1 to 4, `fire_protection` 1 to 4, `frost_walker` 1 to 2, `mending` 1, `projectile_protection` 1 to 4, `protection` 1 to 4, `soul_speed` 1 to 3, `swift_sneak` 1 to 3, `thorns` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+boots:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: binding_curse;1
+    slot: 10
+    page: 3
+```
+
+---
+## Section: `elytra`
+
+### 1. Commented Setup Code Example
+
+```yaml
+elytra:
+  # Configuration section for Mending1.
+  mending1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 4 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `elytra.<option>` | `section` | Any lower case id | 6 shipped | One clickable option in the menu for a elytra. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `elytra.<option>.enchantment` | `str` | `name;level` | for example `binding_curse;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `elytra.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `elytra.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a elytra 6 options across one page: `binding_curse` 1, `mending` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+elytra:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: binding_curse;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `bow`
+
+### 1. Commented Setup Code Example
+
+```yaml
+bow:
+  # Configuration section for Power1.
+  power1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: power;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Power2.
+  power2:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: power;2
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 3
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 12 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `bow.<option>` | `section` | Any lower case id | 14 shipped | One clickable option in the menu for a bow. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `bow.<option>.enchantment` | `str` | `name;level` | for example `flame;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `bow.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `bow.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a bow 14 options across one page: `flame` 1, `infinity` 1, `mending` 1, `power` 1 to 5, `punch` 1 to 2, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+bow:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: flame;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `crossbow`
+
+### 1. Commented Setup Code Example
+
+```yaml
+crossbow:
+  # Configuration section for Multishot.
+  multishot:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: multishot;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 2
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Quick Charge1.
+  quick_charge1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: quick_charge;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 11
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 11 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `crossbow.<option>` | `section` | Any lower case id | 13 shipped | One clickable option in the menu for a crossbow. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `crossbow.<option>.enchantment` | `str` | `name;level` | for example `mending;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `crossbow.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `crossbow.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a crossbow 13 options across one page: `mending` 1, `multishot` 1, `piercing` 1 to 4, `quick_charge` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+crossbow:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: mending;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `fishing_rod`
+
+### 1. Commented Setup Code Example
+
+```yaml
+fishing_rod:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 9 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `fishing_rod.<option>` | `section` | Any lower case id | 11 shipped | One clickable option in the menu for a fishing rod. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `fishing_rod.<option>.enchantment` | `str` | `name;level` | for example `luck_of_the_sea;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `fishing_rod.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `fishing_rod.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a fishing rod 11 options across one page: `luck_of_the_sea` 1 to 3, `lure` 1 to 3, `mending` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+fishing_rod:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: luck_of_the_sea;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `shovel`
+
+### 1. Commented Setup Code Example
+
+```yaml
+shovel:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 12 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `shovel.<option>` | `section` | Any lower case id | 14 shipped | One clickable option in the menu for a shovel. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `shovel.<option>.enchantment` | `str` | `name;level` | for example `efficiency;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `shovel.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `shovel.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a shovel 14 options across one page: `efficiency` 1 to 5, `fortune` 1 to 3, `mending` 1, `silk_touch` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+shovel:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: efficiency;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `pickaxe`
+
+### 1. Commented Setup Code Example
+
+```yaml
+pickaxe:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 12 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `pickaxe.<option>` | `section` | Any lower case id | 14 shipped | One clickable option in the menu for a pickaxe. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `pickaxe.<option>.enchantment` | `str` | `name;level` | for example `efficiency;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `pickaxe.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `pickaxe.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a pickaxe 14 options across one page: `efficiency` 1 to 5, `fortune` 1 to 3, `mending` 1, `silk_touch` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+pickaxe:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: efficiency;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `axe`
+
+### 1. Commented Setup Code Example
+
+```yaml
+axe:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Mending201.
+  mending201:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 2
+  # ... 31 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `axe.<option>` | `section` | Any lower case id | 33 shipped | One clickable option in the menu for a axe. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `axe.<option>.enchantment` | `str` | `name;level` | for example `bane_of_arthropods;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `axe.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `axe.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a axe 33 options across pages 1 and 2: `bane_of_arthropods` 1 to 5, `efficiency` 1 to 5, `fortune` 1 to 3, `mending` 1, `sharpness` 1 to 5, `silk_touch` 1, `smite` 1 to 5, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+axe:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: bane_of_arthropods;1
+    slot: 10
+    page: 3
+```
+
+---
+## Section: `hoe`
+
+### 1. Commented Setup Code Example
+
+```yaml
+hoe:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 12 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `hoe.<option>` | `section` | Any lower case id | 14 shipped | One clickable option in the menu for a hoe. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `hoe.<option>.enchantment` | `str` | `name;level` | for example `efficiency;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `hoe.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `hoe.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a hoe 14 options across one page: `efficiency` 1 to 5, `fortune` 1 to 3, `mending` 1, `silk_touch` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+hoe:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: efficiency;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `shield`
+
+### 1. Commented Setup Code Example
+
+```yaml
+shield:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Unbreaking1.
+  unbreaking1:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: unbreaking;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 17
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # ... 3 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `shield.<option>` | `section` | Any lower case id | 5 shipped | One clickable option in the menu for a shield. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `shield.<option>.enchantment` | `str` | `name;level` | for example `mending;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `shield.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `shield.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a shield 5 options across one page: `mending` 1, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+shield:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: mending;1
+    slot: 10
+    page: 2
+```
+
+---
+## Section: `sword`
+
+### 1. Commented Setup Code Example
+
+```yaml
+sword:
+  # Configuration section for Mending.
+  mending:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 1
+  # Configuration section for Mending201.
+  mending201:
+    # The text or value for Enchantment. Available options: Any valid string text
+    enchantment: mending;1
+    # The numerical value for Slot. Available options: Any valid integer
+    slot: 18
+    # The numerical value for Page. Available options: Any valid integer
+    page: 2
+  # ... 32 more options for this item, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `sword.<option>` | `section` | Any lower case id | 34 shipped | One clickable option in the menu for a sword. The id is only a label; it is never shown to the player and only has to be unique inside this item. |
+| `sword.<option>.enchantment` | `str` | `name;level` | for example `bane_of_arthropods;1` | The enchantment and the level the option grants, separated by a semicolon. The name is lower cased and a `minecraft:` prefix is stripped, so `Sharpness;5` and `minecraft:sharpness;5` both work. An unrecognised name means the option is quietly skipped, but a level that is not a whole number throws while the file is loading, so keep it numeric. |
+| `sword.<option>.slot` | `int` | `0` to one less than `rows` times nine | none, so `0` | Where the option sits in the menu. Two options sharing a slot on the same page means only one of them is reachable, so check the layout after adding any. |
+| `sword.<option>.page` | `int` | `1` or higher | `1` | Which page the option appears on. The menu works out its own page count from the highest number used here, so raising this on one option is all it takes to add a page. |
+
+The shipped list gives a sword 34 options across pages 1 and 2: `bane_of_arthropods` 1 to 5, `fire_aspect` 1 to 2, `knockback` 1 to 2, `looting` 1 to 3, `mending` 1, `sharpness` 1 to 5, `smite` 1 to 5, `sweeping_edge` 1 to 3, `unbreaking` 1 to 3, `vanishing_curse` 1.
+
+Removing an option takes it out of the menu without touching anything a player already has enchanted.
+
+### 3. Practical Setup Example
+
+```yaml
+sword:
+  # keep the shipped options and add one more on a new page
+  custom_option:
+    enchantment: bane_of_arthropods;1
+    slot: 10
+    page: 3
+```
+
+---

--- a/docs/wiki/Config-offenses.yml.md
+++ b/docs/wiki/Config-offenses.yml.md
@@ -1,0 +1,108 @@
+# Detailed Configuration & Setup Guide: `offenses.yml`
+
+This is the technical setup guide for `offenses.yml` in **UltimateDonutSMP**.
+The file holds the preset offences staff pick from, and the escalating punishment tiers each one
+runs through. 61 offences ship with it, covering advertising, cheating, chat behaviour and the
+rest; the list is meant to be edited rather than treated as fixed.
+
+The file opens with its own summary of the syntax, which is worth reading before you change
+anything:
+
+```yaml
+# Configuration file for preset offenses and escalating punishment tiers.
+# Syntax per offense:
+#   <key>:
+#     name: "Display Name"
+#     type: BAN | MUTE | WARN | KICK
+#     wipe: false  # optional, defaults to false
+#     durations:
+#       - "30d"  # 1st offense
+#       - "60d"  # 2nd offense
+#       - "perm" # 3rd offense (and beyond)
+#
+# wipe only fires when the offense actually bans someone. It clears their stats, balance, homes,
+# ender chest, crate keys, auctions, orders and the rest of their progress, the same thing
+# /playerwipe does, and there is no undo. Their punishment history, IP history and any spawners
+# they placed are kept. A tier of "0s" is issued as a warning rather than a ban, so it does not
+# wipe, and neither do MUTE, WARN or KICK offenses.
+```
+
+---
+
+## Section: `offenses`
+
+### 1. Commented Setup Code Example
+
+```yaml
+offenses:
+  advertising:
+    name: "Advertising"
+    type: BAN
+    durations:
+      - "30d"
+
+  advertising-invite-rewards:
+    name: "Advertising Invite Rewards"
+    type: BAN
+    durations:
+      - "30d"
+
+  advertising-irl-trade:
+    name: "Advertising IRL Trade"
+    type: BAN
+    durations:
+      - "3d"
+
+  alt-limit:
+    name: "Alt Limit Violation"
+    type: BAN
+    durations:
+      - "perm"
+  # ... 57 more offences, each in the same shape
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `offenses.<key>` | `section` | Any lower case id | 61 shipped | One offence. The key is the id staff type, so `/offend <player> ban-evasion` picks the `ban-evasion` entry. It is lower cased when read, and it is also what the punishment record stores, so renaming a key detaches it from the history already filed under the old name. |
+| `offenses.<key>.name` | `str` | Any string text | the key itself | The wording shown to players and staff. Left out, the raw key is used instead, so `ban-evasion` would appear in place of `Ban Evasion`. |
+| `offenses.<key>.type` | `str` | `BAN`, `MUTE`, `WARN`, `KICK` | `BAN` | What the offence issues. Case does not matter. Anything the plugin does not recognise silently falls back to `BAN`, so a typo here punishes harder rather than failing loudly. |
+| `offenses.<key>.durations` | `list` | Duration strings, or `perm` | none | One entry per offence tier, in order. The first is the first time somebody commits it, the second the next time, and so on. Once the list runs out the last entry repeats forever, so ending on `perm` makes the third strike permanent. A plain string works as well as a list where an offence only ever has one tier. |
+| `offenses.<key>.wipe` | `bool` | `true`, `false` | `false` | Whether the punishment also wipes the player. Read under any casing, since the rest of the file is lower case. See the warning below before switching it on anywhere. |
+
+Durations take the usual suffixes, `30s`, `15m`, `2h`, `5d`, and can be combined as `5d 15m 30s`.
+`perm` never expires. A tier of `0s`, or a plain `0`, is issued as a warning rather than a ban,
+which is how you
+give somebody a formal first strike that shows in their history without keeping them out.
+
+`wipe` deserves care. It only fires when the offence actually bans somebody, and it clears their
+stats, balance, homes, ender chest, crate keys, auctions, orders and the rest of their progress,
+the same thing `/playerwipe` does. There is no undo. Punishment history, IP history and any
+spawners they placed survive it. Because a `0s` tier is a warning rather than a ban it does not
+wipe, and neither does a `MUTE`, `WARN` or `KICK` offence however the flag is set.
+
+### 3. Practical Setup Example
+
+```yaml
+offenses:
+  # three strikes, then it stops expiring
+  chat-spam:
+    name: "Chat Spam"
+    type: MUTE
+    durations:
+      - "1h"
+      - "12h"
+      - "7d"
+
+  # a formal first warning that costs nothing, then a real ban
+  team-griefing:
+    name: "Team Griefing"
+    type: BAN
+    durations:
+      - "0s"
+      - "14d"
+      - "perm"
+```
+
+---

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -14,7 +14,7 @@
 
 ---
 
-### ⚙️ YAML Configuration Guides (30 Files)
+### ⚙️ YAML Configuration Guides (32 Files)
 
 - **[config.yml Guide](Config-config.yml)**
 - **[messages.yml Guide](Config-messages.yml)**
@@ -35,11 +35,13 @@
 - **[auction-house.yml Guide](Config-auction-house.yml)**
 - **[billford.yml Guide](Config-billford.yml)**
 - **[death-messages.yml Guide](Config-death-messages.yml)**
+- **[enchantments.yml Guide](Config-enchantments.yml)**
 - **[ender-chest.yml Guide](Config-ender-chest.yml)**
 - **[ffa.yml Guide](Config-ffa.yml)**
 - **[freeze.yml Guide](Config-freeze.yml)**
 - **[hide.yml Guide](Config-hide.yml)**
 - **[invsee.yml Guide](Config-invsee.yml)**
+- **[offenses.yml Guide](Config-offenses.yml)**
 - **[orders.yml Guide](Config-orders.yml)**
 - **[pvp.yml Guide](Config-pvp.yml)**
 - **[rtp.yml Guide](Config-rtp.yml)**


### PR DESCRIPTION
`enchantments.yml` and `offenses.yml` were the only two shipped config files with no guide, which is why the sidebar advertised 30 guides for 32 files. Both have one now, and the heading and link list say 32.

Both follow the shape the other pages use: a section per top-level key in file order, the shipped YAML, a key table, then a practical example. Neither opens with a completeness claim.

## offenses.yml

One section, since the file is a single `offenses` map, and the table documents the shape an entry takes rather than giving a row per offence. All 61 of them are the same four keys.

What matters here lives in the code rather than the key names, so the page says it out loud: an unrecognised `type` falls back to `BAN` instead of failing, so a typo punishes harder; the last entry in `durations` repeats forever once somebody runs past the end of the list, which is what makes ending on `perm` work; a tier of `0s`, or a plain `0`, is issued as a warning rather than a ban because `OffendCommand` swaps the type; `durations` takes a bare string as well as a list; and `wipe` is read under any casing. The file's own header comment explains `wipe` and its consequences better than a paraphrase would, so the page quotes it.

## enchantments.yml

Sixteen sections: `messages`, `gui`, and one per item type. The item sections carry the content anyone actually came for, so each lists what that item can be given, read out of the file rather than described in the abstract. A sword gets 34 options across two pages, a shield gets 5.

Reading the code turned up something that would otherwise cost a server owner an evening. `messages` and `gui` are dead as shipped. `EnchantmentsManager` looks them up as `GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT`, the file ships them lower case, and Bukkit config paths are case sensitive, so every lookup misses and the hardcoded defaults win. I checked rather than assumed: against the shipped file `contains("GUI.TITLE")` is false while `contains("gui.title")` is true, and `getString("GUI.TITLE")` hands back the fallback instead of the configured `&#444444pick enchantments`. `gui.buttons` and `gui.sounds` are worse off again, with no reader at all under any casing, since the buttons are built from fixed materials in `EnchantSelectMenu`. Both sections say so in place rather than describing knobs that turn nothing.

Two smaller things the page notes. The plugin also looks for a `trident` section that the file does not ship, so tridents have no options until somebody writes one. And while an unknown enchantment name only makes the plugin skip that option, a level that is not a whole number throws while the file is loading, so `sharpness;V` would take the reload down.

The item sections quote the first two options verbatim and then say how many follow in the same shape. Quoting all 286 in full, twice per section, would have added something like 5000 lines of repetition without telling anybody anything they could not read in one entry.

## Notes

Docs only, nothing under `src/main/java` or `src/main/resources` touched. Both new pages escape `|` inside table cells, so all 71 of their rows come out with the right cell count. Sidebar heading, link list and pages on disk agree at 32, with no orphan in either direction. Suite is at 688, green.
