### PR TITLE
feat(sell): show the total price on the confirm button (#446)

### DIFF
--- a/docs/wiki/Config-menus.yml.md
+++ b/docs/wiki/Config-menus.yml.md
@@ -1605,6 +1605,11 @@ SELL-MENU:
   MULTIPLIER-TITLE: '&8Sell Multipliers'
   AUTO-SELL: true
   MODE: 'confirm'
+  CONFIRM-BUTTON:
+    MATERIAL: LIME_STAINED_GLASS_PANE
+    TITLE: '&a&lConfirm Sell'
+    LORE:
+    - '&a{price_formatted}'
   CROPS-BUTTON:
     MATERIAL: WHEAT
     TITLE: '&#6BF18DCrops'
@@ -1692,6 +1697,9 @@ SELL-MENU:
 | `SELL-MENU.MULTIPLIER-TITLE` | `str` | Any string text | `'&8Sell Multipliers'` | Configures the technical `MULTIPLIER-TITLE` parameter for `SELL-MENU.MULTIPLIER-TITLE` in `menus.yml`. |
 | `SELL-MENU.MODE` | `str` | `confirm`, `close`, `instant` | `'confirm'` | Decides when the menu takes payment. `confirm` shows the Confirm Sell button and gives items back if the player closes without clicking it. `close` sells the whole grid the moment the menu is shut. `instant` pays out item by item as things land, and still settles whatever is left on close. An unrecognised value falls back to `instant`. |
 | `SELL-MENU.AUTO-SELL` | `bool` | `true`, `false` | `true` | Only applies to `MODE: instant`. Leave it `true` for the item-by-item payout as things land in the grid; set it `false` and instant mode holds everything until the player shuts the menu, the same as `MODE: close`. Both `confirm` and `close` ignore it. |
+| `SELL-MENU.CONFIRM-BUTTON.MATERIAL` | `str` | Any string text | `'LIME_STAINED_GLASS_PANE'` | Item used for the Confirm Sell button in `MODE: confirm`. |
+| `SELL-MENU.CONFIRM-BUTTON.TITLE` | `str` | Any string text | `'&a&lConfirm Sell'` | Name of the Confirm Sell button. `{price}` is the compact total of what is in the grid, `{price_formatted}` is the full money format. |
+| `SELL-MENU.CONFIRM-BUTTON.LORE` | `list` | List of configured items/strings | `['&a{price_formatted}']` | Lore under the Confirm Sell button. It is rewritten as items are added or taken out, using the same `{price}` and `{price_formatted}` placeholders as the title. The total includes sell multipliers. |
 | `SELL-MENU.CROPS-BUTTON.MATERIAL` | `str` | Any string text | `'WHEAT'` | Configures the technical `MATERIAL` parameter for `SELL-MENU.CROPS-BUTTON.MATERIAL` in `menus.yml`. |
 | `SELL-MENU.CROPS-BUTTON.TITLE` | `str` | Any string text | `'&#6BF18DCrops'` | Configures the technical `TITLE` parameter for `SELL-MENU.CROPS-BUTTON.TITLE` in `menus.yml`. |
 | `SELL-MENU.CROPS-BUTTON.LORE` | `list` | List of configured items/strings | `[&7Sell crops and farming materials to, &7upgrade your sell multiplier!, ...]` | Configures the technical `LORE` parameter for `SELL-MENU.CROPS-BUTTON.LORE` in `menus.yml`. |
@@ -1728,6 +1736,11 @@ SELL-MENU:
   MULTIPLIER-TITLE: '&8Sell Multipliers'
   AUTO-SELL: true
   MODE: 'confirm'
+  CONFIRM-BUTTON:
+    MATERIAL: LIME_STAINED_GLASS_PANE
+    TITLE: '&a&lConfirm Sell'
+    LORE:
+    - '&a{price_formatted}'
   CROPS-BUTTON:
     MATERIAL: WHEAT
     TITLE: '&#6BF18DCrops'

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -1622,6 +1622,11 @@ public class ShopManager {
         );
     }
 
+    public double previewInventoryContents(Player player, Inventory inventory, int startInclusive, int endExclusive) {
+        PendingSale sale = collectInventorySale(player, inventory, startInclusive, endExclusive);
+        return sale == null ? 0D : sale.totalPayout;
+    }
+
     public SellResult sellInventoryContents(
             Player player,
             Inventory inventory,
@@ -1630,8 +1635,26 @@ public class ShopManager {
             EconomyReason reason,
             boolean sendFeedback
     ) {
-        if (player == null || inventory == null) {
+        PendingSale sale = collectInventorySale(player, inventory, startInclusive, endExclusive);
+        if (sale == null) {
             return emptySale();
+        }
+
+        return executeSale(player, sale, reason, sendFeedback, () -> {
+            for (int slot : sale.soldSlots) {
+                inventory.setItem(slot, null);
+            }
+        });
+    }
+
+    private PendingSale collectInventorySale(
+            Player player,
+            Inventory inventory,
+            int startInclusive,
+            int endExclusive
+    ) {
+        if (player == null || inventory == null) {
+            return null;
         }
 
         PendingSale sale = createPendingSale(player);
@@ -1653,11 +1676,7 @@ public class ShopManager {
             sale.soldSlots.add(slot);
         }
 
-        return executeSale(player, sale, reason, sendFeedback, () -> {
-            for (int slot : sale.soldSlots) {
-                inventory.setItem(slot, null);
-            }
-        });
+        return sale;
     }
 
     private PendingSale createPendingSale(Player player) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
@@ -63,13 +63,21 @@ public class SellMenu extends BaseMenu {
 
     private void buildConfirmSellGUI(Player player) {
         FileConfiguration menus = plugin.getConfigManager().getMenus();
-        
+        double total = plugin.getShopManager().previewInventoryContents(player, inventory, 0, getSellableSlotEnd());
+        String compactPrice = plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, total);
+        String formattedPrice = plugin.getCurrencyManager().formatMoney(total);
+
         Material material = ItemUtils.parseMaterial(menus.getString("SELL-MENU.CONFIRM-BUTTON.MATERIAL", "LIME_STAINED_GLASS_PANE"));
-        String title = menus.getString("SELL-MENU.CONFIRM-BUTTON.TITLE", "&a&lConfirm sell");
-        List<String> lore = menus.getStringList("SELL-MENU.CONFIRM-BUTTON.LORE");
-        if (lore.isEmpty()) {
-            lore = List.of("&7Click to sell all items in the menu.");
-        }
+        String title = applyPricePlaceholders(
+                menus.getString("SELL-MENU.CONFIRM-BUTTON.TITLE", "&a&lConfirm sell"),
+                compactPrice,
+                formattedPrice
+        );
+        List<String> lore = applyPricePlaceholders(
+                resolveConfirmLore(menus.getStringList("SELL-MENU.CONFIRM-BUTTON.LORE")),
+                compactPrice,
+                formattedPrice
+        );
         set(53, ItemUtils.createItem(material, title, lore));
     }
 
@@ -83,6 +91,7 @@ public class SellMenu extends BaseMenu {
                         plugin.getConfigManager().getMessage("WORTH.NO-SELLABLE", "&cThis item is not sellable.")
                 ));
             }
+            buildConfirmSellGUI(player);
             return;
         }
 
@@ -113,7 +122,7 @@ public class SellMenu extends BaseMenu {
         if (rawSlot >= 0 && rawSlot < inventory.getSize()) {
             if (isSellableSlot(rawSlot)) {
                 event.setCancelled(false);
-                if (autoSell) {
+                if (autoSell || confirmMode) {
                     scheduleProcessing(player);
                 }
                 return;
@@ -129,7 +138,7 @@ public class SellMenu extends BaseMenu {
         }
 
         event.setCancelled(false);
-        if (autoSell) {
+        if (autoSell || confirmMode) {
             scheduleProcessing(player);
         }
     }
@@ -143,7 +152,7 @@ public class SellMenu extends BaseMenu {
         }
 
         event.setCancelled(false);
-        if (isAutoSellEnabled() && event.getWhoClicked() instanceof Player player) {
+        if ((isAutoSellEnabled() || confirmMode) && event.getWhoClicked() instanceof Player player) {
             scheduleProcessing(player);
         }
     }
@@ -182,8 +191,12 @@ public class SellMenu extends BaseMenu {
                 return;
             }
 
-            plugin.getShopManager().sellInventoryContents(player, inventory, 0, getSellableSlotEnd());
-            refreshMultiplierButtons(player);
+            if (isAutoSellEnabled()) {
+                plugin.getShopManager().sellInventoryContents(player, inventory, 0, getSellableSlotEnd());
+                refreshMultiplierButtons(player);
+            } else if (confirmMode) {
+                buildConfirmSellGUI(player);
+            }
             player.updateInventory();
         }, PROCESS_DELAY_TICKS);
     }
@@ -240,6 +253,34 @@ public class SellMenu extends BaseMenu {
                 mode,
                 plugin.getConfigManager().getMenus().getBoolean("SELL-MENU.AUTO-SELL", true)
         );
+    }
+
+    static List<String> resolveConfirmLore(List<String> configured) {
+        if (configured == null || configured.isEmpty() || isLegacyConfirmLore(configured)) {
+            return List.of("&a{price_formatted}");
+        }
+        return configured;
+    }
+
+    static boolean isLegacyConfirmLore(List<String> lore) {
+        return lore.size() == 1 && "&7Click to sell all items in the menu.".equals(lore.get(0));
+    }
+
+    static String applyPricePlaceholders(String text, String compactPrice, String formattedPrice) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return text
+                .replace("{price_formatted}", formattedPrice)
+                .replace("%price_formatted%", formattedPrice)
+                .replace("{price}", compactPrice)
+                .replace("%price%", compactPrice);
+    }
+
+    static List<String> applyPricePlaceholders(List<String> lines, String compactPrice, String formattedPrice) {
+        return lines.stream()
+                .map(line -> applyPricePlaceholders(line, compactPrice, formattedPrice))
+                .toList();
     }
 
     static boolean isConfirmMode(String mode) {

--- a/src/main/resources/languages/de_DE.yml
+++ b/src/main/resources/languages/de_DE.yml
@@ -958,7 +958,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/en_US.yml
+++ b/src/main/resources/languages/en_US.yml
@@ -994,7 +994,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: '&a&lConfirm sell'
       LORE:
-      - '&7Click to sell all items in the menu.'
+      - '&a{price_formatted}'
     CROPS-BUTTON:
       TITLE: '&#6BF18DCrops'
       LORE:

--- a/src/main/resources/languages/es_ES.yml
+++ b/src/main/resources/languages/es_ES.yml
@@ -823,7 +823,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/fr_FR.yml
+++ b/src/main/resources/languages/fr_FR.yml
@@ -822,7 +822,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/id_ID.yml
+++ b/src/main/resources/languages/id_ID.yml
@@ -959,7 +959,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/pt_BR.yml
+++ b/src/main/resources/languages/pt_BR.yml
@@ -823,7 +823,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/ru_RU.yml
+++ b/src/main/resources/languages/ru_RU.yml
@@ -822,7 +822,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/languages/zh_CN.yml
+++ b/src/main/resources/languages/zh_CN.yml
@@ -821,7 +821,7 @@ MENUS:
     CONFIRM-BUTTON:
       TITLE: "&a&lConfirm sell"
       LORE:
-      - "&7Click to sell all items in the menu."
+      - "&a{price_formatted}"
     CROPS-BUTTON:
       TITLE: "&#6BF18DCrops"
       LORE:

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1139,8 +1139,9 @@ SELL-MENU:
   CONFIRM-BUTTON:
     MATERIAL: "LIME_STAINED_GLASS_PANE"
     TITLE: "&a&lConfirm Sell"
+    # {price} is the compact total, {price_formatted} is the full money format.
     LORE:
-    - "&7Click to sell all items in the menu."
+    - "&a{price_formatted}"
   CROPS-BUTTON:
     MATERIAL: WHEAT
     TITLE: '&#6BF18DCrops'

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SellMenuTest.java
@@ -4,7 +4,9 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -75,6 +77,50 @@ class SellMenuTest {
         assertTrue(
                 SellMenu.isConfirmMode(menus.getString("SELL-MENU.MODE", "instant")),
                 "menus.yml ships MODE: confirm, so the default sell menu keeps its Confirm Sell button"
+        );
+        assertEquals(
+                List.of("&a{price_formatted}"),
+                menus.getStringList("SELL-MENU.CONFIRM-BUTTON.LORE"),
+                "the confirm button lore must show the live total, not a click hint"
+        );
+    }
+
+    @Test
+    void theOldClickToSellLoreIsTreatedAsTheNewTotalLine() {
+        assertEquals(List.of("&a{price_formatted}"), SellMenu.resolveConfirmLore(List.of()));
+        assertEquals(
+                List.of("&a{price_formatted}"),
+                SellMenu.resolveConfirmLore(List.of("&7Click to sell all items in the menu."))
+        );
+        assertEquals(
+                List.of("&7Click to confirm. Total: {price_formatted}"),
+                SellMenu.resolveConfirmLore(List.of("&7Click to confirm. Total: {price_formatted}")),
+                "custom lore with a price placeholder has to stay as written"
+        );
+        assertEquals(
+                List.of("&7Sell everything in the grid"),
+                SellMenu.resolveConfirmLore(List.of("&7Sell everything in the grid")),
+                "a custom line without a placeholder is still the admin's text"
+        );
+    }
+
+    @Test
+    void pricePlaceholdersPreferTheFullFormatOverTheCompactOne() {
+        assertEquals(
+                "$1,200.00",
+                SellMenu.applyPricePlaceholders("{price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "1.2k",
+                SellMenu.applyPricePlaceholders("{price}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "+$1,200.00 (1.2k)",
+                SellMenu.applyPricePlaceholders("+{price_formatted} ({price})", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                List.of("$1,200.00"),
+                SellMenu.applyPricePlaceholders(List.of("%price_formatted%"), "1.2k", "$1,200.00")
         );
     }
 }


### PR DESCRIPTION
Closes #446

Confirm Sell in /sell used to say "Click to sell all items in the menu" even when the grid was full. It now shows the total of what's in there, including sell multipliers, and that number is the one you actually get paid.

## Confirm button total
Putting items in or taking them out rewrites the button two ticks later, the same delay the instant-sell path already waited so Bukkit has finished moving the stacks, and clicking Confirm rebuilds it immediately so an empty grid goes back to $0. The preview uses the same collector as a real sale rather than a second pricing path.

`{price}` is the compact total and `{price_formatted}` is the full money format; both work in the button title and lore. Shipped lore is `&a{price_formatted}`. A server still sitting on the old click-to-sell line gets the total without anyone editing files. Custom lore is left as written, and placeholders in it still get filled in.

## Notes
Default `SELL-MENU.CONFIRM-BUTTON.LORE` is `&a{price_formatted}` in menus.yml and all 8 language files, and Config-menus.yml.md now lists the confirm button (that page had skipped it). 723 tests, including one that replaces `{price_formatted}` before `{price}` so the compact token cannot chew the formatted one.
