### PR TITLE
feat(fakeplayer): sneak and spawn at look target (#444)

### DIFF
--- a/docs/wiki/Config-staff-mode.yml.md
+++ b/docs/wiki/Config-staff-mode.yml.md
@@ -756,6 +756,15 @@ FAKE-PLAYER:
   # When true, /fakeplayer does not copy the staff member's username, so prefix, suffix, and money text stay off the head.
   # Available options: true, false
   HIDE-NAMETAG: true
+  # When true, the bait crouches like DonutSMP. Crouching also hides leftover nametags on most clients.
+  # Available options: true, false
+  SNEAK: true
+  # When true, /fakeplayer appears at the block or point you are looking at instead of at your feet.
+  # Available options: true, false
+  SPAWN-AT-LOOK-TARGET: true
+  # How far, in blocks, to search for the block you are looking at.
+  # Available options: Any decimal number 1.0 or greater
+  LOOK-RANGE: 32.0
 ```
 
 ### 2. Key Options & Technical Breakdown
@@ -764,6 +773,9 @@ FAKE-PLAYER:
 | :--- | :--- | :--- | :--- | :--- |
 | `FAKE-PLAYER.USE-DEFAULT-SKIN` | `bool` | `true`, `false` | `false` | When `true`, every `/fakeplayer` bait uses Minecraft's default Steve or Alex skin. When `false`, the bait copies the staff member who ran the command. |
 | `FAKE-PLAYER.HIDE-NAMETAG` | `bool` | `true`, `false` | `true` | When `true`, `/fakeplayer` does not copy the staff member's username, so LuckPerms prefix/suffix and below-name money stay off the bait. Set `false` if you want the old labeled look. |
+| `FAKE-PLAYER.SNEAK` | `bool` | `true`, `false` | `true` | When `true`, the bait crouches. That matches DonutSMP and hides leftover nametags on most clients. |
+| `FAKE-PLAYER.SPAWN-AT-LOOK-TARGET` | `bool` | `true`, `false` | `true` | When `true`, `/fakeplayer` appears at the block or point you are looking at. When `false`, it still appears at your feet. |
+| `FAKE-PLAYER.LOOK-RANGE` | `decimal` | `1.0` or greater | `32.0` | How far, in blocks, to search for the block you are looking at. Looking at empty air places the bait a short way along your view instead of at your feet. |
 
 ### 3. Practical Setup Example
 
@@ -771,6 +783,9 @@ FAKE-PLAYER:
 FAKE-PLAYER:
   USE-DEFAULT-SKIN: true
   HIDE-NAMETAG: true
+  SNEAK: true
+  SPAWN-AT-LOOK-TARGET: true
+  LOOK-RANGE: 32.0
 ```
 
 ---

--- a/docs/wiki/Staff-and-Security.md
+++ b/docs/wiki/Staff-and-Security.md
@@ -140,7 +140,7 @@ Spawns fake hidden chests populated with high-tier loot under spawn or wild area
 - Commands: `/spawnstash setup`, `/spawnstash list`, `/spawnstash give`.
 
 ### 2. Fake Player Bait (`/fakeplayer`)
-Spawns a short-lived player bait at your feet. It copies your skin unless `FAKE-PLAYER.USE-DEFAULT-SKIN` is `true` in `staff-mode.yml`, in which case every bait uses Minecraft's default Steve or Alex skin. `HIDE-NAMETAG: true` (the bundled default) keeps prefix, name, and money text off the bait's head.
+Spawns a short-lived player bait at the block you are looking at (or at your feet if `SPAWN-AT-LOOK-TARGET` is `false`). It copies your skin unless `FAKE-PLAYER.USE-DEFAULT-SKIN` is `true` in `staff-mode.yml`, in which case every bait uses Minecraft's default Steve or Alex skin. `HIDE-NAMETAG: true` (the bundled default) keeps prefix, name, and money text off the bait's head. `SNEAK: true` crouches the dummy the way DonutSMP does, which also hides leftover nametags.
 
 ### 3. Spawner Anti-ESP
 Hides spawner block packet data from players beyond visual raycast distance to prevent X-Ray / ESP client hacks from discovering spawner coordinates.

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerManager.java
@@ -3,6 +3,7 @@ package com.bx.ultimateDonutSmp.managers;
 import com.bx.ultimateDonutSmp.UltimateDonutSmp;
 import com.bx.ultimateDonutSmp.utils.ColorUtils;
 import com.bx.ultimateDonutSmp.utils.FakePlayerSkinPolicy;
+import com.bx.ultimateDonutSmp.utils.FakePlayerSpawnTarget;
 import com.bx.ultimateDonutSmp.utils.PermissionUtils;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -68,6 +69,9 @@ public class FakePlayerManager {
     private boolean logToConsole;
     private boolean hideFromTablist;
     private boolean hideNametag;
+    private boolean sneak;
+    private boolean spawnAtLookTarget;
+    private double lookRange;
     private SkinSourceMode skinSourceMode;
     private boolean useDefaultSkin;
     private boolean lockAirPosition;
@@ -153,8 +157,8 @@ public class FakePlayerManager {
             return SpawnResult.fail(message("DISABLED", "&cFakePlayer is currently disabled."));
         }
 
-        Location location = creator.getLocation().clone();
-        if (location.getWorld() == null) {
+        Location location = resolveSpawnLocation(creator);
+        if (location == null || location.getWorld() == null) {
             return SpawnResult.fail(message("INVALID-LOCATION", "&cUnable to spawn a FakePlayer at your current location."));
         }
 
@@ -186,6 +190,7 @@ public class FakePlayerManager {
                 profileName,
                 displayName,
                 location,
+                sneak,
                 now,
                 now + Math.max(1L, ttlSeconds) * 1000L
         );
@@ -344,6 +349,9 @@ public class FakePlayerManager {
         alertCooldownMillis = Math.max(1L, configLong("ALERT-COOLDOWN-SECONDS", 30L)) * 1000L;
         hideFromTablist = configBoolean("HIDE-FROM-TABLIST", true);
         hideNametag = configBoolean("HIDE-NAMETAG", true);
+        sneak = configBoolean("SNEAK", true);
+        spawnAtLookTarget = configBoolean("SPAWN-AT-LOOK-TARGET", true);
+        lookRange = Math.max(1.0D, configDouble("LOOK-RANGE", 32.0D));
         tablistRemoveDelayTicks = Math.max(0L, configLong("TABLIST-REMOVE-DELAY-TICKS", hideFromTablist ? 5L : 200L));
         if (hideFromTablist) {
             tablistRemoveDelayTicks = Math.min(tablistRemoveDelayTicks, 5L);
@@ -453,7 +461,7 @@ public class FakePlayerManager {
 
         Location next = current.clone();
         moveVertical(next, velocity);
-        moveHorizontal(next, velocity);
+        moveHorizontal(next, velocity, fakePlayer.sneaking());
 
         boolean nextOnGround = hasGroundSupport(next);
         if (nextOnGround && velocity.getY() < 0D) {
@@ -513,11 +521,11 @@ public class FakePlayerManager {
         return ground;
     }
 
-    private void moveHorizontal(Location location, Vector velocity) {
+    private void moveHorizontal(Location location, Vector velocity, boolean sneaking) {
         double xVelocity = velocity.getX();
         if (Math.abs(xVelocity) >= 0.00001D) {
             Location movedX = location.clone().add(xVelocity, 0D, 0D);
-            if (intersectsSolid(movedX)) {
+            if (intersectsSolid(movedX, sneaking)) {
                 velocity.setX(0D);
             } else {
                 location.setX(movedX.getX());
@@ -527,7 +535,7 @@ public class FakePlayerManager {
         double zVelocity = velocity.getZ();
         if (Math.abs(zVelocity) >= 0.00001D) {
             Location movedZ = location.clone().add(0D, 0D, zVelocity);
-            if (intersectsSolid(movedZ)) {
+            if (intersectsSolid(movedZ, sneaking)) {
                 velocity.setZ(0D);
             } else {
                 location.setZ(movedZ.getZ());
@@ -552,14 +560,16 @@ public class FakePlayerManager {
                 || hasSolidBlockAt(world, location.getX(), y, location.getZ());
     }
 
-    private boolean intersectsSolid(Location location) {
+    private boolean intersectsSolid(Location location, boolean sneaking) {
         World world = location.getWorld();
         if (world == null) {
             return false;
         }
 
+        double mid = sneaking ? 0.75D : 0.9D;
+        double top = sneaking ? 1.4D : 1.75D;
         double[] xs = {location.getX() - 0.3D, location.getX(), location.getX() + 0.3D};
-        double[] ys = {location.getY() + 0.1D, location.getY() + 0.9D, location.getY() + 1.75D};
+        double[] ys = {location.getY() + 0.1D, location.getY() + mid, location.getY() + top};
         double[] zs = {location.getZ() - 0.3D, location.getZ(), location.getZ() + 0.3D};
         for (double x : xs) {
             for (double y : ys) {
@@ -885,7 +895,8 @@ public class FakePlayerManager {
                 continue;
             }
 
-            BoundingBox hitbox = BoundingBox.of(location.clone().add(0D, 0.9D, 0D), 0.45D, 0.9D, 0.45D);
+            double halfHeight = fakePlayer.hitboxHalfHeight();
+            BoundingBox hitbox = BoundingBox.of(location.clone().add(0D, halfHeight, 0D), 0.45D, halfHeight, 0.45D);
             RayTraceResult hit = hitbox.rayTrace(eye.toVector(), direction, reach);
             if (hit == null) {
                 continue;
@@ -1032,6 +1043,38 @@ public class FakePlayerManager {
                 + " (fakeUuid=" + fakeUuid
                 + ", textureProfileUuid=" + (textureProfileUuid == null ? "none" : textureProfileUuid)
                 + ", uuidSource=" + uuidSource + ").");
+    }
+
+    private Location resolveSpawnLocation(Player creator) {
+        Location standing = creator.getLocation().clone();
+        if (!spawnAtLookTarget) {
+            return standing;
+        }
+
+        Location eye = creator.getEyeLocation();
+        Vector direction = eye.getDirection();
+        World world = standing.getWorld();
+        RayTraceResult hit = world == null ? null : world.rayTraceBlocks(
+                eye,
+                direction,
+                lookRange,
+                FluidCollisionMode.NEVER,
+                true
+        );
+        Vector hitPosition = hit == null ? null : hit.getHitPosition();
+        Vector hitNormal = hit == null || hit.getHitBlockFace() == null
+                ? null
+                : hit.getHitBlockFace().getDirection();
+        double missDistance = Math.min(lookRange, FakePlayerSpawnTarget.DEFAULT_MISS_DISTANCE);
+        return FakePlayerSpawnTarget.resolve(
+                standing,
+                eye,
+                direction,
+                hitPosition,
+                hitNormal,
+                true,
+                missDistance
+        );
     }
 
     static String hiddenProfileName(UUID fakeUuid) {

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerProtocolLibBridge.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerProtocolLibBridge.java
@@ -29,6 +29,7 @@ import org.bukkit.util.Vector;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -55,6 +56,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
     private boolean velocityWarned;
     private boolean noGravityWarned;
     private boolean spawnWarned;
+    private boolean sneakWarned;
 
     FakePlayerProtocolLibBridge(UltimateDonutSmp plugin, FakePlayerManager fakePlayerManager) {
         this.plugin = plugin;
@@ -991,6 +993,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
             return;
         }
         sendNoGravityMetadata(viewer, fakePlayer);
+        sendSneakMetadata(viewer, fakePlayer);
         sendMetadata(viewer, fakePlayer);
         scheduleMetadataRefresh(viewer, fakePlayer);
         sendOptionalSpawnPackets(viewer, fakePlayer);
@@ -1067,6 +1070,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
 
             try {
                 sendNoGravityMetadata(viewer, fakePlayer);
+                sendSneakMetadata(viewer, fakePlayer);
                 sendMetadata(viewer, fakePlayer);
                 if (damage) {
                     send(viewer, createEntityStatus(fakePlayer.entityId(), (byte) 2));
@@ -1605,6 +1609,7 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
         sendNametagHideTeam(viewer, fakePlayer);
         send(viewer, createSpawnEntity(fakePlayer));
         sendNoGravityMetadata(viewer, fakePlayer);
+        sendSneakMetadata(viewer, fakePlayer);
         sendMetadata(viewer, fakePlayer);
         sendOptionalSpawnPackets(viewer, fakePlayer);
     }
@@ -1905,6 +1910,72 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
         return (byte) Math.floorMod((int) (degrees * 256.0F / 360.0F), 256);
     }
 
+    private void sendSneakMetadata(Player viewer, FakePlayerSession fakePlayer) {
+        if (fakePlayer == null || !fakePlayer.sneaking()) {
+            return;
+        }
+        try {
+            send(viewer, createSneakMetadata(fakePlayer));
+        } catch (RuntimeException | LinkageError error) {
+            if (!sneakWarned) {
+                sneakWarned = true;
+                plugin.getLogger().log(Level.WARNING,
+                        "Unable to send fakeplayer sneak metadata on this ProtocolLib/server build.", error);
+            }
+        }
+    }
+
+    private PacketContainer createSneakMetadata(FakePlayerSession fakePlayer) {
+        PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.ENTITY_METADATA);
+        packet.getModifier().writeDefaults();
+        packet.getIntegers().write(0, fakePlayer.entityId());
+
+        List<WrappedDataValue> values = new ArrayList<>();
+        WrappedDataWatcher.Serializer byteSerializer = WrappedDataWatcher.Registry.get(Byte.class);
+        values.add(new WrappedDataValue(0, byteSerializer, (byte) 0x02));
+        WrappedDataValue poseValue = poseCrouchingDataValue();
+        if (poseValue != null) {
+            values.add(poseValue);
+        }
+
+        if (packet.getDataValueCollectionModifier().size() > 0) {
+            packet.getDataValueCollectionModifier().write(0, values);
+            return packet;
+        }
+
+        WrappedDataWatcher watcher = new WrappedDataWatcher();
+        watcher.setObject(new WrappedDataWatcher.WrappedDataWatcherObject(0, byteSerializer), (byte) 0x02);
+        if (poseValue != null) {
+            watcher.setObject(
+                    new WrappedDataWatcher.WrappedDataWatcherObject(poseValue.getIndex(), poseValue.getSerializer()),
+                    poseValue.getValue()
+            );
+        }
+        if (packet.getWatchableCollectionModifier().size() > 0) {
+            packet.getWatchableCollectionModifier().write(0, watcher.getWatchableObjects());
+            return packet;
+        }
+
+        throw new IllegalStateException("ENTITY_METADATA packet has no supported metadata collection fields.");
+    }
+
+    private WrappedDataValue poseCrouchingDataValue() {
+        try {
+            Class<?> poseClass = EnumWrappers.getEntityPoseClass();
+            if (poseClass == null) {
+                return null;
+            }
+            WrappedDataWatcher.Serializer serializer = WrappedDataWatcher.Registry.get(poseClass);
+            Object nmsPose = EnumWrappers.getEntityPoseConverter().getGeneric(EnumWrappers.EntityPose.CROUCHING);
+            if (serializer == null || nmsPose == null) {
+                return null;
+            }
+            return new WrappedDataValue(6, serializer, nmsPose);
+        } catch (RuntimeException | LinkageError ignored) {
+            return null;
+        }
+    }
+
     private void sendMetadata(Player viewer, FakePlayerSession fakePlayer) {
         if (!plugin.getConfigManager().getStaffMode().getBoolean("FAKE-PLAYER.SEND-SKIN-LAYERS-METADATA", true)) {
             return;
@@ -1936,7 +2007,9 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
     }
 
     private void scheduleMetadataRefresh(Player viewer, FakePlayerSession fakePlayer) {
-        if (!plugin.getConfigManager().getStaffMode().getBoolean("FAKE-PLAYER.SEND-SKIN-LAYERS-METADATA", true)) {
+        boolean skinLayers = plugin.getConfigManager().getStaffMode()
+                .getBoolean("FAKE-PLAYER.SEND-SKIN-LAYERS-METADATA", true);
+        if (!skinLayers && (fakePlayer == null || !fakePlayer.sneaking())) {
             return;
         }
 
@@ -1947,7 +2020,10 @@ final class FakePlayerProtocolLibBridge implements FakePlayerPacketBridge {
                     && viewer.isOnline()
                     && fakePlayer.viewers().contains(viewer.getUniqueId())
                     && System.currentTimeMillis() < fakePlayer.expiresAtMillis()) {
-                sendMetadata(viewer, fakePlayer);
+                sendSneakMetadata(viewer, fakePlayer);
+                if (skinLayers) {
+                    sendMetadata(viewer, fakePlayer);
+                }
             }
         }, delayTicks);
     }

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerSession.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FakePlayerSession.java
@@ -20,6 +20,7 @@ final class FakePlayerSession {
     private final String profileName;
     private final String displayName;
     private final Location location;
+    private final boolean sneaking;
     private Location visualLocation;
     private Vector visualVelocity = new Vector(0D, 0D, 0D);
     private boolean visualOnGround;
@@ -43,6 +44,7 @@ final class FakePlayerSession {
             String profileName,
             String displayName,
             Location location,
+            boolean sneaking,
             long createdAtMillis,
             long expiresAtMillis
     ) {
@@ -55,6 +57,7 @@ final class FakePlayerSession {
         this.profileName = profileName;
         this.displayName = displayName;
         this.location = location.clone();
+        this.sneaking = sneaking;
         this.visualLocation = location.clone();
         this.createdAtMillis = createdAtMillis;
         this.expiresAtMillis = expiresAtMillis;
@@ -96,9 +99,21 @@ final class FakePlayerSession {
         return location.clone();
     }
 
+    boolean sneaking() {
+        return sneaking;
+    }
+
+    double eyeHeight() {
+        return sneaking ? 1.27D : 1.62D;
+    }
+
+    double hitboxHalfHeight() {
+        return sneaking ? 0.75D : 0.9D;
+    }
+
     Location eyeLocation() {
         Location eye = location.clone();
-        eye.add(0D, 1.62D, 0D);
+        eye.add(0D, eyeHeight(), 0D);
         return eye;
     }
 
@@ -108,7 +123,7 @@ final class FakePlayerSession {
 
     Location visualEyeLocation() {
         Location eye = visualLocation.clone();
-        eye.add(0D, 1.62D, 0D);
+        eye.add(0D, eyeHeight(), 0D);
         return eye;
     }
 

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/FakePlayerSpawnTarget.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/FakePlayerSpawnTarget.java
@@ -1,0 +1,75 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+/**
+ * Picks where {@code /fakeplayer} should appear: either the staff member's feet, or the point their
+ * crosshair is aimed at.
+ */
+public final class FakePlayerSpawnTarget {
+
+    public static final double FACE_PUSH = 0.51D;
+    public static final double TOP_SURFACE_LIFT = 0.01D;
+    public static final double DEFAULT_MISS_DISTANCE = 8.0D;
+
+    private FakePlayerSpawnTarget() {
+    }
+
+    public static Location resolve(
+            Location standing,
+            Location eye,
+            Vector lookDirection,
+            Vector hitPosition,
+            Vector hitNormal,
+            boolean spawnAtLookTarget,
+            double missDistance
+    ) {
+        if (standing == null) {
+            return null;
+        }
+        if (!spawnAtLookTarget) {
+            return standing.clone();
+        }
+
+        if (hitPosition != null) {
+            Location spawn = new Location(
+                    standing.getWorld(),
+                    hitPosition.getX(),
+                    hitPosition.getY(),
+                    hitPosition.getZ(),
+                    standing.getYaw(),
+                    0F
+            );
+            pushOutOfFace(spawn, hitPosition, hitNormal);
+            return spawn;
+        }
+
+        Vector direction = lookDirection == null ? standing.getDirection() : lookDirection.clone();
+        if (direction.lengthSquared() < 1.0E-8D) {
+            return standing.clone();
+        }
+        direction.normalize();
+
+        Location origin = eye == null ? standing.clone().add(0D, 1.62D, 0D) : eye.clone();
+        Location spawn = origin.add(direction.multiply(Math.max(1.0D, missDistance)));
+        spawn.setYaw(standing.getYaw());
+        spawn.setPitch(0F);
+        return spawn;
+    }
+
+    private static void pushOutOfFace(Location spawn, Vector hitPosition, Vector hitNormal) {
+        if (hitNormal == null || hitNormal.lengthSquared() < 1.0E-8D) {
+            spawn.setY(hitPosition.getY() + TOP_SURFACE_LIFT);
+            return;
+        }
+
+        Vector offset = hitNormal.clone();
+        offset.normalize();
+        if (offset.getY() > 0.5D) {
+            spawn.setY(hitPosition.getY() + TOP_SURFACE_LIFT);
+            return;
+        }
+        spawn.add(offset.multiply(FACE_PUSH));
+    }
+}

--- a/src/main/resources/staff-mode.yml
+++ b/src/main/resources/staff-mode.yml
@@ -277,3 +277,12 @@ FAKE-PLAYER:
   # When true, /fakeplayer does not copy the staff member's username, so prefix, suffix, and money text stay off the head.
   # Available options: true, false
   HIDE-NAMETAG: true
+  # When true, the bait crouches like DonutSMP. Crouching also hides leftover nametags on most clients.
+  # Available options: true, false
+  SNEAK: true
+  # When true, /fakeplayer appears at the block or point you are looking at instead of at your feet.
+  # Available options: true, false
+  SPAWN-AT-LOOK-TARGET: true
+  # How far, in blocks, to search for the block you are looking at.
+  # Available options: Any decimal number 1.0 or greater
+  LOOK-RANGE: 32.0

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/FakePlayerLookAndSneakTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/FakePlayerLookAndSneakTest.java
@@ -1,0 +1,46 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import org.bukkit.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FakePlayerLookAndSneakTest {
+
+    @Test
+    void sneakingShortensTheEyeAndHitbox() {
+        Location feet = new Location(null, 3.0D, 64.0D, 7.0D);
+        FakePlayerSession standing = session(feet, false);
+        FakePlayerSession sneaking = session(feet, true);
+
+        assertFalse(standing.sneaking());
+        assertTrue(sneaking.sneaking());
+        assertEquals(1.62D, standing.eyeHeight(), 0.0001D);
+        assertEquals(1.27D, sneaking.eyeHeight(), 0.0001D);
+        assertEquals(65.62D, standing.eyeLocation().getY(), 0.0001D);
+        assertEquals(65.27D, sneaking.eyeLocation().getY(), 0.0001D);
+        assertEquals(0.9D, standing.hitboxHalfHeight(), 0.0001D);
+        assertEquals(0.75D, sneaking.hitboxHalfHeight(), 0.0001D);
+    }
+
+    private static FakePlayerSession session(Location feet, boolean sneaking) {
+        return new FakePlayerSession(
+                1L,
+                2,
+                UUID.fromString("12345678-1234-1234-1234-123456789abc"),
+                null,
+                UUID.fromString("abcdefab-cdef-abcd-efab-cdefabcdefab"),
+                "staff",
+                "fp123456789abcde",
+                "staff",
+                feet,
+                sneaking,
+                0L,
+                1L
+        );
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/utils/FakePlayerSpawnTargetTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/utils/FakePlayerSpawnTargetTest.java
@@ -1,0 +1,105 @@
+package com.bx.ultimateDonutSmp.utils;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.util.Vector;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FakePlayerSpawnTargetTest {
+
+    @Test
+    void bundledStaffModeSpawnsAtLookAndSneaks() throws Exception {
+        YamlConfiguration config = new YamlConfiguration();
+        config.load(Path.of("src/main/resources", "staff-mode.yml").toFile());
+
+        assertTrue(config.getBoolean("FAKE-PLAYER.SNEAK", false),
+                "staff-mode.yml must ship SNEAK as true so a config restore keeps the DonutSMP crouch");
+        assertTrue(config.getBoolean("FAKE-PLAYER.SPAWN-AT-LOOK-TARGET", false),
+                "staff-mode.yml must ship SPAWN-AT-LOOK-TARGET as true so a config restore keeps spawning on the crosshair");
+        assertEquals(32.0D, config.getDouble("FAKE-PLAYER.LOOK-RANGE", 0.0D), 0.0001D);
+    }
+
+    @Test
+    void feetStayWhenLookTargetIsOff() {
+        Location standing = new Location(null, 10.0D, 64.0D, 10.0D, 90.0F, 45.0F);
+        Location spawn = FakePlayerSpawnTarget.resolve(
+                standing,
+                standing.clone().add(0D, 1.62D, 0D),
+                new Vector(1D, 0D, 0D),
+                new Vector(20.0D, 70.0D, 20.0D),
+                new Vector(0D, 1D, 0D),
+                false,
+                8.0D
+        );
+
+        assertEquals(10.0D, spawn.getX(), 0.0001D);
+        assertEquals(64.0D, spawn.getY(), 0.0001D);
+        assertEquals(10.0D, spawn.getZ(), 0.0001D);
+        assertEquals(90.0F, spawn.getYaw(), 0.0001F);
+        assertEquals(45.0F, spawn.getPitch(), 0.0001F);
+    }
+
+    @Test
+    void topFaceKeepsTheLookedAtPointAndStaffYaw() {
+        Location standing = new Location(null, 10.0D, 64.0D, 10.0D, 180.0F, 12.0F);
+        Location spawn = FakePlayerSpawnTarget.resolve(
+                standing,
+                standing.clone().add(0D, 1.62D, 0D),
+                new Vector(1D, -0.4D, 0D),
+                new Vector(22.5D, 70.0D, 18.25D),
+                new Vector(0D, 1D, 0D),
+                true,
+                8.0D
+        );
+
+        assertEquals(22.5D, spawn.getX(), 0.0001D);
+        assertEquals(70.0D + FakePlayerSpawnTarget.TOP_SURFACE_LIFT, spawn.getY(), 0.0001D);
+        assertEquals(18.25D, spawn.getZ(), 0.0001D);
+        assertEquals(180.0F, spawn.getYaw(), 0.0001F);
+        assertEquals(0.0F, spawn.getPitch(), 0.0001F);
+    }
+
+    @Test
+    void sideFacePushesTheBaitOutOfTheBlock() {
+        Location standing = new Location(null, 0.0D, 64.0D, 0.0D, 0.0F, 0.0F);
+        Location spawn = FakePlayerSpawnTarget.resolve(
+                standing,
+                standing.clone().add(0D, 1.62D, 0D),
+                new Vector(0D, 0D, 1D),
+                new Vector(5.0D, 66.0D, 12.0D),
+                new Vector(0D, 0D, -1D),
+                true,
+                8.0D
+        );
+
+        assertEquals(5.0D, spawn.getX(), 0.0001D);
+        assertEquals(66.0D, spawn.getY(), 0.0001D);
+        assertEquals(12.0D - FakePlayerSpawnTarget.FACE_PUSH, spawn.getZ(), 0.0001D);
+    }
+
+    @Test
+    void aMissPlacesTheBaitAlongTheLookInsteadOfAtTheFeet() {
+        Location standing = new Location(null, 10.0D, 64.0D, 10.0D, 45.0F, -20.0F);
+        Location eye = new Location(null, 10.0D, 65.62D, 10.0D);
+        Location spawn = FakePlayerSpawnTarget.resolve(
+                standing,
+                eye,
+                new Vector(1D, 0D, 0D),
+                null,
+                null,
+                true,
+                8.0D
+        );
+
+        assertEquals(18.0D, spawn.getX(), 0.0001D);
+        assertEquals(65.62D, spawn.getY(), 0.0001D);
+        assertEquals(10.0D, spawn.getZ(), 0.0001D);
+        assertEquals(45.0F, spawn.getYaw(), 0.0001F);
+        assertEquals(0.0F, spawn.getPitch(), 0.0001F);
+    }
+}


### PR DESCRIPTION
Closes #444

The dummy was still standing on your feet, and leftover names could still show. It now crouches like DonutSMP and appears where you are looking.

## Pose and spawn
SNEAK (default true) sends the vanilla crouch flag and pose. That matches DonutSMP and hides leftover nametags on most clients. SPAWN-AT-LOOK-TARGET (default true) raycasts from your eyes. A hit puts the bait on that point, pushed out of the block face; looking at empty air places it a short way along the view instead of under you. LOOK-RANGE is 32. HIDE-NAMETAG is unchanged.

## Notes
New staff-mode.yml keys: SNEAK, SPAWN-AT-LOOK-TARGET, LOOK-RANGE. 729 tests. FakePlayerSpawnTargetTest covers feet vs look vs miss; FakePlayerLookAndSneakTest covers sneak eye height.
