### PR TITLE
fix(shop): replace formatted purchase-price placeholders first (#454)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenu.java
@@ -304,15 +304,14 @@ public class PurchaseShopMenu extends BaseMenu {
         if (currencyType == CurrencyManager.CurrencyType.SHARDS) {
             resolved = resolved
                     .replace("{amount} shards", "{price_formatted}")
-                    .replace("{amount} shards", "{price_formatted}")
                     .replace("%amount% shards", "{price_formatted}")
                     .replace("${amount} shards", "{price_formatted}");
         }
+        resolved = replacePricePlaceholders(resolved, amount, formattedPrice);
         return resolved
                 .replace("{amount}", amount)
                 .replace("${amount}", formattedPrice)
                 .replace("%amount%", amount)
-                .replace("{price_formatted}", formattedPrice)
                 .replace("{currency}", formattedPrice)
                 .replace("{currency_name}", plugin.getCurrencyManager().name(currencyType, totalPrice))
                 .replace("{currency_name_singular}", plugin.getCurrencyManager().singular(currencyType))
@@ -342,11 +341,7 @@ public class PurchaseShopMenu extends BaseMenu {
                     .replace("{price} shards", "{price_formatted}")
                     .replace("%price% shards", "{price_formatted}");
         }
-        return resolved
-                .replace("${price}", formattedPrice)
-                .replace("%price%", amount)
-                .replace("{price}", amount)
-                .replace("{price_formatted}", formattedPrice)
+        return replacePricePlaceholders(resolved, amount, formattedPrice)
                 .replace("{currency}", formattedPrice)
                 .replace("{currency_name}", plugin.getCurrencyManager().name(currencyType, totalPrice))
                 .replace("{currency_name_singular}", plugin.getCurrencyManager().singular(currencyType))
@@ -356,6 +351,19 @@ public class PurchaseShopMenu extends BaseMenu {
                 .replace("{Quantity}", String.valueOf(quantity))
                 .replace("{item-name}", resolveItemName())
                 .replace("{item_name}", resolveItemName());
+    }
+
+    static String replacePricePlaceholders(String text, String compactPrice, String formattedPrice) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return text
+                .replace("${price_formatted}", formattedPrice)
+                .replace("{price_formatted}", formattedPrice)
+                .replace("%price_formatted%", formattedPrice)
+                .replace("${price}", formattedPrice)
+                .replace("%price%", compactPrice)
+                .replace("{price}", compactPrice);
     }
 
     private CurrencyManager.CurrencyType currencyType() {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/PurchaseShopMenuTest.java
@@ -1,0 +1,36 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PurchaseShopMenuTest {
+
+    @Test
+    void purchaseTextReplacesFormattedPriceBeforeCompactPrice() {
+        assertEquals(
+                "$1,200.00",
+                PurchaseShopMenu.replacePricePlaceholders("{price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "1.2k",
+                PurchaseShopMenu.replacePricePlaceholders("{price}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "+$1,200.00 (1.2k)",
+                PurchaseShopMenu.replacePricePlaceholders("+{price_formatted} ({price})", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                PurchaseShopMenu.replacePricePlaceholders("%price_formatted%", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                PurchaseShopMenu.replacePricePlaceholders("${price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                PurchaseShopMenu.replacePricePlaceholders("${price}", "1.2k", "$1,200.00")
+        );
+    }
+}


### PR DESCRIPTION
Closes #454

Purchase confirm text treated `{price}` as a prefix of `{price_formatted}`, so a line using the full-money token came out as compact text plus `_formatted`. The replacements now run longest-first, same idea ShopMenu already used for shop item lore.

## Placeholder order
`PurchaseShopMenu.replacePricePlaceholders` fills `${price_formatted}` first, then `{price_formatted}` / `%price_formatted%`, then `${price}` / `{price}` / `%price%`. The `$` formatted token has to go in before `{price_formatted}`, or the leftover `$` doubles the money symbol. Confirm button text, preview lore, quantity labels and the purchase success message all call that helper.

`${price}` is still the full money string, which is what the shipped `BUY PRICE: &a${price}` lore wants. `{price}` stays the bare/compact amount.

## Notes
Shipped confirm lore is `CLICK TO BUY` with no price token, so a stock menus.yml never showed this. Custom `{price_formatted}` on the confirm button or in `PURCHASE-SHOP-MENU.MESSAGES.SUCCESS` now shows the real money string. 731 tests, including one that feeds `{price_formatted}` and `{price}` in the same string.
