### PR TITLE
fix(amethyst): parse tab-completed type names on a turkish jvm (#467)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolType.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolType.java
@@ -1,5 +1,7 @@
 package com.bx.ultimateDonutSmp.amethyst;
 
+import java.util.Locale;
+
 public enum AmethystToolType {
     DRILL("Amethyst Drill"),
     CHOPPER("Amethyst Tree Chopper"),
@@ -22,7 +24,7 @@ public enum AmethystToolType {
     public static AmethystToolType fromString(String name) {
         if (name == null) return null;
         try {
-            return valueOf(name.toUpperCase().replace(" ", "_").replace("-", "_"));
+            return valueOf(name.toUpperCase(Locale.ROOT).replace(" ", "_").replace("-", "_"));
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolTypeTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/amethyst/AmethystToolTypeTest.java
@@ -1,0 +1,24 @@
+package com.bx.ultimateDonutSmp.amethyst;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AmethystToolTypeTest {
+
+    @Test
+    void tabCompletionNamesParseWhenTheJvmIsTurkish() {
+        Locale previous = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            for (AmethystToolType type : AmethystToolType.values()) {
+                String completion = type.name().toLowerCase(Locale.ROOT).replace('_', '-');
+                assertEquals(type, AmethystToolType.fromString(completion), completion);
+            }
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+}


### PR DESCRIPTION
Closes #467

`/amethysttool give` tab-completes types as hyphenated lowercase names (`drill`, `sell-axe`). `AmethystToolType.fromString` then ran `String.toUpperCase()` with no locale, so on a Turkish JVM `i` becomes `İ` and `drill` turns into `DRİLL`. `valueOf` misses, and the player gets the invalid-type message even though they accepted a tab completion. Shop YAML keys like `DRILL` were already uppercase, so they still parsed.

## Parsing
`fromString` now uppercases with `Locale.ROOT`, matching the locale the tab completer already uses when it builds those names. Config keys (`DRILL`, `SELL-AXE`) and the type name stored on the item (`type.name()`) keep working.

## Notes
739 tests. `AmethystToolTypeTest` sets the JVM default to `tr-TR` and checks every enum's tab-completion name round-trips through `fromString`.
