### PR TITLE
feat(fakeplayer): hide nametag and money text above bait (#444)

### DIFF
--- a/docs/wiki/Config-staff-mode.yml.md
+++ b/docs/wiki/Config-staff-mode.yml.md
@@ -753,6 +753,9 @@ FAKE-PLAYER:
   # When true, /fakeplayer uses Minecraft's default Steve/Alex skin instead of the staff member's.
   # Available options: true, false
   USE-DEFAULT-SKIN: false
+  # When true, /fakeplayer does not copy the staff member's username, so prefix, suffix, and money text stay off the head.
+  # Available options: true, false
+  HIDE-NAMETAG: true
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -760,12 +763,14 @@ FAKE-PLAYER:
 | Option / Key Path | Data Type | Allowed Values | Default | Technical Function & Setup Guide |
 | :--- | :--- | :--- | :--- | :--- |
 | `FAKE-PLAYER.USE-DEFAULT-SKIN` | `bool` | `true`, `false` | `false` | When `true`, every `/fakeplayer` bait uses Minecraft's default Steve or Alex skin. When `false`, the bait copies the staff member who ran the command. |
+| `FAKE-PLAYER.HIDE-NAMETAG` | `bool` | `true`, `false` | `true` | When `true`, `/fakeplayer` does not copy the staff member's username, so LuckPerms prefix/suffix and below-name money stay off the bait. Set `false` if you want the old labeled look. |
 
 ### 3. Practical Setup Example
 
 ```yaml
 FAKE-PLAYER:
   USE-DEFAULT-SKIN: true
+  HIDE-NAMETAG: true
 ```
 
 ---

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -140,7 +140,7 @@ Spawns fake hidden chests populated with high-tier loot under spawn or wild area
 - Commands: `/spawnstash setup`, `/spawnstash list`, `/spawnstash give`.
 
 ### 2. Fake Player Bait (`/fakeplayer`)
-Spawns a short-lived player bait at your feet. It copies your skin unless `FAKE-PLAYER.USE-DEFAULT-SKIN` is `true` in `staff-mode.yml`, in which case every bait uses Minecraft's default Steve or Alex skin.
+Spawns a short-lived player bait at your feet. It copies your skin unless `FAKE-PLAYER.USE-DEFAULT-SKIN` is `true` in `staff-mode.yml`, in which case every bait uses Minecraft's default Steve or Alex skin. `HIDE-NAMETAG: true` (the bundled default) keeps prefix, name, and money text off the bait's head.
 
 ### 3. Spawner Anti-ESP
 Hides spawner block packet data from players beyond visual raycast distance to prevent X-Ray / ESP client hacks from discovering spawner coordinates.

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
@@ -67,6 +67,7 @@ public class FakePlayerManager {
     private long tablistRemoveDelayTicks;
     private boolean logToConsole;
     private boolean hideFromTablist;
+    private boolean hideNametag;
     private SkinSourceMode skinSourceMode;
     private boolean useDefaultSkin;
     private boolean lockAirPosition;
@@ -160,7 +161,7 @@ public class FakePlayerManager {
         UUID textureProfileUuid = extractTextureProfileUuid(skinTexture);
         UUID fakeUuid = resolveFakeUuid(textureProfileUuid);
         String displayName = resolveDisplayName(creator);
-        String profileName = resolveProfileName(creator, displayName);
+        String profileName = resolveProfileName(creator, displayName, fakeUuid);
         Object profile = skinTexture != null && skinTexture.isValid()
                 ? packetBridge.createProfile(creator, fakeUuid, profileName, skinTexture)
                 : packetBridge.createProfile(requireSkinTexture ? creator : null, fakeUuid, profileName);
@@ -342,6 +343,7 @@ public class FakePlayerManager {
         checkIntervalTicks = Math.max(1L, configLong("CHECK-INTERVAL-TICKS", 5L));
         alertCooldownMillis = Math.max(1L, configLong("ALERT-COOLDOWN-SECONDS", 30L)) * 1000L;
         hideFromTablist = configBoolean("HIDE-FROM-TABLIST", true);
+        hideNametag = configBoolean("HIDE-NAMETAG", true);
         tablistRemoveDelayTicks = Math.max(0L, configLong("TABLIST-REMOVE-DELAY-TICKS", hideFromTablist ? 5L : 200L));
         if (hideFromTablist) {
             tablistRemoveDelayTicks = Math.min(tablistRemoveDelayTicks, 5L);
@@ -940,7 +942,10 @@ public class FakePlayerManager {
         return displayName.isBlank() ? player.getName() : displayName;
     }
 
-    private String resolveProfileName(Player player, String displayName) {
+    private String resolveProfileName(Player player, String displayName, UUID fakeUuid) {
+        if (hideNametag) {
+            return hiddenProfileName(fakeUuid);
+        }
         String name = sanitizeProfileName(displayName);
         if (name.isBlank()) {
             name = sanitizeProfileName(player.getName());
@@ -1027,6 +1032,15 @@ public class FakePlayerManager {
                 + " (fakeUuid=" + fakeUuid
                 + ", textureProfileUuid=" + (textureProfileUuid == null ? "none" : textureProfileUuid)
                 + ", uuidSource=" + uuidSource + ").");
+    }
+
+    static String hiddenProfileName(UUID fakeUuid) {
+        String compact = fakeUuid == null ? UUID.randomUUID().toString() : fakeUuid.toString();
+        compact = compact.replace("-", "");
+        if (compact.length() < 14) {
+            compact = (compact + "00000000000000").substring(0, 14);
+        }
+        return ("fp" + compact).substring(0, 16);
     }
 
     private String sanitizeProfileName(String input) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerProtocolLibBridge.java
@@ -12,11 +12,13 @@ import com.comphenix.protocol.events.PacketListener;
 import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.PlayerInfoData;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedDataValue;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.comphenix.protocol.wrappers.WrappedEnumEntityUseAction;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import com.comphenix.protocol.wrappers.WrappedSignedProperty;
+import com.comphenix.protocol.wrappers.WrappedTeamParameters;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -27,10 +29,12 @@ import org.bukkit.util.Vector;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -956,6 +960,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
     @Override
     public void spawn(Player viewer, FakePlayerSession fakePlayer) {
         send(viewer, createPlayerInfoAdd(fakePlayer));
+        sendNametagHideTeam(viewer, fakePlayer);
         long delayTicks = Math.max(0L, plugin.getConfigManager().getStaffMode()
                 .getLong("FAKE-PLAYER.SPAWN-DELAY-TICKS", 20L));
         if (delayTicks <= 0L) {
@@ -974,6 +979,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
     }
 
     private void sendSpawnPackets(Player viewer, FakePlayerSession fakePlayer) {
+        sendNametagHideTeam(viewer, fakePlayer);
         try {
             send(viewer, createSpawnEntity(fakePlayer));
         } catch (RuntimeException error) {
@@ -1001,6 +1007,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
     @Override
     public void destroy(Player viewer, FakePlayerSession fakePlayer) {
         send(viewer, createEntityDestroy(fakePlayer));
+        sendNametagHideTeamRemove(viewer, fakePlayer);
         send(viewer, createPlayerInfoRemove(fakePlayer));
     }
 
@@ -1134,6 +1141,66 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
         );
         writePlayerInfoData(packet, List.of(infoData));
         return packet;
+    }
+
+    private void sendNametagHideTeam(Player viewer, FakePlayerSession fakePlayer) {
+        if (!isHideNametagEnabled() || viewer == null || fakePlayer == null) {
+            return;
+        }
+        try {
+            send(viewer, createNametagHideTeam(fakePlayer));
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to hide fakeplayer nametag.", error);
+        }
+    }
+
+    private void sendNametagHideTeamRemove(Player viewer, FakePlayerSession fakePlayer) {
+        if (!isHideNametagEnabled() || viewer == null || fakePlayer == null) {
+            return;
+        }
+        try {
+            PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.SCOREBOARD_TEAM);
+            packet.getStrings().writeSafely(0, nametagTeamName(fakePlayer.fakeUuid()));
+            packet.getIntegers().writeSafely(0, 1);
+            send(viewer, packet);
+        } catch (RuntimeException | LinkageError error) {
+            plugin.getLogger().log(Level.FINE, "Unable to remove fakeplayer nametag team.", error);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private PacketContainer createNametagHideTeam(FakePlayerSession fakePlayer) {
+        PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.SCOREBOARD_TEAM);
+        String teamName = nametagTeamName(fakePlayer.fakeUuid());
+        packet.getStrings().writeSafely(0, teamName);
+        packet.getIntegers().writeSafely(0, 0);
+
+        WrappedTeamParameters parameters = WrappedTeamParameters.newBuilder()
+                .displayName(WrappedChatComponent.fromText(teamName))
+                .prefix(WrappedChatComponent.fromText(""))
+                .suffix(WrappedChatComponent.fromText(""))
+                .nametagVisibility("never")
+                .collisionRule("always")
+                .color(EnumWrappers.ChatFormatting.WHITE)
+                .options(0)
+                .build();
+        packet.getOptionalTeamParameters().writeSafely(0, Optional.of(parameters));
+
+        StructureModifier<Collection> entries = packet.getSpecificModifier(Collection.class);
+        entries.writeSafely(0, List.of(fakePlayer.profileName()));
+        return packet;
+    }
+
+    private String nametagTeamName(UUID fakeUuid) {
+        String compact = fakeUuid == null ? "00000000000" : fakeUuid.toString().replace("-", "");
+        if (compact.length() < 11) {
+            compact = (compact + "00000000000").substring(0, 11);
+        }
+        return ("udfp_" + compact).substring(0, 16);
+    }
+
+    private boolean isHideNametagEnabled() {
+        return plugin.getConfigManager().getStaffMode().getBoolean("FAKE-PLAYER.HIDE-NAMETAG", true);
     }
 
     private WrappedGameProfile unwrapProfile(Object profile) {
@@ -1535,6 +1602,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
 
         send(viewer, createEntityDestroy(fakePlayer));
         send(viewer, createPlayerInfoAdd(fakePlayer));
+        sendNametagHideTeam(viewer, fakePlayer);
         send(viewer, createSpawnEntity(fakePlayer));
         sendNoGravityMetadata(viewer, fakePlayer);
         sendMetadata(viewer, fakePlayer);

--- a/src/main/resources/staff-mode.yml
+++ b/src/main/resources/staff-mode.yml
@@ -274,3 +274,6 @@ FAKE-PLAYER:
   # When true, /fakeplayer uses Minecraft's default Steve/Alex skin instead of the staff member's.
   # Available options: true, false
   USE-DEFAULT-SKIN: false
+  # When true, /fakeplayer does not copy the staff member's username, so prefix, suffix, and money text stay off the head.
+  # Available options: true, false
+  HIDE-NAMETAG: true

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/FakePlayerNametagTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/FakePlayerNametagTest.java
@@ -1,0 +1,35 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FakePlayerNametagTest {
+
+    @Test
+    void hiddenProfileNameIsUniqueAndLegal() {
+        UUID fakeUuid = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+        String name = FakePlayerManager.hiddenProfileName(fakeUuid);
+
+        assertEquals(16, name.length());
+        assertTrue(name.startsWith("fp"));
+        assertTrue(name.matches("[A-Za-z0-9_]+"));
+        assertEquals(name, FakePlayerManager.hiddenProfileName(fakeUuid));
+        assertNotEquals(name, FakePlayerManager.hiddenProfileName(UUID.randomUUID()));
+    }
+
+    @Test
+    void bundledStaffModeHidesNametagsByDefault() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "staff-mode.yml").toFile());
+
+        assertTrue(config.getBoolean("FAKE-PLAYER.HIDE-NAMETAG", false),
+                "staff-mode.yml must ship HIDE-NAMETAG as true so a config restore keeps prefix and money off the bait");
+    }
+}


### PR DESCRIPTION
Closes #444

/fakeplayer was copying the staff member's username, so rank prefix, [TEST], and the money line showed over the bait the same way they do over the real player. It now keeps that text off the head.

## Nametag

staff-mode.yml has HIDE-NAMETAG, on by default. The spawn message still names the staff member who ran the command. Turn the key off if you want the labeled look back.

## Notes

This is the follow-up from the screenshot on #444, after the default-skin option. Tests cover the unique name and the bundled default.
