### PR TITLE
ci(build): stop concurrent nightly builds racing for the tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ on:
 permissions:
   contents: write
 
+# Two merges landing close together used to race each other for the nightly tag. The tag push is a
+# plain force push with no compare-and-swap, so whichever run finished last won, and the loser died
+# with "cannot lock ref". A slower older run winning would have moved v1.5-pre backwards and
+# published the older jar over the newer one. Cancelling the older run leaves the newest commit on
+# main as the only one that reaches the tag and release steps.
+concurrency:
+  group: build-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two merges landing on `main` within a minute of each other used to race for the nightly tag. Run 33685154845, the build for PR #419, died at "Update Nightly Tag" with:

    ! [remote rejected] v1.5-pre -> v1.5-pre (cannot lock ref 'refs/tags/v1.5-pre': is at a8699245... but expected 5bcf8907...)

PR #420 had merged a minute later, its run reached the tag push first, and the older run was rejected. Everything before that step passed in both.

The red build is the visible half. The half worth fixing is that `git push -f` has no compare-and-swap, so which run wins is pure timing rather than commit order. That time the newer run won and the published jar was right. Had the older run finished last it would have moved `v1.5-pre` backwards, then fallen through to `Release Nightly Build` and replaced the newer jar with the older one, quietly and with a green tick.

A workflow level `concurrency` group with `cancel-in-progress: true` closes both halves at once: a newer push cancels the older in-flight run, so only the newest commit on `main` ever reaches the tag and release steps. Nothing is lost by cancelling, since the newer commit already contains the older one.

## Why not the other two

Retrying the push on rejection turns the build green and makes the real problem worse, because the losing run is the older one and a retry has it overwrite the newer tag on purpose. Letting the step fail softly is worse again: the run would carry on into `Release Nightly Build` and upload the older jar over the newer one. Both hide the symptom and leave a stale nightly more likely than it is today.

## Notes

Nine lines, all of it the new block and a comment explaining why it is there, since a `concurrency` key is easy to delete as noise later. No step is touched, and the tag and release steps are unchanged. This is the first workflow in the repo to use `concurrency`, so there was no house style to follow.

The paths filter on this workflow is `src/**` and `pom.xml`, so a CI-only change does not trigger it. I ran the workflow manually afterwards to confirm it still parses and builds; the tag and release steps stay gated on `push`, so they are exercised by the next merge that touches `src`. Suite is at 688, green.
