### PR TITLE
fix(menus): replace formatted sell-history and bounty prices first (#459)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/menus/BountyMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/BountyMenu.java
@@ -189,10 +189,10 @@ public class BountyMenu extends BaseMenu {
         String playerName = plugin.getBountyManager().getDisplayName(bounty.getTargetUuid());
         String displayName = menus.getString("BOUNTIES-MENU.BOUNTY-BUTTON.NAME", "&#6BF18D{player}")
                 .replace("{player}", playerName);
+        String compactPrice = NumberUtils.format(bounty.getAmount());
+        String formattedPrice = plugin.getCurrencyManager().formatMoney(bounty.getAmount());
         List<String> lore = menus.getStringList("BOUNTIES-MENU.BOUNTY-BUTTON.LORE").stream()
-                .map(line -> line.replace("{player}", playerName)
-                        .replace("{price}", NumberUtils.format(bounty.getAmount()))
-                        .replace("{price_formatted}", plugin.getCurrencyManager().formatMoney(bounty.getAmount())))
+                .map(line -> replaceBountyPlaceholders(line, playerName, compactPrice, formattedPrice))
                 .toList();
 
         Material material = ItemUtils.parseMaterial(
@@ -211,6 +211,16 @@ public class BountyMenu extends BaseMenu {
         meta.setOwningPlayer(resolveOfflinePlayer(bounty.getTargetUuid()));
         item.setItemMeta(meta);
         return item;
+    }
+
+    static String replaceBountyPlaceholders(String line, String playerName, String compactPrice, String formattedPrice) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+        return line
+                .replace("{player}", playerName)
+                .replace("{price_formatted}", formattedPrice)
+                .replace("{price}", compactPrice);
     }
 
     private void buildRefreshButton(FileConfiguration menus) {

--- a/src/main/java/com/bx/ultimateDonutSmp/menus/SellHistoryMenu.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/menus/SellHistoryMenu.java
@@ -160,14 +160,24 @@ public class SellHistoryMenu extends BaseMenu {
     ) {
         Material material = ItemUtils.parseMaterial(entry.itemName());
         String displayName = "&f" + toDisplayName(entry.itemName());
+        String compactPrice = plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, entry.price());
+        String formattedPrice = plugin.getCurrencyManager().formatMoney(entry.price());
+        String amount = NumberUtils.format(entry.amount());
         List<String> lore = menus.getStringList("SELL-HISTORY-MENU.BUTTONS.MATERIAL-ITEM.LORE").stream()
-                .map(line -> line
-                        .replace("{price}", plugin.getCurrencyManager().formatCompactAmount(CurrencyManager.CurrencyType.MONEY, entry.price()))
-                        .replace("{price_formatted}", plugin.getCurrencyManager().formatMoney(entry.price()))
-                        .replace("{amount}", NumberUtils.format(entry.amount())))
+                .map(line -> replaceHistoryPlaceholders(line, compactPrice, formattedPrice, amount))
                 .toList();
 
         return ItemUtils.createItem(material, displayName, lore);
+    }
+
+    static String replaceHistoryPlaceholders(String line, String compactPrice, String formattedPrice, String amount) {
+        if (line == null || line.isEmpty()) {
+            return "";
+        }
+        return line
+                .replace("{price_formatted}", formattedPrice)
+                .replace("{price}", compactPrice)
+                .replace("{amount}", amount);
     }
 
     private String toDisplayName(String value) {

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/BountyMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/BountyMenuTest.java
@@ -1,0 +1,28 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BountyMenuTest {
+
+    @Test
+    void bountyLoreReplacesFormattedPriceBeforeCompactPrice() {
+        assertEquals(
+                "$1,200.00",
+                BountyMenu.replaceBountyPlaceholders("{price_formatted}", "Steve", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "1.2k",
+                BountyMenu.replaceBountyPlaceholders("{price}", "Steve", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "Steve: +$1,200.00 (1.2k)",
+                BountyMenu.replaceBountyPlaceholders("{player}: +{price_formatted} ({price})", "Steve", "1.2k", "$1,200.00")
+        );
+        assertEquals(
+                "$1.2k",
+                BountyMenu.replaceBountyPlaceholders("${price}", "Steve", "1.2k", "$1,200.00")
+        );
+    }
+}

--- a/src/test/java/com/bx/ultimateDonutSmp/menus/SellHistoryMenuTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/menus/SellHistoryMenuTest.java
@@ -1,0 +1,28 @@
+package com.bx.ultimateDonutSmp.menus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SellHistoryMenuTest {
+
+    @Test
+    void historyLoreReplacesFormattedPriceBeforeCompactPrice() {
+        assertEquals(
+                "$1,200.00",
+                SellHistoryMenu.replaceHistoryPlaceholders("{price_formatted}", "1.2k", "$1,200.00", "64")
+        );
+        assertEquals(
+                "1.2k",
+                SellHistoryMenu.replaceHistoryPlaceholders("{price}", "1.2k", "$1,200.00", "64")
+        );
+        assertEquals(
+                "+$1,200.00 (1.2k)",
+                SellHistoryMenu.replaceHistoryPlaceholders("+{price_formatted} ({price})", "1.2k", "$1,200.00", "64")
+        );
+        assertEquals(
+                "64",
+                SellHistoryMenu.replaceHistoryPlaceholders("{amount}", "1.2k", "$1,200.00", "64")
+        );
+    }
+}


### PR DESCRIPTION
Closes #459

Sell history rows and bounty heads ran `{price}` before `{price_formatted}`. `{price}` is a prefix of the longer token, so lore that asked for the full money string came back as the compact amount plus `_formatted`. Same leftover as the sell actionbar and the purchase confirm menu; those two already fill the long token first.

## Sell history and bounty lore
`SellHistoryMenu` and `BountyMenu` now replace `{price_formatted}` first, then `{price}`. `{amount}` and `{player}` stay as they were. Default `menus.yml` still uses `{price}` / `${price}`, so a stock file looks the same. Custom lore that already had `{price_formatted}` now prints the real money string instead of `1.2k_formatted`.

The `$` in the shipped bounty line `&fBounty: &7${price}` is still just a dollar sign in front of `{price}`. That is not the `${price}` shop token, and it still becomes `$` plus the compact amount.

## Notes
734 tests. Two new ones feed `{price_formatted}` and `{price}` in the same string for each menu.
