### PR TITLE
fix(enchantments): read the gui and message keys the file ships

### DIFF
--- a/docs/wiki/Config-enchantments.yml.md
+++ b/docs/wiki/Config-enchantments.yml.md
@@ -5,11 +5,11 @@ The file drives the enchantment picker: which enchantments each kind of item can
 what level, and where each option sits in the menu.
 
 Two things are worth knowing before you edit it. The keys in this file are lower case, unlike
-every other config the plugin ships, and that is not cosmetic: the per item sections below are
-read exactly as written, while the `messages` and `gui` sections are looked up under upper case
-paths and so are never read at all. Each of those two sections says so again in place.
+every other config the plugin ships, and the plugin matches them exactly as written, so `gui.title`
+works and `GUI.TITLE` does not. Get the case wrong and nothing complains; the built in default is
+used instead.
 
-The other is `trident`. The plugin looks for a `trident` section alongside the fourteen below,
+The second is `trident`. The plugin looks for a `trident` section alongside the fourteen below,
 and the file does not ship one, so tridents have no options until you add it yourself.
 
 ---
@@ -36,11 +36,6 @@ messages:
 | `messages.select` | `str` | Any string text | `'&fClick to select'` | The lore line on an option the player has not picked yet. |
 | `messages.selected` | `str` | Any string text | `'&aSelected'` | The lore line on an option they have picked. |
 | `messages.cannot` | `str` | Any string text | `'&fCannot add this enchantment'` | The lore line on an option that conflicts with something already chosen. |
-
-Nothing below this heading is read by the plugin as it ships. `EnchantmentsManager` looks these
-values up under upper case paths (`GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT`), and Bukkit
-config paths are case sensitive, so the lower case keys in the file never match and the built in
-defaults are used instead. Editing them changes nothing today.
 
 ### 3. Practical Setup Example
 
@@ -78,54 +73,6 @@ gui:
     next: 53
     # The numerical value for Confirm. Available options: Any valid integer
     confirm: 52
-  # Configuration section for Buttons.
-  buttons:
-    # Configuration section for Cancel.
-    cancel:
-      # The text or value for Material. Available options: Any valid string text
-      material: RED_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14cancel'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to return'
-    # Configuration section for Confirm.
-    confirm:
-      # The text or value for Material. Available options: Any valid string text
-      material: LIME_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14confirm'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to confirm enchants'
-    # Configuration section for Page Filler.
-    page_filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: false
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&7 '
-    # Configuration section for Filler.
-    filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: true
-      # The text or value for Slots. Available options: Any valid string text
-      slots: 1,9,10
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Displayname. Available options: Any valid string text
-      displayname: '&7 '
-  # Configuration section for Sounds.
-  sounds:
-    # Configuration section for Click.
-    click:
-      # The text or value for Name. Available options: Any valid string text
-      name: BLOCK_ENCHANTMENT_TABLE_USE
-      # The decimal value for Volume. Available options: Any decimal number
-      volume: 1.0
-      # The decimal value for Pitch. Available options: Any decimal number
-      pitch: 1.0
 # Configuration section for Helmet.
 ```
 
@@ -140,13 +87,11 @@ gui:
 | `gui.slots.prev` | `int` | A slot number | `45` | The previous page button. |
 | `gui.slots.next` | `int` | A slot number | `53` | The next page button. |
 | `gui.slots.confirm` | `int` | A slot number | `52` | The confirm button. |
-| `gui.buttons.*` | `section` | Materials, names, lore | see the block above | Intended to style the cancel, confirm and filler items. No code reads this subtree under any casing; the buttons are built in `EnchantSelectMenu` from fixed materials. |
-| `gui.sounds.*` | `section` | A sound, volume and pitch | `BLOCK_ENCHANTMENT_TABLE_USE` | Intended to set the click sound. Nothing reads this subtree either. |
 
-Nothing below this heading is read by the plugin as it ships. `EnchantmentsManager` looks these
-values up under upper case paths (`GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT`), and Bukkit
-config paths are case sensitive, so the lower case keys in the file never match and the built in
-defaults are used instead. Editing them changes nothing today.
+`gui.buttons` and `gui.sounds` used to sit in this section, describing button materials, names,
+lore, filler panes and a click sound. No code ever read them, under any casing, so they were taken
+out rather than left advertising settings that did nothing. The cancel, confirm and page arrows are
+built into the menu; changing them needs a code change rather than a config one.
 
 ### 3. Practical Setup Example
 
@@ -168,54 +113,6 @@ gui:
     next: 53
     # The numerical value for Confirm. Available options: Any valid integer
     confirm: 52
-  # Configuration section for Buttons.
-  buttons:
-    # Configuration section for Cancel.
-    cancel:
-      # The text or value for Material. Available options: Any valid string text
-      material: RED_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14cancel'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to return'
-    # Configuration section for Confirm.
-    confirm:
-      # The text or value for Material. Available options: Any valid string text
-      material: LIME_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14confirm'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to confirm enchants'
-    # Configuration section for Page Filler.
-    page_filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: false
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&7 '
-    # Configuration section for Filler.
-    filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: true
-      # The text or value for Slots. Available options: Any valid string text
-      slots: 1,9,10
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Displayname. Available options: Any valid string text
-      displayname: '&7 '
-  # Configuration section for Sounds.
-  sounds:
-    # Configuration section for Click.
-    click:
-      # The text or value for Name. Available options: Any valid string text
-      name: BLOCK_ENCHANTMENT_TABLE_USE
-      # The decimal value for Volume. Available options: Any decimal number
-      volume: 1.0
-      # The decimal value for Pitch. Available options: Any decimal number
-      pitch: 1.0
 # Configuration section for Helmet.
 ```
 

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/EnchantmentsManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/EnchantmentsManager.java
@@ -95,52 +95,52 @@ public class EnchantmentsManager {
 
     public String getGuiTitle() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getString("GUI.TITLE", "&8Pick enchantments") : "&8pick enchantments";
+        return config != null ? config.getString("gui.title", "&8Pick enchantments") : "&8pick enchantments";
     }
 
     public int getGuiRows() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.ROWS", 6) : 6;
+        return config != null ? config.getInt("gui.rows", 6) : 6;
     }
 
     public int getCancelSlot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.SLOTS.CANCEL", 46) : 46;
+        return config != null ? config.getInt("gui.slots.cancel", 46) : 46;
     }
 
     public int getPrevSlot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.SLOTS.PREV", 45) : 45;
+        return config != null ? config.getInt("gui.slots.prev", 45) : 45;
     }
 
     public int getNextSlot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.SLOTS.NEXT", 53) : 53;
+        return config != null ? config.getInt("gui.slots.next", 53) : 53;
     }
 
     public int getConfirmSlot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.SLOTS.CONFIRM", 52) : 52;
+        return config != null ? config.getInt("gui.slots.confirm", 52) : 52;
     }
 
     public int getItemSlot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getInt("GUI.SLOTS.ITEM", 0) : 0;
+        return config != null ? config.getInt("gui.slots.item", 0) : 0;
     }
 
     public String getMessageSelect() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getString("MESSAGES.SELECT", "&fClick to select") : "&fclick to select";
+        return config != null ? config.getString("messages.select", "&fClick to select") : "&fclick to select";
     }
 
     public String getMessageSelected() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getString("MESSAGES.SELECTED", "&aSelected") : "&aselected";
+        return config != null ? config.getString("messages.selected", "&aSelected") : "&aselected";
     }
 
     public String getMessageCannot() {
         FileConfiguration config = plugin.getConfigManager().getEnchantments();
-        return config != null ? config.getString("MESSAGES.CANNOT", "&fCannot add this enchantment") : "&fcannot add this enchantment";
+        return config != null ? config.getString("messages.cannot", "&fCannot add this enchantment") : "&fcannot add this enchantment";
     }
 
     private void mapMaterials() {

--- a/src/main/resources/enchantments.yml
+++ b/src/main/resources/enchantments.yml
@@ -24,54 +24,6 @@ gui:
     next: 53
     # The numerical value for Confirm. Available options: Any valid integer
     confirm: 52
-  # Configuration section for Buttons.
-  buttons:
-    # Configuration section for Cancel.
-    cancel:
-      # The text or value for Material. Available options: Any valid string text
-      material: RED_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14cancel'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to return'
-    # Configuration section for Confirm.
-    confirm:
-      # The text or value for Material. Available options: Any valid string text
-      material: LIME_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&#39FF14confirm'
-      # Configuration section for Lore.
-      lore:
-      - '&fClick to confirm enchants'
-    # Configuration section for Page Filler.
-    page_filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: false
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Name. Available options: Any valid string text
-      name: '&7 '
-    # Configuration section for Filler.
-    filler:
-      # Determines whether Enabled is enabled or disabled. Available options: true, false
-      enabled: true
-      # The text or value for Slots. Available options: Any valid string text
-      slots: 1,9,10
-      # The text or value for Material. Available options: Any valid string text
-      material: GRAY_STAINED_GLASS_PANE
-      # The text or value for Displayname. Available options: Any valid string text
-      displayname: '&7 '
-  # Configuration section for Sounds.
-  sounds:
-    # Configuration section for Click.
-    click:
-      # The text or value for Name. Available options: Any valid string text
-      name: BLOCK_ENCHANTMENT_TABLE_USE
-      # The decimal value for Volume. Available options: Any decimal number
-      volume: 1.0
-      # The decimal value for Pitch. Available options: Any decimal number
-      pitch: 1.0
 # Configuration section for Helmet.
 helmet:
   # Configuration section for Protection1.

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/EnchantmentsConfigKeyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/EnchantmentsConfigKeyTest.java
@@ -1,0 +1,87 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EnchantmentsManager used to look these values up as GUI.TITLE and MESSAGES.SELECT while
+ * enchantments.yml shipped them as gui.title and messages.select. Bukkit config paths are case
+ * sensitive, so every lookup missed and the hardcoded fallback was used instead, which made the
+ * whole gui and messages part of the file look configurable while doing nothing. Most of it went
+ * unnoticed because the shipped values matched the fallbacks anyway; only the menu title differed.
+ *
+ * <p>Rather than pin the ten paths by hand, this reads the lookups back out of the manager, so it
+ * fails whichever side drifts: renaming a key in the file, or re-casing a path in the code.
+ */
+class EnchantmentsConfigKeyTest {
+
+    private static final Pattern ROOT_LOOKUP = Pattern.compile(
+            "config\\.get(?:String|Int|Boolean|Double|StringList)\\(\"([^\"]+)\""
+    );
+
+    private static YamlConfiguration enchantments() {
+        return YamlConfiguration.loadConfiguration(new File("src/main/resources/enchantments.yml"));
+    }
+
+    private static List<String> lookupPaths() throws Exception {
+        String source = Files.readString(
+                new File("src/main/java/com/bx/ultimateDonutSmp/managers/EnchantmentsManager.java").toPath(),
+                StandardCharsets.UTF_8
+        );
+        List<String> paths = new ArrayList<>();
+        Matcher matcher = ROOT_LOOKUP.matcher(source);
+        while (matcher.find()) {
+            paths.add(matcher.group(1));
+        }
+        return paths;
+    }
+
+    @Test
+    void everyPathTheManagerLooksUpIsShippedInTheFile() throws Exception {
+        List<String> paths = lookupPaths();
+        assertTrue(paths.size() >= 10, "expected to find the gui and message lookups, found " + paths);
+
+        YamlConfiguration config = enchantments();
+        for (String path : paths) {
+            assertTrue(
+                    config.contains(path),
+                    "EnchantmentsManager reads " + path + " but enchantments.yml does not ship it, so the"
+                            + " lookup silently falls back to a hardcoded default"
+            );
+        }
+    }
+
+    @Test
+    void theUnreadButtonAndSoundSubtreesAreNoLongerShipped() {
+        YamlConfiguration config = enchantments();
+        for (String path : List.of("gui.buttons", "gui.sounds")) {
+            assertFalse(
+                    config.contains(path),
+                    "nothing reads " + path + ", so shipping it advertises settings that do nothing"
+            );
+        }
+    }
+
+    @Test
+    void theItemCategoriesTheMenuLoadsAreStillPresent() {
+        YamlConfiguration config = enchantments();
+        for (String category : List.of("helmet", "chestplate", "leggings", "boots", "elytra", "bow",
+                "crossbow", "fishing_rod", "shovel", "pickaxe", "axe", "hoe", "shield", "sword")) {
+            assertTrue(
+                    config.isConfigurationSection(category),
+                    category + " has no options, so that item would open an empty enchant menu"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`enchantments.yml` ships its keys in lower case. `EnchantmentsManager` looked them up as `GUI.TITLE`, `GUI.SLOTS.CANCEL`, `MESSAGES.SELECT` and so on, and Bukkit config paths are case sensitive, so all ten lookups missed and the hardcoded fallback won every time. The `gui` and `messages` sections have been decoration since the file was written.

The lookups are now lower case, so the file works as written.

## What actually changes for a server

Less than it sounds. Of the ten keys, nine already ship a value identical to the fallback they were losing to, which is why nobody noticed: `gui.rows` ships `6` against a default of `6`, `gui.slots.cancel` ships `46` against `46`, and all three `messages` lines match theirs word for word. The slots looked like they worked right up until somebody changed one.

The single visible difference is the menu title, which becomes the shipped `&#444444pick enchantments` instead of the hardcoded `&8Pick enchantments`. Anyone who had already edited the file gets what they asked for instead of being quietly ignored.

## gui.buttons and gui.sounds

These are gone rather than fixed. No code read them under any casing: `EnchantSelectMenu` builds the cancel, confirm and page arrows from fixed materials, and there were no entries for the arrows in the first place. `filler` and `page_filler` described slot filling the menu does not implement at all, so wiring them up would have been a feature rather than a fix. Same treatment as the four dead `PUNISHMENTS` keys in #419.

Removal was checked by parsing the file before and after: 16 paths disappear, all of them under `gui.buttons.` or `gui.sounds.`, and no other value moves.

## Test

`EnchantmentsConfigKeyTest` reads the lookup paths back out of `EnchantmentsManager` with a regex and asserts every one of them exists in the shipped file, so it fails whichever side drifts, a key renamed in the yaml or a path re-cased in the code. Pinning the ten paths by hand would only have caught one direction.

I checked it fails for the right reason before trusting it. Against the old manager it reports `EnchantmentsManager reads GUI.TITLE but enchantments.yml does not ship it, so the lookup silently falls back to a hardcoded default`. Two smaller tests cover the removed subtrees staying out and the fourteen item categories still being present, since an empty category means an empty enchant menu.

## Notes

`Config-enchantments.yml.md` loses both "not read as shipped" warnings, since they are no longer true, and its intro now says the case matters rather than that the sections are dead. The `gui` yaml is requoted from the file as it now stands and the two rows for the removed subtrees are gone. Suite is at 691, green.
