### PR TITLE
fix(settings): restore six settings buttons lost in the menu rebuild (#427)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -33,6 +33,8 @@ public final class PlayerSettingsMenu extends BaseMenu {
             "PAY_CONFIRM_MENUS", "AUTO_CONFIRM_TPAS", "HOTBAR_MESSAGES", "NOTIFICATION_SOUNDS",
             "FOLLOW_ALERT_SETTINGS", "DISPLAY_DONUT_PLUS", "CHAINMAIL_ON_RESPAWN", "EXPLOSION_PARTICLES",
             "EXPLOSION_SOUNDS", "TELEPORT_ALERTS", "RTP_COORDINATES", "FAST_CRYSTALS", "RANDOMIZED_COORDS",
+            "TOTEM_PARTICLES", "HIDE_ALL_PLAYERS", "QUIET_SPAWN", "DUEL_MUSIC", "TEAM_INVITES",
+            "CLEAR_ENTITIES_MESSAGES",
             "TPA_REQUESTS", "TPA_HERE_REQUESTS", "PAYMENTS", "WORTH_DISPLAY", "MONEY_NAMETAGS",
             "JOIN_LEAVE_MESSAGES", "PAY_ALERTS", "ADVANCEMENT_MESSAGES", "AUCTION_NOTIFICATIONS",
             "AMETHYST_BREAK_MESSAGES", "DUEL_REQUESTS", "DEATH_MESSAGES", "KEY_ALL_NOTIFICATIONS",
@@ -248,8 +250,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
                     !data.isKeyAllNotificationsEnabled(), data::setKeyAllNotificationsEnabled);
             case "TPA_CONFIRM_MENUS" -> toggle(player, "TPA Confirmation Menus",
                     !data.isTpaConfirmMenuEnabled(), data::setTpaConfirmMenuEnabled);
-            case "LUNAR_TEAMMATES" -> toggle(player, "Lunar Teammates",
-                    !data.isLunarTeammatesEnabled(), data::setLunarTeammatesEnabled);
             case "TPA_HERE_REQUESTS" -> {
                 data.setTpaHereRequestsChoice(nextThreeChoice(data.getTpaHereRequestsChoice()));
                 sendChoiceMessage(player, "TPA Here Requests", formatThreeChoice(data.getTpaHereRequestsChoice()));
@@ -430,7 +430,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
             case "AMETHYST_BREAK_MESSAGES" -> state(data.isAmethystBreakMessagesEnabled());
             case "KEY_ALL_NOTIFICATIONS" -> state(data.isKeyAllNotificationsEnabled());
             case "TPA_CONFIRM_MENUS" -> state(data.isTpaConfirmMenuEnabled());
-            case "LUNAR_TEAMMATES" -> state(data.isLunarTeammatesEnabled());
             case "TPA_HERE_REQUESTS" -> new ButtonState(formatThreeChoice(data.getTpaHereRequestsChoice()), true);
             case "DISABLE_PHANTOM_SPAWN" -> {
                 boolean disabled = !data.isPhantomEnabled();

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/PlayerSettingDefaults.java
@@ -197,6 +197,17 @@ public final class PlayerSettingDefaults {
         bindings.put("RTP_COORDINATES", bool(
                 PlayerData::isRtpCoordinatesEnabled, PlayerData::setRtpCoordinatesEnabled));
         bindings.put("FAST_CRYSTALS", bool(PlayerData::isFastCrystalsEnabled, PlayerData::setFastCrystalsEnabled));
+        bindings.put("TOTEM_PARTICLES", bool(
+                PlayerData::isTotemParticlesEnabled, PlayerData::setTotemParticlesEnabled));
+        bindings.put("HIDE_ALL_PLAYERS", bool(
+                PlayerData::isHideAllPlayersEnabled, PlayerData::setHideAllPlayersEnabled));
+        bindings.put("QUIET_SPAWN", bool(
+                PlayerData::isQuietSpawnEnabled, PlayerData::setQuietSpawnEnabled));
+        bindings.put("DUEL_MUSIC", bool(PlayerData::isDuelMusicEnabled, PlayerData::setDuelMusicEnabled));
+        bindings.put("TEAM_INVITES", bool(
+                PlayerData::isTeamInvitesEnabled, PlayerData::setTeamInvitesEnabled));
+        bindings.put("CLEAR_ENTITIES_MESSAGES", bool(
+                PlayerData::isClearEntitiesMessagesEnabled, PlayerData::setClearEntitiesMessagesEnabled));
         bindings.put("RANDOMIZED_COORDS", bool(PlayerData::isRandomizedCoords, PlayerData::setRandomizedCoords));
         bindings.put("TPA_REQUESTS", threeChoice(
                 PlayerData::getTpaRequestsChoice, PlayerData::setTpaRequestsChoice));

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -851,6 +851,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -887,6 +887,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: '&8Leaderboards'
     TYPE-MENU:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -716,6 +716,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -715,6 +715,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -852,6 +852,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -716,6 +716,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -715,6 +715,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -714,6 +714,36 @@ MENUS:
         LORE:
         - '&7Show the coordinates /rtp drops you at'
         - '&fCurrently: {status}'
+      TEAM_INVITES:
+        DISPLAY-NAME: '&#6BF18DTeam Invites'
+        LORE:
+        - '&7Receive team invitations'
+        - '&fCurrently: {status}'
+      DUEL_MUSIC:
+        DISPLAY-NAME: '&#6BF18DDuel Music'
+        LORE:
+        - '&7Play music and sounds during duels'
+        - '&fCurrently: {status}'
+      CLEAR_ENTITIES_MESSAGES:
+        DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+        LORE:
+        - '&7Show the entity clear countdown'
+        - '&fCurrently: {status}'
+      HIDE_ALL_PLAYERS:
+        DISPLAY-NAME: '&#6BF18DHide All Players'
+        LORE:
+        - '&7Hide every other player from view'
+        - '&fCurrently: {status}'
+      TOTEM_PARTICLES:
+        DISPLAY-NAME: '&#6BF18DTotem Particles'
+        LORE:
+        - '&7Show totem particles on use'
+        - '&fCurrently: {status}'
+      QUIET_SPAWN:
+        DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+        LORE:
+        - '&7Silence the spawn teleport effects'
+        - '&fCurrently: {status}'
   LEADERBOARDS-MENU:
     TITLE: "&8Leaderboards"
     TYPE-MENU:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -771,6 +771,20 @@ SETTINGS-MENU:
       LORE:
       - '&7Auto-confirm teleport requests'
       - '&fCurrently: {status}'
+    TEAM_INVITES:
+      DISPLAY-NAME: '&#6BF18DTeam Invites'
+      MATERIAL: SHIELD
+      SLOT: 34
+      LORE:
+      - '&7Receive team invitations'
+      - '&fCurrently: {status}'
+    DUEL_MUSIC:
+      DISPLAY-NAME: '&#6BF18DDuel Music'
+      MATERIAL: JUKEBOX
+      SLOT: 35
+      LORE:
+      - '&7Play music and sounds during duels'
+      - '&fCurrently: {status}'
     # Row 5 - the scoreboard and the lines on it
     SCOREBOARD_VISIBILITY:
       DISPLAY-NAME: '&#6BF18DShow Scoreboard'
@@ -814,6 +828,13 @@ SETTINGS-MENU:
       LORE:
       - '&7Show the playtime line on the scoreboard'
       - '&fCurrently: {status}'
+    CLEAR_ENTITIES_MESSAGES:
+      DISPLAY-NAME: '&#6BF18DClear Entities Messages'
+      MATERIAL: HOPPER
+      SLOT: 42
+      LORE:
+      - '&7Show the entity clear countdown'
+      - '&fCurrently: {status}'
     # Row 6 - the world around you
     QUICK_AUCTION_PURCHASE:
       DISPLAY-NAME: '&#6BF18DQuick Auction Purchase'
@@ -856,6 +877,27 @@ SETTINGS-MENU:
       SLOT: 50
       LORE:
       - '&7Destroy thrown ender pearls when you die'
+      - '&fCurrently: {status}'
+    HIDE_ALL_PLAYERS:
+      DISPLAY-NAME: '&#6BF18DHide All Players'
+      MATERIAL: PLAYER_HEAD
+      SLOT: 51
+      LORE:
+      - '&7Hide every other player from view'
+      - '&fCurrently: {status}'
+    TOTEM_PARTICLES:
+      DISPLAY-NAME: '&#6BF18DTotem Particles'
+      MATERIAL: TOTEM_OF_UNDYING
+      SLOT: 52
+      LORE:
+      - '&7Show totem particles on use'
+      - '&fCurrently: {status}'
+    QUIET_SPAWN:
+      DISPLAY-NAME: '&#6BF18DQuiet Spawn Teleportation'
+      MATERIAL: RESPAWN_ANCHOR
+      SLOT: 53
+      LORE:
+      - '&7Silence the spawn teleport effects'
       - '&fCurrently: {status}'
 LEADERBOARDS-MENU:
   TITLE: '&8Leaderboards'

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/PlayerSettingsConfigurationTest.java
@@ -57,7 +57,13 @@ class PlayerSettingsConfigurationTest {
             "SHOW_KILLS",
             "SHOW_DEATHS",
             "SHOW_PLAYTIME",
-            "COMBAT_TIMER"
+            "COMBAT_TIMER",
+            "TEAM_INVITES",
+            "DUEL_MUSIC",
+            "CLEAR_ENTITIES_MESSAGES",
+            "HIDE_ALL_PLAYERS",
+            "TOTEM_PARTICLES",
+            "QUIET_SPAWN"
     );
 
     @Test
@@ -117,18 +123,24 @@ class PlayerSettingsConfigurationTest {
                 Map.entry("DUEL_REQUESTS", 31),
                 Map.entry("PAY_CONFIRM_MENUS", 32),
                 Map.entry("AUTO_CONFIRM_TPAS", 33),
+                Map.entry("TEAM_INVITES", 34),
+                Map.entry("DUEL_MUSIC", 35),
                 Map.entry("SCOREBOARD_VISIBILITY", 36),
                 Map.entry("SHOW_MONEY", 37),
                 Map.entry("SHOW_SHARDS", 38),
                 Map.entry("SHOW_KILLS", 39),
                 Map.entry("SHOW_DEATHS", 40),
                 Map.entry("SHOW_PLAYTIME", 41),
+                Map.entry("CLEAR_ENTITIES_MESSAGES", 42),
                 Map.entry("QUICK_AUCTION_PURCHASE", 45),
                 Map.entry("QUICK_AUCTION_SELL", 46),
                 Map.entry("DISABLE_MOB_SPAWN", 47),
                 Map.entry("DISABLE_PHANTOM_SPAWN", 48),
                 Map.entry("NIGHT_VISION", 49),
-                Map.entry("DESTROY_PEARL_ON_DEATH", 50)
+                Map.entry("DESTROY_PEARL_ON_DEATH", 50),
+                Map.entry("HIDE_ALL_PLAYERS", 51),
+                Map.entry("TOTEM_PARTICLES", 52),
+                Map.entry("QUIET_SPAWN", 53)
         );
         groupedSlots.forEach((key, slot) ->
                 assertEquals(slot, buttons.getInt(key + ".SLOT"), key));


### PR DESCRIPTION
Closes #427

Six settings had a working click handler, a stored flag and live code reading that flag, but no way
for a player to reach them. `0231fba0` remade the settings layout and replaced `LAYOUT_SLOTS` with
`VALID_SETTINGS`, and these six fell out of both the new set and the rewritten `menus.yml` while
everything behind them stayed. Since `shouldRenderButton` drops any key outside `VALID_SETTINGS`,
none of them has drawn since, and nothing else in the plugin calls their setters, so the flags have
been frozen at their defaults for every player.

## What came back

| Setting | Slot | What the flag still drives |
| --- | --- | --- |
| Team Invites | 34 | `TeamCommand` refuses an invite to a player who turned them off |
| Duel Music | 35 | the duel sound channel |
| Clear Entities Messages | 42 | the `ClearLagManager` countdown |
| Hide All Players | 51 | `PlayerVisibilityManager` |
| Totem Particles | 52 | `PlayerSettingEffectsListener` |
| Quiet Spawn Teleportation | 53 | the spawn teleport effects |

Each one gets its key back in `VALID_SETTINGS`, a button block on a free slot with an icon nothing
else on its row uses, a `PlayerSettingDefaults` binding so `DEFAULT` and `ENABLED: false` behave the
way they do everywhere else, and its display name and lore in all eight language files. The names and
lore follow the current sentence style rather than the small-caps spelling some of them had before
`0231fba0` normalised it.

Slots went where the theme fits: the team and duel toggles finish the "who may reach you" row, the
clear-entities notice sits after the scoreboard lines, and the three that change what you see around
you finish the last row.

## Two that did not come back

`LUNAR_TEAMMATES` was removed on purpose. `bf4153aa` took it out of both `VALID_SETTINGS` and
`menus.yml` and gave its slot to Combat Timer, and only the two switch arms were left behind. Those
arms are unreachable, so this deletes them rather than restoring a button somebody deliberately
retired. `LunarTeammatesTask` is untouched.

`TEAM_CHAT` is a different case again, and it stays exactly as it is. It is not unreachable: `/team
chat` toggles it through `TeamCommand`, so the feature works today and only the menu shortcut is
missing. It also does not fit the pattern the other six follow, because the state lives in a
`TeamManager` set that is cleared on reload rather than in `PlayerData`, which means it can take no
binding and `DEFAULT` would mean nothing for it. Its handler also refuses outright for anyone not in
a team. Whether that shortcut is worth rebuilding is a design question rather than this bug, so it is
left for a separate decision.

## Notes

`PlayerSettingsMenuButtonCoverageTest` from #426 already locks `VALID_SETTINGS` and the `menus.yml`
button list to each other, and it covers the six new keys without any change. `TEAM_CHAT` does not
trip it, because both sides agree the key is absent.

The layout test gained the six keys and their slots. It asserts every button belongs to one of the
six row groups, so the slot map there is the authority on where each one sits.

Suite is 693 tests, all green. No `docs/wiki/` page lists the individual settings buttons, so there
was nothing to update there.
