### PR TITLE
feat(fakeplayer): force the default Steve or Alex skin (#444)

### DIFF
--- a/docs/wiki/Config-staff-mode.yml.md
+++ b/docs/wiki/Config-staff-mode.yml.md
@@ -742,3 +742,31 @@ MESSAGES:
 
 ---
 
+## Section: `FAKE-PLAYER`
+
+`/fakeplayer` copies the staff member's skin unless this is turned on. Minecraft then picks Steve or Alex from the bait's UUID, the same way it does for any player with no custom skin.
+
+### 1. Commented Setup Code Example
+
+```yaml
+FAKE-PLAYER:
+  # When true, /fakeplayer uses Minecraft's default Steve/Alex skin instead of the staff member's.
+  # Available options: true, false
+  USE-DEFAULT-SKIN: false
+```
+
+### 2. Key Options & Technical Breakdown
+
+| Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
+| :--- | :--- | :--- | :--- | :--- |
+| `FAKE-PLAYER.USE-DEFAULT-SKIN` | `bool` | `true`, `false` | `false` | When `true`, every `/fakeplayer` bait uses Minecraft's default Steve or Alex skin. When `false`, the bait copies the staff member who ran the command. |
+
+### 3. Practical Setup Example
+
+```yaml
+FAKE-PLAYER:
+  USE-DEFAULT-SKIN: true
+```
+
+---
+

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -139,8 +139,8 @@ Spawns fake hidden chests populated with high-tier loot under spawn or wild area
 - Alerts staff whenever an x-raying player digs directly to the bait chest.
 - Commands: `/spawnstash setup`, `/spawnstash list`, `/spawnstash give`.
 
-### 2. Fake Player Bait
-Generates invisible fake player entities around players suspected of using KillAura or Auto-Clickers.
+### 2. Fake Player Bait (`/fakeplayer`)
+Spawns a short-lived player bait at your feet. It copies your skin unless `FAKE-PLAYER.USE-DEFAULT-SKIN` is `true` in `staff-mode.yml`, in which case every bait uses Minecraft's default Steve or Alex skin.
 
 ### 3. Spawner Anti-ESP
 Hides spawner block packet data from players beyond visual raycast distance to prevent X-Ray / ESP client hacks from discovering spawner coordinates.

--- a/src/main/java/com/bx/ultimateDonutSmp/commands/FakePlayerCommand.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/commands/FakePlayerCommand.java
@@ -44,10 +44,12 @@ public class FakePlayerCommand implements CommandExecutor {
             return true;
         }
 
-        send(sender, manager.publicMessage(
-                "SKIN-LOOKUP",
-                "&7checking skin data..."
-        ));
+        if (!manager.usesDefaultSkin()) {
+            send(sender, manager.publicMessage(
+                    "SKIN-LOOKUP",
+                    "&7checking skin data..."
+            ));
+        }
         manager.spawnAsync(player, result -> send(sender, result.message()));
         return true;
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
@@ -2,6 +2,7 @@ package com.bx.ultimateDonutSmp.managers;
 
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
+import com.bx.ultimateDonutSmp.utils.FakePlayerSkinPolicy;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -67,6 +68,7 @@ public class FakePlayerManager {
     private boolean logToConsole;
     private boolean hideFromTablist;
     private SkinSourceMode skinSourceMode;
+    private boolean useDefaultSkin;
     private boolean lockAirPosition;
     private boolean simulatePhysics;
     private boolean hitResponseEnabled;
@@ -120,12 +122,16 @@ public class FakePlayerManager {
         return val;
     }
 
-    public SpawnResult spawn(Player creator) {
-        return spawnWithTexture(creator, null);
+    public boolean usesDefaultSkin() {
+        return useDefaultSkin;
     }
 
-    private SpawnResult spawnWithTexture(Player creator, TablistManager.SkinTexture skinTexture) {
-        return spawnWithTexture(creator, skinTexture, configBoolean("REQUIRE-SKIN-TEXTURE", true));
+    public SpawnResult spawn(Player creator) {
+        return spawnWithTexture(
+                creator,
+                null,
+                FakePlayerSkinPolicy.requireCreatorSkinTexture(
+                        useDefaultSkin, configBoolean("REQUIRE-SKIN-TEXTURE", true)));
     }
 
     private SpawnResult spawnWithTexture(
@@ -200,12 +206,18 @@ public class FakePlayerManager {
             return;
         }
 
-        boolean requireSkinTexture = configBoolean("REQUIRE-SKIN-TEXTURE", true);
-
         if (creator == null || !isAvailable() || !isEnabled()) {
             callback.accept(spawn(creator));
             return;
         }
+
+        if (!FakePlayerSkinPolicy.shouldCopyCreatorSkin(useDefaultSkin)) {
+            callback.accept(spawnWithTexture(creator, null, false));
+            return;
+        }
+
+        boolean requireSkinTexture = FakePlayerSkinPolicy.requireCreatorSkinTexture(
+                useDefaultSkin, configBoolean("REQUIRE-SKIN-TEXTURE", true));
 
         UUID creatorId = creator.getUniqueId();
         String creatorName = creator.getName();
@@ -336,6 +348,7 @@ public class FakePlayerManager {
         }
         logToConsole = configBoolean("LOG-TO-CONSOLE", true);
         skinSourceMode = SkinSourceMode.fromConfig(configString("SKIN-SOURCE-MODE", "AUTO"));
+        useDefaultSkin = configBoolean("USE-DEFAULT-SKIN", false);
         simulatePhysics = configBoolean("SIMULATE-PHYSICS", true);
         lockAirPosition = configBoolean("LOCK-AIR-POSITION", false) && !simulatePhysics;
         hitResponseEnabled = configBoolean("HIT-RESPONSE.ENABLED", true);

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/FakePlayerSkinPolicy.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/FakePlayerSkinPolicy.java
@@ -1,0 +1,22 @@
+package com.bx.ultimateDonutSmp.utils;
+
+/**
+ * Decides whether a fakeplayer copies the staff member who spawned it, or uses Minecraft's default
+ * Steve/Alex skin.
+ *
+ * <p>{@code REQUIRE-SKIN-TEXTURE} is a gate on copying that skin. It has nothing to copy when the
+ * server asked for the default look, so it must not refuse the spawn in that case.
+ */
+public final class FakePlayerSkinPolicy {
+
+    private FakePlayerSkinPolicy() {
+    }
+
+    public static boolean shouldCopyCreatorSkin(boolean useDefaultSkin) {
+        return !useDefaultSkin;
+    }
+
+    public static boolean requireCreatorSkinTexture(boolean useDefaultSkin, boolean requireSkinTexture) {
+        return shouldCopyCreatorSkin(useDefaultSkin) && requireSkinTexture;
+    }
+}

--- a/src/main/resources/staff-mode.yml
+++ b/src/main/resources/staff-mode.yml
@@ -270,3 +270,7 @@ MESSAGES:
   CUSTOM-ITEM-NO-TARGET: '&cRight-click a player to use this tool.'
   # The text or value for Reload Success. Available options: Any valid string text
   RELOAD-SUCCESS: '&aStaff mode config reloaded.'
+FAKE-PLAYER:
+  # When true, /fakeplayer uses Minecraft's default Steve/Alex skin instead of the staff member's.
+  # Available options: true, false
+  USE-DEFAULT-SKIN: false

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/FakePlayerSkinPolicyTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/FakePlayerSkinPolicyTest.java
@@ -1,0 +1,40 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FakePlayerSkinPolicyTest {
+
+    @Test
+    void stockSettingsStillCopyTheStaffMember() {
+        assertTrue(FakePlayerSkinPolicy.shouldCopyCreatorSkin(false));
+        assertTrue(FakePlayerSkinPolicy.requireCreatorSkinTexture(false, true));
+    }
+
+    @Test
+    void forcingTheDefaultSkinSkipsTheCreatorAndTheTextureGate() {
+        assertFalse(FakePlayerSkinPolicy.shouldCopyCreatorSkin(true));
+        assertFalse(FakePlayerSkinPolicy.requireCreatorSkinTexture(true, true));
+        assertFalse(FakePlayerSkinPolicy.requireCreatorSkinTexture(true, false));
+    }
+
+    @Test
+    void theTextureGateStillAppliesWhenTheCreatorSkinIsWanted() {
+        assertFalse(FakePlayerSkinPolicy.requireCreatorSkinTexture(false, false));
+        assertTrue(FakePlayerSkinPolicy.requireCreatorSkinTexture(false, true));
+    }
+
+    @Test
+    void bundledStaffModeLeavesCreatorSkinsOn() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "staff-mode.yml").toFile());
+
+        assertFalse(config.getBoolean("FAKE-PLAYER.USE-DEFAULT-SKIN", true),
+                "staff-mode.yml must ship USE-DEFAULT-SKIN as false so a config restore keeps copying the staff member");
+    }
+}


### PR DESCRIPTION
Closes #444

/fakeplayer copied the staff member who ran it, and there was no switch for the default Steve/Alex look. REQUIRE-SKIN-TEXTURE only refused a spawn when that copied skin wasn't ready; if the skin was there, the bait still looked like you. FAKE-PLAYER.USE-DEFAULT-SKIN in staff-mode.yml is the switch. Leave it false and the old behaviour stays. Set it true and the bait is created with no skin texture, so Minecraft draws Steve or Alex from the UUID.

## Why a boolean instead of a new SKIN-SOURCE-MODE
SKIN-SOURCE-MODE is where we fetch the staff member's skin from (SkinsRestorer, GameProfile, auto). Putting "don't copy anyone" into that list mixes two different questions. A boolean next to REQUIRE-SKIN-TEXTURE is the thing people will look for. I also skipped a Steve-or-Alex picker. The report asked for the player's skin versus a default skin, and the client already picks Steve or Alex from the UUID when the profile has no textures.

## Notes
Key: `FAKE-PLAYER.USE-DEFAULT-SKIN`, default `false`. No language file changes. 719 tests, including FakePlayerSkinPolicyTest for the texture-gate interaction.
