### PR TITLE
fix(homes): keep homes in their numbered slots when deleting or setting out of order (#435)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/HomeBedrockManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/HomeBedrockManager.java
@@ -231,8 +231,7 @@ public final class HomeBedrockManager {
     }
 
     public void openCreateForm(Player player) {
-        int homeCount = plugin.getHomeManager().getHomeCount(player.getUniqueId());
-        String defaultName = homeCount == 0 ? "home" : "home" + (homeCount + 1);
+        String defaultName = nextAvailableHomeName(player);
 
         CustomForm.Builder form = CustomForm.builder()
                 .title(plain("Set New Home"))
@@ -341,6 +340,17 @@ public final class HomeBedrockManager {
 
     private boolean enabled() {
         return plugin.getServer().getPluginManager().isPluginEnabled("floodgate");
+    }
+
+    private String nextAvailableHomeName(Player player) {
+        int counter = 1;
+        while (true) {
+            String candidate = counter == 1 ? "home" : "home" + counter;
+            if (plugin.getHomeManager().getHome(player.getUniqueId(), candidate) == null) {
+                return candidate;
+            }
+            counter++;
+        }
     }
 
     private String plain(String value) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/HomeMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/HomeMenu.java
@@ -58,13 +58,19 @@ public class HomeMenu extends BaseMenu {
         List<Home> homes = new ArrayList<>(plugin.getHomeManager().getHomes(player.getUniqueId()));
         homes.sort(Comparator.comparingLong(Home::getCreatedAt));
 
+        Map<Integer, Home> slotToHome = resolveHomeSlots(homes);
+
         int maxHomes = plugin.getHomeManager().getMaxHomes(player);
-        int totalPages = plugin.getHomeManager().getMaxHomePages(player);
+        int highestSlot = maxHomes - 1;
+        for (int slot : slotToHome.keySet()) {
+            highestSlot = Math.max(highestSlot, slot);
+        }
+        int totalPages = Math.max(1, (int) Math.ceil((highestSlot + 1) / (double) HOMES_PER_PAGE));
         page = clampPage(page, totalPages);
 
         buildPageButtons(totalPages);
         buildTeamButtons(player);
-        buildHomeButtons(player, homes, maxHomes);
+        buildHomeButtons(player, slotToHome, maxHomes);
     }
 
     @Override
@@ -166,7 +172,7 @@ public class HomeMenu extends BaseMenu {
         slotActions.put(TEAM_ACTION_SLOT, (p, click) -> setTeamHome(p, team));
     }
 
-    private void buildHomeButtons(Player player, List<Home> homes, int maxHomes) {
+    private void buildHomeButtons(Player player, Map<Integer, Home> slotToHome, int maxHomes) {
         int startIndex = page * HOMES_PER_PAGE;
 
         for (int i = 0; i < HOMES_PER_PAGE; i++) {
@@ -175,8 +181,9 @@ public class HomeMenu extends BaseMenu {
             int actionSlot = HOME_ACTION_SLOTS[i];
             String key = "HOME-" + (i + 1);
 
-            if (globalIndex < homes.size()) {
-                setUsedHomeButtons(player, homes.get(globalIndex), key, globalIndex, teleportSlot, actionSlot);
+            Home home = slotToHome.get(globalIndex);
+            if (home != null) {
+                setUsedHomeButtons(player, home, key, globalIndex, teleportSlot, actionSlot);
                 continue;
             }
 
@@ -222,7 +229,7 @@ public class HomeMenu extends BaseMenu {
     }
 
     private void setAvailableHomeButtons(Player player, String key, int globalIndex, int teleportSlot, int actionSlot) {
-        String suggestedName = defaultHomeName(globalIndex);
+        String suggestedName = defaultAvailableHomeName(player, globalIndex);
         Map<String, String> placeholders = emptyHomePlaceholders(globalIndex);
 
         set(teleportSlot, ItemUtils.createItem(
@@ -241,7 +248,7 @@ public class HomeMenu extends BaseMenu {
         slotActions.put(teleportSlot, (p, click) -> {
             if (plugin.getHomeManager().setHome(p, suggestedName)) {
                 p.sendMessage(ColorUtils.toComponent(plugin.getConfigManager().getMessage("HOME.SET")));
-                new HomeMenu(plugin).open(p);
+                new HomeMenu(plugin, page).open(p);
             } else {
                 p.sendMessage(ColorUtils.toComponent("&cYou cannot create another home right now."));
             }
@@ -349,6 +356,78 @@ public class HomeMenu extends BaseMenu {
 
     private String defaultHomeName(int index) {
         return index == 0 ? "home" : "home" + (index + 1);
+    }
+
+    private String defaultAvailableHomeName(Player player, int index) {
+        String base = defaultHomeName(index);
+        if (plugin.getHomeManager().getHome(player.getUniqueId(), base) == null) {
+            return base;
+        }
+        int counter = 1;
+        while (true) {
+            String candidate = counter == 1 ? "home" : "home" + counter;
+            if (plugin.getHomeManager().getHome(player.getUniqueId(), candidate) == null) {
+                return candidate;
+            }
+            counter++;
+        }
+    }
+
+    static int parseHomeSlot(String name) {
+        if (name == null || name.isBlank()) {
+            return -1;
+        }
+        String trimmed = name.trim();
+        if (trimmed.equalsIgnoreCase("home")) {
+            return 0;
+        }
+        if (trimmed.regionMatches(true, 0, "home", 0, 4)) {
+            String suffix = trimmed.substring(4);
+            try {
+                int number = Integer.parseInt(suffix);
+                if (number >= 1) {
+                    return number - 1;
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        try {
+            int number = Integer.parseInt(trimmed);
+            if (number >= 1) {
+                return number - 1;
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        return -1;
+    }
+
+    static Map<Integer, Home> resolveHomeSlots(List<Home> homes) {
+        Map<Integer, Home> slotMap = new HashMap<>();
+        if (homes == null || homes.isEmpty()) {
+            return slotMap;
+        }
+
+        List<Home> unassigned = new ArrayList<>();
+        for (Home home : homes) {
+            if (home == null) continue;
+            int slot = parseHomeSlot(home.getName());
+            if (slot >= 0 && !slotMap.containsKey(slot)) {
+                slotMap.put(slot, home);
+            } else {
+                unassigned.add(home);
+            }
+        }
+
+        int nextSlot = 0;
+        for (Home home : unassigned) {
+            while (slotMap.containsKey(nextSlot)) {
+                nextSlot++;
+            }
+            slotMap.put(nextSlot, home);
+            nextSlot++;
+        }
+
+        return slotMap;
     }
 
     private String friendlyWorldName(Location location) {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/HomeMenuSlotResolutionTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/HomeMenuSlotResolutionTest.java
@@ -1,0 +1,125 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.models.Home;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HomeMenuSlotResolutionTest {
+
+    private final UUID playerUuid = UUID.randomUUID();
+
+    @Test
+    void parseHomeSlotHandlesStandardAliases() {
+        assertEquals(0, HomeMenu.parseHomeSlot("home"));
+        assertEquals(0, HomeMenu.parseHomeSlot("Home"));
+        assertEquals(0, HomeMenu.parseHomeSlot("HOME"));
+        assertEquals(0, HomeMenu.parseHomeSlot("home1"));
+        assertEquals(0, HomeMenu.parseHomeSlot("Home1"));
+        assertEquals(0, HomeMenu.parseHomeSlot("1"));
+
+        assertEquals(1, HomeMenu.parseHomeSlot("home2"));
+        assertEquals(1, HomeMenu.parseHomeSlot("Home2"));
+        assertEquals(1, HomeMenu.parseHomeSlot("2"));
+
+        assertEquals(2, HomeMenu.parseHomeSlot("home3"));
+        assertEquals(4, HomeMenu.parseHomeSlot("home5"));
+        assertEquals(9, HomeMenu.parseHomeSlot("home10"));
+    }
+
+    @Test
+    void parseHomeSlotRejectsNonNumberedOrInvalidNames() {
+        assertEquals(-1, HomeMenu.parseHomeSlot("base"));
+        assertEquals(-1, HomeMenu.parseHomeSlot("farm"));
+        assertEquals(-1, HomeMenu.parseHomeSlot("homestead"));
+        assertEquals(-1, HomeMenu.parseHomeSlot("home0"));
+        assertEquals(-1, HomeMenu.parseHomeSlot("0"));
+        assertEquals(-1, HomeMenu.parseHomeSlot("-1"));
+        assertEquals(-1, HomeMenu.parseHomeSlot(null));
+        assertEquals(-1, HomeMenu.parseHomeSlot("   "));
+    }
+
+    @Test
+    void emptyHomesReturnsEmptyMap() {
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of());
+        assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void sequentialHomesMapToSequentialSlots() {
+        Home h1 = new Home(playerUuid, "home", null, 100L);
+        Home h2 = new Home(playerUuid, "home2", null, 200L);
+        Home h3 = new Home(playerUuid, "home3", null, 300L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(h1, h2, h3));
+
+        assertEquals(h1, resolved.get(0));
+        assertEquals(h2, resolved.get(1));
+        assertEquals(h3, resolved.get(2));
+    }
+
+    @Test
+    void creatingHome2WithoutHome1StaysInSlot2() {
+        Home h2 = new Home(playerUuid, "home2", null, 100L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(h2));
+
+        assertNull(resolved.get(0), "Slot 1 should remain empty");
+        assertEquals(h2, resolved.get(1), "Home 2 should be in slot index 1");
+        assertNull(resolved.get(2), "Slot 3 should remain empty");
+    }
+
+    @Test
+    void deletingMiddleHomeLeavesSlotEmptyWithoutMovingSubsequentHomes() {
+        Home h1 = new Home(playerUuid, "home", null, 100L);
+        Home h3 = new Home(playerUuid, "home3", null, 300L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(h1, h3));
+
+        assertEquals(h1, resolved.get(0), "Home 1 should remain in slot index 0");
+        assertNull(resolved.get(1), "Slot index 1 (Home 2) should be empty");
+        assertEquals(h3, resolved.get(2), "Home 3 should stay in slot index 2");
+    }
+
+    @Test
+    void customNamedHomesFillLowestUnclaimedSlots() {
+        Home farm = new Home(playerUuid, "farm", null, 100L);
+        Home base = new Home(playerUuid, "base", null, 200L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(farm, base));
+
+        assertEquals(farm, resolved.get(0));
+        assertEquals(base, resolved.get(1));
+    }
+
+    @Test
+    void mixedCustomAndNumberedHomesPreserveExplicitSlots() {
+        Home h1 = new Home(playerUuid, "home", null, 100L);
+        Home h3 = new Home(playerUuid, "home3", null, 200L);
+        Home farm = new Home(playerUuid, "farm", null, 300L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(h1, h3, farm));
+
+        assertEquals(h1, resolved.get(0), "Home 1 should be in slot 0");
+        assertEquals(farm, resolved.get(1), "Farm should take the lowest unclaimed slot (slot 1)");
+        assertEquals(h3, resolved.get(2), "Home 3 should stay in slot 2");
+    }
+
+    @Test
+    void multipleHomesTargetingSameSlotDoNotCollideOrOverwrite() {
+        Home h2Named = new Home(playerUuid, "home2", null, 100L);
+        Home h2Number = new Home(playerUuid, "2", null, 200L);
+
+        Map<Integer, Home> resolved = HomeMenu.resolveHomeSlots(List.of(h2Named, h2Number));
+
+        assertEquals(2, resolved.size());
+        assertEquals(h2Named, resolved.get(1));
+        assertEquals(h2Number, resolved.get(0), "Second home should be placed into next free slot");
+    }
+}


### PR DESCRIPTION
Closes #435

The `/homes` inventory GUI previously assumed saved homes were stored contiguously starting at index zero, mapping `homes.get(globalIndex)` straight to slot `globalIndex`. When someone deleted a home or created one out of sequential order like setting Home 2 before Home 1, remaining homes shifted left into earlier columns. That left an empty button suggesting a name that was already taken by the shifted home, so clicking it either failed with an error or overwrote an existing position. This change resolves homes to their respective slot numbers and falls back to the lowest free slot for custom-named homes, preventing duplicate numbers and letting players set homes in arbitrary slots.

## Home slot resolution
`HomeMenu` now parses the slot number from names like `home`, `home2`, or numeric aliases, pinning them to their matching menu column. Custom-named homes claim the lowest unclaimed slot in creation order. Empty slots suggest their standard default name, falling back to the lowest free numbered candidate if that name was taken by a custom home.

## Bedrock form defaults
`HomeBedrockManager` used the total home count to construct the new home name in `openCreateForm`. If a player had two homes after deleting their second one, it suggested `home3`, which was already saved. It now scans for the lowest available home name instead of deriving it from count alone.

## Notes
- No new configuration or message keys were added.
- Existing tests in `HomeDeleteConfirmationTest` and `HomePermissionTest` remain green.
- Added 9 unit tests in `HomeMenuSlotResolutionTest` covering name parsing, sequential layouts, gap handling after deletion, and custom name slot assignments.
- Full test suite passed with 703 tests.
