### PR TITLE
fix(spawners): live refresh main menu and compute fill percentage from all drops (#433)

### DIFF
--- a/docs/wiki/Crates-and-Spawners.md
+++ b/docs/wiki/Crates-and-Spawners.md
@@ -30,6 +30,7 @@ UltimateDonutSMP includes custom mob spawners engineered for high-performance mo
 - **Spawner Stacking**: Place matching spawners onto an existing spawner to stack them (e.g., `x64 Pig Spawner`).
 - **Upgrade System**: Upgrade spawner rate, spawn count, and mob drop multipliers via GUI.
 - **Grouped Loot Storage**: Drops collect with each item type kept together in one run, so a skeleton spawner shows all of its arrows and then all of its bones instead of alternating the two down every page. Storage that filled up before this landed is tidied the next time the spawner produces anything.
+- **Live Menu Refresh**: The spawner main menu and storage views refresh automatically in the background while open, updating stored item counts, fill percentage, and stored XP live without needing to close and reopen the menu.
 - **Break Safeguards**: Requires Silk Touch or admin bypass permissions to break stacked spawners without losing count. Creative mode is exempt from that requirement, and a spawner broken in Creative is removed instead of being handed back, matching the way placing one in Creative costs nothing.
 
 ### Player Spawner Commands (`/spawner`):

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/SpawnerManager.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.managers;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import com.bx.ultimateDonutSmp.menus.SpawnerMainMenu;
 import com.bx.ultimateDonutSmp.menus.SpawnerPanelMenu;
 import com.bx.ultimateDonutSmp.menus.SpawnerStorageMenu;
 import com.bx.ultimateDonutSmp.menus.SpawnerWorldListMenu;
@@ -91,6 +92,7 @@ public class SpawnerManager {
     private final Set<Long> temporarySpawnerIds = new HashSet<>();
     private final Map<Long, List<SpawnerLootEntry>> pendingLootMap = new java.util.concurrent.ConcurrentHashMap<>();
     private final Map<UUID, SpawnerStorageMenu> openStorageMenus = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Map<UUID, SpawnerMainMenu> openMainMenus = new java.util.concurrent.ConcurrentHashMap<>();
     private boolean serverWipeMode;
     private boolean enabled;
     private boolean xpEnabled;
@@ -1292,6 +1294,64 @@ public class SpawnerManager {
                 }
             });
         }
+    }
+
+    public void registerOpenMainMenu(Player player, SpawnerMainMenu menu) {
+        if (player == null || menu == null) {
+            return;
+        }
+        openMainMenus.put(player.getUniqueId(), menu);
+    }
+
+    public void unregisterOpenMainMenu(Player player, SpawnerMainMenu menu) {
+        if (player == null || menu == null) {
+            return;
+        }
+        openMainMenus.remove(player.getUniqueId(), menu);
+    }
+
+    public void refreshOpenMainMenus() {
+        if (openMainMenus.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<UUID, SpawnerMainMenu> entry : openMainMenus.entrySet()) {
+            Player player = Bukkit.getPlayer(entry.getKey());
+            if (player == null || !player.isOnline()) {
+                openMainMenus.remove(entry.getKey(), entry.getValue());
+                continue;
+            }
+
+            SpawnerMainMenu menu = entry.getValue();
+            plugin.getSpigotScheduler().runEntity(player, () -> {
+                if (player.isOnline()) {
+                    menu.refresh(player);
+                }
+            });
+        }
+    }
+
+    public long getTotalStorageCapacity(SpawnerInstance instance) {
+        if (instance == null) {
+            return storageCapPerLootKey;
+        }
+        SpawnerTypeDefinition def = getTypeDefinition(instance.getMobTypeKey());
+        return calculateTotalStorageCapacity(def, instance.getDisabledLootKeys(), storageCapPerLootKey);
+    }
+
+    public static long calculateTotalStorageCapacity(SpawnerTypeDefinition def, Set<String> disabledKeys, long storageCapPerLootKey) {
+        long baseCap = Math.max(1L, storageCapPerLootKey);
+        if (def == null || def.drops().isEmpty()) {
+            return baseCap;
+        }
+        long enabledCount = def.drops().stream()
+                .filter(drop -> disabledKeys == null || (!disabledKeys.contains(drop.key().toUpperCase(Locale.US))
+                        && !disabledKeys.contains(drop.material().name())))
+                .count();
+        if (enabledCount <= 0L) {
+            enabledCount = def.drops().size();
+        }
+        return enabledCount * baseCap;
     }
 
     private void processSpawnerGeneration(SpawnerInstance instance, long now, long intervalMillis) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerMainMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SpawnerMainMenu.java
@@ -29,6 +29,30 @@ public class SpawnerMainMenu extends BaseMenu {
     }
 
     @Override
+    public void open(Player player) {
+        super.open(player);
+        plugin.getSpawnerManager().registerOpenMainMenu(player, this);
+    }
+
+    @Override
+    public void onClose(Player player) {
+        plugin.getSpawnerManager().unregisterOpenMainMenu(player, this);
+    }
+
+    public void refresh(Player player) {
+        if (player == null || inventory == null) {
+            return;
+        }
+        SpawnerInstance instance = plugin.getSpawnerManager().getSpawner(spawnerId);
+        if (instance == null) {
+            player.closeInventory();
+            return;
+        }
+        renderDynamicButtons(instance);
+        player.updateInventory();
+    }
+
+    @Override
     public void build(Player player) {
         SpawnerInstance instance = plugin.getSpawnerManager().getSpawner(spawnerId);
         if (instance == null) {
@@ -48,6 +72,12 @@ public class SpawnerMainMenu extends BaseMenu {
         Material fillerMat = Material.matchMaterial(fillerMatName);
         if (fillerMat == null) fillerMat = Material.GRAY_STAINED_GLASS_PANE;
         fill(fillerMat);
+
+        renderDynamicButtons(instance);
+    }
+
+    private void renderDynamicButtons(SpawnerInstance instance) {
+        FileConfiguration config = plugin.getConfigManager().getMenus();
 
         // 1. Spawner Storage Button
         int storageSlot = config.getInt("SPAWNER-MENUS.MAIN-MENU.STORAGE-BUTTON.SLOT", 11);
@@ -103,9 +133,10 @@ public class SpawnerMainMenu extends BaseMenu {
 
         // 2. Mob Head Button (Spawner Count & Quick Sell)
         int headSlot = config.getInt("SPAWNER-MENUS.MAIN-MENU.MOB-HEAD-BUTTON.SLOT", 13);
-        long totalCapacity = plugin.getSpawnerManager().getStorageCapPerLootKey();
+        long totalCapacity = plugin.getSpawnerManager().getTotalStorageCapacity(instance);
         long currentTotal = instance.getTotalStoredItems();
-        double fillPercentage = totalCapacity > 0 ? Math.min(100.0, (currentTotal / (double) totalCapacity) * 100.0) : 0.0;
+        double fillPercentage = calculateFillPercentage(currentTotal, totalCapacity);
+        String formattedPercentage = formatFillPercentage(fillPercentage);
         String mobLabel = instance.getMobTypeKey().replace('_', ' ').toUpperCase();
 
         SpawnerTypeDefinition def = plugin.getSpawnerManager().getTypeDefinition(instance.getMobTypeKey());
@@ -119,11 +150,11 @@ public class SpawnerMainMenu extends BaseMenu {
         List<String> headLore = new ArrayList<>();
         if (rawHeadLore.isEmpty()) {
             headLore.add("&e• &fClick to sell items and collect xp");
-            headLore.add("&7Storage: &e" + String.format(java.util.Locale.US, "%.1f", fillPercentage) + "% Filled.");
+            headLore.add("&7Storage: &e" + formattedPercentage + "% Filled.");
         } else {
             for (String line : rawHeadLore) {
                 headLore.add(line
-                        .replace("{percentage}", String.format(java.util.Locale.US, "%.1f", fillPercentage))
+                        .replace("{percentage}", formattedPercentage)
                         .replace("{stack}", NumberUtils.format(instance.getStackAmount()))
                         .replace("{mob}", mobLabel));
             }
@@ -141,8 +172,8 @@ public class SpawnerMainMenu extends BaseMenu {
         boolean xpButtonEnabled = plugin.getSpawnerManager().isXpEnabled()
                 && config.getBoolean("SPAWNER-MENUS.MAIN-MENU.COLLECT-XP-BUTTON.ENABLED", true);
 
+        int xpSlot = config.getInt("SPAWNER-MENUS.MAIN-MENU.COLLECT-XP-BUTTON.SLOT", 15);
         if (xpButtonEnabled) {
-            int xpSlot = config.getInt("SPAWNER-MENUS.MAIN-MENU.COLLECT-XP-BUTTON.SLOT", 15);
             String xpMatName = config.getString("SPAWNER-MENUS.MAIN-MENU.COLLECT-XP-BUTTON.MATERIAL", "EXPERIENCE_BOTTLE");
             Material xpMat = Material.matchMaterial(xpMatName);
             if (xpMat == null) xpMat = Material.EXPERIENCE_BOTTLE;
@@ -162,7 +193,23 @@ public class SpawnerMainMenu extends BaseMenu {
             }
 
             set(xpSlot, ItemUtils.createItem(xpMat, xpTitle, xpLore));
+        } else {
+            String fillerMatName = config.getString("SPAWNER-MENUS.MAIN-MENU.FILLER-MATERIAL", "GRAY_STAINED_GLASS_PANE");
+            Material fillerMat = Material.matchMaterial(fillerMatName);
+            if (fillerMat == null) fillerMat = Material.GRAY_STAINED_GLASS_PANE;
+            set(xpSlot, ItemUtils.createItem(fillerMat, " "));
         }
+    }
+
+    static double calculateFillPercentage(long currentTotal, long totalCapacity) {
+        if (totalCapacity <= 0L || currentTotal <= 0L) {
+            return 0.0;
+        }
+        return Math.min(100.0, (currentTotal / (double) totalCapacity) * 100.0);
+    }
+
+    static String formatFillPercentage(double fillPercentage) {
+        return String.format(java.util.Locale.US, "%.1f", fillPercentage);
     }
 
     @Override

--- a/src/main/java/com/bx/ultimateDonutSmp/tasks/SpawnerGenerationTask.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/tasks/SpawnerGenerationTask.java
@@ -16,10 +16,11 @@ public class SpawnerGenerationTask implements Runnable {
         long periodTicks = Math.max(20L, configuredSeconds * 20L);
         plugin.getSpigotScheduler().runGlobalTimer(new SpawnerGenerationTask(plugin), periodTicks, periodTicks);
 
-        // 1-second auto-refresh task for open Spawner Storage GUI windows
+        // 1-second auto-refresh task for open Spawner GUI windows (storage and main menu)
         plugin.getSpigotScheduler().runGlobalTimer(() -> {
             if (plugin.getSpawnerManager() != null && plugin.getSpawnerManager().isEnabled()) {
                 plugin.getSpawnerManager().refreshOpenStorageMenus();
+                plugin.getSpawnerManager().refreshOpenMainMenus();
             }
         }, 20L, 20L);
     }

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SpawnerMainMenuCapacityTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SpawnerMainMenuCapacityTest.java
@@ -1,0 +1,119 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import com.bx.ultimateDonutSmp.managers.SpawnerManager;
+import com.bx.ultimateDonutSmp.models.SpawnerTypeDefinition;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpawnerMainMenuCapacityTest {
+
+    @Test
+    void emptySpawnerStorageYieldsZeroPercent() {
+        assertEquals(0.0, SpawnerMainMenu.calculateFillPercentage(0L, 1000L));
+        assertEquals("0.0", SpawnerMainMenu.formatFillPercentage(0.0));
+    }
+
+    @Test
+    void halfFullStorageYieldsFiftyPercent() {
+        assertEquals(50.0, SpawnerMainMenu.calculateFillPercentage(500L, 1000L));
+        assertEquals("50.0", SpawnerMainMenu.formatFillPercentage(50.0));
+    }
+
+    @Test
+    void completelyFullStorageDisplaysHundredPercent() {
+        assertEquals(100.0, SpawnerMainMenu.calculateFillPercentage(1000L, 1000L));
+        assertEquals("100.0", SpawnerMainMenu.formatFillPercentage(100.0));
+    }
+
+    @Test
+    void overCapacityStorageIsClampedAtHundredPercent() {
+        assertEquals(100.0, SpawnerMainMenu.calculateFillPercentage(2500L, 1000L));
+        assertEquals("100.0", SpawnerMainMenu.formatFillPercentage(100.0));
+    }
+
+    @Test
+    void zeroOrNegativeCapacitySafelyYieldsZeroPercent() {
+        assertEquals(0.0, SpawnerMainMenu.calculateFillPercentage(100L, 0L));
+        assertEquals(0.0, SpawnerMainMenu.calculateFillPercentage(100L, -50L));
+        assertEquals(0.0, SpawnerMainMenu.calculateFillPercentage(-10L, 100L));
+    }
+
+    @Test
+    void capacityCalculationAccountsForEveryEnabledDrop() {
+        SpawnerTypeDefinition ironGolem = new SpawnerTypeDefinition(
+                "IRON_GOLEM",
+                "Iron Golem",
+                EntityType.IRON_GOLEM,
+                Material.IRON_INGOT,
+                1L,
+                3.7,
+                null,
+                List.of(
+                        new SpawnerTypeDefinition.DropDefinition("IRON_INGOT", Material.IRON_INGOT, 3, 5, 1.0),
+                        new SpawnerTypeDefinition.DropDefinition("POPPY", Material.POPPY, 0, 2, 0.45)
+                )
+        );
+
+        // 2 active drops with 10,000 cap per loot key = 20,000 total capacity
+        long twoDropsCapacity = SpawnerManager.calculateTotalStorageCapacity(ironGolem, Set.of(), 10_000L);
+        assertEquals(20_000L, twoDropsCapacity);
+
+        // When storage reaches 20,000 items, fill percentage is 100.0%
+        double fillPercentage = SpawnerMainMenu.calculateFillPercentage(20_000L, twoDropsCapacity);
+        assertEquals(100.0, fillPercentage);
+        assertEquals("100.0", SpawnerMainMenu.formatFillPercentage(fillPercentage));
+    }
+
+    @Test
+    void disabledDropsReduceTotalCapacityAccordingly() {
+        SpawnerTypeDefinition ironGolem = new SpawnerTypeDefinition(
+                "IRON_GOLEM",
+                "Iron Golem",
+                EntityType.IRON_GOLEM,
+                Material.IRON_INGOT,
+                1L,
+                3.7,
+                null,
+                List.of(
+                        new SpawnerTypeDefinition.DropDefinition("IRON_INGOT", Material.IRON_INGOT, 3, 5, 1.0),
+                        new SpawnerTypeDefinition.DropDefinition("POPPY", Material.POPPY, 0, 2, 0.45)
+                )
+        );
+
+        // Poppy disabled -> only Iron Ingot counts towards capacity (10,000 items)
+        long singleDropCapacity = SpawnerManager.calculateTotalStorageCapacity(ironGolem, Set.of("POPPY"), 10_000L);
+        assertEquals(10_000L, singleDropCapacity);
+
+        // Once Iron Ingot fills 10,000 items, it hits 100.0%
+        double fillPercentage = SpawnerMainMenu.calculateFillPercentage(10_000L, singleDropCapacity);
+        assertEquals(100.0, fillPercentage);
+        assertEquals("100.0", SpawnerMainMenu.formatFillPercentage(fillPercentage));
+    }
+
+    @Test
+    void missingDefinitionOrAllDisabledDropsFallBackSafely() {
+        long fallback = SpawnerManager.calculateTotalStorageCapacity(null, Set.of(), 5_000L);
+        assertEquals(5_000L, fallback);
+
+        SpawnerTypeDefinition singleDrop = new SpawnerTypeDefinition(
+                "BLAZE",
+                "Blaze",
+                EntityType.BLAZE,
+                Material.BLAZE_ROD,
+                1L,
+                3.7,
+                null,
+                List.of(new SpawnerTypeDefinition.DropDefinition("BLAZE_ROD", Material.BLAZE_ROD, 1, 1, 1.0))
+        );
+
+        // Even if all drops are disabled in filter, capacity falls back to definition size rather than zero
+        long allDisabled = SpawnerManager.calculateTotalStorageCapacity(singleDrop, Set.of("BLAZE_ROD"), 5_000L);
+        assertEquals(5_000L, allDisabled);
+    }
+}


### PR DESCRIPTION
Closes #433

The middle button in the spawner main menu kept showing \