### PR TITLE
fix(duels): stop players staying invincible after a duel ends (#469)

### DIFF
--- a/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/DuelManager.java
@@ -1784,17 +1784,18 @@ public class DuelManager {
             return;
         }
 
-        Player player = Bukkit.getPlayer(uuid);
-        if (player == null || location == null) {
+        Player initialPlayer = Bukkit.getPlayer(uuid);
+        if (initialPlayer == null || location == null) {
             // No destination or nobody to send there: the transition still has to be lifted,
             // otherwise the player keeps the duel damage immunity for the rest of the session.
             if (clearTransition) {
-                if (player == null) {
+                if (initialPlayer == null) {
                     clearTransitionTracking(uuid);
                 } else {
-                    plugin.getSpigotScheduler().runEntityLater(player, () -> {
-                        if (player.isOnline()) {
-                            restoreTransitionState(player);
+                    plugin.getSpigotScheduler().runGlobalLater(() -> {
+                        Player livePlayer = Bukkit.getPlayer(uuid);
+                        if (livePlayer != null && livePlayer.isOnline()) {
+                            restoreTransitionState(livePlayer);
                         } else {
                             clearTransitionTracking(uuid);
                         }
@@ -1804,8 +1805,9 @@ public class DuelManager {
             return;
         }
 
-        plugin.getSpigotScheduler().runEntityLater(player, () -> {
-            if (!player.isOnline()) {
+        plugin.getSpigotScheduler().runGlobalLater(() -> {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null || !player.isOnline()) {
                 if (clearTransition) {
                     clearTransitionTracking(uuid);
                 }
@@ -1818,20 +1820,28 @@ public class DuelManager {
                     plugin.getLogger().warning("Duel return teleport failed for " + player.getName()
                             + ": " + error.getMessage());
                 }
-                plugin.getSpigotScheduler().runEntity(player, () -> {
-                    if (!player.isOnline()) {
+                Runnable finishTask = () -> {
+                    Player livePlayer = Bukkit.getPlayer(uuid);
+                    if (livePlayer == null || !livePlayer.isOnline()) {
                         if (clearTransition) {
                             clearTransitionTracking(uuid);
                         }
                         return;
                     }
                     if (Boolean.TRUE.equals(success)) {
-                        healPlayer(player);
+                        healPlayer(livePlayer);
                     }
                     if (clearTransition) {
-                        restoreTransitionState(player);
+                        restoreTransitionState(livePlayer);
                     }
-                });
+                };
+
+                Player livePlayer = Bukkit.getPlayer(uuid);
+                if (livePlayer != null && livePlayer.isOnline()) {
+                    plugin.getSpigotScheduler().runEntity(livePlayer, finishTask);
+                } else {
+                    plugin.getSpigotScheduler().runGlobal(finishTask);
+                }
             });
         }, delayTicks);
     }
@@ -2179,6 +2189,9 @@ public class DuelManager {
         restoreTransitionState(player);
         player.setGameMode(GameMode.SURVIVAL);
         healPlayer(player);
+        if (!isProtectedByOtherFeature(player.getUniqueId())) {
+            player.setInvulnerable(false);
+        }
         applyArenaRules(player, arena);
         if (teleportLocation != null) {
             executeInternalTeleportAsync(player, teleportLocation);
@@ -3713,7 +3726,7 @@ public class DuelManager {
                 player.getGameMode(),
                 player.getAllowFlight(),
                 player.isFlying(),
-                player.isInvulnerable(),
+                isProtectedByOtherFeature(player.getUniqueId()),
                 player.isCollidable()
         ));
         applyTemporaryVanish(player);
@@ -3734,23 +3747,28 @@ public class DuelManager {
         }
 
         UUID uuid = player.getUniqueId();
+        Player livePlayer = Bukkit.getPlayer(uuid);
+        if (livePlayer != null && livePlayer.isOnline()) {
+            player = livePlayer;
+        }
+
         TransitionPlayerState state = transitionStates.remove(uuid);
         transitionDeadlines.remove(uuid);
         // Without a stored snapshot we fall back to plain survival defaults, so players kept
         // invulnerable by another feature are left alone instead of losing their god/staff mode.
-        boolean keepExternalProtection = state == null && isProtectedByOtherFeature(uuid);
+        boolean keepExternalProtection = isProtectedByOtherFeature(uuid);
         if (state == null) {
             state = new TransitionPlayerState(GameMode.SURVIVAL, false, false, false, true);
         }
-        if (!keepExternalProtection) {
-            if (player.getGameMode() != state.gameMode()) {
-                player.setGameMode(state.gameMode());
-            }
-            player.setAllowFlight(state.allowFlight());
-            player.setFlying(state.allowFlight() && state.flying());
-            player.setInvulnerable(state.invulnerable());
-            player.setCollidable(state.collidable());
+        if (player.getGameMode() != state.gameMode()) {
+            player.setGameMode(state.gameMode());
         }
+        player.setAllowFlight(state.allowFlight());
+        player.setFlying(state.allowFlight() && state.flying());
+        if (!keepExternalProtection) {
+            player.setInvulnerable(false);
+        }
+        player.setCollidable(state.collidable());
         player.resetPlayerTime();
         player.resetPlayerWeather();
         transitionTitles.remove(uuid);
@@ -3760,12 +3778,23 @@ public class DuelManager {
     }
 
     private boolean isProtectedByOtherFeature(UUID uuid) {
-        if (uuid == null) {
+        if (uuid == null || plugin == null) {
             return false;
         }
 
-        return (plugin.getGodModeManager() != null && plugin.getGodModeManager().isInGodMode(uuid))
-                || (plugin.getStaffModeManager() != null && plugin.getStaffModeManager().isInStaffMode(uuid));
+        try {
+            if (plugin.getGodModeManager() != null && plugin.getGodModeManager().isInGodMode(uuid)) {
+                return true;
+            }
+        } catch (Throwable ignored) {
+        }
+        try {
+            if (plugin.getStaffModeManager() != null && plugin.getStaffModeManager().isInStaffMode(uuid)) {
+                return true;
+            }
+        } catch (Throwable ignored) {
+        }
+        return false;
     }
 
     private void armTransitionDeadline(UUID uuid) {
@@ -3790,6 +3819,11 @@ public class DuelManager {
         transitionStates.remove(uuid);
         transitionDeadlines.remove(uuid);
         transitionTitles.remove(uuid);
+
+        Player player = Bukkit.getPlayer(uuid);
+        if (player != null && player.isOnline() && !isProtectedByOtherFeature(uuid)) {
+            player.setInvulnerable(false);
+        }
     }
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/managers/FfaManager.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/managers/FfaManager.java
@@ -2326,17 +2326,25 @@ public class FfaManager {
                         plugin.getLogger().warning("FFA return teleport failed for " + player.getName()
                                 + ": " + error.getMessage());
                     }
-                    plugin.getSpigotScheduler().runEntity(player, () -> {
-                        if (!player.isOnline()) {
+                    Runnable finishTask = () -> {
+                        Player livePlayer = Bukkit.getPlayer(uuid);
+                        if (livePlayer == null || !livePlayer.isOnline()) {
                             clearTransitionTracking(uuid);
                             return;
                         }
                         if (Boolean.TRUE.equals(success)) {
-                            player.setNoDamageTicks(60);
+                            livePlayer.setNoDamageTicks(60);
                         }
-                        restoreTransitionState(player);
+                        restoreTransitionState(livePlayer);
                         updateCombatLock(uuid);
-                    });
+                    };
+
+                    Player livePlayer = Bukkit.getPlayer(uuid);
+                    if (livePlayer != null && livePlayer.isOnline()) {
+                        plugin.getSpigotScheduler().runEntity(livePlayer, finishTask);
+                    } else {
+                        plugin.getSpigotScheduler().runGlobal(finishTask);
+                    }
                 });
             });
         }, delayTicks);
@@ -2627,7 +2635,7 @@ public class FfaManager {
                 player.getGameMode(),
                 player.getAllowFlight(),
                 player.isFlying(),
-                player.isInvulnerable(),
+                isProtectedByOtherFeature(uuid),
                 player.isCollidable()
         ));
         applyTemporaryVanish(player);
@@ -2647,13 +2655,22 @@ public class FfaManager {
         }
 
         UUID uuid = player.getUniqueId();
+        Player livePlayer = Bukkit.getPlayer(uuid);
+        if (livePlayer != null && livePlayer.isOnline()) {
+            player = livePlayer;
+        }
+
         TransitionPlayerState state = transitionStates.remove(uuid);
         transitionDeadlines.remove(uuid);
+        boolean keepExternalProtection = isProtectedByOtherFeature(uuid);
         if (state == null) {
             transitionTitles.remove(uuid);
             transitioningPlayers.remove(uuid);
             TitleUtils.clearTitle(player);
             clearTemporaryVanish(player);
+            if (!keepExternalProtection) {
+                player.setInvulnerable(false);
+            }
             return;
         }
 
@@ -2662,12 +2679,34 @@ public class FfaManager {
         }
         player.setAllowFlight(state.allowFlight());
         player.setFlying(state.allowFlight() && state.flying());
-        player.setInvulnerable(state.invulnerable());
+        if (!keepExternalProtection) {
+            player.setInvulnerable(false);
+        }
         player.setCollidable(state.collidable());
         transitionTitles.remove(uuid);
         transitioningPlayers.remove(uuid);
         TitleUtils.clearTitle(player);
         clearTemporaryVanish(player);
+    }
+
+    private boolean isProtectedByOtherFeature(UUID uuid) {
+        if (uuid == null || plugin == null) {
+            return false;
+        }
+
+        try {
+            if (plugin.getGodModeManager() != null && plugin.getGodModeManager().isInGodMode(uuid)) {
+                return true;
+            }
+        } catch (Throwable ignored) {
+        }
+        try {
+            if (plugin.getStaffModeManager() != null && plugin.getStaffModeManager().isInStaffMode(uuid)) {
+                return true;
+            }
+        } catch (Throwable ignored) {
+        }
+        return false;
     }
 
     private void armTransitionDeadline(UUID uuid) {
@@ -2692,6 +2731,11 @@ public class FfaManager {
         transitionStates.remove(uuid);
         transitionDeadlines.remove(uuid);
         transitionTitles.remove(uuid);
+
+        Player player = Bukkit.getPlayer(uuid);
+        if (player != null && player.isOnline() && !isProtectedByOtherFeature(uuid)) {
+            player.setInvulnerable(false);
+        }
     }
 
     /**

--- a/src/main/java/com/bx/ultimateDonutSmp/utils/AttributeUtils.java
+++ b/src/main/java/com/bx/ultimateDonutSmp/utils/AttributeUtils.java
@@ -39,7 +39,7 @@ public final class AttributeUtils {
             if (value instanceof Attribute attribute) {
                 return attribute;
             }
-        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        } catch (Throwable ignored) {
         }
 
         try {
@@ -47,7 +47,7 @@ public final class AttributeUtils {
             if (value instanceof Attribute attribute) {
                 return attribute;
             }
-        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        } catch (Throwable ignored) {
         }
 
         return null;

--- a/src/test/java/com/bx/ultimateDonutSmp/managers/DuelTransitionInvulnerabilityTest.java
+++ b/src/test/java/com/bx/ultimateDonutSmp/managers/DuelTransitionInvulnerabilityTest.java
@@ -1,0 +1,241 @@
+package com.bx.ultimateDonutSmp.managers;
+
+import com.bx.ultimateDonutSmp.UltimateDonutSmp;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sun.reflect.ReflectionFactory;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuelTransitionInvulnerabilityTest {
+
+    private static final UUID PLAYER_UUID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+
+    private Server originalServer;
+    private UltimateDonutSmp plugin;
+    private DuelManager duelManager;
+    private AtomicBoolean liveInvulnerable;
+    private Player livePlayer;
+    private GodModeManager godModeManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalServer = Bukkit.getServer();
+        liveInvulnerable = new AtomicBoolean(true);
+
+        livePlayer = proxy(Player.class, (method, args) -> switch (method.getName()) {
+            case "getUniqueId" -> PLAYER_UUID;
+            case "getName" -> "Fighter";
+            case "isOnline" -> true;
+            case "isDead" -> false;
+            case "isInvulnerable" -> liveInvulnerable.get();
+            case "setInvulnerable" -> {
+                liveInvulnerable.set((Boolean) args[0]);
+                yield null;
+            }
+            case "getGameMode" -> GameMode.SURVIVAL;
+            case "setGameMode" -> null;
+            case "getAllowFlight" -> false;
+            case "setAllowFlight" -> null;
+            case "isFlying" -> false;
+            case "setFlying" -> null;
+            case "isCollidable" -> true;
+            case "setCollidable" -> null;
+            case "resetPlayerTime" -> null;
+            case "resetPlayerWeather" -> null;
+            default -> null;
+        });
+
+        installServer(livePlayer);
+
+        plugin = build(UltimateDonutSmp.class);
+        PlayerVisibilityManager visibilityManager = build(PlayerVisibilityManager.class);
+        ConfigManager configManager = build(ConfigManager.class);
+        YamlConfiguration duels = YamlConfiguration.loadConfiguration(new File("src/main/resources/duels.yml"));
+        set(configManager, "duels", duels);
+
+        godModeManager = new GodModeManager();
+        set(plugin, "godModeManager", godModeManager);
+        set(plugin, "playerVisibilityManager", visibilityManager);
+        set(plugin, "configManager", configManager);
+
+        duelManager = build(DuelManager.class);
+        set(duelManager, "plugin", plugin);
+        set(duelManager, "transitioningPlayers", new HashSet<UUID>());
+        set(duelManager, "transitionStates", new HashMap<UUID, Object>());
+        set(duelManager, "transitionDeadlines", new HashMap<UUID, Long>());
+        set(duelManager, "transitionTitles", new HashMap<UUID, Object>());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        setServer(originalServer);
+    }
+
+    @Test
+    void restoreTransitionStateEnforcesVulnerabilityForNormalPlayer() throws Exception {
+        liveInvulnerable.set(true);
+        invoke(duelManager, "applyTransitionState", livePlayer);
+
+        invoke(duelManager, "restoreTransitionState", livePlayer);
+
+        assertFalse(liveInvulnerable.get(), "duel restore must enforce invulnerable=false for normal players");
+        assertFalse(duelManager.isTransitioning(PLAYER_UUID));
+    }
+
+    @Test
+    void restoreTransitionStatePreservesGodModeProtection() throws Exception {
+        godModeManager.toggle(PLAYER_UUID);
+        liveInvulnerable.set(true);
+
+        invoke(duelManager, "applyTransitionState", livePlayer);
+        invoke(duelManager, "restoreTransitionState", livePlayer);
+
+        assertTrue(liveInvulnerable.get(), "players in god mode must retain invulnerability on return");
+    }
+
+    @Test
+    void restoreTransitionStateResolvesLivePlayerWhenPassedStalePlayer() throws Exception {
+        AtomicBoolean staleInvulnerable = new AtomicBoolean(true);
+        Player stalePlayer = proxy(Player.class, (method, args) -> switch (method.getName()) {
+            case "getUniqueId" -> PLAYER_UUID;
+            case "getName" -> "Fighter";
+            case "isOnline" -> true;
+            case "setInvulnerable" -> {
+                staleInvulnerable.set((Boolean) args[0]);
+                yield null;
+            }
+            default -> null;
+        });
+
+        liveInvulnerable.set(true);
+        invoke(duelManager, "applyTransitionState", livePlayer);
+        invoke(duelManager, "restoreTransitionState", stalePlayer);
+
+        assertFalse(liveInvulnerable.get(), "restoreTransitionState must apply to the live player instance");
+    }
+
+    @Test
+    void clearTransitionTrackingClearsInvulnerabilityForOnlinePlayer() throws Exception {
+        liveInvulnerable.set(true);
+        invoke(duelManager, "applyTransitionState", livePlayer);
+
+        invoke(duelManager, "clearTransitionTracking", PLAYER_UUID);
+
+        assertFalse(liveInvulnerable.get(), "clearTransitionTracking must drop invulnerability for online players");
+        assertFalse(duelManager.isTransitioning(PLAYER_UUID));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static Object invoke(Object target, String methodName, Object arg) throws Exception {
+        for (Method m : target.getClass().getDeclaredMethods()) {
+            if (m.getName().equals(methodName) && m.getParameterCount() == 1) {
+                m.setAccessible(true);
+                return m.invoke(target, arg);
+            }
+        }
+        throw new NoSuchMethodException(methodName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T build(Class<T> type) throws Exception {
+        Constructor<?> constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(type, Object.class.getConstructor());
+        return (T) constructor.newInstance();
+    }
+
+    private static void set(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private interface Handler {
+        Object handle(Method method, Object[] args) throws Throwable;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, Handler handler) {
+        return (T) Proxy.newProxyInstance(
+                DuelTransitionInvulnerabilityTest.class.getClassLoader(),
+                new Class<?>[]{type},
+                (instance, method, args) -> switch (method.getName()) {
+                    case "hashCode" -> System.identityHashCode(instance);
+                    case "equals" -> instance == args[0];
+                    case "toString" -> type.getSimpleName() + "-stub";
+                    default -> handler.handle(method, args);
+                }
+        );
+    }
+
+    private void installServer(Player onlinePlayer) throws Exception {
+        setServer(proxy(Server.class, (method, args) -> switch (method.getName()) {
+            case "getPlayer" -> {
+                if (PLAYER_UUID.equals(args[0])) {
+                    yield onlinePlayer;
+                }
+                if (originalServer != null) {
+                    yield method.invoke(originalServer, args);
+                }
+                yield null;
+            }
+            case "getOnlinePlayers" -> Set.of(onlinePlayer);
+            case "getRegistry" -> {
+                if (originalServer != null) {
+                    Object reg = method.invoke(originalServer, args);
+                    if (reg != null) {
+                        yield reg;
+                    }
+                }
+                Class<?> registryClass = Class.forName("org.bukkit.Registry");
+                yield Proxy.newProxyInstance(
+                        registryClass.getClassLoader(),
+                        new Class<?>[]{registryClass},
+                        (rProxy, rMethod, rArgs) -> defaultValue(rMethod)
+                );
+            }
+            default -> {
+                if (originalServer != null) {
+                    yield method.invoke(originalServer, args);
+                }
+                yield defaultValue(method);
+            }
+        }));
+    }
+
+    private static Object defaultValue(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        return null;
+    }
+
+    private static void setServer(Server server) throws Exception {
+        Field field = Bukkit.class.getDeclaredField("server");
+        field.setAccessible(true);
+        field.set(null, server);
+    }
+}


### PR DESCRIPTION
Duel and FFA transitions apply temporary invulnerability while players are in the post-match phase and waiting for return teleports. However, `restoreTransitionState` previously restored whatever `state.invulnerable()` held, or left the player invulnerable if the return delayed runnable executed against a stale entity instance or fell through without clearing invulnerability. Additionally, if the transition state was cleaned up or timed out, invulnerability was never revoked on the live player.

### Changes
- Re-query the live player instance via `Bukkit.getPlayer(uuid)` before running return completion tasks.
- Schedule return teleport delays via `runGlobalLater` so entity disposal does not swallow return callbacks.
- Explicitly reset `player.setInvulnerable(false)` upon restoring transition state or clearing transition tracking, unless the player is actively in god mode or staff mode.
- Apply matching parity fixes to FFA match transitions.
- Catch `Throwable` reflectively in `AttributeUtils` to avoid registry initialization issues in headless test environments.
- Add unit tests covering player return state and god mode preservation.

Closes #469
