### PR TITLE
refactor(settings): delete the unreachable team chat menu handler

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenu.java
@@ -270,7 +270,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
             }
             case "PAY_CONFIRM_MENUS" -> toggle(player, "Pay Confirmation Menus",
                     !data.isPayConfirmMenuEnabled(), data::setPayConfirmMenuEnabled);
-            case "TEAM_CHAT" -> toggleTeamChat(player);
             case "DESTROY_PEARL_ON_DEATH" -> toggle(player, "Destroy Pearl on Death",
                     !data.isDestroyPearlOnDeath(), data::setDestroyPearlOnDeath);
             case "RANDOMIZED_COORDS" -> {
@@ -442,7 +441,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
                 yield state(disabled);
             }
             case "PAY_CONFIRM_MENUS" -> state(data.isPayConfirmMenuEnabled());
-            case "TEAM_CHAT" -> state(plugin.getTeamManager().isTeamChatEnabled(player.getUniqueId()));
             case "DESTROY_PEARL_ON_DEATH" -> state(data.isDestroyPearlOnDeath());
             case "RANDOMIZED_COORDS" -> state(data.isRandomizedCoords());
             case "DEATH_MESSAGES" -> state(data.isDeathMessagesEnabled());
@@ -560,26 +558,6 @@ public final class PlayerSettingsMenu extends BaseMenu {
                     }
                     rebuildIfOpen(player);
                 }));
-    }
-
-    private void toggleTeamChat(Player player) {
-        var team = plugin.getTeamManager().getTeam(player);
-        if (team == null) {
-            player.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessage("TEAM.NO-TEAM")));
-            return;
-        }
-        if (!plugin.getTeamManager().canUseTeamChat(team, player.getUniqueId())) {
-            player.sendMessage(ColorUtils.toComponent(
-                    plugin.getConfigManager().getMessage("TEAM.NO-TEAM-CHAT-PERMISSION")
-            ));
-            return;
-        }
-        plugin.getTeamManager().toggleTeamChat(player.getUniqueId());
-        sendToggleMessage(
-                player,
-                "Team chat sending mode",
-                plugin.getTeamManager().isTeamChatEnabled(player.getUniqueId())
-        );
     }
 
     private void toggle(Player player, String label, boolean enabled, BooleanSetter setter) {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenuButtonCoverageTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/PlayerSettingsMenuButtonCoverageTest.java
@@ -5,20 +5,38 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * PlayerSettingsMenu#shouldRenderButton drops any key missing from VALID_SETTINGS, and a key with
- * no entry under SETTINGS-MENU.BUTTONS has nothing to draw. Either half going missing leaves a
- * setting that players can never reach even though its click handler and stored flag still work,
- * which is how the RTP coordinates toggle stopped being reachable.
+ * A setting reaches a player through three lists that have to agree: a {@code case} label in
+ * PlayerSettingsMenu to act on the click, an entry in VALID_SETTINGS because shouldRenderButton
+ * drops anything else, and a block under SETTINGS-MENU.BUTTONS to draw. Drop any one of them and
+ * the setting silently stops being reachable while its stored flag carries on driving behaviour.
+ *
+ * <p>That is not hypothetical. A settings layout rebuild left nine keys holding a handler and a
+ * live flag with no button and no VALID_SETTINGS entry, and nothing noticed until a player asked
+ * why they could not turn the RTP coordinates message off.</p>
  */
 class PlayerSettingsMenuButtonCoverageTest {
+
+    private static final Path MENU_SOURCE = Path.of(
+            "src", "main", "java", "com", "bx", "ultimateDonutSmp", "menus", "PlayerSettingsMenu.java");
+
+    /** A {@code case} arm, including multi-label arms such as {@code case "A", "B" ->}. */
+    private static final Pattern CASE_ARM =
+            Pattern.compile("case\\s+((?:\"[A-Z_]+\"\\s*,\\s*)*\"[A-Z_]+\")\\s*->");
+
+    private static final Pattern QUOTED_LABEL = Pattern.compile("\"([A-Z_]+)\"");
 
     @Test
     void everySettingsButtonIsRenderableAndEveryRenderableSettingHasAButton() throws Exception {
@@ -27,6 +45,31 @@ class PlayerSettingsMenuButtonCoverageTest {
 
         assertEquals(renderable, buttons,
                 "SETTINGS-MENU.BUTTONS and VALID_SETTINGS must list the same keys");
+    }
+
+    @Test
+    void everyHandledSettingIsRenderableAndEveryRenderableSettingIsHandled() throws Exception {
+        assertEquals(validSettings(), handledSettings(),
+                "every case label in PlayerSettingsMenu must appear in VALID_SETTINGS and back");
+    }
+
+    /**
+     * Both switches are read together, so a key handled on the click side but missing from the
+     * status side still has to be in VALID_SETTINGS. Enum arms carry no quotes and are skipped.
+     */
+    private static Set<String> handledSettings() throws Exception {
+        String source = Files.readString(MENU_SOURCE, StandardCharsets.UTF_8);
+        Set<String> labels = new TreeSet<>();
+        Matcher arms = CASE_ARM.matcher(source);
+        while (arms.find()) {
+            Matcher label = QUOTED_LABEL.matcher(arms.group(1));
+            while (label.find()) {
+                labels.add(label.group(1));
+            }
+        }
+        assertFalse(labels.isEmpty(),
+                "found no case labels in " + MENU_SOURCE + "; is the working directory the module root?");
+        return labels;
     }
 
     /**


### PR DESCRIPTION
Follow-up to #427, which restored six settings buttons and left this one open on purpose.

`TEAM_CHAT` had a click handler, a status renderer and a `toggleTeamChat` helper in
`PlayerSettingsMenu`, none of which anything could reach. `0231fba0` lost the key from both
`VALID_SETTINGS` and `menus.yml`, and `shouldRenderButton` drops whatever is not in the set, so the
three members have been unreachable since. Nothing changes at runtime here; this only removes code
that already could not run.

It goes rather than coming back as a button because team chat is not stuck the way the six in #427
were. `/team chat` toggles it through `TeamCommand` and is listed in the wiki command table, so the
feature works and always has. Restoring the button would also have meant putting it at slot 43 or 44,
in the scoreboard row, since rows one to four are full and team chat sending really belongs beside
Team Chat Visibility at slot 7. On top of that the handler refuses outright for anyone not in a team,
so most players clicking it would only get an error.

## The check this unlocks

`PlayerSettingsMenuButtonCoverageTest` already tied `VALID_SETTINGS` and the `menus.yml` button list
together. That pairing misses the case that actually happened: when a key drops out of both lists at
once and only its handler survives, the two sides still agree and the test stays green. Nine keys
went that way in one commit and nothing noticed until a player asked why they could not turn the RTP
coordinates message off.

The new assertion reads every `case` label out of `PlayerSettingsMenu` and requires that set to equal
`VALID_SETTINGS`, so a setting can no longer keep a handler after losing its button, and a key cannot
be listed as renderable with nothing to handle the click. `TEAM_CHAT` was the one thing standing in
the way of turning that on, which is the other half of why it goes now rather than later.

Verified by reintroducing the original accident. Dropping `RANDOMIZED_COORDS` from `VALID_SETTINGS`
alone fails both tests; dropping it from `VALID_SETTINGS` **and** `menus.yml` while leaving its
handler, which is exactly what `0231fba0` did, fails only the new one.

## Notes

Reading Java sources from a test follows `FoliaSchedulerUsageTest`, which walks `src/main/java` the
same way. Enum arms carry no quotes and are skipped, and multi-label arms are handled.

`TEAM_CHAT_VISIBILITY` is a different setting and is untouched. `ColorUtils` is still used elsewhere
in the class, so no import went stale.

Suite is 694 tests, all green.
