### PR TITLE
feat(join): log player join and quit in the server log (#450)

### DIFF
--- a/docs/wiki/Config-config.yml.md
+++ b/docs/wiki/Config-config.yml.md
@@ -268,6 +268,11 @@ SETTINGS:
   # player joins before sending them to spawn. Raise it when another plugin moves players
   # around on join. Available options: Any valid integer
   FIRST-JOIN-SPAWN-DELAY-TICKS: 20
+  # Writes a [JOIN] or [QUIT] line into the server log when a player connects or
+  # disconnects. Independent of the in-game join and leave messages, so staff can
+  # still see traffic in latest.log after those chat lines are turned off.
+  # Available options: true, false
+  LOG-JOIN-QUIT: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -307,6 +312,7 @@ SETTINGS:
 | `SETTINGS.AFK-MENU` | `bool` | `true`, `false` | `true` | Configures the technical `AFK-MENU` parameter for `SETTINGS.AFK-MENU` in `config.yml`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | `true`, `false` | `true` | Teleports a player to the spawn location the first time they join. Does nothing until `/setspawn` has been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
 | `SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS` | `int` | Any valid integer number | `20` | How long the plugin waits after the join before running that teleport. Values below `1` are treated as `1` and anything above `1200` is capped there. |
+| `SETTINGS.LOG-JOIN-QUIT` | `bool` | `true`, `false` | `true` | Writes a `[JOIN] PlayerName` or `[QUIT] PlayerName` line into the server log on connect and disconnect. Uses the real name even if the player is vanished. Independent of the in-game join and leave messages, so turning those chat lines off still leaves the log record. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Any decimal number | `'1.0'` | Configures the technical `WORTH-DEFAULT-VALUE` parameter for `SETTINGS.WORTH-DEFAULT-VALUE` in `config.yml`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer number | `'50'` | Configures the technical `MOB-SPAWN-RADIUS` parameter for `SETTINGS.MOB-SPAWN-RADIUS` in `config.yml`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer number | `'40'` | Configures the technical `PHANTOM-SPAWN-RADIUS` parameter for `SETTINGS.PHANTOM-SPAWN-RADIUS` in `config.yml`. |
@@ -396,6 +402,11 @@ SETTINGS:
   # player joins before sending them to spawn. Raise it when another plugin moves players
   # around on join. Available options: Any valid integer
   FIRST-JOIN-SPAWN-DELAY-TICKS: 20
+  # Writes a [JOIN] or [QUIT] line into the server log when a player connects or
+  # disconnects. Independent of the in-game join and leave messages, so staff can
+  # still see traffic in latest.log after those chat lines are turned off.
+  # Available options: true, false
+  LOG-JOIN-QUIT: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -545,6 +545,11 @@ SETTINGS:
   # player joins before sending them to spawn. Raise it when another plugin moves players
   # around on join. Available options: Any valid integer
   FIRST-JOIN-SPAWN-DELAY-TICKS: 20
+  # Writes a [JOIN] or [QUIT] line into the server log when a player connects or
+  # disconnects. Independent of the in-game join and leave messages, so staff can
+  # still see traffic in latest.log after those chat lines are turned off.
+  # Available options: true, false
+  LOG-JOIN-QUIT: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer
@@ -583,6 +588,7 @@ SETTINGS:
 | `SETTINGS.AFK-MENU` | `bool` | true, false | `True` | Configures `AFK-MENU` for `SETTINGS`. |
 | `SETTINGS.TELEPORT-SPAWN-ON-FIRST-JOIN` | `bool` | true, false | `True` | Teleports a player to spawn on their first join. Needs `/setspawn` to have been run. Ignored while `FIRST-JOIN-RTP.ENABLED` is `true`. |
 | `SETTINGS.FIRST-JOIN-SPAWN-DELAY-TICKS` | `int` | Any valid integer | `20` | How long the plugin waits after the join before running that teleport. Values below `1` become `1`, anything above `1200` is capped there. |
+| `SETTINGS.LOG-JOIN-QUIT` | `bool` | true, false | `True` | Writes a `[JOIN] PlayerName` or `[QUIT] PlayerName` line into the server log on connect and disconnect. Uses the real name even if the player is vanished. Independent of the in-game join and leave messages, so turning those chat lines off still leaves the log record. |
 | `SETTINGS.WORTH-DEFAULT-VALUE` | `float` | Configured values | `1.0` | Configures `WORTH-DEFAULT-VALUE` for `SETTINGS`. |
 | `SETTINGS.MOB-SPAWN-RADIUS` | `int` | Any valid integer | `50` | Configures `MOB-SPAWN-RADIUS` for `SETTINGS`. |
 | `SETTINGS.PHANTOM-SPAWN-RADIUS` | `int` | Any valid integer | `40` | Configures `PHANTOM-SPAWN-RADIUS` for `SETTINGS`. |

--- a/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/listeners/PlayerJoinQuitListener.java
@@ -26,6 +26,7 @@ public class PlayerJoinQuitListener implements Listener {
 
     static final long DEFAULT_FIRST_JOIN_SPAWN_DELAY_TICKS = 20L;
     static final long MAX_FIRST_JOIN_SPAWN_DELAY_TICKS = 1200L;
+    static final String JOIN_QUIT_LOG_PATH = "SETTINGS.LOG-JOIN-QUIT";
     private static final long FIRST_JOIN_SPAWN_RETRY_DELAY_TICKS = 20L;
 
     private final UltimateDonutSmp plugin;
@@ -86,6 +87,7 @@ public class PlayerJoinQuitListener implements Listener {
         Player player = event.getPlayer();
         String joinMsg = event.getJoinMessage();
         event.setJoinMessage(null);
+        logJoinQuit("JOIN", player);
 
         // 1. Maintenance checkmode
         if (plugin.getMaintenanceManager() != null && plugin.getMaintenanceManager().isMaintenanceActive()) {
@@ -334,6 +336,28 @@ public class PlayerJoinQuitListener implements Listener {
         return Math.max(1L, Math.min(MAX_FIRST_JOIN_SPAWN_DELAY_TICKS, configured));
     }
 
+    /**
+     * A greppable join or quit line for latest.log. Chat join and leave messages never
+     * reach the console because they are resent per player, so this is the staff-facing
+     * record of who connected. Uses the real name, not a vanished disguise.
+     */
+    static String joinQuitLogLine(String kind, String playerName) {
+        if (kind == null || kind.isBlank() || playerName == null || playerName.isBlank()) {
+            return null;
+        }
+        return "[" + kind + "] " + playerName;
+    }
+
+    private void logJoinQuit(String kind, Player player) {
+        if (!plugin.getConfigManager().getConfig().getBoolean(JOIN_QUIT_LOG_PATH, true)) {
+            return;
+        }
+        String line = joinQuitLogLine(kind, player.getName());
+        if (line != null) {
+            plugin.getLogger().info(line);
+        }
+    }
+
     static boolean deniesMaintenanceLogin(boolean maintenanceActive, boolean hasBypass, boolean hasLobbyDestination) {
         return maintenanceActive && !hasBypass && !hasLobbyDestination;
     }
@@ -366,6 +390,7 @@ public class PlayerJoinQuitListener implements Listener {
         Player player = event.getPlayer();
         String quitMsg = event.getQuitMessage();
         event.setQuitMessage(null);
+        logJoinQuit("QUIT", player);
 
         TitleUtils.cancelPendingReset(player.getUniqueId());
         plugin.getNetworkStaffChatManager().handleStaffLeave(player);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -129,6 +129,11 @@ SETTINGS:
   # player joins before sending them to spawn. Raise it when another plugin moves players
   # around on join. Available options: Any valid integer
   FIRST-JOIN-SPAWN-DELAY-TICKS: 20
+  # Writes a [JOIN] or [QUIT] line into the server log when a player connects or
+  # disconnects. Independent of the in-game join and leave messages, so staff can
+  # still see traffic in latest.log after those chat lines are turned off.
+  # Available options: true, false
+  LOG-JOIN-QUIT: true
   # The decimal value for Worth Default Value. Available options: Any decimal number
   WORTH-DEFAULT-VALUE: 1.0
   # The numerical value for Mob Spawn Radius. Available options: Any valid integer

--- a/src/test/java/com/bx/ultimateDonutSmp/listeners/JoinQuitLogTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/listeners/JoinQuitLogTest.java
@@ -1,0 +1,41 @@
+package com.bx.ultimateDonutSmp.listeners;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Join and leave chat is resent per player, which never reaches latest.log. These pin the
+ * console lines that replace that missing record, and the switch that can silence them.
+ */
+class JoinQuitLogTest {
+
+    @Test
+    void bundledConfigShipsJoinQuitLoggingOn() {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new File("src/main/resources/config.yml"));
+        assertTrue(config.contains(PlayerJoinQuitListener.JOIN_QUIT_LOG_PATH));
+        assertTrue(config.getBoolean(PlayerJoinQuitListener.JOIN_QUIT_LOG_PATH));
+    }
+
+    @Test
+    void aJoinLineNamesThePlayer() {
+        assertEquals("[JOIN] Steve", PlayerJoinQuitListener.joinQuitLogLine("JOIN", "Steve"));
+    }
+
+    @Test
+    void aQuitLineNamesThePlayer() {
+        assertEquals("[QUIT] Alex", PlayerJoinQuitListener.joinQuitLogLine("QUIT", "Alex"));
+    }
+
+    @Test
+    void aBlankNameIsNotLogged() {
+        assertNull(PlayerJoinQuitListener.joinQuitLogLine("JOIN", " "));
+        assertNull(PlayerJoinQuitListener.joinQuitLogLine("QUIT", null));
+        assertNull(PlayerJoinQuitListener.joinQuitLogLine("", "Steve"));
+    }
+}


### PR DESCRIPTION
Closes #450

Join and leave chat never made it into latest.log. The plugin clears the server's own message and sends it to each player, so staff grepping the log for who connected came up empty. This writes a [JOIN] and [QUIT] line through the plugin logger instead.

## Console lines
On connect and disconnect the log gets `[JOIN] PlayerName` or `[QUIT] PlayerName`. It uses the real name even if they are vanished, because a disguise in the staff log is useless. Chat join/leave settings stay as they are; this is a separate record.

## Config
`SETTINGS.LOG-JOIN-QUIT` ships on. Turn it off if you don't want the extra lines. Existing servers pick the key up on the next config merge. The config.yml wiki page and the configuration reference both list it.

## Notes
738 tests. JoinQuitLogTest covers the line format, blank names, and that the bundled config ships the switch on.
