### PR TITLE
fix(shop): replace dollar formatted shop-price placeholders first (#460)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/ShopMenu.java
@@ -358,13 +358,11 @@ public class ShopMenu extends BaseMenu {
                 : item.pricePerUnit();
         String formattedPrice = plugin.getCurrencyManager().format(currencyType, price);
         String rawPrice = plugin.getCurrencyManager().formatAmount(currencyType, price);
-        String result = plugin.getCurrencyManager().applyStaticPlaceholders(line)
-                .replace("{price_formatted}", formattedPrice)
-                .replace("%price_formatted%", formattedPrice)
-                .replace("${price_formatted}", formattedPrice)
-                .replace("${price}", formattedPrice)
-                .replace("{price}", rawPrice)
-                .replace("%price%", rawPrice);
+        String result = replacePricePlaceholders(
+                plugin.getCurrencyManager().applyStaticPlaceholders(line),
+                rawPrice,
+                formattedPrice
+        );
 
         String normalizedLine = ColorUtils.normalizeLabel(line);
         if ((normalizedLine.contains("buy price:") || normalizedLine.contains("harga beli:")) && !line.contains("{price")) {
@@ -374,6 +372,19 @@ public class ShopMenu extends BaseMenu {
             }
         }
         return result;
+    }
+
+    static String replacePricePlaceholders(String line, String rawPrice, String formattedPrice) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+        return line
+                .replace("${price_formatted}", formattedPrice)
+                .replace("{price_formatted}", formattedPrice)
+                .replace("%price_formatted%", formattedPrice)
+                .replace("${price}", formattedPrice)
+                .replace("{price}", rawPrice)
+                .replace("%price%", rawPrice);
     }
 
     private void buildBackButton() {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/ShopMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/ShopMenuTest.java
@@ -1,0 +1,32 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ShopMenuTest {
+
+    @Test
+    void shopLoreReplacesDollarFormattedPriceBeforeBraceFormattedPrice() {
+        assertEquals(
+                "$1,200.00",
+                ShopMenu.replacePricePlaceholders("${price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                ShopMenu.replacePricePlaceholders("{price_formatted}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "1.2k",
+                ShopMenu.replacePricePlaceholders("{price}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                ShopMenu.replacePricePlaceholders("${price}", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1,200.00",
+                ShopMenu.replacePricePlaceholders("%price_formatted%", "1.2k", "$1,200.00")
+        );
+    }
+}


### PR DESCRIPTION
Closes #460

Shop item lore treated `{price_formatted}` as a chunk of `${price_formatted}`, so a line using the dollar-formatted token came out with the money symbol twice. Purchase confirm already fills `${price_formatted}` first; shop lore now uses that same longest-first pass.

## Placeholder order
`ShopMenu.replacePricePlaceholders` fills `${price_formatted}` before `{price_formatted}` and `%price_formatted%`, then `${price}`, `{price}` and `%price%`. `{price}` is still the bare number. `${price}` is still the full money string.

## Notes
Shipped shop.yml lore is usually a `Buy price:` line with no placeholder, so a default shop never showed this. Custom `${price_formatted}` in an item's LORE now renders once. 732 tests, including one that feeds `${price_formatted}` on its own.
