### PR TITLE
fix(wiki): escape the pipes that eat table cells

### DIFF
--- a/docs/wiki/Commands-and-Permissions.md
+++ b/docs/wiki/Commands-and-Permissions.md
@@ -108,7 +108,7 @@ This page contains the complete reference guide for all commands, aliases, synta
 | `/serverwipe` | `/serverwipe <confirm\|cancel>` | Guarded admin server wipe execution | `ultimatedonutsmp.admin.serverwipe` |
 | `/playerwipe` | `/playerwipe <player> [confirm]` | Wipe everything stored about one player | `ultimatedonutsmp.admin.playerwipe` |
 | `/playerunwipe` | `/playerunwipe <player> [confirm]` | Restore a wiped player from the backup their wipe left behind | `ultimatedonutsmp.admin.playerunwipe` |
-| `/uds` | `/uds <reload|version|status>` | Main plugin administration & hot-reload | `ultimatedonutsmp.admin.uds` |
+| `/uds` | `/uds <reload\|version\|status>` | Main plugin administration & hot-reload | `ultimatedonutsmp.admin.uds` |
 
 ---
 

--- a/docs/wiki/Config-amethyst-tools.yml.md
+++ b/docs/wiki/Config-amethyst-tools.yml.md
@@ -106,7 +106,7 @@ AMETHYST-TOOLS:
 | `AMETHYST-TOOLS.PARTICLES.BLOCK-MATERIAL` | `str` | Any string text | `'PURPLE_CONCRETE_POWDER'` | Configures the technical `BLOCK-MATERIAL` parameter for `AMETHYST-TOOLS.PARTICLES.BLOCK-MATERIAL` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.PARTICLES.COUNT` | `int` | Any valid integer number | `'12'` | Configures the technical `COUNT` parameter for `AMETHYST-TOOLS.PARTICLES.COUNT` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.PARTICLES.SPREAD` | `float` | Any decimal number | `'0.4'` | Configures the technical `SPREAD` parameter for `AMETHYST-TOOLS.PARTICLES.SPREAD` in `amethyst-tools.yml`. |
-| `AMETHYST-TOOLS.SOUNDS.USE` | `str` | Any string text | `'minecraft:block.amethyst_block.hit|...'` | Configures the technical `USE` parameter for `AMETHYST-TOOLS.SOUNDS.USE` in `amethyst-tools.yml`. |
+| `AMETHYST-TOOLS.SOUNDS.USE` | `str` | Any string text | `'minecraft:block.amethyst_block.hit\|...'` | Configures the technical `USE` parameter for `AMETHYST-TOOLS.SOUNDS.USE` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.SOUNDS.EXPIRE` | `str` | Any string text | `'minecraft:entity.lightning_bolt.imp...'` | Configures the technical `EXPIRE` parameter for `AMETHYST-TOOLS.SOUNDS.EXPIRE` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.SOUNDS.BREAK` | `str` | Any string text | `'minecraft:block.amethyst_block.brea...'` | Configures the technical `BREAK` parameter for `AMETHYST-TOOLS.SOUNDS.BREAK` in `amethyst-tools.yml`. |
 | `AMETHYST-TOOLS.SOUNDS.ACTIVATE` | `str` | Any string text | `'minecraft:block.amethyst_block.reso...'` | Configures the technical `ACTIVATE` parameter for `AMETHYST-TOOLS.SOUNDS.ACTIVATE` in `amethyst-tools.yml`. |

--- a/docs/wiki/Config-spawn-stash.yml.md
+++ b/docs/wiki/Config-spawn-stash.yml.md
@@ -154,7 +154,7 @@ MESSAGES:
 | `MESSAGES.SPAWNER-CLAIMED-DROPPED` | `str` | Any string text | `'&aclaimed &f{amount}x {spawner}&a. ...'` | Configures the technical `SPAWNER-CLAIMED-DROPPED` parameter for `MESSAGES.SPAWNER-CLAIMED-DROPPED` in `spawn-stash.yml`. |
 | `MESSAGES.INVALID-TYPE` | `str` | Any string text | `'&cunknown stash type '&f{type}&c'. ...'` | Configures the technical `INVALID-TYPE` parameter for `MESSAGES.INVALID-TYPE` in `spawn-stash.yml`. |
 | `MESSAGES.INVALID-CONFIG` | `str` | Any string text | `'&cspawnstash config is invalid: &f{...'` | Configures the technical `INVALID-CONFIG` parameter for `MESSAGES.INVALID-CONFIG` in `spawn-stash.yml`. |
-| `MESSAGES.ALERT` | `list` | List of configured items/strings | `['&8[&dspawnstash&8] &f{player} &7triggered &d{reason}&7 on stash &f#{id}&7 (&f{type}&7)', '&7location: &f{world} {x}, {y}, {z} &8| &7created by: &f{creator}']` | Configures the technical `ALERT` parameter for `MESSAGES.ALERT` in `spawn-stash.yml`. |
+| `MESSAGES.ALERT` | `list` | List of configured items/strings | `['&8[&dspawnstash&8] &f{player} &7triggered &d{reason}&7 on stash &f#{id}&7 (&f{type}&7)', '&7location: &f{world} {x}, {y}, {z} &8\| &7created by: &f{creator}']` | Configures the technical `ALERT` parameter for `MESSAGES.ALERT` in `spawn-stash.yml`. |
 | `MESSAGES.ALERT-HOVER` | `str` | Any string text | `'&eclick to teleport to &f{player}'` | Configures the technical `ALERT-HOVER` parameter for `MESSAGES.ALERT-HOVER` in `spawn-stash.yml`. |
 
 ### 3. Practical Setup Example

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/WikiTableRowTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/WikiTableRowTest.java
@@ -1,0 +1,98 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A "|" inside a code span still splits a markdown table cell: GitHub cuts the row into cells before
+ * it parses inline code, so `a|b` in a value silently turns one cell into two and pushes the last
+ * cell, usually the whole description, off the end of the row. It has to be written as `a\|b`.
+ *
+ * <p>Rows are checked against their own table's header rather than a fixed column count, because
+ * these pages carry two, three and four column tables beside the five column option tables, and a
+ * fixed count reports every short table as broken.
+ */
+class WikiTableRowTest {
+
+    private static final Path WIKI = Path.of("docs", "wiki");
+
+    /** Splits on the pipes that actually separate cells, leaving escaped ones alone. */
+    private static final Pattern CELL_SEPARATOR = Pattern.compile("(?<!\\\\)\\|");
+
+    private static final Pattern SEPARATOR_ROW = Pattern.compile("^\\|[\\s:\\-|]+\\|$");
+
+    private static int cellCount(String row) {
+        // "|a|b|" splits to ["", "a", "b", ""], so two of the pieces are the outer edges.
+        return CELL_SEPARATOR.split(row, -1).length - 2;
+    }
+
+    private static List<String> mismatchedRows(Path page) throws IOException {
+        List<String> problems = new ArrayList<>();
+        List<String> lines = Files.readAllLines(page, StandardCharsets.UTF_8);
+
+        boolean insideFence = false;
+        Integer headerCells = null;
+
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            if (line.startsWith("```")) {
+                insideFence = !insideFence;
+                continue;
+            }
+            if (insideFence) {
+                continue;
+            }
+
+            String trimmed = line.trim();
+            if (!trimmed.startsWith("|")) {
+                headerCells = null;
+                continue;
+            }
+            if (SEPARATOR_ROW.matcher(trimmed).matches()) {
+                continue;
+            }
+            if (headerCells == null) {
+                headerCells = cellCount(trimmed);
+                continue;
+            }
+
+            int cells = cellCount(trimmed);
+            if (cells != headerCells) {
+                problems.add(page.getFileName() + ":" + (i + 1)
+                        + " has " + cells + " cells but its table header has " + headerCells
+                        + ". An unescaped | inside a code span is the usual cause. Line: "
+                        + trimmed.substring(0, Math.min(120, trimmed.length())));
+            }
+        }
+        return problems;
+    }
+
+    @Test
+    void everyWikiTableRowMatchesItsHeader() throws IOException {
+        assertTrue(Files.isDirectory(WIKI), "docs/wiki is missing, so this test is checking nothing");
+
+        List<String> problems = new ArrayList<>();
+        List<Path> pages;
+        try (Stream<Path> walk = Files.list(WIKI)) {
+            pages = walk.filter(p -> p.toString().endsWith(".md")).sorted().toList();
+        }
+
+        assertTrue(pages.size() > 30, "expected the wiki pages to be present, found " + pages.size());
+
+        for (Path page : pages) {
+            problems.addAll(mismatchedRows(page));
+        }
+
+        assertTrue(problems.isEmpty(), "wiki table rows lose cells:\n" + String.join("\n", problems));
+    }
+}


### PR DESCRIPTION
Three table rows lose their last cell to an unescaped `|` inside a code span. GitHub cuts a row into cells before it parses inline code, so a pipe in a value turns one cell into two and pushes the description off the end of the row.

- `Commands-and-Permissions.md` line 111, the `/uds <reload|version|status>` usage. Every neighbouring row already writes it `\|`, so this one was simply missed.
- `Config-amethyst-tools.yml.md` line 109, a sound value of the usual `sound|volume|pitch` shape.
- `Config-spawn-stash.yml.md` line 157, a list default carrying `&8|` in its second entry.

## The count in the task was wrong, and it was mine

I raised this task claiming 114 rows across eight pages. It is three, and one of them is on a page the task never mentioned.

The 114 came from a checker that assumed every table on a config guide page has five columns, and flagged any row that did not split into seven pieces. Those pages carry two, three and four column tables beside the option tables: the ender chest row-to-slots table, the placeholder tables on `Config-menus.yml.md` and `Config-staff-mode.yml.md`, the shop placeholder list. 111 of the 114 were ordinary short tables rendering exactly as intended. Comparing each row against its own table's header instead of a fixed five brings the real number down to three.

Worth saying that PR #415 is not affected. It used the same flawed rule, but the four pages it touched are five column throughout, so the rule happened to hold there; re-checking them the correct way reports them clean, and escaping a pipe inside a code span is harmless even where it was not strictly needed.

## The test

`WikiTableRowTest` walks every page under `docs/wiki`, remembers each table's header, and asserts every body row has the same number of cells, splitting on `(?<!\\)\|` so escaped pipes are left alone. Fenced code blocks are skipped, since a quoted yaml block is full of unescaped pipes and none of them are table cells.

It compares against the header rather than a fixed count, which is precisely the mistake that produced the 114 and would have made the test report 111 false failures on day one. I checked it fails usefully before trusting it: putting the spawn-stash pipe back gets `Config-spawn-stash.yml.md:157 has 6 cells but its table header has 5. An unescaped | inside a code span is the usual cause.`

## Notes

Three one-character edits and one new test. No source or config touched. Suite is at 692, green.
