### PR TITLE
fix(sell): replace formatted sell-price placeholders first (#452)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -302,7 +302,7 @@ SETTINGS:
 | `SETTINGS.SHARDS-KILL-COOLDOWN-SECONDS` | `int` | Any valid integer number | `'600'` | Time a killer must wait before the same victim rewards shards again. Set to `0` to reward every kill. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-MESSAGE` | `str` | Any string text | `'&cNo Shard &7(killed recently, {time} left)'` | Action bar shown when a kill reward is skipped by the cooldown. Supports `{time}` and `{seconds}`. Leave empty to stay silent. |
 | `SETTINGS.MONEY-PER-DEFAULT` | `float` | Any decimal number | `'1000.0'` | Configures the technical `MONEY-PER-DEFAULT` parameter for `SETTINGS.MONEY-PER-DEFAULT` in `config.yml`. |
-| `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `'&a+$%price%'` | Configures the technical `SELL-MESSAGE` parameter for `SETTINGS.SELL-MESSAGE` in `config.yml`. |
+| `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `'&a+$%price%'` | Action bar shown when a player sells items. `%price%` / `{price}` is the compact amount; `%price_formatted%` / `{price_formatted}` is the full money format. |
 | `SETTINGS.SPAWN-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `SPAWN-MENU` parameter for `SETTINGS.SPAWN-MENU` in `config.yml`. |
 | `SETTINGS.AFK-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `AFK-MENU` parameter for `SETTINGS.AFK-MENU` in `config.yml`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | `true`, `false` | `true` | Teleports a player to the spawn location the first time they join. Does nothing until `/setspawn` has been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -578,7 +578,7 @@ SETTINGS:
 | `SETTINGS.SHARDS-KILL-COOLDOWN-SECONDS` | `int` | Any valid integer | `600` | Time a killer must wait before the same victim rewards shards again. Set to `0` to reward every kill. |
 | `SETTINGS.SHARDS-KILL-COOLDOWN-MESSAGE` | `str` | Any string text | `&cNo Shard &7(killed recently, {time} left)` | Action bar shown when a kill reward is skipped by the cooldown. Supports `{time}` and `{seconds}`. Leave empty to stay silent. |
 | `SETTINGS.MONEY-PER-DEFAULT` | `float` | Configured values | `1000.0` | Configures `MONEY-PER-DEFAULT` for `SETTINGS`. |
-| `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `&a+$%price%` | Configures `SELL-MESSAGE` for `SETTINGS`. |
+| `SETTINGS.SELL-MESSAGE` | `str` | Any string text | `&a+$%price%` | Action bar shown when a player sells items. `%price%` / `{price}` is the compact amount; `%price_formatted%` / `{price_formatted}` is the full money format. |
 | `SETTINGS.SPAWN-MENU` | `bool` | true, false | `True` | Configures `SPAWN-MENU` for `SETTINGS`. |
 | `SETTINGS.AFK-MENU` | `bool` | true, false | `True` | Configures `AFK-MENU` for `SETTINGS`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | true, false | `True` | Teleports a player to spawn on their first join. Needs `/setspawn` to have been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/ShopManager.java
@@ -1838,13 +1838,23 @@ public class ShopManager {
     }
 
     private void sendSellFeedback(Player player, double totalPayout) {
-        String sellMsg = plugin.getConfigManager().getConfig()
-                .getString("SETTINGS.SELL-MESSAGE", "&a+{price_formatted}")
-                .replace("%price%", plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, totalPayout))
-                .replace("%price_formatted%", plugin.getCurrencyManager().formatMoney(totalPayout))
-                .replace("{price}", plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, totalPayout))
-                .replace("{price_formatted}", plugin.getCurrencyManager().formatMoney(totalPayout));
+        String sellMsg = applySellPricePlaceholders(
+                plugin.getConfigManager().getConfig().getString("SETTINGS.SELL-MESSAGE", "&a+{price_formatted}"),
+                plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, totalPayout),
+                plugin.getCurrencyManager().formatMoney(totalPayout)
+        );
         PlayerSettingUtils.sendActionBar(plugin, player, sellMsg);
+    }
+
+    public static String applySellPricePlaceholders(String text, String compactPrice, String formattedPrice) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return text
+                .replace("{price_formatted}", formattedPrice)
+                .replace("%price_formatted%", formattedPrice)
+                .replace("{price}", compactPrice)
+                .replace("%price%", compactPrice);
     }
 
     private List<Long> getSellProgressLevels() {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellMenu.java
@@ -267,14 +267,7 @@ public class SellMenu extends BaseMenu {
     }
 
     static String applyPricePlaceholders(String text, String compactPrice, String formattedPrice) {
-        if (text == null || text.isEmpty()) {
-            return "";
-        }
-        return text
-                .replace("{price_formatted}", formattedPrice)
-                .replace("%price_formatted%", formattedPrice)
-                .replace("{price}", compactPrice)
-                .replace("%price%", compactPrice);
+        return ShopManager.applySellPricePlaceholders(text, compactPrice, formattedPrice);
     }
 
     static List<String> applyPricePlaceholders(List<String> lines, String compactPrice, String formattedPrice) {

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/ShopManagerTest.java
@@ -124,6 +124,26 @@ class ShopManagerTest {
     }
 
     @Test
+    void sellActionbarReplacesFormattedPriceBeforeCompactPrice() {
+        assertEquals(
+                "$1,200.00",
+                ShopManager.applySellPricePlaceholders("{price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "&a+$1.2k",
+                ShopManager.applySellPricePlaceholders("&a+$%price%", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "&a+$1,200.00 (1.2k)",
+                ShopManager.applySellPricePlaceholders("&a+{price_formatted} ({price})", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "&a+$1,200.00",
+                ShopManager.applySellPricePlaceholders("&a+%price_formatted%", "1.2k", "$1,200.00")
+        );
+    }
+
+    @Test
     void readsCurrencyNames() {
         assertEquals(ShopManager.Currency.SHARD, ShopManager.parseCurrency("SHARD"));
         assertEquals(ShopManager.Currency.SHARD, ShopManager.parseCurrency("shards"));


### PR DESCRIPTION
Closes #452

SETTINGS.SELL-MESSAGE treated `{price}` as a prefix of `{price_formatted}`, so an actionbar using the full-money token came out as compact text plus `_formatted`. The replacements now run longest-first, same order the /sell confirm button already used.

## Placeholder order
`ShopManager.applySellPricePlaceholders` fills `{price_formatted}` / `%price_formatted%` before `{price}` / `%price%`. The sell actionbar and the confirm button both call that helper. Shipped config still uses `%price%`, which was never broken; the Java fallback `&a+{price_formatted}` and any admin who copied that token now show the real money string.

## Notes
Config-config.yml.md and Configuration-Reference.md now name both placeholder pairs. 724 tests, including one that feeds `{price_formatted}` and `{price}` in the same string.
